### PR TITLE
Add Fallout 76 Support to RenoDX

### DIFF
--- a/src/games/fallout76/0x2E5E8174.hlsl
+++ b/src/games/fallout76/0x2E5E8174.hlsl
@@ -1,0 +1,81 @@
+// ---- Created with 3Dmigoto v1.3.16 on Sun May 12 21:52:50 2024
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb2 : register(b2)
+{
+  float4 cb2[1];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = t1.Sample(s1_s, v1.xy).xy;
+  r0.z = dot(r0.xy, r0.xy);
+  r0.w = sqrt(r0.z);
+  r1.xy = float2(-0.5,-0.5) + v1.xy;
+  r1.x = dot(r1.xy, r1.xy);
+  r1.x = sqrt(r1.x);
+  r1.x = saturate(r1.x * 0.100000001 + -0.0179999992);
+  r1.x = r1.x * r0.w;
+  r1.y = cmp(r1.x < 0.00100000005);
+  r0.z = rsqrt(r0.z);
+  r0.xy = r0.xy * r0.zz;
+  r0.z = min(cb2[0].y, r1.x);
+  r0.xy = r0.xy * r0.zz;
+  r0.xy = cb2[0].xx * r0.xy;
+  r2.xyzw = r0.xyxy * float4(-0.5,-0.5,-0.25,-0.25) + v1.xyxy;
+  r1.xz = t1.Sample(s1_s, r2.xy).xy;
+  r3.xyz = t0.Sample(s0_s, r2.xy).xyz;
+  r2.xy = t1.Sample(s1_s, r2.zw).xy;
+  r4.xyz = t0.Sample(s0_s, r2.zw).xyz;
+  r5.xyzw = t0.Sample(s0_s, v1.xy).xyzw;
+  r0.xy = r0.xy * float2(0.25,0.25) + v1.xy;
+  r2.zw = t1.Sample(s1_s, r0.xy).xy;
+  r0.xyz = t0.Sample(s0_s, r0.xy).xyz;
+  if (r1.y != 0) {
+    o0.xyzw = r5.xyzw;
+    return;
+  }
+  r1.x = dot(r1.xz, r1.xz);
+  r1.x = sqrt(r1.x);
+  r1.x = -r1.x + r0.w;
+  r1.x = saturate(-abs(r1.x) * cb2[0].z + 1);
+  r1.y = dot(r2.xy, r2.xy);
+  r1.y = sqrt(r1.y);
+  r1.y = -r1.y + r0.w;
+  r1.y = saturate(-abs(r1.y) * cb2[0].z + 1);
+  r1.z = r1.x + r1.y;
+  r4.xyz = r4.xyz * r1.yyy;
+  r1.xyw = r3.xyz * r1.xxx + r4.xyz;
+  r1.z = 1 + r1.z;
+  r1.xyw = r1.xyw + r5.xyz;
+  r2.x = dot(r2.zw, r2.zw);
+  r2.x = sqrt(r2.x);
+  r0.w = -r2.x + r0.w;
+  r0.w = saturate(-abs(r0.w) * cb2[0].z + 1);
+  r1.z = r1.z + r0.w;
+  r0.xyz = r0.xyz * r0.www + r1.xyw;
+  r0.w = 0.00100000005 + r1.z;
+  o0.xyz = r0.xyz / r0.www;
+  o0.w = 1;
+  return;
+}

--- a/src/games/fallout76/addon.cpp
+++ b/src/games/fallout76/addon.cpp
@@ -1,0 +1,322 @@
+/*
+ * Copyright (C) 2023 Carlos Lopez
+ * SPDX-License-Identifier: MIT
+ */
+
+#define ImTextureID ImU64
+
+#define DEBUG_LEVEL_0
+
+#include <embed/0x2CA9CD55.h> // text/UI
+#include <embed/0xA6AB1C75.h> // text
+#include <embed/0xF2CCBA8C.h> // UI
+#include <embed/0x69B52EA7.h> // Images
+#include <embed/0x6CF04AC0.h> // UI
+#include <embed/0x7AAE8C2B.h> // Images
+#include <embed/0x28213F99.h> // UI
+#include <embed/0x21A11DE7.h> // UI
+#include <embed/0x4B3388FE.h> // UI
+#include <embed/0x4D248432.h> // UI
+#include <embed/0x19558629.h> // UI
+#include <embed/0x46A6A1FE.h> // Loading Screen
+#include <embed/0xFEA4E7DB.h> // Loading Screen
+#include <embed/0xD66588EF.h> // Loading Screen
+#include <embed/0x3C8AF2C9.h> // Loading Screen Composite
+#include <embed/0x0F2CC0D1.h> // video
+//#include <embed/0x7684FC16.h> // FXAA
+#include <embed/0x2C63040A.h> // LUT
+#include <embed/0x160805BC.h> // LUT?
+#include <embed/0x3778E664.h> // TAA
+#include <embed/0xAF2731D9.h> // TAA
+//#include <embed/0x73F96489.h> // TAA?
+//#include <embed/0xC9C77523.h> // DOF?
+//#include <embed/0x283C8F43.h> // DOF?
+
+#include <embed/0x1BDD7570.h> // Tonemap
+#include <embed/0x2A868728.h> // Tonemap
+#include <embed/0x5D002D1E.h> // Tonemap
+#include <embed/0xBF6561E2.h> // Tonemap
+//#include <embed/0x438DFC72.h>
+
+
+#include <chrono>
+
+#include <deps/imgui/imgui.h>
+#include <include/reshade.hpp>
+#include "../../mods/shaderReplaceMod.hpp"
+#include "../../mods/swapChainUpgradeMod.hpp"
+#include "../../utils/userSettingUtil.hpp"
+#include "./shared.h"
+
+extern "C" __declspec(dllexport) const char* NAME = "RenoDX - Fallout 76";
+extern "C" __declspec(dllexport) const char* DESCRIPTION = "RenoDX for Fallout 76";
+
+ShaderReplaceMod::CustomShaders customShaders = {
+  CustomSwapchainShader(0x2CA9CD55),  // text/UI
+  CustomSwapchainShader(0xA6AB1C75),  // text
+  CustomSwapchainShader(0xF2CCBA8C),  // UI
+  CustomSwapchainShader(0x69B52EA7),  // Images
+  CustomSwapchainShader(0x6CF04AC0),  // UI
+  CustomSwapchainShader(0x7AAE8C2B),  // Images
+  CustomSwapchainShader(0x28213F99),  // UI
+  CustomSwapchainShader(0x21A11DE7),  // UI
+  CustomSwapchainShader(0x4B3388FE),  // UI
+  CustomSwapchainShader(0x4D248432),  // UI
+  CustomSwapchainShader(0x19558629),  // UI
+  CustomSwapchainShader(0x0F2CC0D1),  // video
+  CustomSwapchainShader(0x19558629),  // Loading Screen
+  CustomSwapchainShader(0xFEA4E7DB),  // Loading Screen
+  CustomSwapchainShader(0xD66588EF),  // Loading Screen
+  CustomSwapchainShader(0x3C8AF2C9),  // Loading Screen
+  CustomShaderEntry(0x1BDD7570),      // Tonemap
+  CustomShaderEntry(0x2A868728),      // Tonemap
+  CustomShaderEntry(0x5D002D1E),      // Tonemap
+  CustomShaderEntry(0xBF6561E2),      // Tonemap
+  CustomShaderEntry(0x2C63040A),      // LUT
+  CustomShaderEntry(0x160805BC),      // LUT?
+  
+
+  //CustomShaderEntry(0x7684FC16),      // FXAA
+  CustomShaderEntry(0x3778E664),      // TAA
+  CustomShaderEntry(0xAF2731D9),      // TAA
+  //CustomShaderEntry(0x438DFC72),      // TAA
+  //CustomShaderEntry(0x73F96489),      // TAA?
+  
+  //CustomShaderEntry(0xC9C77523),      // DOF?
+  //CustomShaderEntry(0x283C8F43),      // DOF?
+
+
+
+
+};
+
+ShaderInjectData shaderInjection;
+
+// clang-format off
+UserSettingUtil::UserSettings userSettings = {
+  new UserSettingUtil::UserSetting {
+    .key = "toneMapType",
+    .binding = &shaderInjection.toneMapType,
+    .valueType = UserSettingUtil::UserSettingValueType::integer,
+    .defaultValue = 3.f,
+    .canReset = false,
+    .label = "Tone Mapper",
+    .section = "Tone Mapping",
+    .tooltip = "Sets the tone mapper type",
+    .labels = {"Vanilla", "None", "ACES", "RenoDRT"}
+  },
+  new UserSettingUtil::UserSetting {
+    .key = "toneMapPeakNits",
+    .binding = &shaderInjection.toneMapPeakNits,
+    .defaultValue = 1000.f,
+    .canReset = false,
+    .label = "Peak Brightness",
+    .section = "Tone Mapping",
+    .tooltip = "Sets the value of peak white in nits",
+    .min = 48.f,
+    .max = 4000.f
+  },
+  new UserSettingUtil::UserSetting {
+    .key = "toneMapGameNits",
+    .binding = &shaderInjection.toneMapGameNits,
+    .defaultValue = 203.f,
+    .canReset = false,
+    .label = "Game Brightness",
+    .section = "Tone Mapping",
+    .tooltip = "Sets the value of 100%% white in nits",
+    .min = 48.f,
+    .max = 500.f
+  },
+  new UserSettingUtil::UserSetting {
+    .key = "toneMapUINits",
+    .binding = &shaderInjection.toneMapUINits,
+    .defaultValue = 203.f,
+    .canReset = false,
+    .label = "UI Brightness",
+    .section = "Tone Mapping",
+    .tooltip = "Sets the brightness of UI and HUD elements in nits",
+    .min = 48.f,
+    .max = 500.f
+  },
+  new UserSettingUtil::UserSetting {
+    .key = "toneMapGammaCorrection",
+    .binding = &shaderInjection.toneMapGammaCorrection,
+    .valueType = UserSettingUtil::UserSettingValueType::boolean,
+    .canReset = false,
+    .label = "Gamma Correction",
+    .section = "Tone Mapping",
+    .tooltip = "Emulates a 2.2 EOTF (use with HDR or sRGB)",
+  },
+  new UserSettingUtil::UserSetting {
+    .key = "colorGradeExposure",
+    .binding = &shaderInjection.colorGradeExposure,
+    .defaultValue = 1.f,
+    .label = "Exposure",
+    .section = "Color Grading",
+    .max = 10.f,
+    .format = "%.2f"
+  },
+  new UserSettingUtil::UserSetting {
+    .key = "colorGradeHighlights",
+    .binding = &shaderInjection.colorGradeHighlights,
+    .defaultValue = 50.f,
+    .label = "Highlights",
+    .section = "Color Grading",
+    .max = 100.f,
+    .parse = [](float value) { return value * 0.02f; }
+  },
+  new UserSettingUtil::UserSetting {
+    .key = "colorGradeShadows",
+    .binding = &shaderInjection.colorGradeShadows,
+    .defaultValue = 50.f,
+    .label = "Shadows",
+    .section = "Color Grading",
+    .max = 100.f,
+    .parse = [](float value) { return value * 0.02f; }
+  },
+  new UserSettingUtil::UserSetting {
+    .key = "colorGradeContrast",
+    .binding = &shaderInjection.colorGradeContrast,
+    .defaultValue = 50.f,
+    .label = "Contrast",
+    .section = "Color Grading",
+    .max = 100.f,
+    .parse = [](float value) { return value * 0.02f; }
+  },
+  new UserSettingUtil::UserSetting {
+    .key = "colorGradeSaturation",
+    .binding = &shaderInjection.colorGradeSaturation,
+    .defaultValue = 50.f,
+    .label = "Saturation",
+    .section = "Color Grading",
+    .max = 100.f,
+    .parse = [](float value) { return value * 0.02f; }
+  },
+  new UserSettingUtil::UserSetting {
+    .key = "colorGradeLUTStrength",
+    .binding = &shaderInjection.colorGradeLUTStrength,
+    .defaultValue = 100.f,
+    .label = "LUT Strength",
+    .section = "Color Grading",
+    .max = 100.f,
+    .parse = [](float value) { return value * 0.01f; }
+  },
+  new UserSettingUtil::UserSetting {
+    .key = "colorGradeLUTScaling",
+    .binding = &shaderInjection.colorGradeLUTScaling,
+    .defaultValue = 50.f,
+    .label = "LUT Scaling",
+    .section = "Color Grading",
+    .tooltip = "Scales the color grade LUT to full range when size is clamped.",
+    .max = 100.f,
+    .parse = [](float value) { return value * 0.01f; }
+  },
+  new UserSettingUtil::UserSetting {
+    .key = "fxBloom",
+    .binding = &shaderInjection.fxBloom,
+    .defaultValue = 50.f,
+    .label = "Bloom",
+    .section = "Effects",
+    .max = 100.f,
+    .parse = [](float value) { return value * 0.02f; }
+  },
+  new UserSettingUtil::UserSetting {
+    .key = "fxAutoExposure",
+    .binding = &shaderInjection.fxAutoExposure,
+    .defaultValue = 50.f,
+    .label = "Auto Exposure",
+    .section = "Effects",
+    .max = 100.f,
+    .parse = [](float value) { return value * 0.02f; }
+  },
+  new UserSettingUtil::UserSetting {
+    .key = "fxSceneFilter",
+    .binding = &shaderInjection.fxSceneFilter,
+    .defaultValue = 50.f,
+    .label = "Scene Filter",
+    .section = "Effects",
+    .max = 100.f,
+    .parse = [](float value) { return value * 0.02f; }
+  },
+  /* game already has DOF slider
+  new UserSettingUtil::UserSetting {
+    .key = "fxDoF",
+    .binding = &shaderInjection.fxDoF,
+    .defaultValue = 50.f,
+    .label = "Depth of Field",
+    .section = "Effects",
+    .max = 100.f,
+    .parse = [](float value) { return value * 0.02f; }
+  },
+  */
+  new UserSettingUtil::UserSetting {
+    .key = "fxFilmGrain",
+    .binding = &shaderInjection.fxFilmGrain,
+    .defaultValue = 0.f,
+    .label = "Film Grain",
+    .section = "Effects",
+    .max = 100.f,
+    .parse = [](float value) { return value * 0.02f; }
+  },
+};
+
+// clang-format on
+
+static void onPresetOff() {
+  UserSettingUtil::updateUserSetting("toneMapType", 0.f);
+  UserSettingUtil::updateUserSetting("toneMapPeakNits", 203.f);
+  UserSettingUtil::updateUserSetting("toneMapGameNits", 203.f);
+  UserSettingUtil::updateUserSetting("toneMapUINits", 203.f);
+  UserSettingUtil::updateUserSetting("toneMapGammaCorrection", 0);
+  UserSettingUtil::updateUserSetting("colorGradeExposure", 1.f);
+  UserSettingUtil::updateUserSetting("colorGradeHighlights", 50.f);
+  UserSettingUtil::updateUserSetting("colorGradeShadows", 50.f);
+  UserSettingUtil::updateUserSetting("colorGradeContrast", 50.f);
+  UserSettingUtil::updateUserSetting("colorGradeSaturation", 50.f);
+  UserSettingUtil::updateUserSetting("colorGradeLUTStrength", 100.f);
+  UserSettingUtil::updateUserSetting("colorGradeLUTScaling", 0.f);
+  UserSettingUtil::updateUserSetting("fxBloom", 50.f);
+  UserSettingUtil::updateUserSetting("fxAutoExposure", 50.f);
+  UserSettingUtil::updateUserSetting("fxSceneFilter", 50.f);
+  UserSettingUtil::updateUserSetting("fxDoF", 50.f);
+  UserSettingUtil::updateUserSetting("fxFilmGrain", 0.f);
+}
+
+static auto start = std::chrono::steady_clock::now();
+
+static void on_present(
+  reshade::api::command_queue* queue,
+  reshade::api::swapchain* swapchain,
+  const reshade::api::rect* source_rect,
+  const reshade::api::rect* dest_rect,
+  uint32_t dirty_rect_count,
+  const reshade::api::rect* dirty_rects
+) {
+  auto end = std::chrono::steady_clock::now();
+  shaderInjection.elapsedTime = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+}
+
+BOOL APIENTRY DllMain(HMODULE hModule, DWORD fdwReason, LPVOID) {
+  switch (fdwReason) {
+    case DLL_PROCESS_ATTACH:
+
+      ShaderReplaceMod::forcePipelineCloning = true;
+      ShaderReplaceMod::expectedConstantBufferIndex = 11;
+      ShaderReplaceMod::traceUnmodifiedShaders = true;
+      if (!reshade::register_addon(hModule)) return FALSE;
+
+      reshade::register_event<reshade::addon_event::present>(on_present);
+
+      break;
+    case DLL_PROCESS_DETACH:
+      reshade::unregister_addon(hModule);
+      reshade::unregister_event<reshade::addon_event::present>(on_present);
+      break;
+  }
+
+  UserSettingUtil::use(fdwReason, &userSettings, &onPresetOff);
+  SwapChainUpgradeMod::use(fdwReason);
+  ShaderReplaceMod::use(fdwReason, customShaders, &shaderInjection);
+
+  return TRUE;
+}

--- a/src/games/fallout76/fallout 76 notes.txt
+++ b/src/games/fallout76/fallout 76 notes.txt
@@ -1,0 +1,72 @@
+completed
+    UI
+
+maybe completed:
+    taa
+        0xAF2731D9.ps_5_0.hlsl
+
+todo:
+    tonemapping
+        0x2A868728.hlsl
+        0xBF6561E2.hlsl
+        0x5D002D1E.hlsl
+        0xBF6561E2.hlsl
+    lut?
+        0x2C63040A.hlsl
+        0x160805BC.hlsl
+    no idea but looks important
+        0x1BF9D9D2.hlsl
+    vignette
+        0x2E5E8174.hlsl
+    dof?
+        0x283C8F43.hlsl
+        0xC9C77523.hlsl
+    fxaa
+        0x7684FC16.hlsl
+    taa
+        0x3778E664
+    also taa?
+        0x73F96489.hlsl
+
+
+notes (use quick search in vscode)
+    references to 2.2:
+        (0.454545468)
+        r7.xyz = float3(2.20000005,2.20000005,2.20000005) * r7.xyz;
+
+    converting srgb to ycbcr:
+        dot(r3.xyz, float3(0.212500006,0.715399981,0.0720999986))
+
+    found in tonemapping shaders in both fallout 4 and 76:
+        if (r0.w != 0) {
+            o0.xyz = r0.xyz;
+            o0.w = 1;
+            return;
+        }
+
+    bt.601 primaries:
+        r2.xy = float2(0.298999995,0.587000012) * r2.xy;
+        r0.y = dot(float3(0.298999995,0.587000012,0.114), r1.xyz);
+
+# HLSL decompiling
+
+* `x + 4294967295u`        = `x - 1u`
+* `mad(a, b, c)`           = `(a * b) + c`
+  
+* `exp2(log2(abs(x)) * y)` = `pow(x, y)`
+* `exp2(log2(x) * y)`      = `pow(x, y)`
+* `exp2(y * log2(x))`      = `pow(x, y)`
+
+* `((b-a) * t) + a`        = `lerp(a, b, t)`
+* `(t * (b-a)) + a`        = `lerp(a, b, t)`
+* `(1-t)*a + t*b`          = `lerp(a, b, t)`
+* `mad((b-a), t, a)`       = `lerp(a, b, t)`
+* `mad(t, (b-a), a)`       = `lerp(a, b, t)`
+
+* `log2(x)`                = `log10(x)/log10(2)`
+* `log2(x*y)`              = `log2(x) + log2(y)`
+* `log2(x) * y`            = `log10(x) * (z*log10(2))`
+
+* `exp2(x) * y`            = `log10(x) * (z*log10(2))`
+
+* `0.416666657`            = `1 / 2.4`

--- a/src/games/fallout76/fxaa_0x7684FC16.ps_5_0.hlsl
+++ b/src/games/fallout76/fxaa_0x7684FC16.ps_5_0.hlsl
@@ -1,0 +1,196 @@
+// ---- Created with 3Dmigoto v1.3.16 on Sun May 12 21:52:59 2024
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb2 : register(b2)
+{
+  float4 cb2[1];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = t0.SampleLevel(s0_s, v1.xy, 0).xyzw;
+  r1.xyz = t0.Gather(s0_s, v1.xy).xyz;
+  r2.xyz = t0.Gather(s0_s, v1.xy, int2(-1, -1)).xzw;
+  r1.w = max(r1.x, r0.y);
+  r2.w = min(r1.x, r0.y);
+  r1.w = max(r1.z, r1.w);
+  r2.w = min(r2.w, r1.z);
+  r3.x = max(r2.y, r2.x);
+  r3.y = min(r2.y, r2.x);
+  r1.w = max(r3.x, r1.w);
+  r2.w = min(r3.y, r2.w);
+  r3.x = 0.165999994 * r1.w;
+  r1.w = -r2.w + r1.w;
+  r2.w = max(0.0833000019, r3.x);
+  r2.w = cmp(r1.w >= r2.w);
+  if (r2.w != 0) {
+    r2.w = t0.SampleLevel(s0_s, v1.xy, 0, int2(1, -1)).y;
+    r3.x = t0.SampleLevel(s0_s, v1.xy, 0, int2(-1, 1)).y;
+    r3.yz = r2.yx + r1.xz;
+    r1.w = 1 / r1.w;
+    r3.w = r3.y + r3.z;
+    r3.yz = r0.yy * float2(-2,-2) + r3.yz;
+    r4.x = r2.w + r1.y;
+    r2.w = r2.z + r2.w;
+    r4.y = r1.z * -2 + r4.x;
+    r2.w = r2.y * -2 + r2.w;
+    r2.z = r3.x + r2.z;
+    r1.y = r3.x + r1.y;
+    r3.x = abs(r3.y) * 2 + abs(r4.y);
+    r2.w = abs(r3.z) * 2 + abs(r2.w);
+    r3.y = r2.x * -2 + r2.z;
+    r1.y = r1.x * -2 + r1.y;
+    r3.x = abs(r3.y) + r3.x;
+    r1.y = abs(r1.y) + r2.w;
+    r2.z = r2.z + r4.x;
+    r1.y = cmp(r3.x >= r1.y);
+    r2.z = r3.w * 2 + r2.z;
+    r2.x = r1.y ? r2.y : r2.x;
+    r1.x = r1.y ? r1.x : r1.z;
+    r1.z = r1.y ? cb2[0].y : cb2[0].x;
+    r2.y = r2.z * 0.0833333358 + -r0.y;
+    r2.z = r2.x + -r0.y;
+    r2.w = r1.x + -r0.y;
+    r2.x = r2.x + r0.y;
+    r1.x = r1.x + r0.y;
+    r3.x = cmp(abs(r2.z) >= abs(r2.w));
+    r2.z = max(abs(r2.z), abs(r2.w));
+    r1.z = r3.x ? -r1.z : r1.z;
+    r1.w = saturate(abs(r2.y) * r1.w);
+    r2.y = r1.y ? cb2[0].x : 0;
+    r2.w = r1.y ? 0 : cb2[0].y;
+    r3.yz = r1.zz * float2(0.5,0.5) + v1.xy;
+    r3.y = r1.y ? v1.x : r3.y;
+    r3.z = r1.y ? r3.z : v1.y;
+    r4.xy = r3.yz + -r2.yw;
+    r5.xy = r3.yz + r2.yw;
+    r3.y = r1.w * -2 + 3;
+    r3.z = t0.SampleLevel(s0_s, r4.xy, 0).y;
+    r1.w = r1.w * r1.w;
+    r3.w = t0.SampleLevel(s0_s, r5.xy, 0).y;
+    r1.x = r3.x ? r2.x : r1.x;
+    r2.x = 0.25 * r2.z;
+    r2.z = -r1.x * 0.5 + r0.y;
+    r1.w = r3.y * r1.w;
+    r2.z = cmp(r2.z < 0);
+    r3.x = -r1.x * 0.5 + r3.z;
+    r3.y = -r1.x * 0.5 + r3.w;
+    r3.zw = cmp(abs(r3.xy) >= r2.xx);
+    r4.z = -r2.y * 1.5 + r4.x;
+    r4.x = r3.z ? r4.x : r4.z;
+    r4.w = -r2.w * 1.5 + r4.y;
+    r4.z = r3.z ? r4.y : r4.w;
+    r4.yw = ~(int2)r3.zw;
+    r4.y = (int)r4.w | (int)r4.y;
+    r4.w = r2.y * 1.5 + r5.x;
+    r5.x = r3.w ? r5.x : r4.w;
+    r4.w = r2.w * 1.5 + r5.y;
+    r5.z = r3.w ? r5.y : r4.w;
+    if (r4.y != 0) {
+      if (r3.z == 0) {
+        r3.x = t0.SampleLevel(s0_s, r4.xz, 0).y;
+      }
+      if (r3.w == 0) {
+        r3.y = t0.SampleLevel(s0_s, r5.xz, 0).y;
+      }
+      r4.y = -r1.x * 0.5 + r3.x;
+      r3.x = r3.z ? r3.x : r4.y;
+      r3.z = -r1.x * 0.5 + r3.y;
+      r3.y = r3.w ? r3.y : r3.z;
+      r3.zw = cmp(abs(r3.xy) >= r2.xx);
+      r4.y = -r2.y * 2 + r4.x;
+      r4.x = r3.z ? r4.x : r4.y;
+      r4.y = -r2.w * 2 + r4.z;
+      r4.z = r3.z ? r4.z : r4.y;
+      r4.yw = ~(int2)r3.zw;
+      r4.y = (int)r4.w | (int)r4.y;
+      r4.w = r2.y * 2 + r5.x;
+      r5.x = r3.w ? r5.x : r4.w;
+      r4.w = r2.w * 2 + r5.z;
+      r5.z = r3.w ? r5.z : r4.w;
+      if (r4.y != 0) {
+        if (r3.z == 0) {
+          r3.x = t0.SampleLevel(s0_s, r4.xz, 0).y;
+        }
+        if (r3.w == 0) {
+          r3.y = t0.SampleLevel(s0_s, r5.xz, 0).y;
+        }
+        r4.y = -r1.x * 0.5 + r3.x;
+        r3.x = r3.z ? r3.x : r4.y;
+        r3.z = -r1.x * 0.5 + r3.y;
+        r3.y = r3.w ? r3.y : r3.z;
+        r3.zw = cmp(abs(r3.xy) >= r2.xx);
+        r4.y = -r2.y * 4 + r4.x;
+        r4.x = r3.z ? r4.x : r4.y;
+        r4.y = -r2.w * 4 + r4.z;
+        r4.z = r3.z ? r4.z : r4.y;
+        r4.yw = ~(int2)r3.zw;
+        r4.y = (int)r4.w | (int)r4.y;
+        r4.w = r2.y * 4 + r5.x;
+        r5.x = r3.w ? r5.x : r4.w;
+        r4.w = r2.w * 4 + r5.z;
+        r5.z = r3.w ? r5.z : r4.w;
+        if (r4.y != 0) {
+          if (r3.z == 0) {
+            r3.x = t0.SampleLevel(s0_s, r4.xz, 0).y;
+          }
+          if (r3.w == 0) {
+            r3.y = t0.SampleLevel(s0_s, r5.xz, 0).y;
+          }
+          r4.y = -r1.x * 0.5 + r3.x;
+          r3.x = r3.z ? r3.x : r4.y;
+          r1.x = -r1.x * 0.5 + r3.y;
+          r3.y = r3.w ? r3.y : r1.x;
+          r3.zw = cmp(abs(r3.xy) >= r2.xx);
+          r1.x = -r2.y * 12 + r4.x;
+          r4.x = r3.z ? r4.x : r1.x;
+          r1.x = -r2.w * 12 + r4.z;
+          r4.z = r3.z ? r4.z : r1.x;
+          r1.x = r2.y * 12 + r5.x;
+          r5.x = r3.w ? r5.x : r1.x;
+          r1.x = r2.w * 12 + r5.z;
+          r5.z = r3.w ? r5.z : r1.x;
+        }
+      }
+    }
+    r1.x = v1.x + -r4.x;
+    r2.y = v1.y + -r4.z;
+    r1.x = r1.y ? r1.x : r2.y;
+    r2.xy = -v1.xy + r5.xz;
+    r2.x = r1.y ? r2.x : r2.y;
+    r2.yw = cmp(r3.xy < float2(0,0));
+    r3.x = r2.x + r1.x;
+    r2.yz = cmp((int2)r2.zz != (int2)r2.yw);
+    r2.w = 1 / r3.x;
+    r3.x = cmp(r1.x < r2.x);
+    r1.x = min(r2.x, r1.x);
+    r2.x = r3.x ? r2.y : r2.z;
+    r1.w = r1.w * r1.w;
+    r1.x = r1.x * -r2.w + 0.5;
+    r1.w = 0.75 * r1.w;
+    r1.x = (int)r1.x & (int)r2.x;
+    r1.x = max(r1.x, r1.w);
+    r1.xz = r1.xx * r1.zz + v1.xy;
+    r2.x = r1.y ? v1.x : r1.x;
+    r2.y = r1.y ? r1.z : v1.y;
+    r0.xyz = t0.SampleLevel(s0_s, r2.xy, 0).xyz;
+  }
+  o0.xyzw = r0.xyzw;
+  return;
+}

--- a/src/games/fallout76/images_0x69B52EA7.ps_5_0.hlsl
+++ b/src/games/fallout76/images_0x69B52EA7.ps_5_0.hlsl
@@ -1,0 +1,73 @@
+#include "../../shaders/color.hlsl"
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sun May 12 21:52:57 2024
+
+cbuffer Constants : register(b0)
+{
+  float4 fsize : packoffset(c0);
+  float4 offset : packoffset(c1);
+  float4 scolor : packoffset(c2);
+  float4 srctexscale : packoffset(c3);
+  float4 texscale : packoffset(c4);
+}
+
+SamplerState sampler_srctex_s : register(s0);
+SamplerState sampler_tex_s : register(s1);
+Texture2D<float4> srctex : register(t0);
+Texture2D<float4> tex : register(t1);
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : TEXCOORD0,
+  float4 v1 : TEXCOORD1,
+  float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.x = 0;
+  r0.y = -fsize.x;
+  while (true) {
+    r0.z = cmp(fsize.x < r0.y);
+    if (r0.z != 0) break;
+    r1.x = offset.x + r0.y;
+    r2.x = r0.x;
+    r2.y = -fsize.y;
+    while (true) {
+      r0.z = cmp(fsize.y < r2.y);
+      if (r0.z != 0) break;
+      r1.y = offset.y + r2.y;
+      r0.zw = r1.xy * texscale.xy + v2.xy;
+      r0.z = tex.Sample(sampler_tex_s, r0.zw).w;
+      r2.x = r2.x + r0.z;
+      r2.y = 1 + r2.y;
+    }
+    r0.x = r2.x;
+    r0.y = 1 + r0.y;
+  }
+  r0.x = fsize.w * r0.x;
+  r0.x = saturate(fsize.z * r0.x);
+  r0.yz = srctexscale.xy * v2.xy;
+  r1.xyzw = srctex.Sample(sampler_srctex_s, r0.yz).xyzw;
+  r0.x = scolor.w * r0.x;
+  r0.xyzw = scolor.xyzw * r0.xxxx;
+  r2.x = 1 + -r1.w;
+  r0.xyzw = r0.xyzw * r2.xxxx + r1.xyzw;
+  r1.xyz = v1.xyz;
+  r1.w = 1;
+  r0.xyzw = r1.xyzw * r0.xyzw;
+  r0.xyzw = v1.wwww * r0.xyzw;
+  o0.xyzw = saturate(v0.xyzw * r0.wwww + r0.xyzw);
+
+  o0.rgb = injectedData.toneMapGammaCorrection ? pow(o0.rgb, 2.2f) : linearFromSRGB(o0.rgb);
+  o0.rgb *= injectedData.toneMapUINits / 80.f;
+
+  return;
+}

--- a/src/games/fallout76/images_0x7AAE8C2B.ps_5_0.hlsl
+++ b/src/games/fallout76/images_0x7AAE8C2B.ps_5_0.hlsl
@@ -1,0 +1,31 @@
+#include "../../shaders/color.hlsl"
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sun May 12 21:52:59 2024
+
+SamplerState sampler_tex_s : register(s0);
+Texture2D<float4> tex : register(t0);
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : COLOR0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = tex.Sample(sampler_tex_s, v1.xy).xyzw;
+  o0.w = v0.w * r0.w;
+  o0.xyz = r0.xyz;
+
+  o0.rgb = injectedData.toneMapGammaCorrection ? pow(o0.rgb, 2.2f) : linearFromSRGB(o0.rgb);
+  o0.rgb *= injectedData.toneMapUINits / 80.f;
+
+  return;
+}

--- a/src/games/fallout76/load_0x46A6A1FE.ps_5_0.hlsl
+++ b/src/games/fallout76/load_0x46A6A1FE.ps_5_0.hlsl
@@ -1,0 +1,27 @@
+#include "../../shaders/color.hlsl"
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sun May 12 21:52:53 2024
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s0_s : register(s0);
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  o0.xyzw = t0.Sample(s0_s, v1.xy).xyzw;
+
+  o0.rgb = injectedData.toneMapGammaCorrection ? pow(o0.rgb, 2.2f) : linearFromSRGB(o0.rgb);
+  o0.rgb *= injectedData.toneMapUINits / 80.f;
+
+  return;
+}

--- a/src/games/fallout76/load_0xD66588EF.ps_5_0.hlsl
+++ b/src/games/fallout76/load_0xD66588EF.ps_5_0.hlsl
@@ -1,0 +1,35 @@
+#include "../../shaders/color.hlsl"
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sun May 12 21:53:14 2024
+
+SamplerState sampler_tex_s : register(s0);
+Texture2D<float4> tex : register(t0);
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : COLOR0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float2 v3 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = tex.Sample(sampler_tex_s, v3.xy).xyzw;
+  r0.xyzw = saturate(r0.xyzw * v2.xyzw + v1.xyzw);
+  r0.w = v0.w * r0.w;
+  o0.xyz = r0.xyz * r0.www;
+  o0.w = r0.w;
+
+  o0.rgb = injectedData.toneMapGammaCorrection ? pow(o0.rgb, 2.2f) : linearFromSRGB(o0.rgb);
+  o0.rgb *= injectedData.toneMapUINits / 80.f;
+
+  return;
+}

--- a/src/games/fallout76/load_0xFEA4E7DB.ps_5_0.hlsl
+++ b/src/games/fallout76/load_0xFEA4E7DB.ps_5_0.hlsl
@@ -1,0 +1,34 @@
+#include "../../shaders/color.hlsl"
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sun May 12 21:53:20 2024
+
+SamplerState sampler_tex_s : register(s0);
+Texture2D<float4> tex : register(t0);
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : COLOR0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float2 v3 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = tex.Sample(sampler_tex_s, v3.xy).xyzw;
+  r0.xyzw = saturate(r0.xyzw * v2.xyzw + v1.xyzw);
+  o0.w = v0.w * r0.w;
+  o0.xyz = r0.xyz;
+
+  o0.rgb = injectedData.toneMapGammaCorrection ? pow(o0.rgb, 2.2f) : linearFromSRGB(o0.rgb);
+  o0.rgb *= injectedData.toneMapUINits / 80.f;
+
+  return;
+}

--- a/src/games/fallout76/load_composite_0x3C8AF2C9.ps_5_0.hlsl
+++ b/src/games/fallout76/load_composite_0x3C8AF2C9.ps_5_0.hlsl
@@ -1,0 +1,68 @@
+#include "../../shaders/color.hlsl"
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sun May 12 21:52:52 2024
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s9_s : register(s9);
+
+cbuffer cb2 : register(b2)
+{
+  float4 cb2[2];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyz = t0.Sample(s9_s, v1.xy).xyz;
+  r1.xyz = log2(r0.xyz);
+  r1.xyz = cb2[1].xxx * r1.xyz;
+  r1.xyz = exp2(r1.xyz);
+  r2.xyz = cmp(float3(0,0,0) != cb2[0].yzw);
+  r0.xyz = r2.xxx ? r1.xyz : r0.xyz;
+  r1.x = dot(float3(0.627403975,0.329281986,0.0433136001), r0.xyz);
+  r1.y = dot(float3(0.0690969974,0.919539988,0.0113612004), r0.xyz);
+  r1.z = dot(float3(0.0163915996,0.088013202,0.895595014), r0.xyz);
+  r0.xyz = r2.yyy ? r1.xyz : r0.xyz;
+  r1.xyz = cb2[0].xxx * r0.xyz;
+  r1.xyz = float3(9.99999975e-005,9.99999975e-005,9.99999975e-005) * r1.xyz;
+  r1.xyz = log2(abs(r1.xyz));
+  r1.xyz = float3(0.159301758,0.159301758,0.159301758) * r1.xyz;
+  r1.xyz = exp2(r1.xyz);
+  r2.xyw = r1.xyz * float3(18.8515625,18.8515625,18.8515625) + float3(0.8359375,0.8359375,0.8359375);
+  r1.xyz = r1.xyz * float3(18.6875,18.6875,18.6875) + float3(1,1,1);
+  r1.xyz = r2.xyw / r1.xyz;
+  r1.xyz = log2(r1.xyz);
+  r1.xyz = float3(78.84375,78.84375,78.84375) * r1.xyz;
+  r1.xyz = exp2(r1.xyz);
+  r2.xyw = -cb2[1].zzz + r1.xyz;
+  r3.xy = cb2[1].wy + -cb2[1].zz;
+  r2.xyw = saturate(r2.xyw / r3.xxx);
+  r3.xyz = r2.xyw * r3.yyy + cb2[1].zzz;
+  r4.xyz = float3(1,1,1) + -r2.xyw;
+  r2.xyw = cb2[1].yyy * r2.xyw;
+  r2.xyw = r3.xyz * r4.xyz + r2.xyw;
+  r2.xyw = min(r2.xyw, r1.xyz);
+  r3.xyz = cmp(cb2[1].zzz < r1.xyz);
+  r1.xyz = r3.xyz ? r2.xyw : r1.xyz;
+  o0.xyz = r2.zzz ? r1.xyz : r0.xyz;
+  o0.w = 1;
+
+  o0.rgb = injectedData.toneMapGammaCorrection ? pow(o0.rgb, 2.2f) : linearFromSRGB(o0.rgb);
+  o0.rgb *= injectedData.toneMapUINits / 80.f;
+
+  return;
+}

--- a/src/games/fallout76/lut2_0x160805BC.ps_5_0.hlsl
+++ b/src/games/fallout76/lut2_0x160805BC.ps_5_0.hlsl
@@ -1,0 +1,242 @@
+#include "../../shaders/tonemap.hlsl"
+#include "../../shaders/filmgrain.hlsl"
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sun May 12 21:52:46 2024
+Texture3D<float4> t6 : register(t6);
+
+Texture3D<float4> t5 : register(t5);
+
+Texture3D<float4> t4 : register(t4);
+
+Texture3D<float4> t3 : register(t3);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s6_s : register(s6);
+
+SamplerState s5_s : register(s5);
+
+SamplerState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb2 : register(b2)
+{
+  float4 cb2[2];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = t0.Sample(s0_s, v1.xy).xyzw;
+
+  float vanillaMidGray = .18f;
+  float renoDRTContrast = 1.f;
+  float renoDRTFlare = .5f;
+  float renoDRTShadows = 1.f;
+  float renoDRTDechroma = .83f;
+  float renoDRTSaturation = 2.f;
+  float renoDRTHighlights = 1.0f;
+
+  ToneMapParams tmParams = {
+    injectedData.toneMapType,
+    injectedData.toneMapPeakNits,
+    injectedData.toneMapGameNits,
+    injectedData.toneMapGammaCorrection - 1,  // LUT output was in 2.2
+    injectedData.colorGradeExposure,
+    injectedData.colorGradeHighlights,
+    injectedData.colorGradeShadows,
+    injectedData.colorGradeContrast,
+    injectedData.colorGradeSaturation,
+    vanillaMidGray,
+    vanillaMidGray * 100.f,
+    renoDRTHighlights,
+    renoDRTShadows,
+    renoDRTContrast,
+    renoDRTSaturation,
+    renoDRTDechroma,
+    renoDRTFlare
+  };
+
+  ToneMapLUTParams lutParams = buildLUTParams(
+    s3_s,
+    injectedData.colorGradeLUTStrength,
+    injectedData.colorGradeLUTScaling,  // Cleans up raised black floor
+    TONE_MAP_LUT_TYPE__2_2,
+    TONE_MAP_LUT_TYPE__2_2,
+    16
+  );
+
+  float3 outputColor = r0.rgb;
+  if (injectedData.colorGradeLUTStrength == 0.f || tmParams.type == 1.f) {
+    outputColor = toneMap(outputColor, tmParams);
+  } else {
+    float3 hdrColor;
+    float3 sdrColor;
+    if (tmParams.type == 3.f) {
+      tmParams.renoDRTSaturation *= tmParams.saturation;
+
+      sdrColor = renoDRTToneMap(outputColor, tmParams, true);
+
+      tmParams.renoDRTHighlights *= tmParams.highlights;
+      tmParams.renoDRTShadows *= tmParams.shadows;
+      tmParams.renoDRTContrast *= tmParams.contrast;
+
+      hdrColor = renoDRTToneMap(outputColor, tmParams);
+
+    } else {
+      outputColor = applyUserColorGrading(
+        outputColor,
+        tmParams.exposure,
+        tmParams.highlights,
+        tmParams.shadows,
+        tmParams.contrast,
+        tmParams.saturation
+      );
+
+      if (tmParams.type == 2.f) {
+        hdrColor = acesToneMap(outputColor, tmParams);
+        sdrColor = acesToneMap(outputColor, tmParams, true);
+      } else {
+        hdrColor = saturate(outputColor);
+        sdrColor = saturate(outputColor);
+      }
+    }
+
+    r0.xyz = sdrColor;
+
+
+
+    r1.xyz = r0.xyz; // float3(0.9375,0.9375,0.9375) + float3(0.03125,0.03125,0.03125);
+    
+    //r2.xyz = t3.Sample(s3_s, r1.xyz).xyz;
+    r2.xyz = sampleLUT(r0.xyz, lutParams, t3);
+
+    
+    r2.xyz = cb2[0].xxx * r2.xyz;
+    r0.xyz = r0.xyz * cb2[1].xxx + r2.xyz;
+    o0.w = r0.w;
+    
+    //r2.xyz = t4.Sample(s4_s, r1.xyz).xyz;
+    lutParams.lutSampler = s4_s;
+    r2.xyz = sampleLUT(r1.xyz, lutParams, t4);
+
+    r0.xyz = r2.xyz * cb2[0].yyy + r0.xyz;
+
+    //r2.xyz = t5.Sample(s5_s, r1.xyz).xyz;
+    lutParams.lutSampler = s5_s;
+    r2.xyz = sampleLUT(r1.xyz, lutParams, t5);
+
+    
+    //r1.xyz = t6.Sample(s6_s, r1.xyz).xyz;
+    lutParams.lutSampler = s6_s;
+    r1.xyz = sampleLUT(r1.xyz, lutParams, t6);
+
+    
+    r0.xyz = r2.xyz * cb2[0].zzz + r0.xyz;
+
+    //o0.xyz = r1.xyz * cb2[0].www + r0.xyz;
+    float3 lutColor = r1.xyz * cb2[0].www + r0.xyz;
+
+    if (tmParams.type == 0.f) {
+      outputColor = lerp(outputColor, lutColor, lutParams.strength);
+    } else {
+      outputColor = toneMapUpgrade(hdrColor, sdrColor, lutColor, lutParams.strength);
+    }
+  }
+  o0.rgb = outputColor;
+  if (injectedData.fxFilmGrain) {
+    float3 grainedColor = computeFilmGrain(
+      o0.rgb,
+      v1.xy,
+      frac(injectedData.elapsedTime / 1000.f),
+      injectedData.fxFilmGrain * 0.03f,
+      1.f
+    );
+    o0.xyz = grainedColor;
+  }
+  
+  
+  if (!injectedData.toneMapGammaCorrection) {
+    o0.rgb = gammaCorrectSafe(o0.rgb, true);
+  }
+
+  o0.rgb *= injectedData.toneMapGameNits / 80.f;
+  return;
+}
+
+
+/*
+// ---- Created with 3Dmigoto v1.3.16 on Sun May 12 21:52:46 2024
+Texture3D<float4> t6 : register(t6);
+
+Texture3D<float4> t5 : register(t5);
+
+Texture3D<float4> t4 : register(t4);
+
+Texture3D<float4> t3 : register(t3);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s6_s : register(s6);
+
+SamplerState s5_s : register(s5);
+
+SamplerState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb2 : register(b2)
+{
+  float4 cb2[2];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = t0.Sample(s0_s, v1.xy).xyzw;
+  r1.xyz = r0.xyz * float3(0.9375,0.9375,0.9375) + float3(0.03125,0.03125,0.03125);
+  r2.xyz = t3.Sample(s3_s, r1.xyz).xyz;
+  r2.xyz = cb2[0].xxx * r2.xyz;
+  r0.xyz = r0.xyz * cb2[1].xxx + r2.xyz;
+  o0.w = r0.w;
+  r2.xyz = t4.Sample(s4_s, r1.xyz).xyz;
+  r0.xyz = r2.xyz * cb2[0].yyy + r0.xyz;
+  r2.xyz = t5.Sample(s5_s, r1.xyz).xyz;
+  r1.xyz = t6.Sample(s6_s, r1.xyz).xyz;
+  r0.xyz = r2.xyz * cb2[0].zzz + r0.xyz;
+  o0.xyz = r1.xyz * cb2[0].www + r0.xyz;
+  return;
+}
+*/

--- a/src/games/fallout76/lut_0x2C63040A.ps_5_0.hlsl
+++ b/src/games/fallout76/lut_0x2C63040A.ps_5_0.hlsl
@@ -1,0 +1,180 @@
+#include "../../shaders/tonemap.hlsl"
+#include "../../shaders/filmgrain.hlsl"
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sun May 12 21:52:50 2024
+Texture3D<float4> t6 : register(t6);
+
+Texture3D<float4> t5 : register(t5);
+
+Texture3D<float4> t4 : register(t4);
+
+Texture3D<float4> t3 : register(t3);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s6_s : register(s6);
+
+SamplerState s5_s : register(s5);
+
+SamplerState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb2 : register(b2)
+{
+  float4 cb2[2];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+
+  r0.xyzw = t0.Sample(s0_s, v1.xy).xyzw;
+  //r0.xyz = log2(r0.xyz);
+
+  o0.w = r0.w;
+
+  float vanillaMidGray = .18f;
+  float renoDRTContrast = 1.f;
+  float renoDRTFlare = .5f;
+  float renoDRTShadows = 1.f;
+  float renoDRTDechroma = .83f;
+  float renoDRTSaturation = 2.f;
+  float renoDRTHighlights = 1.0f;
+
+  ToneMapParams tmParams = {
+    injectedData.toneMapType,
+    injectedData.toneMapPeakNits,
+    injectedData.toneMapGameNits,
+    injectedData.toneMapGammaCorrection - 1,  // LUT output was in 2.2
+    injectedData.colorGradeExposure,
+    injectedData.colorGradeHighlights,
+    injectedData.colorGradeShadows,
+    injectedData.colorGradeContrast,
+    injectedData.colorGradeSaturation,
+    vanillaMidGray,
+    vanillaMidGray * 100.f,
+    renoDRTHighlights,
+    renoDRTShadows,
+    renoDRTContrast,
+    renoDRTSaturation,
+    renoDRTDechroma,
+    renoDRTFlare
+  };
+
+  ToneMapLUTParams lutParams = buildLUTParams(
+    s3_s,
+    injectedData.colorGradeLUTStrength,
+    injectedData.colorGradeLUTScaling,  // Cleans up raised black floor
+    TONE_MAP_LUT_TYPE__2_2,
+    TONE_MAP_LUT_TYPE__2_2,
+    16
+  );
+
+  float3 outputColor = r0.rgb;
+  if (injectedData.colorGradeLUTStrength == 0.f || tmParams.type == 1.f) {
+    outputColor = toneMap(outputColor, tmParams);
+  } else {
+    float3 hdrColor;
+    float3 sdrColor;
+    if (tmParams.type == 3.f) {
+      tmParams.renoDRTSaturation *= tmParams.saturation;
+
+      sdrColor = renoDRTToneMap(outputColor, tmParams, true);
+
+      tmParams.renoDRTHighlights *= tmParams.highlights;
+      tmParams.renoDRTShadows *= tmParams.shadows;
+      tmParams.renoDRTContrast *= tmParams.contrast;
+
+      hdrColor = renoDRTToneMap(outputColor, tmParams);
+
+    } else {
+      outputColor = applyUserColorGrading(
+        outputColor,
+        tmParams.exposure,
+        tmParams.highlights,
+        tmParams.shadows,
+        tmParams.contrast,
+        tmParams.saturation
+      );
+
+      if (tmParams.type == 2.f) {
+        hdrColor = acesToneMap(outputColor, tmParams);
+        sdrColor = acesToneMap(outputColor, tmParams, true);
+      } else {
+        hdrColor = saturate(outputColor);
+        sdrColor = saturate(outputColor);
+      }
+    }
+
+    //r0.xyz = float3(0.454545468,0.454545468,0.454545468) * r0.xyz;
+    //r0.xyz = exp2(r0.xyz);
+
+    r0.xyz = sdrColor;  
+    r1.xyz = r0.xyz;// * float3(0.9375,0.9375,0.9375) + float3(0.03125,0.03125,0.03125);
+  
+    //r2.xyz = t3.Sample(s3_s, r1.xyz).xyz;
+    r2.xyz = sampleLUT(r1.xyz, lutParams, t3);
+
+    r2.xyz = cb2[0].xxx * r2.xyz;
+    r0.xyz = r0.xyz * cb2[1].xxx + r2.xyz;
+
+    //r2.xyz = t4.Sample(s4_s, r1.xyz).xyz;
+    lutParams.lutSampler = s4_s;
+    r2.xyz = sampleLUT(r1.xyz, lutParams, t4);
+
+    r0.xyz = r2.xyz * cb2[0].yyy + r0.xyz;
+    
+    //r2.xyz = t5.Sample(s5_s, r1.xyz).xyz;
+    lutParams.lutSampler = s5_s;
+    r2.xyz = sampleLUT(r1.xyz, lutParams, t5);
+    
+    //r1.xyz = t6.Sample(s6_s, r1.xyz).xyz;
+    lutParams.lutSampler = s6_s;
+    r1.xyz = sampleLUT(r1.xyz, lutParams, t6);
+
+    r0.xyz = r2.xyz * cb2[0].zzz + r0.xyz;
+    o0.xyz = r1.xyz * cb2[0].www + r0.xyz;
+
+
+    if (tmParams.type == 0.f) {
+      outputColor = lerp(outputColor, o0.xyz, lutParams.strength);
+    } else {
+      outputColor = toneMapUpgrade(hdrColor, sdrColor, o0.xyz, lutParams.strength);
+    }
+  }
+  o0.rgb = outputColor;
+  if (injectedData.fxFilmGrain) {
+    float3 grainedColor = computeFilmGrain(
+      o0.rgb,
+      v1.xy,
+      frac(injectedData.elapsedTime / 1000.f),
+      injectedData.fxFilmGrain * 0.03f,
+      1.f
+    );
+    o0.xyz = grainedColor;
+  }
+
+  if (!injectedData.toneMapGammaCorrection) {
+    o0.rgb = gammaCorrectSafe(o0.rgb, true);
+  }
+
+  o0.rgb *= injectedData.toneMapGameNits / 80.f;
+  return;
+}

--- a/src/games/fallout76/maybe_dof_0x10E611D9.ps_5_0.hlsl
+++ b/src/games/fallout76/maybe_dof_0x10E611D9.ps_5_0.hlsl
@@ -1,0 +1,68 @@
+// ---- Created with 3Dmigoto v1.3.16 on Wed May 15 18:40:56 2024
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb2 : register(b2)
+{
+  float4 cb2[5];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.x = t2.Sample(s2_s, v1.xy).x;
+  r0.x = 1 + -r0.x;
+  r0.y = r0.x * cb2[2].z + cb2[2].y;
+  r0.x = cmp(9.99999975e-006 < r0.x);
+  r0.y = cb2[2].w / r0.y;
+  r0.z = cb2[0].z + -r0.y;
+  r0.z = r0.z / cb2[0].x;
+  r0.w = cmp(r0.y < cb2[0].z);
+  r1.xyz = cmp(float3(0,0,0) != cb2[1].wyz);
+  r0.w = r0.w ? r1.y : 0;
+  r0.z = r0.w ? r0.z : 0;
+  r0.w = -cb2[0].z + r0.y;
+  r0.w = r0.w / cb2[0].y;
+  r1.y = cmp(cb2[0].z < r0.y);
+  r1.y = r1.z ? r1.y : 0;
+  r1.x = ~(int)r1.x;
+  r0.x = (int)r0.x | (int)r1.x;
+  r0.z = saturate(r1.y ? r0.w : r0.z);
+  r0.z = cb2[1].x * r0.z;
+  r0.x = r0.x ? r0.z : 0;
+  r1.xyzw = t1.Sample(s1_s, v1.xy).xyzw;
+  r2.xyzw = t0.Sample(s0_s, v1.xy).xyzw;
+  r1.xyzw = -r2.xyzw + r1.xyzw;
+  r1.xyzw = r0.xxxx * r1.xyzw + r2.xyzw;
+  r0.xzw = cb2[3].xyz + -r1.xyz;
+  r2.x = cb2[4].x + -cb2[4].y;
+  r2.x = 1 / r2.x;
+  r2.y = cb2[4].y * r2.x;
+  r0.y = saturate(r0.y * r2.x + -r2.y);
+  r0.y = cb2[3].w * r0.y;
+  o0.xyz = r0.yyy * r0.xzw + r1.xyz;
+  o0.w = r1.w;
+  return;
+}

--- a/src/games/fallout76/maybe_dof_0x283C8F43.ps_5_0.hlsl
+++ b/src/games/fallout76/maybe_dof_0x283C8F43.ps_5_0.hlsl
@@ -1,0 +1,65 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sun May 12 21:52:49 2024
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb2 : register(b2)
+{
+  float4 cb2[3];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.x = t2.Sample(s2_s, v1.xy).x;
+  r0.x = 1 + -r0.x;
+  r0.y = r0.x * cb2[2].z + cb2[2].y;
+  r0.x = cmp(9.99999975e-006 < r0.x);
+  r0.y = cb2[2].w / r0.y;
+  r0.z = cb2[0].z + -r0.y;
+  r0.z = r0.z / cb2[0].x;
+  r0.w = cmp(r0.y < cb2[0].z);
+  r1.xyz = cmp(float3(0,0,0) != cb2[1].wyz);
+  r0.w = r0.w ? r1.y : 0;
+  r0.z = r0.w ? r0.z : 0;
+  r0.w = -cb2[0].z + r0.y;
+  r0.y = cmp(cb2[0].z < r0.y);
+  r0.y = r1.z ? r0.y : 0;
+  r1.x = ~(int)r1.x;
+  r0.x = (int)r0.x | (int)r1.x;
+  r0.w = r0.w / cb2[0].y;
+  r0.y = saturate(r0.y ? r0.w : r0.z);
+  r0.y = cb2[1].x * r0.y;
+  r0.x = r0.x ? r0.y : 0;
+  r1.xyzw = t1.Sample(s1_s, v1.xy).xyzw;
+  r2.xyzw = t0.Sample(s0_s, v1.xy).xyzw;
+  // r1.xyzw = -r2.xyzw + r1.xyzw;
+  // o0.xyzw = r0.xxxx * r1.xyzw + r2.xyzw;
+  
+  // o0.xyzw = r0.xxxx * (r1.xyzw - r2.xyzw) + r2.xyzw;
+  o0.xyzw = lerp(r2.xyzw, r1.xyzw, r0.x * injectedData.fxDoF);
+  return;
+}

--- a/src/games/fallout76/maybe_dof_0xC9C77523.ps_5_0.hlsl
+++ b/src/games/fallout76/maybe_dof_0xC9C77523.ps_5_0.hlsl
@@ -1,0 +1,57 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sun May 12 21:53:12 2024
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb2 : register(b2)
+{
+  float4 cb2[3];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.x = t2.Sample(s2_s, v1.xy).x;
+  r0.x = 1 + -r0.x;
+  r0.y = r0.x * cb2[2].z + cb2[2].y;
+  r0.x = cmp(9.99999975e-006 < r0.x);
+  r0.y = cb2[2].w / r0.y;
+  r0.y = -cb2[0].z + r0.y;
+  r0.y = saturate(r0.y / cb2[0].y);
+  r0.y = cb2[1].x * r0.y;
+  r0.z = cmp(0 != cb2[1].w);
+  r0.z = ~(int)r0.z;
+  r0.x = (int)r0.z | (int)r0.x;
+  r0.x = r0.x ? r0.y : 0;
+  r1.xyzw = t1.Sample(s1_s, v1.xy).xyzw;
+  r2.xyzw = t0.Sample(s0_s, v1.xy).xyzw;
+  // r1.xyzw = -r2.xyzw + r1.xyzw;
+  // o0.xyzw = r0.xxxx * r1.xyzw + r2.xyzw;
+  
+  // o0.xyzw = r0.xxxx * (r1.xyzw - r2.xyzw) + r2.xyzw;
+  o0.xyzw = lerp(r2.xyzw, r1.xyzw, r0.x * injectedData.fxDoF);
+  return;
+}

--- a/src/games/fallout76/shared.h
+++ b/src/games/fallout76/shared.h
@@ -1,0 +1,34 @@
+#ifndef SRC_FALLOUT76_SHARED_H_
+#define SRC_FALLOUT76_SHARED_H_
+
+// Must be 32bit aligned
+// Should be 4x32
+struct ShaderInjectData {
+  float toneMapType;
+  float toneMapPeakNits;
+  float toneMapGameNits;
+  float toneMapUINits;
+  float toneMapGammaCorrection;
+  float colorGradeExposure;
+  float colorGradeHighlights;
+  float colorGradeShadows;
+  float colorGradeContrast;
+  float colorGradeSaturation;
+  float colorGradeLUTStrength;
+  float colorGradeLUTScaling;
+  float fxBloom;
+  float fxAutoExposure;
+  float fxSceneFilter;
+  float fxDoF;
+  float fxFilmGrain;
+  float elapsedTime;
+  float renoDRTFlare;
+};
+
+#ifndef __cplusplus
+cbuffer cb11 : register(b11) {
+  ShaderInjectData injectedData : packoffset(c0);
+}
+#endif
+
+#endif  // SRC_FALLOUT76_SHARED_H_

--- a/src/games/fallout76/taa_0x3778E664.ps_5_0.hlsl
+++ b/src/games/fallout76/taa_0x3778E664.ps_5_0.hlsl
@@ -1,0 +1,275 @@
+#include "../../shaders/color.hlsl"
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sun May 12 21:52:51 2024
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb2 : register(b2)
+{
+  float4 cb2[5];
+}
+
+cbuffer cb12 : register(b12)
+{
+  float4 cb12[53];
+}
+
+// Convert render input for HDR
+float3 convertRenderInput(float3 render) {
+  render /= injectedData.toneMapGameNits / 80.f;
+  render /= injectedData.toneMapPeakNits / injectedData.toneMapGameNits;
+  render = pow(saturate(render), 1.f / 2.2f); // Apply inverse gamma correction
+  return render;
+}
+
+// Convert render output for HDR
+float3 convertRenderOutput(float3 render) {
+  render = pow(saturate(render), 2.2f); // Apply gamma correction
+  render *= injectedData.toneMapPeakNits / injectedData.toneMapGameNits;
+  render *= injectedData.toneMapGameNits / 80.f;
+  return render;
+}
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_Target0,
+  out float4 o1 : SV_Target1)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8,r9,r10,r11,r12,r13,r14,r15;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = -cb2[3].xy + v1.xy;
+  r0.z = t3.Sample(s3_s, r0.xy).x;
+  r1.xy = cb2[3].xy + v1.xy;
+  r0.w = t3.Sample(s3_s, r1.xy).x;
+  r2.xyzw = cb2[3].xyxy * float4(1,0,1,-1) + v1.xyxy;
+  r1.z = t3.Sample(s3_s, r2.zw).x;
+  r0.w = min(r1.z, r0.w);
+  r0.w = min(r0.z, r0.w);
+  r0.z = cmp(r0.w == r0.z);
+  r3.xy = r0.zz ? r0.xy : r1.xy;
+  
+  r4.xyz = t0.Sample(s0_s, r0.xy).yxz;
+  r4.yxz = convertRenderInput(r4.yxz); // HDR input conversion
+
+  r5.xyz = t0.Sample(s0_s, r1.xy).yxz;
+  r5.yxz = convertRenderInput(r5.yxz); // HDR input conversion
+
+  r0.x = cmp(r0.w == r1.z);
+  r0.xy = r0.xx ? r2.zw : r3.xy;
+  r1.xyzw = cb2[3].xyxy * float4(-1,1,0,-1) + v1.xyxy;
+  r0.z = t3.Sample(s3_s, r1.zw).x;
+  r0.w = min(r0.z, r0.w);
+  r3.x = t3.Sample(s3_s, r2.xy).x;
+  r0.w = min(r3.x, r0.w);
+  r3.x = cmp(r0.w == r3.x);
+  r0.xy = r3.xx ? r2.xy : r0.xy;
+  r0.z = cmp(r0.w == r0.z);
+  r0.xy = r0.zz ? r1.zw : r0.xy;
+  r3.xyzw = cb2[3].xyxy * float4(0,1,-1,0) + v1.xyxy;
+  r0.z = t3.Sample(s3_s, r3.zw).x;
+  r0.w = min(r0.z, r0.w);
+  r6.x = t3.Sample(s3_s, r1.xy).x;
+  r0.w = min(r6.x, r0.w);
+  r6.x = cmp(r0.w == r6.x);
+  r0.xy = r6.xx ? r1.xy : r0.xy;
+  r0.z = cmp(r0.w == r0.z);
+  r0.xy = r0.zz ? r3.zw : r0.xy;
+  r0.z = t3.Sample(s3_s, v1.xy).x;
+  r0.w = min(r0.z, r0.w);
+  r6.x = t3.Sample(s3_s, r3.xy).x;
+  r0.w = min(r6.x, r0.w);
+  r6.x = cmp(r0.w == r6.x);
+  r0.z = cmp(r0.w == r0.z);
+  r0.xy = r6.xx ? r3.xy : r0.xy;
+  r0.xy = r0.zz ? v1.xy : r0.xy;
+  r0.xy = t2.Sample(s2_s, r0.xy).xy;
+  r0.zw = v1.xy + r0.xy;
+  r0.xy = cb12[52].zw * r0.xy;
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = cb12[50].y * r0.x;
+  r0.x = min(1, r0.x);
+  r6.xy = t1.Sample(s1_s, r0.zw).xz;
+  r7.xyz = t0.Sample(s0_s, r1.zw).yxz;
+  r7.yxz = convertRenderInput(r7.yxz); // HDR input conversion
+
+  r1.xyz = t0.Sample(s0_s, r1.xy).yxz;
+  r1.yxz = convertRenderInput(r1.yxz); // HDR input conversion
+
+  r7.w = dot(r7.xzy, float3(0.5,0.25,0.25));
+  r0.y = cmp(r7.w < r6.x);
+  r1.w = dot(r1.xzy, float3(0.5,0.25,0.25));
+  r6.z = cmp(r1.w < r6.x);
+
+  r8.xyz = t0.Sample(s0_s, r3.zw).yxz;
+  r8.yxz = convertRenderInput(r8.yxz); // HDR input conversion
+
+  r3.xyz = t0.Sample(s0_s, r3.xy).yxz;
+  r3.yxz = convertRenderInput(r3.yxz); // HDR input conversion
+
+  r8.w = dot(r8.xzy, float3(0.5,0.25,0.25));
+  r6.w = cmp(r8.w < r6.x);
+  r3.w = dot(r3.xzy, float3(0.5,0.25,0.25));
+  r7.x = cmp(r3.w < r6.x);
+  
+  r9.xyz = t0.Sample(s0_s, v1.xy).xyz;
+  r9.xyz = convertRenderInput(r9.xyz); // HDR input conversion
+
+  r10.x = dot(r9.yzx, float3(0.5,0.25,0.25));
+  r9.w = cmp(r10.x < r6.x);
+  r10.yz = r9.xz;
+  r11.x = cmp(r10.x < 1.00100005);
+  r11.xyz = r11.xxx ? r10.yzx : float3(1.00100005,1.00100005,1.00100005);
+  r11.xyz = r9.www ? float3(1.00100005,1.00100005,1.00100005) : r11.xyz;
+  r11.w = cmp(r3.w < r11.z);
+  r12.xyz = r11.www ? r3.yzw : r11.xyz;
+  r11.xyz = r7.xxx ? r11.xyz : r12.xyz;
+  r12.xyz = cb2[2].zzz * r8.yxz;
+  r12.xyz = r1.yxz * cb2[2].www + r12.xyz;
+  r12.xyz = r3.yxz * cb2[2].yyy + r12.xyz;
+  r12.xyz = r9.xyz * cb2[2].xxx + r12.xyz;
+  r1.x = cmp(r8.w < r11.z);
+  r13.xyz = r1.xxx ? r8.yzw : r11.xyz;
+  r11.xyz = r6.www ? r11.xyz : r13.xyz;
+  r1.x = cmp(r1.w < r11.z);
+  r13.xyz = r1.xxx ? r1.yzw : r11.xyz;
+  r11.xyz = r6.zzz ? r11.xyz : r13.xyz;
+  r1.x = cmp(r7.w < r11.z);
+  r13.xyz = r1.xxx ? r7.yzw : r11.xyz;
+  r11.xyz = r0.yyy ? r11.xyz : r13.xyz;
+  r13.xyz = t0.Sample(s0_s, r2.xy).yxz;
+  r13.yxz = convertRenderInput(r13.yxz); // HDR input conversion
+
+  r2.xyz = t0.Sample(s0_s, r2.zw).yxz;
+  r2.yxz = convertRenderInput(r2.yxz); // HDR input conversion
+
+  r13.w = dot(r13.xzy, float3(0.5,0.25,0.25));
+  r1.x = cmp(r13.w < r11.z);
+  r14.xyz = r1.xxx ? r13.yzw : r11.xyz;
+  r1.x = cmp(r13.w < r6.x);
+  r11.xyz = r1.xxx ? r11.xyz : r14.xyz;
+  r2.w = dot(r2.xzy, float3(0.5,0.25,0.25));
+  r2.x = cmp(r2.w < r11.z);
+  r14.xyz = r2.xxx ? r2.yzw : r11.xyz;
+  r2.x = cmp(r2.w < r6.x);
+  r11.xyz = r2.xxx ? r11.xyz : r14.xyz;
+  r4.w = dot(r4.xzy, float3(0.5,0.25,0.25));
+  r3.x = cmp(r4.w < r11.z);
+  r14.xyz = r3.xxx ? r4.yzw : r11.xyz;
+  r3.x = cmp(r4.w < r6.x);
+  r11.yzw = r3.xxx ? r11.xyz : r14.xyz;
+  r5.w = dot(r5.xzy, float3(0.5,0.25,0.25));
+  r4.x = cmp(r5.w < r11.w);
+  r14.yzw = r4.xxx ? r5.yzw : r11.yzw;
+  r4.x = cmp(-0.00100000005 < r10.x);
+  r15.xyz = r4.xxx ? r10.yzx : float3(-0.00100000005,-0.00100000005,-0.00100000005);
+  r15.xyz = r9.www ? r15.xyz : float3(-0.00100000005,-0.00100000005,-0.00100000005);
+  r4.x = cmp(r15.z < r3.w);
+  r3.yzw = r4.xxx ? r3.yzw : r15.xyz;
+  r3.yzw = r7.xxx ? r3.yzw : r15.xyz;
+  r4.x = cmp(r3.w < r8.w);
+  r8.xyz = r4.xxx ? r8.yzw : r3.yzw;
+  r3.yzw = r6.www ? r8.xyz : r3.yzw;
+  r4.x = cmp(r3.w < r1.w);
+  r1.yzw = r4.xxx ? r1.yzw : r3.yzw;
+  r1.yzw = r6.zzz ? r1.yzw : r3.yzw;
+  r3.y = cmp(r1.w < r7.w);
+  r3.yzw = r3.yyy ? r7.yzw : r1.yzw;
+  r1.yzw = r0.yyy ? r3.yzw : r1.yzw;
+  r0.y = cmp(r1.w < r13.w);
+  r3.yzw = r0.yyy ? r13.yzw : r1.yzw;
+  r1.xyz = r1.xxx ? r3.yzw : r1.yzw;
+  r0.y = cmp(r1.z < r2.w);
+  r2.yzw = r0.yyy ? r2.yzw : r1.xyz;
+  r1.xyz = r2.xxx ? r2.yzw : r1.xyz;
+  r0.y = cmp(r1.z < r4.w);
+  r2.xyz = r0.yyy ? r4.yzw : r1.xyz;
+  r1.xyz = r3.xxx ? r2.xyz : r1.xyz;
+  r14.x = r1.y;
+  r0.y = cmp(r1.z < r5.w);
+  r2.xyz = r0.yyy ? r5.yzw : r1.xyz;
+  r0.y = cmp(r5.w < r6.x);
+  r11.x = r2.y;
+  r1.xy = r0.yy ? r2.zx : r1.zx;
+  r2.xyzw = r0.yyyy ? r11.xyzw : r14.xyzw;
+  r0.y = -r1.y * 0.25 + r1.x;
+  r0.y = -r2.x * 0.25 + r0.y;
+  r1.z = r0.y + r0.y;
+  r0.y = -r2.y * 0.25 + r2.w;
+  r0.y = -r2.z * 0.25 + r0.y;
+  r3.z = r0.y + r0.y;
+  r1.w = r2.x;
+  r3.xyw = r2.wyz;
+  r0.y = cmp(1 < r2.w);
+  r2.x = cmp(r1.x < 0);
+  r1.xyzw = r2.xxxx ? r3.xyzw : r1.xyzw;
+  r2.xyzw = r0.yyyy ? r1.xyzw : r3.xyzw;
+  r0.y = max(r6.x, r1.x);
+  r6.x = min(r0.y, r2.x);
+  r2.xyzw = r2.xyzw + -r1.xyzw;
+  r0.y = min(r0.z, r0.w);
+  r0.zw = cmp(r0.zw >= float2(1,1));
+  r0.y = cmp(0 >= r0.y);
+  r0.y = (int)r0.z | (int)r0.y;
+  r0.y = (int)r0.w | (int)r0.y;
+  r10.w = 0;
+  r0.zw = r0.yy ? r10.xw : r6.xy;
+  r1.x = r6.x + -r1.x;
+  r1.x = r1.x / r2.x;
+  r0.z = r0.z + -r10.x;
+  r3.x = r0.x * r0.x;
+  r0.x = sqrt(r0.x);
+  r3.x = -r3.x * r3.x + 1;
+  r3.y = cb2[4].x + -cb2[4].y;
+  r3.y = r0.x * r3.y + cb2[4].y;
+  r0.w = r0.x + -r0.w;
+  o0.z = r0.x;
+  r0.x = -abs(r0.w) * 20 + 1;
+  r0.x = max(0, r0.x);
+  r0.w = min(r3.y, r0.x);
+  r0.w = r0.w * r3.x;
+  r3.x = r0.w * r0.z + r10.x;
+  r0.z = r0.w * r0.z;
+  r0.z = cmp(abs(r0.z) < 0.00999999978);
+  o0.x = saturate(r0.z ? r10.x : r3.x);
+  o0.yw = float2(0,0);
+  r0.z = cmp(0.00999999978 < r2.x);
+  r0.z = r0.z ? r1.x : 0.5;
+  r1.xyz = r0.zzz * r2.yzw + r1.yzw;
+  r1.xyz = r0.yyy ? r9.xyz : r1.xyz;
+  r2.xyz = r0.yyy ? r9.xyz : r12.xyz;
+  r3.xyz = r9.xyz + -r2.xyz;
+  r0.xyz = r0.xxx * r3.xyz + r2.xyz;
+  r1.xyz = r1.xyz + -r0.xyz;
+  r0.xyz = saturate(r0.www * r1.xyz + r0.xyz);
+  r1.xyz = r0.xyz + -r2.xyz;
+  r0.xyz = saturate(r1.xyz * cb2[4].zzz + r0.xyz);
+  r1.xyz = r2.xyz + -r0.xyz;
+  o1.xyz = saturate(cb2[4].www * r1.xyz + r0.xyz);
+
+  // HDR output conversion
+  o1.xyz = convertRenderOutput(o1.xyz);
+
+  o1.w = 1;
+  return;
+}

--- a/src/games/fallout76/taa_0xAF2731D9.ps_5_0.hlsl
+++ b/src/games/fallout76/taa_0xAF2731D9.ps_5_0.hlsl
@@ -1,0 +1,349 @@
+#include "../../shaders/color.hlsl"
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sun May 12 21:53:08 2024
+Texture2D<float4> t5 : register(t5);  // previous frame?
+
+Texture2D<float4> t4 : register(t4);  // normal
+
+Texture2D<float4> t3 : register(t3);  // depth
+
+Texture2D<float4> t2 : register(t2);  // black
+
+Texture2D<float4> t1 : register(t1);  // motion vectors
+
+Texture2D<float4> t0 : register(t0);  // render
+
+SamplerState s5_s : register(s5);
+
+SamplerState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb2 : register(b2)
+{
+  float4 cb2[5];
+}
+
+cbuffer cb12 : register(b12)
+{
+  float4 cb12[53];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+// convert render input for HDR
+float3 convertRenderInput(float3 render) {
+  render /= injectedData.toneMapGameNits / 80.f;
+  render /= injectedData.toneMapPeakNits / injectedData.toneMapGameNits;
+  render = pow(saturate(render), 1.f / 2.2f); // apply inverse gamma correction
+  return render;
+}
+
+// convert render output for HDR
+float3 convertRenderOutput(float3 render) {
+  render = pow(saturate(render), 2.2f); // apply gamma correction
+  render *= injectedData.toneMapPeakNits / injectedData.toneMapGameNits;
+  render *= injectedData.toneMapGameNits / 80.f;
+  return render;
+}
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_Target0,
+  out float4 o1 : SV_Target1)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8,r9,r10,r11,r12,r13,r14,r15,r16;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  // sample depth textures and various offsets
+  r0.xy = -cb2[3].xy + v1.xy;
+  r0.z = t3.Sample(s3_s, r0.xy).x;  // depth -
+  r1.xy = cb2[3].xy + v1.xy;
+  r0.w = t3.Sample(s3_s, r1.xy).x;  // depth +
+  r2.xyzw = cb2[3].xyxy * float4(1,0,1,-1) + v1.xyxy;
+  r1.z = t3.Sample(s3_s, r2.zw).x;  // depth 1, -1
+  r0.w = min(r1.z, r0.w);
+  r0.w = min(r0.z, r0.w);
+  r0.z = cmp(r0.w == r0.z);
+  r3.xy = r0.zz ? r0.xy : r1.xy;
+
+  r4.xyz = t0.Sample(s0_s, r0.xy).yxz;  // render - (r4)
+  r4.yxz = convertRenderInput(r4.yxz);  // HDR input conversion
+
+  r5.xyz = t0.Sample(s0_s, r1.xy).yxz;  // render + (r5)
+  r5.yxz = convertRenderInput(r5.yxz);  // HDR input conversion
+
+  r0.x = cmp(r0.w == r1.z);
+  r0.xy = r0.xx ? r2.zw : r3.xy;
+  r1.xyzw = cb2[3].xyxy * float4(-1,1,0,-1) + v1.xyxy;
+  r0.z = t3.Sample(s3_s, r1.zw).x;
+  r0.w = min(r0.z, r0.w);
+  r3.x = t3.Sample(s3_s, r2.xy).x;
+  r0.w = min(r3.x, r0.w);
+  r3.x = cmp(r0.w == r3.x);
+  r0.xy = r3.xx ? r2.xy : r0.xy;
+  r0.z = cmp(r0.w == r0.z);
+  r0.xy = r0.zz ? r1.zw : r0.xy;
+  r3.xyzw = cb2[3].xyxy * float4(0,1,-1,0) + v1.xyxy;
+  r0.z = t3.Sample(s3_s, r3.zw).x;
+  r0.w = min(r0.z, r0.w);
+  r6.x = t3.Sample(s3_s, r1.xy).x;
+  r0.w = min(r6.x, r0.w);
+  r6.x = cmp(r0.w == r6.x);
+  r0.xy = r6.xx ? r1.xy : r0.xy;
+  r0.z = cmp(r0.w == r0.z);
+  r0.xy = r0.zz ? r3.zw : r0.xy;
+  r0.z = t3.Sample(s3_s, v1.xy).x;
+  r0.w = min(r0.z, r0.w);
+  r6.x = t3.Sample(s3_s, r3.xy).x;
+  r0.w = min(r6.x, r0.w);
+  r6.x = cmp(r0.w == r6.x);
+  r0.xy = r6.xx ? r3.xy : r0.xy;
+  r0.z = cmp(r0.w == r0.z);
+  r0.w = r0.w * r0.w + -0.949999988;
+  r0.w = saturate(20 * r0.w);
+  r0.w = 1 + -r0.w;
+  r0.xy = r0.zz ? v1.xy : r0.xy;
+  r0.xy = t2.Sample(s2_s, r0.xy).xy;
+  r6.xy = v1.xy + r0.xy;
+  r0.xy = cb12[52].zw * r0.xy;
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = cb12[50].y * r0.x;
+  r0.x = min(1, r0.x);
+  r7.xyzw = t1.Sample(s1_s, r6.xy).xyzw;  // sample motion vectors
+  // Calculate luminance and comparison for TAA
+  r5.w = dot(r5.xzy, float3(0.5,0.25,0.25));  // r5 luminance
+  r0.y = cmp(r5.w < r7.x);
+  r4.w = dot(r4.xzy, float3(0.5,0.25,0.25));  // r4 luminance
+
+  r8.xyz = t0.Sample(s0_s, r2.zw).yxz;
+  r8.yxz = convertRenderInput(r8.yxz);  // HDR input conversion
+  
+  r2.xyz = t0.Sample(s0_s, r2.xy).yxz;
+  r2.yxz = convertRenderInput(r2.yxz);  // HDR input conversion
+
+  r8.w = dot(r8.xzy, float3(0.5,0.25,0.25));  // r8 luminance
+  r0.z = cmp(r8.w < r7.x);
+  r2.w = dot(r2.xzy, float3(0.5,0.25,0.25));  // r7 luminance
+  r2.x = cmp(r2.w < r7.x);
+
+  r9.xyz = t0.Sample(s0_s, r1.zw).yxz;
+  r9.yxz = convertRenderInput(r9.yxz);  // HDR input conversion
+
+  r1.xyz = t0.Sample(s0_s, r1.xy).yxz;
+  r1.yxz = convertRenderInput(r1.yxz);  // HDR input conversion
+
+  r9.w = dot(r9.xzy, float3(0.5,0.25,0.25));
+  r4.x = cmp(r9.w < r7.x);
+  r1.w = dot(r1.xzy, float3(0.5,0.25,0.25));
+  r5.x = cmp(r1.w < r7.x);
+
+  r10.xyz = t0.Sample(s0_s, r3.zw).yxz;
+  r10.yxz = convertRenderInput(r10.yxz);  // HDR input conversion
+
+  r3.xyz = t0.Sample(s0_s, r3.xy).yxz;
+  r3.yxz = convertRenderInput(r3.yxz);  // HDR input conversion
+
+  r10.w = dot(r10.xzy, float3(0.5,0.25,0.25));
+  r6.z = cmp(r10.w < r7.x);
+  r11.xyz = cb2[2].zzz * r10.yxz;
+  r11.xyz = r1.yxz * cb2[2].www + r11.xyz;
+  r11.xyz = r3.yxz * cb2[2].yyy + r11.xyz;
+  r3.w = dot(r3.xzy, float3(0.5,0.25,0.25));
+  r1.x = cmp(r3.w < r7.x);
+
+  r12.xyz = t0.Sample(s0_s, v1.xy).xyz; // center
+  r12.xyz = convertRenderInput(r12.xyz);  // HDR input conversion
+
+  r13.x = dot(r12.yzx, float3(0.5,0.25,0.25));  // center luminance
+  r3.x = cmp(r13.x < r7.x);
+  r13.yz = r12.xz;
+  r6.w = cmp(r13.x < 1.00100005);
+  r14.xyz = r6.www ? r13.yzx : float3(1.00100005,1.00100005,1.00100005);
+  r14.xyz = r3.xxx ? float3(1.00100005,1.00100005,1.00100005) : r14.xyz;
+  r6.w = cmp(r3.w < r14.z);
+  r15.xyz = r6.www ? r3.yzw : r14.xyz;
+  r14.xyz = r1.xxx ? r14.xyz : r15.xyz;
+  r6.w = cmp(r10.w < r14.z);
+  r15.xyz = r6.www ? r10.yzw : r14.xyz;
+  r14.xyz = r6.zzz ? r14.xyz : r15.xyz;
+  r6.w = cmp(r1.w < r14.z);
+  r15.xyz = r6.www ? r1.yzw : r14.xyz;
+  r14.xyz = r5.xxx ? r14.xyz : r15.xyz;
+  r6.w = cmp(r9.w < r14.z);
+  r15.xyz = r6.www ? r9.yzw : r14.xyz;
+  r14.xyz = r4.xxx ? r14.xyz : r15.xyz;
+  r6.w = cmp(r2.w < r14.z);
+  r15.xyz = r6.www ? r2.yzw : r14.xyz;
+  r14.xyz = r2.xxx ? r14.xyz : r15.xyz;
+  r6.w = cmp(r8.w < r14.z);
+  r15.xyz = r6.www ? r8.yzw : r14.xyz;
+  r14.xyz = r0.zzz ? r14.xyz : r15.xyz;
+  r6.w = cmp(r4.w < r14.z);
+  r15.xyz = r6.www ? r4.yzw : r14.xyz;
+  r6.w = cmp(r4.w < r7.x);
+  r14.yzw = r6.www ? r14.xyz : r15.xyz;
+  r8.x = cmp(r5.w < r14.w);
+  r15.yzw = r8.xxx ? r5.yzw : r14.yzw;
+  r8.x = cmp(-0.00100000005 < r13.x);
+  r16.xyz = r8.xxx ? r13.yzx : float3(-0.00100000005,-0.00100000005,-0.00100000005);
+  r16.xyz = r3.xxx ? r16.xyz : float3(-0.00100000005,-0.00100000005,-0.00100000005);
+  r3.x = cmp(r16.z < r3.w);
+  r3.xyz = r3.xxx ? r3.yzw : r16.xyz;
+  r3.xyz = r1.xxx ? r3.xyz : r16.xyz;
+  r1.x = r13.x + -r3.w;
+  r1.x = 0.200000003 + -abs(r1.x);
+  r3.w = cmp(r3.z < r10.w);
+  r10.xyz = r3.www ? r10.yzw : r3.xyz;
+  r3.xyz = r6.zzz ? r10.xyz : r3.xyz;
+  r3.w = r13.x + -r10.w;
+  r3.w = 0.200000003 + -abs(r3.w);
+  r3.w = ceil(r3.w);
+  r6.z = cmp(r3.z < r1.w);
+  r10.xyz = r6.zzz ? r1.yzw : r3.xyz;
+  r3.xyz = r5.xxx ? r10.xyz : r3.xyz;
+  r1.y = r13.x + -r1.w;
+  r1.y = 0.200000003 + -abs(r1.y);
+  r1.z = cmp(r3.z < r9.w);
+  r9.xyz = r1.zzz ? r9.yzw : r3.xyz;
+  r3.xyz = r4.xxx ? r9.xyz : r3.xyz;
+  r1.z = r13.x + -r9.w;
+  r1.z = 0.200000003 + -abs(r1.z);
+  r1.w = cmp(r3.z < r2.w);
+  r9.xyz = r1.www ? r2.yzw : r3.xyz;
+  r2.xyz = r2.xxx ? r9.xyz : r3.xyz;
+  r1.w = r13.x + -r2.w;
+  r1.w = 0.200000003 + -abs(r1.w);
+  r1.xyzw = ceil(r1.xyzw);
+  r2.w = cmp(r2.z < r8.w);
+  r3.xyz = r2.www ? r8.yzw : r2.xyz;
+  r2.xyz = r0.zzz ? r3.xyz : r2.xyz;
+  r0.z = r13.x + -r8.w;
+  r0.z = 0.200000003 + -abs(r0.z);
+  r2.w = cmp(r2.z < r4.w);
+  r3.xyz = r2.www ? r4.yzw : r2.xyz;
+  r2.xyz = r6.www ? r3.xyz : r2.xyz;
+  r2.w = r13.x + -r4.w;
+  r2.w = 0.200000003 + -abs(r2.w);
+  r2.w = ceil(r2.w);
+  r15.x = r2.y;
+  r3.x = cmp(r2.z < r5.w);
+  r3.xyz = r3.xxx ? r5.yzw : r2.xyz;
+  r4.xw = r0.yy ? r3.xz : r2.xz;
+  r14.x = r3.y;
+  r8.xyzw = r0.yyyy ? r14.xyzw : r15.xyzw;
+  r0.y = r13.x + -r5.w;
+  r0.y = 0.200000003 + -abs(r0.y);
+  r0.yz = ceil(r0.yz);
+  r0.y = 4 + -r0.y;
+  r0.y = r0.y + -r2.w;
+  r0.y = r0.y + -r0.z;
+  r0.y = r0.y + -r1.w;
+  r0.y = r0.y + -r1.z;
+  r0.y = r0.y + -r1.y;
+  r0.y = r0.y + -r3.w;
+  r0.y = saturate(r0.y + -r1.x);
+  r0.z = cmp(1 < r8.w);
+  r1.x = -r8.y * 0.25 + r8.w;
+  r1.x = -r8.z * 0.25 + r1.x;
+  r1.y = r1.x + r1.x;
+  r4.z = r8.x;
+  r1.xzw = r8.yzw;
+  r2.x = -r4.x * 0.25 + r4.w;
+  r2.x = -r8.x * 0.25 + r2.x;
+  r4.y = r2.x + r2.x;
+  r2.x = cmp(r4.w < 0);
+  r2.xyzw = r2.xxxx ? r1.xyzw : r4.xyzw;
+  r3.xyzw = r0.zzzz ? r2.xyzw : r1.xyzw;
+  r0.z = max(r7.x, r2.w);
+  r5.x = min(r0.z, r3.w);
+  r5.z = r3.w;
+  r5.y = r2.w;
+  r8.z = r1.w;
+  r8.x = r7.x;
+  r8.y = r4.w;
+  r0.z = 0.949999988 * r7.y;
+  r0.y = r0.y * 0.25 + r0.z;
+  r6.zw = -cb2[1].xy + v1.xy;
+  r0.z = t4.SampleLevel(s4_s, r6.zw, 0).w;
+  r1.w = t5.SampleLevel(s5_s, r6.zw, 0).w;
+  r1.w = cmp(r1.w != 0.000000);
+  r6.zw = r1.ww ? float2(1,0.200000003) : 0;
+  r0.z = 255 * r0.z;
+  r0.z = (uint)r0.z;
+  r0.z = cmp((int)r0.z == 1);
+  r0.z = r0.z ? 0 : 1;
+  r0.y = saturate(r0.y * r0.z);
+  r0.z = cmp(r0.y < 0.902499974);
+  r5.xyz = r0.zzz ? r5.xyz : r8.xyz;
+  r1.w = min(r6.x, r6.y);
+  r6.xy = cmp(r6.xy >= float2(1,1));
+  r1.w = cmp(0 >= r1.w);
+  r1.w = (int)r6.x | (int)r1.w;
+  r1.w = (int)r6.y | (int)r1.w;
+  r13.w = 0;
+  r5.w = r7.z;
+  r2.w = min(r7.w, r6.z);
+  r6.w = saturate(r6.w + r2.w);
+  r7.xy = r1.ww ? r13.xw : r5.xw;
+  r5.xy = r5.zx + -r5.yy;
+  r6.z = sqrt(r0.x);
+  r0.x = r0.x * r0.x;
+  r0.x = -r0.x * r0.x + 1;
+  r2.w = r6.z + -r7.y;
+  r3.w = r7.x + -r13.x;
+  r5.zw = -abs(r2.ww) * float2(20,100) + float2(1,1);
+  r5.zw = max(float2(0,0), r5.zw);
+  r2.w = -0.800000012 + r6.w;
+  r2.w = ceil(r2.w);
+  r0.w = -r2.w * r0.w + 1;
+  r0.w = r0.w * r5.z;
+  r6.y = r5.w * r0.y;
+  r0.y = cb2[4].x + -cb2[4].y;
+  r0.y = r6.z * r0.y + cb2[4].y;
+  o0.yzw = r6.yzw;
+  r0.y = min(r0.y, r0.w);
+  r2.w = 0.99000001 + -r0.y;
+  r0.y = r6.y * r2.w + r0.y;
+  r0.x = r0.y * r0.x;
+  r0.y = r0.x * r3.w + r13.x;
+  r2.w = r0.x * r3.w;
+  r2.w = cmp(abs(r2.w) < 0.00999999978);
+  o0.x = saturate(r2.w ? r13.x : r0.y);
+  r2.xyz = r0.zzz ? r2.xyz : r4.xyz;
+  r1.xyz = r0.zzz ? r3.xyz : r1.xyz;
+  r1.xyz = r1.xyz + -r2.xyz;
+  r0.y = cmp(0.00999999978 < r5.x);
+  r0.z = r5.y / r5.x;
+  r0.y = r0.y ? r0.z : 0.5;
+  r1.xyz = r0.yyy * r1.xyz + r2.xyz;
+  r1.xyz = r1.www ? r12.xyz : r1.xyz;
+  r2.xyz = r12.xyz * cb2[2].xxx + r11.xyz;
+  r2.xyz = r1.www ? r12.xyz : r2.xyz;
+  r3.xyz = r12.xyz + -r2.xyz;
+  r0.yzw = r0.www * r3.xyz + r2.xyz;
+  r1.xyz = r1.xyz + -r0.yzw;
+  r0.xyz = saturate(r0.xxx * r1.xyz + r0.yzw);
+  r1.xyz = r0.xyz + -r2.xyz;
+  r0.xyz = saturate(r1.xyz * cb2[4].zzz + r0.xyz);
+  r1.xyz = r2.xyz + -r0.xyz;
+  o1.xyz = saturate(cb2[4].www * r1.xyz + r0.xyz);
+  
+  o1.xyz = convertRenderOutput(o1.xyz);  // HDR output conversion
+
+  o1.w = 1;
+  return;
+}

--- a/src/games/fallout76/text_0x2CA9CD55.ps_5_0.hlsl
+++ b/src/games/fallout76/text_0x2CA9CD55.ps_5_0.hlsl
@@ -1,0 +1,31 @@
+#include "../../shaders/color.hlsl"
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sun May 12 21:52:50 2024
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : COLOR0,
+  float4 v1 : COLOR1,
+  float4 v2 : TEXCOORD0,
+  float4 v3 : TEXCOORD1,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = saturate(v0.xyzw * v3.xyzw + v2.xyzw);
+  o0.w = v1.w * r0.w;
+  o0.xyz = r0.xyz;
+
+  o0.rgb = injectedData.toneMapGammaCorrection ? pow(o0.rgb, 2.2f) : linearFromSRGB(o0.rgb);
+  o0.rgb *= injectedData.toneMapUINits / 80.f;
+
+  return;
+}

--- a/src/games/fallout76/text_0xA6AB1C75.ps_5_0.hlsl
+++ b/src/games/fallout76/text_0xA6AB1C75.ps_5_0.hlsl
@@ -1,0 +1,32 @@
+#include "../../shaders/color.hlsl"
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sun May 12 21:53:07 2024
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : COLOR0,
+  float4 v1 : COLOR1,
+  float4 v2 : TEXCOORD0,
+  float4 v3 : TEXCOORD1,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = saturate(v0.xyzw * v3.xyzw + v2.xyzw);
+  r0.w = v1.w * r0.w;
+  o0.xyz = r0.xyz * r0.www;
+  o0.w = r0.w;
+
+  o0.rgb = injectedData.toneMapGammaCorrection ? pow(o0.rgb, 2.2f) : linearFromSRGB(o0.rgb);
+  o0.rgb *= injectedData.toneMapUINits / 80.f;
+
+  return;
+}

--- a/src/games/fallout76/tonemap_0x1BDD7570.ps_5_0.hlsl
+++ b/src/games/fallout76/tonemap_0x1BDD7570.ps_5_0.hlsl
@@ -1,0 +1,182 @@
+#include "../../shaders/color.hlsl"
+#include "../../shaders/tonemap.hlsl"
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sun May 12 21:52:47 2024
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);  // depth
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);  // render
+
+SamplerState s8_s : register(s8);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+/* 
+fo76: 2 cbuffers  63 values in all 4 shaders
+
+fo4:  1 cbuffer   5  values in 2 shaders
+      1 cbuffer   6  values in 2 shaders
+
+why so different?
+*/
+cbuffer cb2 : register(b2)
+{
+  float4 cb2[8];
+}
+
+cbuffer cb12 : register(b12)
+{
+  float4 cb12[55];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+
+
+  /* depth tests */
+  r0.xyz = t0.Sample(s0_s, v1.xy).xyz;
+
+  //const float3 renderInput = r0.xyz;
+
+  r0.w = t3.SampleLevel(s3_s, v1.xy, 0).w;  // use LOD level 0
+
+  //const float depthMask = r0.w;
+
+  r0.w = 255 * r0.w;  // scale depth
+  // depth stencil test?
+  // related to bloom?
+  r0.w = (uint)r0.w;
+  r0.w = cmp((int)r0.w == 1);
+  
+  r1.xy = (int2)v0.xy;
+  r1.zw = float2(0,0);
+  r1.x = t4.Load(r1.xyz).x;
+  r1.x = cmp(r1.x < 0.99999994);
+  r0.w = r0.w ? r1.x : 0;
+  if (r0.w != 0) {
+    o0.xyz = r0.xyz;
+    o0.w = 1;
+    return; // exit shader early based on depth?
+  }
+
+  /* various color calculations */
+  r0.w = t1.Sample(s1_s, v1.xy).x;
+  r1.x = t1.Sample(s1_s, float2(0.5,0.5)).x;
+  r1.yz = v1.xy * cb2[7].zw + float2(-0.5,-0.5);
+  r2.xy = floor(r1.yz);
+  r2.xy = float2(1,1) + r2.xy;
+  r2.xy = r2.xy / cb2[7].zw;
+  r1.yz = frac(r1.yz);
+  r2.xyzw = t2.Gather(s8_s, r2.xy).xyzw;
+  r3.xy = float2(1,1) + -r1.yz;
+  r2.xyzw = log2(r2.xwyz);
+  r2.xy = r3.xx * r2.yx;
+  r2.xy = exp2(r2.xy);
+  r1.yw = r2.wz * r1.yy;
+  r1.yw = exp2(r1.yw);
+  r1.yw = r2.xy * r1.yw;
+  r1.yw = log2(r1.yw);
+  r1.y = r3.y * r1.y;
+  r1.y = exp2(r1.y);
+  r1.z = r1.z * r1.w;
+  r1.z = exp2(r1.z);
+  r1.y = r1.y * r1.z;
+
+
+  /* color adjustments based on parameters */
+  r1.zw = cb2[1].xy * r0.ww;
+  r1.y = max(r1.y, r1.z);
+  r1.y = min(r1.y, r1.w);
+  r1.z = 1 + -cb2[1].z;
+  r1.y = log2(r1.y);
+  r1.y = r1.z * r1.y;
+  r1.y = exp2(r1.y);
+  r1.x = log2(r1.x);
+  r1.x = cb2[1].z * r1.x;
+  r1.x = exp2(r1.x);
+  r1.x = r1.y * r1.x;
+  r1.y = cmp(1.00000001e-010 < cb12[54].x);
+  r1.x = max(9.99999975e-005, r1.x);
+  r1.x = cb12[54].y / r1.x;
+  r1.x = r1.y ? cb12[54].x : r1.x;
+  r1.x = max(cb12[54].z, r1.x);
+  r1.x = min(cb12[54].w, r1.x);
+  r0.w = max(9.99999975e-005, r0.w);
+  r0.w = cb12[54].y / r0.w;
+  r0.w = r1.y ? cb12[54].x : r0.w;
+  r0.w = max(cb12[54].z, r0.w);
+  r0.w = min(cb12[54].w, r0.w);
+  r0.w = log2(r0.w);
+  r0.w = -cb2[1].w * r0.w;
+  r0.w = exp2(r0.w);
+  r1.x = log2(r1.x);
+  r1.x = cb2[1].w * r1.x;
+  r1.x = exp2(r1.x);
+  r0.w = r1.x * r0.w;
+  r0.xyz = r0.xyz * r0.www; // not auto exposure
+
+  r0.w = cmp(0.5 < cb2[2].w);
+
+  const float3 untonemapped = r0.xyz;
+
+  /* tone mapping */
+  if (injectedData.toneMapType == 0) { // Vanilla
+    r1.x = max(9.99999975e-005, cb2[2].y);
+    r1.y = 0.560000002 / r1.x; // .56 = 11.2 (linear white point) * .5 * .1 (linear angle)?
+    r1.y = 2.43000007 + r1.y;
+    r1.x = r1.x * r1.x;
+    r1.x = 0.140000001 / r1.x;
+    r1.x = r1.y + r1.x;
+    r1.y = cb2[0].x * cb2[0].x;
+    r1.y = -r1.y * 2.43000007 + 0.0299999993; // -r1.y * 2.43 * .03 (linear strength) * .01 (linear toe)?
+    r1.z = -0.589999974 + r1.x;
+    r1.y = r1.z * cb2[0].x + r1.y;
+    r1.xzw = r1.xxx * r0.xyz + float3(0.0299999993,0.0299999993,0.0299999993); // .03 = .3 (linear strength) * .1 (linear angle)?
+    r1.xzw = r1.xzw * r0.xyz;
+    r2.xyz = r0.xyz * float3(2.43000007,2.43000007,2.43000007) + float3(0.589999974,0.589999974,0.589999974);
+    r2.xyz = r0.xyz * r2.xyz + r1.yyy;
+    r1.xyz = saturate(r1.xzw / r2.xyz);
+    r0.xyz = r0.www ? r1.xyz : r0.xyz;
+  }
+  else { // untonemapped
+    r0.xyz = untonemapped;
+  }
+  r1.x = dot(r0.xyz, float3(0.212500006,0.715399981,0.0720999986)); // converting srgb to ycbcr
+  r0.w = 0;
+  float3 outputColor = r0.xyz; // before scene filter
+  r0.xyzw = -r1.xxxx + r0.xyzw;
+  r0.xyzw = cb2[3].xxxx * r0.xyzw + r1.xxxx;
+  r1.xyzw = r1.xxxx * cb2[4].xyzw + -r0.xyzw;
+  r0.xyzw = cb2[4].wwww * r1.xyzw + r0.xyzw;
+  r0.w = cb2[3].w * r0.w;
+  r0.xyz = cb2[3].www * r0.xyz + -cb2[0].xxx;
+  o0.xyz = cb2[3].zzz * r0.xyz + cb2[0].xxx;  // final output color
+  o0.w = r0.w;
+
+  o0.xyz = lerp(outputColor, o0.xyz, injectedData.fxSceneFilter);
+  return;
+}

--- a/src/games/fallout76/tonemap_0x2A868728.ps_5_0.hlsl
+++ b/src/games/fallout76/tonemap_0x2A868728.ps_5_0.hlsl
@@ -1,0 +1,186 @@
+#include "../../shaders/color.hlsl"
+#include "../../shaders/tonemap.hlsl"
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sun May 12 21:52:49 2024
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s8_s : register(s8);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb2 : register(b2)
+{
+  float4 cb2[8];
+}
+
+cbuffer cb12 : register(b12)
+{
+  float4 cb12[55];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyz = t0.Sample(s0_s, v1.xy).xyz;
+  r0.w = t3.SampleLevel(s3_s, v1.xy, 0).w;
+  r0.w = 255 * r0.w;
+  r0.w = (uint)r0.w;
+  r0.w = cmp((int)r0.w == 1);
+  r1.xy = (int2)v0.xy;
+  r1.zw = float2(0,0);
+  r1.x = t4.Load(r1.xyz).x;
+  r1.x = cmp(r1.x < 0.99999994);
+  r0.w = r0.w ? r1.x : 0;
+  if (r0.w != 0) {
+    o0.xyz = r0.xyz;
+    o0.w = 1;
+    return;
+  }
+  r0.w = t1.Sample(s1_s, v1.xy).x;
+  r1.x = t1.Sample(s1_s, float2(0.5,0.5)).x;
+  r1.y = cmp(0.5 < cb2[0].z);
+  if (r1.y != 0) {
+    r1.yz = v1.xy * cb2[7].zw + float2(-0.5,-0.5);
+    r2.xy = floor(r1.yz);
+    r2.xy = float2(1,1) + r2.xy;
+    r2.xy = r2.xy / cb2[7].zw;
+    r1.yz = frac(r1.yz);
+    r2.xyzw = t2.Gather(s8_s, r2.xy).xyzw;
+    r3.xy = float2(1,1) + -r1.yz;
+    r2.xyzw = log2(r2.xwyz);
+    r2.xy = r3.xx * r2.yx;
+    r2.xy = exp2(r2.xy);
+    r1.yw = r2.wz * r1.yy;
+    r1.yw = exp2(r1.yw);
+    r1.yw = r2.xy * r1.yw;
+    r1.yw = log2(r1.yw);
+    r1.y = r3.y * r1.y;
+    r1.y = exp2(r1.y);
+    r1.z = r1.z * r1.w;
+    r1.z = exp2(r1.z);
+    r1.y = r1.y * r1.z;
+  } else {
+    r1.y = t2.Sample(s2_s, v1.xy).x;
+  }
+  r1.zw = cb2[1].xy * r0.ww;
+  r1.y = max(r1.y, r1.z);
+  r1.y = min(r1.y, r1.w);
+  r1.z = 1 + -cb2[1].z;
+  r1.y = log2(r1.y);
+  r1.y = r1.z * r1.y;
+  r1.y = exp2(r1.y);
+  r1.x = log2(r1.x);
+  r1.x = cb2[1].z * r1.x;
+  r1.x = exp2(r1.x);
+  r1.x = r1.y * r1.x;
+  r1.y = cmp(1.00000001e-010 < cb12[54].x);
+  r1.x = max(9.99999975e-005, r1.x);
+  r1.x = cb12[54].y / r1.x;
+  r1.x = r1.y ? cb12[54].x : r1.x;
+  r1.x = max(cb12[54].z, r1.x);
+  r1.x = min(cb12[54].w, r1.x);
+  r0.w = max(9.99999975e-005, r0.w);
+  r0.w = cb12[54].y / r0.w;
+  r0.w = r1.y ? cb12[54].x : r0.w;
+  r0.w = max(cb12[54].z, r0.w);
+  r0.w = min(cb12[54].w, r0.w);
+  r0.w = log2(r0.w);
+  r0.w = -cb2[1].w * r0.w;
+  r0.w = exp2(r0.w);
+  r1.x = log2(r1.x);
+  r1.x = cb2[1].w * r1.x;
+  r1.x = exp2(r1.x);
+  r0.w = r1.x * r0.w;
+  r0.xyz = r0.xyz * r0.www; // not auto exposure
+
+  r1.x = cmp(0.5 < cb2[2].w);
+
+  const float3 untonemapped = r0.xyz; // store untonemapped image
+
+  if (r1.x != 0 & injectedData.toneMapType == 0) { // Vanilla
+    r1.xy = float2(-1,-2) + cb2[2].xx;
+    r2.xyz = r0.xyz * float3(2.50999999,2.50999999,2.50999999) + float3(0.0299999993,0.0299999993,0.0299999993);
+    r2.xyz = r2.xyz * r0.xyz;
+    r3.xyz = r0.xyz * float3(2.43000007,2.43000007,2.43000007) + float3(0.589999974,0.589999974,0.589999974);
+    r4.xyz = r0.xyz * r3.xyz + float3(0.140000001,0.140000001,0.140000001);
+    r2.xyz = saturate(r2.xyz / r4.xyz);
+    r1.xy = cmp(abs(r1.xy) < float2(9.99999975e-005,9.99999975e-005));
+    r1.z = max(9.99999975e-005, cb2[2].y);
+    r1.w = 0.560000002 / r1.z;
+    r1.w = 2.43000007 + r1.w;
+    r2.w = r1.z * r1.z;
+    r2.w = 0.140000001 / r2.w;
+    r1.w = r2.w + r1.w;
+    r2.w = cb2[0].x * cb2[0].x;
+    r2.w = -r2.w * 2.43000007 + 0.0299999993;
+    r3.w = -0.589999974 + r1.w;
+    r2.w = r3.w * cb2[0].x + r2.w;
+    r4.xyz = r1.www * r0.xyz + float3(0.0299999993,0.0299999993,0.0299999993);
+    r4.xyz = r4.xyz * r0.xyz;
+    r3.xyz = r0.xyz * r3.xyz + r2.www;
+    r3.xyz = saturate(r4.xyz / r3.xyz);
+    r4.xyz = r0.xyz + r0.xyz;
+    r5.xyz = r0.xyz * float3(0.300000012,0.300000012,0.300000012) + float3(0.0500000007,0.0500000007,0.0500000007);
+    r1.w = 0.200000003 * cb2[2].z;
+    r5.xyz = r4.xyz * r5.xyz + r1.www;
+    r6.xyz = r0.xyz * float3(0.300000012,0.300000012,0.300000012) + float3(0.5,0.5,0.5);
+    r4.xyz = r4.xyz * r6.xyz + float3(0.0599999987,0.0599999987,0.0599999987);
+    r4.xyz = r5.xyz / r4.xyz;
+    r4.xyz = -cb2[2].zzz * float3(3.33333325,3.33333325,3.33333325) + r4.xyz;
+    r5.xy = r1.zz * float2(0.150000006,0.150000006) + float2(0.0500000007,0.5);
+    r1.w = r1.z * r5.x + r1.w;
+    r1.z = r1.z * r5.y + 0.0599999987;
+    r1.z = r1.w / r1.z;
+    r1.z = -cb2[2].z * 3.33333325 + r1.z;
+    r1.z = 1 / r1.z;
+    r4.xyz = r4.xyz * r1.zzz;
+    r1.yzw = r1.yyy ? r3.xyz : r4.xyz;
+    r0.xyz = r1.xxx ? r2.xyz : r1.yzw;
+  }
+  else { // untonemapped
+    r0.xyz = untonemapped;
+  }
+  r1.x = dot(r0.xyz, float3(0.212500006,0.715399981,0.0720999986));
+  r0.w = 0;
+  float3 outputColor = r0.xyz; // before scene filter
+  r0.xyzw = -r1.xxxx + r0.xyzw;
+  r0.xyzw = cb2[3].xxxx * r0.xyzw + r1.xxxx;
+  r1.xyzw = r1.xxxx * cb2[4].xyzw + -r0.xyzw;
+  r0.xyzw = cb2[4].wwww * r1.xyzw + r0.xyzw;
+  r1.w = cb2[3].w * r0.w;
+  r0.xyz = cb2[3].www * r0.xyz + -cb2[0].xxx;
+  r1.xyz = cb2[3].zzz * r0.xyz + cb2[0].xxx;
+  r0.xyzw = cb2[5].xyzw + -r1.xyzw;
+  o0.xyzw = cb2[5].wwww * r0.xyzw + r1.xyzw;
+
+  o0.xyz = lerp(outputColor, o0.xyz, injectedData.fxSceneFilter);
+  return;
+}

--- a/src/games/fallout76/tonemap_0x5D002D1E.ps_5_0.hlsl
+++ b/src/games/fallout76/tonemap_0x5D002D1E.ps_5_0.hlsl
@@ -1,0 +1,160 @@
+#include "../../shaders/color.hlsl"
+#include "../../shaders/tonemap.hlsl"
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sun May 12 21:52:55 2024
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s8_s : register(s8);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb2 : register(b2)
+{
+  float4 cb2[8];
+}
+
+cbuffer cb12 : register(b12)
+{
+  float4 cb12[55];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyz = t0.Sample(s0_s, v1.xy).xyz;
+  r0.w = t3.SampleLevel(s3_s, v1.xy, 0).w;
+  r0.w = 255 * r0.w;
+  r0.w = (uint)r0.w;
+  r0.w = cmp((int)r0.w == 1);
+  r1.xy = (int2)v0.xy;
+  r1.zw = float2(0,0);
+  r1.x = t4.Load(r1.xyz).x;
+  r1.x = cmp(r1.x < 0.99999994);
+  r0.w = r0.w ? r1.x : 0;
+  if (r0.w != 0) {
+    o0.xyz = r0.xyz;
+    o0.w = 1;
+    return;
+  }
+  r0.w = t1.Sample(s1_s, v1.xy).x;
+  r1.x = t1.Sample(s1_s, float2(0.5,0.5)).x;
+  r1.yz = v1.xy * cb2[7].zw + float2(-0.5,-0.5);
+  r2.xy = floor(r1.yz);
+  r2.xy = float2(1,1) + r2.xy;
+  r2.xy = r2.xy / cb2[7].zw;
+  r1.yz = frac(r1.yz);
+  r2.xyzw = t2.Gather(s8_s, r2.xy).xyzw;
+  r3.xy = float2(1,1) + -r1.yz;
+  r2.xyzw = log2(r2.xwyz);
+  r2.xy = r3.xx * r2.yx;
+  r2.xy = exp2(r2.xy);
+  r1.yw = r2.wz * r1.yy;
+  r1.yw = exp2(r1.yw);
+  r1.yw = r2.xy * r1.yw;
+  r1.yw = log2(r1.yw);
+  r1.y = r3.y * r1.y;
+  r1.y = exp2(r1.y);
+  r1.z = r1.z * r1.w;
+  r1.z = exp2(r1.z);
+  r1.y = r1.y * r1.z;
+  r1.zw = cb2[1].xy * r0.ww;
+  r1.y = max(r1.y, r1.z);
+  r1.y = min(r1.y, r1.w);
+  r1.z = 1 + -cb2[1].z;
+  r1.y = log2(r1.y);
+  r1.y = r1.z * r1.y;
+  r1.y = exp2(r1.y);
+  r1.x = log2(r1.x);
+  r1.x = cb2[1].z * r1.x;
+  r1.x = exp2(r1.x);
+  r1.x = r1.y * r1.x;
+  r1.y = cmp(1.00000001e-010 < cb12[54].x);
+  r1.x = max(9.99999975e-005, r1.x);
+  r1.x = cb12[54].y / r1.x;
+  r1.x = r1.y ? cb12[54].x : r1.x;
+  r1.x = max(cb12[54].z, r1.x);
+  r1.x = min(cb12[54].w, r1.x);
+  r0.w = max(9.99999975e-005, r0.w);
+  r0.w = cb12[54].y / r0.w;
+  r0.w = r1.y ? cb12[54].x : r0.w;
+  r0.w = max(cb12[54].z, r0.w);
+  r0.w = min(cb12[54].w, r0.w);
+  r0.w = log2(r0.w);
+  r0.w = -cb2[1].w * r0.w;
+  r0.w = exp2(r0.w);
+  r1.x = log2(r1.x);
+  r1.x = cb2[1].w * r1.x;
+  r1.x = exp2(r1.x);
+  r0.w = r1.x * r0.w;
+  r0.xyz = r0.xyz * r0.www;  // not auto exposure
+  r0.w = cmp(0.5 < cb2[2].w);
+  
+  const float3 untonemapped = r0.xyz;
+
+  // tonemapping
+  if (injectedData.toneMapType == 0) { // vanilla
+    r1.x = max(9.99999975e-005, cb2[2].y);
+    r1.y = 0.560000002 / r1.x;
+    r1.y = 2.43000007 + r1.y;
+    r1.x = r1.x * r1.x;
+    r1.x = 0.140000001 / r1.x;
+    r1.x = r1.y + r1.x;
+    r1.y = cb2[0].x * cb2[0].x;
+    r1.y = -r1.y * 2.43000007 + 0.0299999993;
+    r1.z = -0.589999974 + r1.x;
+    r1.y = r1.z * cb2[0].x + r1.y;
+    r1.xzw = r1.xxx * r0.xyz + float3(0.0299999993,0.0299999993,0.0299999993);
+    r1.xzw = r1.xzw * r0.xyz;
+    r2.xyz = r0.xyz * float3(2.43000007,2.43000007,2.43000007) + float3(0.589999974,0.589999974,0.589999974);
+    r2.xyz = r0.xyz * r2.xyz + r1.yyy;
+    r1.xyz = saturate(r1.xzw / r2.xyz);
+    r0.xyz = r0.www ? r1.xyz : r0.xyz;
+  }
+  else { // untonemapped
+    r0.xyz = untonemapped;
+  }
+
+  // scene filter adjustments
+  r1.x = dot(r0.xyz, float3(0.212500006,0.715399981,0.0720999986));
+  r0.w = 0;
+  float3 outputColor = r0.xyz; // before scene filter
+  r0.xyzw = -r1.xxxx + r0.xyzw;
+  r0.xyzw = cb2[3].xxxx * r0.xyzw + r1.xxxx;
+  r1.xyzw = r1.xxxx * cb2[4].xyzw + -r0.xyzw;
+  r0.xyzw = cb2[4].wwww * r1.xyzw + r0.xyzw;
+  r1.w = cb2[3].w * r0.w;
+  r0.xyz = cb2[3].www * r0.xyz + -cb2[0].xxx;
+  r1.xyz = cb2[3].zzz * r0.xyz + cb2[0].xxx;
+  r0.xyzw = cb2[5].xyzw + -r1.xyzw;
+  o0.xyzw = cb2[5].wwww * r0.xyzw + r1.xyzw;
+
+  o0.xyz = lerp(outputColor, o0.xyz, injectedData.fxSceneFilter);
+
+  return;
+}

--- a/src/games/fallout76/tonemap_0xBF6561E2.ps_5_0.hlsl
+++ b/src/games/fallout76/tonemap_0xBF6561E2.ps_5_0.hlsl
@@ -1,0 +1,188 @@
+#include "../../shaders/color.hlsl"
+#include "../../shaders/tonemap.hlsl"
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sun May 12 21:53:11 2024
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s8_s : register(s8);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb2 : register(b2)
+{
+  float4 cb2[8];
+}
+
+cbuffer cb12 : register(b12)
+{
+  float4 cb12[55];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyz = t0.Sample(s0_s, v1.xy).xyz;
+  r0.w = t3.SampleLevel(s3_s, v1.xy, 0).w;
+  r0.w = 255 * r0.w;
+  r0.w = (uint)r0.w;
+  r0.w = cmp((int)r0.w == 1);
+  r1.xy = (int2)v0.xy;
+  r1.zw = float2(0,0);
+  r1.x = t4.Load(r1.xyz).x;
+  r1.x = cmp(r1.x < 0.99999994);
+  r0.w = r0.w ? r1.x : 0;
+  if (r0.w != 0) {
+    o0.xyz = r0.xyz;
+    o0.w = 1;
+    return;
+  }
+  r0.w = t1.Sample(s1_s, v1.xy).x;
+  r1.x = t1.Sample(s1_s, float2(0.5,0.5)).x;
+  r1.y = cmp(0.5 < cb2[0].z);
+  if (r1.y != 0) {
+    r1.yz = v1.xy * cb2[7].zw + float2(-0.5,-0.5);
+    r2.xy = floor(r1.yz);
+    r2.xy = float2(1,1) + r2.xy;
+    r2.xy = r2.xy / cb2[7].zw;
+    r1.yz = frac(r1.yz);
+    r2.xyzw = t2.Gather(s8_s, r2.xy).xyzw;
+    r3.xy = float2(1,1) + -r1.yz;
+    r2.xyzw = log2(r2.xwyz);
+    r2.xy = r3.xx * r2.yx;
+    r2.xy = exp2(r2.xy);
+    r1.yw = r2.wz * r1.yy;
+    r1.yw = exp2(r1.yw);
+    r1.yw = r2.xy * r1.yw;
+    r1.yw = log2(r1.yw);
+    r1.y = r3.y * r1.y;
+    r1.y = exp2(r1.y);
+    r1.z = r1.z * r1.w;
+    r1.z = exp2(r1.z);
+    r1.y = r1.y * r1.z;
+  } else {
+    r1.y = t2.Sample(s2_s, v1.xy).x;
+  }
+  r1.zw = cb2[1].xy * r0.ww;
+  r1.y = max(r1.y, r1.z);
+  r1.y = min(r1.y, r1.w);
+  r1.z = 1 + -cb2[1].z;
+  r1.y = log2(r1.y);
+  r1.y = r1.z * r1.y;
+  r1.y = exp2(r1.y);
+  r1.x = log2(r1.x);
+  r1.x = cb2[1].z * r1.x;
+  r1.x = exp2(r1.x);
+  r1.x = r1.y * r1.x;
+  r1.y = cmp(1.00000001e-010 < cb12[54].x);
+  r1.x = max(9.99999975e-005, r1.x);
+  r1.x = cb12[54].y / r1.x;
+  r1.x = r1.y ? cb12[54].x : r1.x;
+  r1.x = max(cb12[54].z, r1.x);
+  r1.x = min(cb12[54].w, r1.x);
+  r0.w = max(9.99999975e-005, r0.w);
+  r0.w = cb12[54].y / r0.w;
+  r0.w = r1.y ? cb12[54].x : r0.w;
+  r0.w = max(cb12[54].z, r0.w);
+  r0.w = min(cb12[54].w, r0.w);
+  r0.w = log2(r0.w);
+  r0.w = -cb2[1].w * r0.w;
+  r0.w = exp2(r0.w);
+  r1.x = log2(r1.x);
+  r1.x = cb2[1].w * r1.x;
+  r1.x = exp2(r1.x);
+  r0.w = r1.x * r0.w;
+  r0.xyz = r0.xyz * r0.www; // not auto exposure
+  r1.x = cmp(0.5 < cb2[2].w);
+
+  const float3 untonemapped = r0.xyz;
+
+  // tonemapping
+  if (r1.x != 0 & injectedData.toneMapType == 0) { // vanilla
+    r1.xy = float2(-1,-2) + cb2[2].xx;
+    r2.xyz = r0.xyz * float3(2.50999999,2.50999999,2.50999999) + float3(0.0299999993,0.0299999993,0.0299999993);
+    r2.xyz = r2.xyz * r0.xyz;
+    r3.xyz = r0.xyz * float3(2.43000007,2.43000007,2.43000007) + float3(0.589999974,0.589999974,0.589999974);
+    r4.xyz = r0.xyz * r3.xyz + float3(0.140000001,0.140000001,0.140000001);
+    r2.xyz = saturate(r2.xyz / r4.xyz);
+    r1.xy = cmp(abs(r1.xy) < float2(9.99999975e-005,9.99999975e-005));
+    r1.z = max(9.99999975e-005, cb2[2].y);
+    r1.w = 0.560000002 / r1.z;
+    r1.w = 2.43000007 + r1.w;
+    r2.w = r1.z * r1.z;
+    r2.w = 0.140000001 / r2.w;
+    r1.w = r2.w + r1.w;
+    r2.w = cb2[0].x * cb2[0].x;
+    r2.w = -r2.w * 2.43000007 + 0.0299999993;
+    r3.w = -0.589999974 + r1.w;
+    r2.w = r3.w * cb2[0].x + r2.w;
+    r4.xyz = r1.www * r0.xyz + float3(0.0299999993,0.0299999993,0.0299999993);
+    r4.xyz = r4.xyz * r0.xyz;
+    r3.xyz = r0.xyz * r3.xyz + r2.www;
+    r3.xyz = saturate(r4.xyz / r3.xyz);
+    r4.xyz = r0.xyz + r0.xyz;
+    r5.xyz = r0.xyz * float3(0.300000012,0.300000012,0.300000012) + float3(0.0500000007,0.0500000007,0.0500000007);
+    r1.w = 0.200000003 * cb2[2].z;
+    r5.xyz = r4.xyz * r5.xyz + r1.www;
+    r6.xyz = r0.xyz * float3(0.300000012,0.300000012,0.300000012) + float3(0.5,0.5,0.5);
+    r4.xyz = r4.xyz * r6.xyz + float3(0.0599999987,0.0599999987,0.0599999987);
+    r4.xyz = r5.xyz / r4.xyz;
+    r4.xyz = -cb2[2].zzz * float3(3.33333325,3.33333325,3.33333325) + r4.xyz;
+    r5.xy = r1.zz * float2(0.150000006,0.150000006) + float2(0.0500000007,0.5);
+    r1.w = r1.z * r5.x + r1.w;
+    r1.z = r1.z * r5.y + 0.0599999987;
+    r1.z = r1.w / r1.z;
+    r1.z = -cb2[2].z * 3.33333325 + r1.z;
+    r1.z = 1 / r1.z;
+    r4.xyz = r4.xyz * r1.zzz;
+    r1.yzw = r1.yyy ? r3.xyz : r4.xyz;
+    r0.xyz = r1.xxx ? r2.xyz : r1.yzw;
+  }
+  else { // untonemapped
+    r0.xyz = untonemapped;
+  }
+
+  // scene filter adjustment
+  r1.x = dot(r0.xyz, float3(0.212500006,0.715399981,0.0720999986));
+  r0.w = 0;
+  float3 outputColor = r0.xyz; // before scene filter
+  r0.xyzw = -r1.xxxx + r0.xyzw;
+  r0.xyzw = cb2[3].xxxx * r0.xyzw + r1.xxxx;
+  r1.xyzw = r1.xxxx * cb2[4].xyzw + -r0.xyzw;
+  r0.xyzw = cb2[4].wwww * r1.xyzw + r0.xyzw;
+  r0.w = cb2[3].w * r0.w;
+  r0.xyz = cb2[3].www * r0.xyz + -cb2[0].xxx;
+  o0.xyz = cb2[3].zzz * r0.xyz + cb2[0].xxx;
+  o0.w = r0.w;
+
+  o0.xyz = lerp(outputColor, o0.xyz, injectedData.fxSceneFilter);
+
+  return;
+}

--- a/src/games/fallout76/ui_0x21A11DE7.ps_5_0.hlsl
+++ b/src/games/fallout76/ui_0x21A11DE7.ps_5_0.hlsl
@@ -1,0 +1,35 @@
+#include "../../shaders/color.hlsl"
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sun May 12 21:52:48 2024
+
+SamplerState sampler_tex_s : register(s0);
+Texture2D<float4> tex : register(t0);
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : TEXCOORD0,
+  float4 v1 : TEXCOORD1,
+  float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = tex.Sample(sampler_tex_s, v2.xy).xyzw;
+  r1.xyz = v1.xyz;
+  r1.w = 1;
+  r0.xyzw = r1.xyzw * r0.xyzw;
+  r0.xyzw = v1.wwww * r0.xyzw;
+  o0.xyzw = saturate(v0.xyzw * r0.wwww + r0.xyzw);
+
+  o0.rgb = injectedData.toneMapGammaCorrection ? pow(o0.rgb, 2.2f) : linearFromSRGB(o0.rgb);
+  o0.rgb *= injectedData.toneMapUINits / 80.f;
+
+  return;
+}

--- a/src/games/fallout76/ui_0x28213F99.ps_5_0.hlsl
+++ b/src/games/fallout76/ui_0x28213F99.ps_5_0.hlsl
@@ -1,0 +1,31 @@
+#include "../../shaders/color.hlsl"
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sun May 12 21:52:49 2024
+
+SamplerState sampler_tex_s : register(s0);
+Texture2D<float4> tex : register(t0);
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float2 v0 : TEXCOORD0,
+  float4 v1 : COLOR0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.x = tex.Sample(sampler_tex_s, v0.xy).x;
+  o0.w = v1.w * r0.x;
+  o0.xyz = v1.xyz;
+
+  o0.rgb = injectedData.toneMapGammaCorrection ? pow(o0.rgb, 2.2f) : linearFromSRGB(o0.rgb);
+  o0.rgb *= injectedData.toneMapUINits / 80.f;
+
+  return;
+}

--- a/src/games/fallout76/ui_0x4B3388FE.ps_5_0.hlsl
+++ b/src/games/fallout76/ui_0x4B3388FE.ps_5_0.hlsl
@@ -1,0 +1,51 @@
+#include "../../shaders/color.hlsl"
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sun May 12 21:52:54 2024
+
+cbuffer Constants : register(b0)
+{
+  float4 fsize : packoffset(c0);
+  float4 texscale : packoffset(c1);
+}
+
+SamplerState sampler_tex_s : register(s0);
+Texture2D<float4> tex : register(t0);
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : TEXCOORD0,
+  float4 v1 : TEXCOORD1,
+  float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = float4(0,0,0,0);
+  r1.x = -fsize.x;
+  while (true) {
+    r1.y = cmp(fsize.x < r1.x);
+    if (r1.y != 0) break;
+    r1.yz = r1.xx * texscale.xy + v2.xy;
+    r2.xyzw = tex.Sample(sampler_tex_s, r1.yz).xyzw;
+    r0.xyzw = r2.xyzw + r0.xyzw;
+    r1.x = 1 + r1.x;
+  }
+  r0.xyzw = fsize.wwww * r0.xyzw;
+  r1.xyz = v1.xyz;
+  r1.w = 1;
+  r0.xyzw = r1.xyzw * r0.xyzw;
+  r0.xyzw = v1.wwww * r0.xyzw;
+  o0.xyzw = saturate(v0.xyzw * r0.wwww + r0.xyzw);
+
+  o0.rgb = injectedData.toneMapGammaCorrection ? pow(o0.rgb, 2.2f) : linearFromSRGB(o0.rgb);
+  o0.rgb *= injectedData.toneMapUINits / 80.f;
+
+  return;
+}

--- a/src/games/fallout76/ui_0x4D248432.ps_5_0.hlsl
+++ b/src/games/fallout76/ui_0x4D248432.ps_5_0.hlsl
@@ -1,0 +1,34 @@
+#include "../../shaders/color.hlsl"
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sun May 12 21:52:55 2024
+
+SamplerState sampler_tex_s : register(s0);
+Texture2D<float4> tex : register(t0);
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : COLOR0,
+  float4 v1 : COLOR1,
+  float2 v2 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = tex.Sample(sampler_tex_s, v2.xy).xyzw;
+  r0.xyzw = -v0.xyzw + r0.xyzw;
+  r0.xyzw = v1.xxxx * r0.xyzw + v0.xyzw;
+  o0.w = v1.w * r0.w;
+  o0.xyz = r0.xyz;
+
+  o0.rgb = injectedData.toneMapGammaCorrection ? pow(o0.rgb, 2.2f) : linearFromSRGB(o0.rgb);
+  o0.rgb *= injectedData.toneMapUINits / 80.f;
+
+  return;
+}

--- a/src/games/fallout76/ui_0x6CF04AC0.ps_5_0.hlsl
+++ b/src/games/fallout76/ui_0x6CF04AC0.ps_5_0.hlsl
@@ -1,0 +1,26 @@
+#include "../../shaders/color.hlsl"
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sun May 12 21:52:57 2024
+
+cbuffer Constants : register(b0)
+{
+  float4 cxmul : packoffset(c0);
+}
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  out float4 o0 : SV_Target0)
+{
+  o0.xyzw = cxmul.xyzw;
+
+  o0.rgb = injectedData.toneMapGammaCorrection ? pow(o0.rgb, 2.2f) : linearFromSRGB(o0.rgb);
+  o0.rgb *= injectedData.toneMapUINits / 80.f;
+
+  return;
+}

--- a/src/games/fallout76/ui_0xF2CCBA8C.ps_5_0.hlsl
+++ b/src/games/fallout76/ui_0xF2CCBA8C.ps_5_0.hlsl
@@ -1,0 +1,24 @@
+#include "../../shaders/color.hlsl"
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sun May 12 21:53:18 2024
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : COLOR0,
+  float4 v1 : COLOR1,
+  out float4 o0 : SV_Target0)
+{
+  o0.w = v1.w * v0.w;
+  o0.xyz = v0.xyz;
+
+  o0.rgb = injectedData.toneMapGammaCorrection ? pow(o0.rgb, 2.2f) : linearFromSRGB(o0.rgb);
+  o0.rgb *= injectedData.toneMapUINits / 80.f;
+
+  return;
+}

--- a/src/games/fallout76/ui_nav_0x19558629.ps_5_0.hlsl
+++ b/src/games/fallout76/ui_nav_0x19558629.ps_5_0.hlsl
@@ -1,0 +1,47 @@
+#include "../../shaders/color.hlsl"
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sun May 12 21:52:47 2024
+
+cbuffer Constants : register(b0)
+{
+  float4 cmatadd : packoffset(c0);
+  float4x4 cmatmul : packoffset(c1);
+}
+
+SamplerState sampler_tex_s : register(s0);
+Texture2D<float4> tex : register(t0);
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : TEXCOORD0,
+  float4 v1 : TEXCOORD1,
+  float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = tex.Sample(sampler_tex_s, v2.xy).xyzw;
+  r1.x = dot(r0.xyzw, cmatmul._m00_m10_m20_m30);
+  r1.y = dot(r0.xyzw, cmatmul._m01_m11_m21_m31);
+  r1.z = dot(r0.xyzw, cmatmul._m02_m12_m22_m32);
+  r1.w = dot(r0.xyzw, cmatmul._m03_m13_m23_m33);
+  r0.x = saturate(cmatadd.w + r0.w);
+  r0.xyzw = saturate(cmatadd.xyzw * r0.xxxx + r1.xyzw);
+  r1.xyz = v1.xyz;
+  r1.w = 1;
+  r0.xyzw = r1.xyzw * r0.xyzw;
+  r0.xyzw = v1.wwww * r0.xyzw;
+  o0.xyzw = saturate(v0.xyzw * r0.wwww + r0.xyzw);
+
+  o0.rgb = injectedData.toneMapGammaCorrection ? pow(o0.rgb, 2.2f) : linearFromSRGB(o0.rgb);
+  o0.rgb *= injectedData.toneMapUINits / 80.f;
+
+  return;
+}

--- a/src/games/fallout76/video_0x0F2CC0D1.ps_5_0.hlsl
+++ b/src/games/fallout76/video_0x0F2CC0D1.ps_5_0.hlsl
@@ -1,0 +1,35 @@
+#include "../../shaders/tonemap.hlsl"
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sun May 12 21:52:45 2024
+
+SamplerState SampBase_s : register(s0);
+Texture2D<float4> TexBase : register(t0);
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = TexBase.Sample(SampBase_s, v1.xy).xyzw;
+  o0.xyzw = r0.zyxw;
+
+  o0.rgb = saturate(o0.rgb);  // clamp colors 0-1
+  // convert from sRGB to linear and apply gamma 2.2 correction
+  o0.rgb = injectedData.toneMapGammaCorrection ? pow(o0.rgb, 2.2f) : linearFromSRGB(o0.rgb);
+  float videoPeak = injectedData.toneMapPeakNits / (injectedData.toneMapGameNits / 203.f);
+  // apply BT.2446A inverse tonemapping
+  o0.rgb = bt2446a_inverse_tonemapping_bt709(o0.rgb, 100.f * injectedData.toneMapGameNits/injectedData.toneMapPeakNits, videoPeak);
+  o0.rgb *= injectedData.toneMapPeakNits / videoPeak;
+  o0.rgb /= 80.f;
+  return;
+}

--- a/src/games/fallout76/xx_0xD2943ACD.hlsl
+++ b/src/games/fallout76/xx_0xD2943ACD.hlsl
@@ -1,0 +1,3278 @@
+// ---- Created with 3Dmigoto v1.3.16 on Sun May 12 21:53:14 2024
+struct u0_t {
+  float val[28];
+};
+RWStructuredBuffer<u0_t> u0 : register(u0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[21];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main)
+{
+// Needs manual fix for instruction:
+// unknown dcl_: dcl_resource_raw t0
+// Needs manual fix for instruction:
+// unknown dcl_: dcl_resource_raw t1
+// Needs manual fix for instruction:
+// unknown dcl_: dcl_uav_raw u1
+// Needs manual fix for instruction:
+// unknown dcl_: dcl_uav_raw u2
+// Needs manual fix for instruction:
+// unknown dcl_: dcl_uav_raw u3
+// Needs manual fix for instruction:
+// unknown dcl_: dcl_uav_raw u4
+// Needs manual fix for instruction:
+// unknown dcl_: dcl_uav_raw u5
+// Needs manual fix for instruction:
+// unknown dcl_: dcl_uav_raw u6
+// Needs manual fix for instruction:
+// unknown dcl_: dcl_uav_raw u7
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8,r9,r10,r11,r12,r13,r14,r15,r16,r17,r18,r19,r20,r21,r22,r23,r24,r25,r26,r27,r28,r29,r30,r31,r32,r33,r34,r35,r36,r37,r38,r39,r40,r41,r42,r43,r44,r45,r46,r47,r48,r49,r50,r51,r52,r53,r54,r55,r56,r57,r58,r59,r60,r61,r62,r63,r64,r65,r66,r67,r68,r69,r70,r71,r72;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+// Needs manual fix for instruction:
+// unknown dcl_: dcl_thread_group 1, 1, 1
+  r0.x = cmp((uint)vThreadID.x < asuint(cb0[8].x));
+  if (r0.x != 0) {
+    r0.x = u0[vThreadID.x].val[0/4];
+    r0.y = u0[vThreadID.x].val[0/4+1];
+    r0.z = u0[vThreadID.x].val[0/4+2];
+    r1.x = u0[vThreadID.x].val[16/4];
+    r1.y = u0[vThreadID.x].val[16/4+1];
+    r1.z = u0[vThreadID.x].val[16/4+2];
+    r2.x = u0[vThreadID.x].val[32/4];
+    r2.y = u0[vThreadID.x].val[32/4+1];
+    r2.z = u0[vThreadID.x].val[32/4+2];
+    r2.w = u0[vThreadID.x].val[32/4+3];
+    r3.x = u0[vThreadID.x].val[48/4];
+    r3.y = u0[vThreadID.x].val[48/4+1];
+    r3.z = u0[vThreadID.x].val[48/4+2];
+    r3.w = u0[vThreadID.x].val[48/4+3];
+    r4.x = u0[vThreadID.x].val[64/4];
+    r4.y = u0[vThreadID.x].val[64/4+1];
+    r4.z = u0[vThreadID.x].val[64/4+2];
+    r4.w = u0[vThreadID.x].val[64/4+3];
+    r5.x = u0[vThreadID.x].val[80/4];
+    r5.y = u0[vThreadID.x].val[80/4+1];
+    r5.z = u0[vThreadID.x].val[80/4+2];
+    r5.w = u0[vThreadID.x].val[80/4+3];
+    r0.w = u0[vThreadID.x].val[96/4];
+    r1.w = asint(cb0[8].z) + 7;
+    r1.w = (uint)r1.w >> 3;
+    r6.x = 0;
+    while (true) {
+      r6.y = cmp((uint)r6.x >= (uint)r1.w);
+      if (r6.y != 0) break;
+      r6.y = (uint)r6.x << 4;
+    // No code for instruction (needs manual fix):
+        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r7.xyzw, r6.y, t0.xyzw
+    // No code for instruction (needs manual fix):
+        store_raw u2.xyzw, r6.y, r7.xyzw
+      r6.x = (int)r6.x + 1;
+    }
+    r1.w = dot(cb0[4].xyz, cb0[3].xyz);
+    r7.xyz = r1.xyz;
+    r8.xyzw = r2.xyzw;
+    r9.xyzw = r3.xyzw;
+    r10.xyzw = r4.xyzw;
+    r11.xyzw = r5.xyzw;
+    r6.xyzw = r0.xyzw;
+    r7.w = cb0[6].y;
+    r12.x = cb0[9].y;
+    r12.y = cb0[10].y;
+    r12.z = cb0[11].y;
+    r12.w = 0;
+    while (true) {
+      r13.x = cmp((uint)r12.w >= asuint(cb0[8].y));
+      if (r13.x != 0) break;
+      r13.xyzw = cmp((int4)r12.wwww == int4(0,1,2,3));
+      r14.xyzw = cmp((int4)r12.wwww == int4(4,5,6,7));
+      r15.xyzw = cmp((int4)r12.wwww == int4(8,9,10,11));
+      r16.xyz = r13.xxx ? cb0[9].xzw : 0;
+      r17.xyz = r13.yyy ? cb0[10].xzw : 0;
+      r16.xyz = (int3)r16.xyz | (int3)r17.xyz;
+      r17.xyz = r13.zzz ? cb0[11].xzw : 0;
+      r16.xyz = (int3)r16.xyz | (int3)r17.xyz;
+      r17.xyzw = r13.wwww ? cb0[12].xzwy : 0;
+      r16.xyz = (int3)r16.xyz | (int3)r17.xyz;
+      r18.xyzw = r14.xxxx ? cb0[13].xzwy : 0;
+      r16.xyz = (int3)r16.xyz | (int3)r18.xyz;
+      r19.xyzw = r14.yyyy ? cb0[14].xzwy : 0;
+      r16.xyz = (int3)r16.xyz | (int3)r19.xyz;
+      r20.xyzw = r14.zzzz ? cb0[15].xzwy : 0;
+      r14.xyz = (int3)r16.xyz | (int3)r20.xyz;
+      r16.xyzw = r14.wwww ? cb0[16].xzwy : 0;
+      r14.xyz = (int3)r14.xyz | (int3)r16.xyz;
+      r21.xyzw = r15.xxxx ? cb0[17].xzwy : 0;
+      r14.xyz = (int3)r14.xyz | (int3)r21.xyz;
+      r22.xyzw = r15.yyyy ? cb0[18].xzwy : 0;
+      r14.xyz = (int3)r14.xyz | (int3)r22.xyz;
+      r23.xyzw = r15.zzzz ? cb0[19].xzwy : 0;
+      r14.xyz = (int3)r14.xyz | (int3)r23.xyz;
+      r15.xyzw = r15.wwww ? cb0[20].xzwy : 0;
+      r14.xyz = (int3)r14.xyz | (int3)r15.xyz;
+      r13.w = (uint)r14.x >> 16;
+      r14.x = r14.x ? 0.000000 : 0;
+      r14.x = mad((int)r14.x, 3, (int)r13.w);
+      r15.xy = cmp((int2)r14.yz == int2(1,1));
+      r14.yz = cmp((int2)r14.zy != int2(1,1));
+      r14.yz = r14.yz ? r15.xy : 0;
+      r15.xy = ~(int2)r14.yz;
+      r14.w = r15.y ? r15.x : 0;
+      r13.xy = r13.xy ? r12.xy : 0;
+      r13.x = (int)r13.x | (int)r13.y;
+      r13.y = r13.z ? r12.z : 0;
+      r13.x = (int)r13.x | (int)r13.y;
+      r13.x = (int)r13.x | (int)r17.w;
+      r13.x = (int)r13.x | (int)r18.w;
+      r13.x = (int)r13.x | (int)r19.w;
+      r13.x = (int)r13.x | (int)r20.w;
+      r13.x = (int)r13.x | (int)r16.w;
+      r13.x = (int)r13.x | (int)r21.w;
+      r13.x = (int)r13.x | (int)r22.w;
+      r13.x = (int)r13.x | (int)r23.w;
+      r13.x = (int)r13.x | (int)r15.w;
+      r15.xyzw = r10.xyzw;
+      r16.xyzw = r11.xyzw;
+      r17.xyz = r6.xyz;
+      r18.xyz = r7.xyz;
+      r19.xy = r8.yw;
+      r20.xy = r9.xy;
+      r13.y = r7.w;
+      r13.z = r8.x;
+      r21.x = r8.z;
+      r17.w = r9.w;
+      r18.w = r6.w;
+      r21.w = 0;
+      r22.x = r13.w;
+      while (true) {
+        r22.w = cmp((uint)r22.x >= (uint)r14.x);
+        if (r22.w != 0) break;
+        r22.w = (int)r22.x & 1;
+        r23.x = (uint)r22.x >> 1;
+        r23.x = (uint)r23.x << 2;
+      // No code for instruction (needs manual fix):
+            ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r23.y, r23.x, t0.xxxx
+        r23.z = (uint)r23.y >> 16;
+        r23.y = (int)r23.y & 0x0000ffff;
+        r23.w = (int)-r22.w + 1;
+        r23.y = (int)r23.w * (int)r23.y;
+        r23.y = mad((int)r23.z, (int)r22.w, (int)r23.y);
+        r22.xyz = (int3)r22.xxx + int3(3,1,2);
+        r24.xy = (int2)r22.yz & int2(1,1);
+        r22.yz = (uint2)r22.yz >> int2(1,1);
+        r22.yz = (uint2)r22.yz << int2(2,2);
+      // No code for instruction (needs manual fix):
+            ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r23.z, r22.y, t0.xxxx
+        r24.z = (uint)r23.z >> 16;
+        r23.z = (int)r23.z & 0x0000ffff;
+        r25.xy = (int2)-r24.xy + int2(1,1);
+        r23.z = (int)r23.z * (int)r25.x;
+        r23.z = mad((int)r24.z, (int)r24.x, (int)r23.z);
+      // No code for instruction (needs manual fix):
+            ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r24.z, r22.z, t0.xxxx
+        r24.w = (uint)r24.z >> 16;
+        r24.z = (int)r24.z & 0x0000ffff;
+        r24.z = (int)r25.y * (int)r24.z;
+        r24.z = mad((int)r24.w, (int)r24.y, (int)r24.z);
+        if (r14.w != 0) {
+          r24.w = (int)r23.y * asint(cb0[5].x);
+        // No code for instruction (needs manual fix):
+                ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r24.w, r24.w, t1.xxxx
+          r26.x = f16tof32(r24.w);
+          r24.w = (uint)r24.w >> 16;
+          r26.y = f16tof32(r24.w);
+          r24.w = mad((int)r23.y, asint(cb0[5].x), 4);
+        // No code for instruction (needs manual fix):
+                ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r24.w, r24.w, t1.xxxx
+          r26.z = f16tof32(r24.w);
+          r25.z = (int)r23.z * asint(cb0[5].x);
+        // No code for instruction (needs manual fix):
+                ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r25.z, r25.z, t1.xxxx
+          r27.x = f16tof32(r25.z);
+          r25.z = (uint)r25.z >> 16;
+          r27.y = f16tof32(r25.z);
+          r25.z = mad((int)r23.z, asint(cb0[5].x), 4);
+        // No code for instruction (needs manual fix):
+                ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r25.z, r25.z, t1.xxxx
+          r27.z = f16tof32(r25.z);
+          r25.w = (int)r24.z * asint(cb0[5].x);
+        // No code for instruction (needs manual fix):
+                ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r25.w, r25.w, t1.xxxx
+          r28.x = f16tof32(r25.w);
+          r25.w = (uint)r25.w >> 16;
+          r28.y = f16tof32(r25.w);
+          r25.w = mad((int)r24.z, asint(cb0[5].x), 4);
+        // No code for instruction (needs manual fix):
+                ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r25.w, r25.w, t1.xxxx
+          r28.z = f16tof32(r25.w);
+          r29.xyz = -cb0[3].xyz + r26.xyz;
+          r29.x = dot(r29.xyz, cb0[4].xyz);
+          r30.xyz = -cb0[3].xyz + r27.xyz;
+          r29.y = dot(r30.xyz, cb0[4].xyz);
+          r30.xyz = -cb0[3].xyz + r28.xyz;
+          r29.z = dot(r30.xyz, cb0[4].xyz);
+          r30.xyz = cmp(float3(0,0,0) < r29.xyz);
+          r26.w = (int)r30.y | (int)r30.x;
+          r26.w = (int)r30.z | (int)r26.w;
+          r30.xyz = cmp(r29.xyz < float3(0,0,0));
+          r27.w = (int)r30.y | (int)r30.x;
+          r27.w = (int)r30.z | (int)r27.w;
+          if (r13.x == 0) {
+            r30.xyz = cmp(abs(r29.xyz) < float3(9.99999975e-005,9.99999975e-005,9.99999975e-005));
+            r28.w = r30.y ? r30.x : 0;
+            r28.w = r30.z ? r28.w : 0;
+            r29.w = (int)r26.w & (int)r27.w;
+            r28.w = (int)r28.w | (int)r29.w;
+            if (r28.w != 0) {
+              r30.x = dot(cb0[0].xyz, r26.xyz);
+              r30.y = dot(cb0[1].xyz, r26.xyz);
+              r30.z = dot(cb0[2].xyz, r26.xyz);
+              r31.x = dot(cb0[0].xyz, r27.xyz);
+              r31.y = dot(cb0[1].xyz, r27.xyz);
+              r31.z = dot(cb0[2].xyz, r27.xyz);
+              r32.x = dot(cb0[0].xyz, r28.xyz);
+              r32.y = dot(cb0[1].xyz, r28.xyz);
+              r32.z = dot(cb0[2].xyz, r28.xyz);
+              r33.xyz = min(r32.xyz, r31.xyz);
+              r33.xyz = min(r33.xyz, r30.xyz);
+              r17.xyz = min(r33.xyz, r17.xyz);
+              r31.xyz = max(r32.xyz, r31.xyz);
+              r30.xyz = max(r31.xyz, r30.xyz);
+              r18.xyz = max(r30.xyz, r18.xyz);
+              r28.w = (uint)r24.w >> 16;
+              r30.x = f16tof32(r28.w);
+              r31.xyz = mad((int3)r23.yyy, asint(cb0[5].xxx), asint(cb0[5].yzw));
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r28.w, r31.x, t1.xxxx
+              r29.w = (int)r28.w & 255;
+              r29.w = (uint)r29.w;
+              r32.x = r29.w * 0.00784313772 + -1;
+              if (8 == 0) r31.x = 0; else if (8+8 < 32) {               r31.x = (uint)r28.w << (32-(8 + 8)); r31.x = (uint)r31.x >> (32-8);              } else r31.x = (uint)r28.w >> 8;
+              if (8 == 0) r31.w = 0; else if (8+16 < 32) {               r31.w = (uint)r28.w << (32-(8 + 16)); r31.w = (uint)r31.w >> (32-8);              } else r31.w = (uint)r28.w >> 16;
+              r31.xw = (uint2)r31.xw;
+              r32.yz = r31.xw * float2(0.00784313772,0.00784313772) + float2(-1,-1);
+              r28.w = (uint)r28.w >> 24;
+              r28.w = (uint)r28.w;
+              r30.y = r28.w * 0.00784313772 + -1;
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r28.w, r31.y, t1.xxxx
+              r29.w = (int)r28.w & 255;
+              r29.w = (uint)r29.w;
+              r33.x = r29.w * 0.00784313772 + -1;
+              if (8 == 0) r31.x = 0; else if (8+8 < 32) {               r31.x = (uint)r28.w << (32-(8 + 8)); r31.x = (uint)r31.x >> (32-8);              } else r31.x = (uint)r28.w >> 8;
+              if (8 == 0) r31.y = 0; else if (8+16 < 32) {               r31.y = (uint)r28.w << (32-(8 + 16)); r31.y = (uint)r31.y >> (32-8);              } else r31.y = (uint)r28.w >> 16;
+              r31.xy = (uint2)r31.xy;
+              r33.yz = r31.xy * float2(0.00784313772,0.00784313772) + float2(-1,-1);
+              r28.w = (uint)r28.w >> 24;
+              r28.w = (uint)r28.w;
+              r30.z = r28.w * 0.00784313772 + -1;
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r28.w, r31.z, t1.xxxx
+              r31.x = f16tof32(r28.w);
+              r28.w = (uint)r28.w >> 16;
+              r31.y = f16tof32(r28.w);
+              r28.w = mad((int)r23.y, asint(cb0[5].x), (int)r13.y);
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r28.w, r28.w, t1.xxxx
+              r29.w = (int)r28.w & 255;
+              r29.w = (uint)r29.w;
+              r34.x = 0.00392156886 * r29.w;
+              if (8 == 0) r31.z = 0; else if (8+8 < 32) {               r31.z = (uint)r28.w << (32-(8 + 8)); r31.z = (uint)r31.z >> (32-8);              } else r31.z = (uint)r28.w >> 8;
+              if (8 == 0) r31.w = 0; else if (8+16 < 32) {               r31.w = (uint)r28.w << (32-(8 + 16)); r31.w = (uint)r31.w >> (32-8);              } else r31.w = (uint)r28.w >> 16;
+              r31.zw = (uint2)r31.zw;
+              r34.yz = float2(0.00392156886,0.00392156886) * r31.zw;
+              r28.w = (uint)r28.w >> 24;
+              r28.w = (uint)r28.w;
+              r34.w = 0.00392156886 * r28.w;
+              r30.w = mad((int)r23.y, asint(cb0[5].x), asint(cb0[6].z));
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r32.w, r30.w, t1.xxxx
+              r35.x = f16tof32(r32.w);
+              r32.w = (uint)r32.w >> 16;
+              r35.y = f16tof32(r32.w);
+              r30.w = (int)r30.w + 4;
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r36.xy, r30.w, t1.xyxx
+              r35.z = f16tof32(r36.x);
+              r37.xw = (uint2)r36.xy >> int2(16,24);
+              r35.w = f16tof32(r37.x);
+              r37.x = (int)r36.y & 255;
+              if (8 == 0) r37.y = 0; else if (8+8 < 32) {               r37.y = (uint)r36.y << (32-(8 + 8)); r37.y = (uint)r37.y >> (32-8);              } else r37.y = (uint)r36.y >> 8;
+              if (8 == 0) r37.z = 0; else if (8+16 < 32) {               r37.z = (uint)r36.y << (32-(8 + 16)); r37.z = (uint)r37.z >> (32-8);              } else r37.z = (uint)r36.y >> 16;
+              r30.w = (uint)r25.z >> 16;
+              r38.x = f16tof32(r30.w);
+              r36.xzw = mad((int3)r23.zzz, asint(cb0[5].xxx), asint(cb0[5].yzw));
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r30.w, r36.x, t1.xxxx
+              r32.w = (int)r30.w & 255;
+              r32.w = (uint)r32.w;
+              r39.x = r32.w * 0.00784313772 + -1;
+              if (8 == 0) r40.x = 0; else if (8+8 < 32) {               r40.x = (uint)r30.w << (32-(8 + 8)); r40.x = (uint)r40.x >> (32-8);              } else r40.x = (uint)r30.w >> 8;
+              if (8 == 0) r40.y = 0; else if (8+16 < 32) {               r40.y = (uint)r30.w << (32-(8 + 16)); r40.y = (uint)r40.y >> (32-8);              } else r40.y = (uint)r30.w >> 16;
+              r40.xy = (uint2)r40.xy;
+              r39.yz = r40.xy * float2(0.00784313772,0.00784313772) + float2(-1,-1);
+              r30.w = (uint)r30.w >> 24;
+              r30.w = (uint)r30.w;
+              r38.y = r30.w * 0.00784313772 + -1;
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r30.w, r36.z, t1.xxxx
+              r32.w = (int)r30.w & 255;
+              r32.w = (uint)r32.w;
+              r40.x = r32.w * 0.00784313772 + -1;
+              if (8 == 0) r36.x = 0; else if (8+8 < 32) {               r36.x = (uint)r30.w << (32-(8 + 8)); r36.x = (uint)r36.x >> (32-8);              } else r36.x = (uint)r30.w >> 8;
+              if (8 == 0) r36.z = 0; else if (8+16 < 32) {               r36.z = (uint)r30.w << (32-(8 + 16)); r36.z = (uint)r36.z >> (32-8);              } else r36.z = (uint)r30.w >> 16;
+              r36.xz = (uint2)r36.xz;
+              r40.yz = r36.xz * float2(0.00784313772,0.00784313772) + float2(-1,-1);
+              r30.w = (uint)r30.w >> 24;
+              r30.w = (uint)r30.w;
+              r38.z = r30.w * 0.00784313772 + -1;
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r30.w, r36.w, t1.xxxx
+              r41.x = f16tof32(r30.w);
+              r30.w = (uint)r30.w >> 16;
+              r41.y = f16tof32(r30.w);
+              r30.w = mad((int)r23.z, asint(cb0[5].x), (int)r13.y);
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r30.w, r30.w, t1.xxxx
+              r32.w = (int)r30.w & 255;
+              r32.w = (uint)r32.w;
+              r42.x = 0.00392156886 * r32.w;
+              if (8 == 0) r36.x = 0; else if (8+8 < 32) {               r36.x = (uint)r30.w << (32-(8 + 8)); r36.x = (uint)r36.x >> (32-8);              } else r36.x = (uint)r30.w >> 8;
+              if (8 == 0) r36.z = 0; else if (8+16 < 32) {               r36.z = (uint)r30.w << (32-(8 + 16)); r36.z = (uint)r36.z >> (32-8);              } else r36.z = (uint)r30.w >> 16;
+              r36.xz = (uint2)r36.xz;
+              r42.yz = float2(0.00392156886,0.00392156886) * r36.xz;
+              r30.w = (uint)r30.w >> 24;
+              r30.w = (uint)r30.w;
+              r42.w = 0.00392156886 * r30.w;
+              r33.w = mad((int)r23.z, asint(cb0[5].x), asint(cb0[6].z));
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r36.w, r33.w, t1.xxxx
+              r43.x = f16tof32(r36.w);
+              r36.w = (uint)r36.w >> 16;
+              r43.y = f16tof32(r36.w);
+              r33.w = (int)r33.w + 4;
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r41.zw, r33.w, t1.xxxy
+              r43.z = f16tof32(r41.z);
+              r44.xw = (uint2)r41.zw >> int2(16,24);
+              r43.w = f16tof32(r44.x);
+              r44.x = (int)r41.w & 255;
+              if (8 == 0) r44.y = 0; else if (8+8 < 32) {               r44.y = (uint)r41.w << (32-(8 + 8)); r44.y = (uint)r44.y >> (32-8);              } else r44.y = (uint)r41.w >> 8;
+              if (8 == 0) r44.z = 0; else if (8+16 < 32) {               r44.z = (uint)r41.w << (32-(8 + 16)); r44.z = (uint)r44.z >> (32-8);              } else r44.z = (uint)r41.w >> 16;
+              r33.w = (uint)r25.w >> 16;
+              r45.x = f16tof32(r33.w);
+              r46.xyz = mad((int3)r24.zzz, asint(cb0[5].xxx), asint(cb0[5].yzw));
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r33.w, r46.x, t1.xxxx
+              r36.w = (int)r33.w & 255;
+              r36.w = (uint)r36.w;
+              r47.x = r36.w * 0.00784313772 + -1;
+              if (8 == 0) r46.x = 0; else if (8+8 < 32) {               r46.x = (uint)r33.w << (32-(8 + 8)); r46.x = (uint)r46.x >> (32-8);              } else r46.x = (uint)r33.w >> 8;
+              if (8 == 0) r46.w = 0; else if (8+16 < 32) {               r46.w = (uint)r33.w << (32-(8 + 16)); r46.w = (uint)r46.w >> (32-8);              } else r46.w = (uint)r33.w >> 16;
+              r46.xw = (uint2)r46.xw;
+              r47.yz = r46.xw * float2(0.00784313772,0.00784313772) + float2(-1,-1);
+              r33.w = (uint)r33.w >> 24;
+              r33.w = (uint)r33.w;
+              r45.y = r33.w * 0.00784313772 + -1;
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r33.w, r46.y, t1.xxxx
+              r36.w = (int)r33.w & 255;
+              r36.w = (uint)r36.w;
+              r48.x = r36.w * 0.00784313772 + -1;
+              if (8 == 0) r46.x = 0; else if (8+8 < 32) {               r46.x = (uint)r33.w << (32-(8 + 8)); r46.x = (uint)r46.x >> (32-8);              } else r46.x = (uint)r33.w >> 8;
+              if (8 == 0) r46.y = 0; else if (8+16 < 32) {               r46.y = (uint)r33.w << (32-(8 + 16)); r46.y = (uint)r46.y >> (32-8);              } else r46.y = (uint)r33.w >> 16;
+              r46.xy = (uint2)r46.xy;
+              r48.yz = r46.xy * float2(0.00784313772,0.00784313772) + float2(-1,-1);
+              r33.w = (uint)r33.w >> 24;
+              r33.w = (uint)r33.w;
+              r45.z = r33.w * 0.00784313772 + -1;
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r33.w, r46.z, t1.xxxx
+              r46.x = f16tof32(r33.w);
+              r33.w = (uint)r33.w >> 16;
+              r46.y = f16tof32(r33.w);
+              r33.w = mad((int)r24.z, asint(cb0[5].x), (int)r13.y);
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r33.w, r33.w, t1.xxxx
+              r36.w = (int)r33.w & 255;
+              r36.w = (uint)r36.w;
+              r49.x = 0.00392156886 * r36.w;
+              if (8 == 0) r46.z = 0; else if (8+8 < 32) {               r46.z = (uint)r33.w << (32-(8 + 8)); r46.z = (uint)r46.z >> (32-8);              } else r46.z = (uint)r33.w >> 8;
+              if (8 == 0) r46.w = 0; else if (8+16 < 32) {               r46.w = (uint)r33.w << (32-(8 + 16)); r46.w = (uint)r46.w >> (32-8);              } else r46.w = (uint)r33.w >> 16;
+              r46.zw = (uint2)r46.zw;
+              r49.yz = float2(0.00392156886,0.00392156886) * r46.zw;
+              r33.w = (uint)r33.w >> 24;
+              r33.w = (uint)r33.w;
+              r49.w = 0.00392156886 * r33.w;
+              r38.w = mad((int)r24.z, asint(cb0[5].x), asint(cb0[6].z));
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r39.w, r38.w, t1.xxxx
+              r50.x = f16tof32(r39.w);
+              r39.w = (uint)r39.w >> 16;
+              r50.y = f16tof32(r39.w);
+              r38.w = (int)r38.w + 4;
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r51.xy, r38.w, t1.xyxx
+              r50.z = f16tof32(r51.x);
+              r52.xw = (uint2)r51.xy >> int2(16,24);
+              r50.w = f16tof32(r52.x);
+              r52.x = (int)r51.y & 255;
+              if (8 == 0) r52.y = 0; else if (8+8 < 32) {               r52.y = (uint)r51.y << (32-(8 + 8)); r52.y = (uint)r52.y >> (32-8);              } else r52.y = (uint)r51.y >> 8;
+              if (8 == 0) r52.z = 0; else if (8+16 < 32) {               r52.z = (uint)r51.y << (32-(8 + 16)); r52.z = (uint)r52.z >> (32-8);              } else r52.z = (uint)r51.y >> 16;
+              r51.xzw = r27.xyz + -r26.xyz;
+              r38.w = dot(cb0[4].xyz, r51.xzw);
+              r39.w = cmp(abs(r38.w) < 1.1920929e-007);
+              r53.xyz = cb0[4].xyz * r1.www + -r26.xyz;
+              r40.w = dot(cb0[4].xyz, r53.xyz);
+              r38.w = rcp(r38.w);
+              r38.w = r40.w * r38.w;
+              r38.w = max(-5, r38.w);
+              r38.w = min(5, r38.w);
+              r40.w = r39.w ? 0.5 : r38.w;
+              r53.xyz = r28.xyz + -r27.xyz;
+              r41.z = dot(cb0[4].xyz, r53.xyz);
+              r45.w = cmp(abs(r41.z) < 1.1920929e-007);
+              r54.xyz = cb0[4].xyz * r1.www + -r27.xyz;
+              r47.w = dot(cb0[4].xyz, r54.xyz);
+              r41.z = rcp(r41.z);
+              r41.z = r47.w * r41.z;
+              r41.z = max(-5, r41.z);
+              r41.z = min(5, r41.z);
+              r47.w = r45.w ? 0.5 : r41.z;
+              r54.xyz = -r28.xyz + r26.xyz;
+              r48.w = dot(cb0[4].xyz, r54.xyz);
+              r53.w = cmp(abs(r48.w) < 1.1920929e-007);
+              r55.xyz = cb0[4].xyz * r1.www + -r28.xyz;
+              r54.w = dot(cb0[4].xyz, r55.xyz);
+              r48.w = rcp(r48.w);
+              r48.w = r54.w * r48.w;
+              r48.w = max(-5, r48.w);
+              r48.w = min(5, r48.w);
+              r54.w = r53.w ? 0.5 : r48.w;
+              r55.xy = cmp(r40.ww < float2(0,0.5));
+              r40.w = cmp(1 < r40.w);
+              r40.w = (int)r40.w | (int)r55.x;
+              r39.w = (int)r39.w | (int)r40.w;
+              r38.w = r39.w ? 0.5 : r38.w;
+              r51.xzw = r38.www * r51.xzw + r26.xyz;
+              r55.xzw = r39.xyz + -r32.xyz;
+              r55.xzw = r38.www * r55.xzw + r32.xyz;
+              r39.w = dot(r55.xzw, r55.xzw);
+              r39.w = rsqrt(r39.w);
+              r55.xzw = r55.xzw * r39.www;
+              r56.xyz = r40.xyz + -r33.xyz;
+              r56.xyz = r38.www * r56.xyz + r33.xyz;
+              r39.w = dot(r56.xyz, r56.xyz);
+              r39.w = rsqrt(r39.w);
+              r56.xyz = r56.xyz * r39.www;
+              r57.xyz = r38.xyz + -r30.xyz;
+              r57.xyz = r38.www * r57.xyz + r30.xyz;
+              r39.w = dot(r57.xyz, r57.xyz);
+              r39.w = rsqrt(r39.w);
+              r57.xyz = r57.xyz * r39.www;
+              r58.xy = r41.xy + -r31.xy;
+              r58.xy = r38.ww * r58.xy + r31.xy;
+              r59.xyzw = r42.xyzw + -r34.xyzw;
+              r59.xyzw = r38.wwww * r59.xyzw + r34.xyzw;
+              r60.xyzw = r55.yyyy ? r35.xyzw : r43.xyzw;
+              r61.xyzw = r55.yyyy ? r37.xyzw : r44.xyzw;
+              r58.zw = cmp(r47.ww < float2(0,0.5));
+              r38.w = cmp(1 < r47.w);
+              r38.w = (int)r38.w | (int)r58.z;
+              r38.w = (int)r38.w | (int)r45.w;
+              r38.w = r38.w ? 0.5 : r41.z;
+              r53.xyz = r38.www * r53.xyz + r27.xyz;
+              r62.xyz = r47.xyz + -r39.xyz;
+              r62.xyz = r38.www * r62.xyz + r39.xyz;
+              r39.w = dot(r62.xyz, r62.xyz);
+              r39.w = rsqrt(r39.w);
+              r62.xyz = r62.xyz * r39.www;
+              r63.xyz = r48.xyz + -r40.xyz;
+              r63.xyz = r38.www * r63.xyz + r40.xyz;
+              r39.w = dot(r63.xyz, r63.xyz);
+              r39.w = rsqrt(r39.w);
+              r63.xyz = r63.xyz * r39.www;
+              r64.xyz = r45.xyz + -r38.xyz;
+              r64.xyz = r38.www * r64.xyz + r38.xyz;
+              r39.w = dot(r64.xyz, r64.xyz);
+              r39.w = rsqrt(r39.w);
+              r64.xyz = r64.xyz * r39.www;
+              r65.xy = r46.xy + -r41.xy;
+              r65.xy = r38.ww * r65.xy + r41.xy;
+              r66.xyzw = r49.xyzw + -r42.xyzw;
+              r42.xyzw = r38.wwww * r66.xyzw + r42.xyzw;
+              r66.xyzw = r58.wwww ? r43.xyzw : r50.xyzw;
+              r67.xyzw = r58.wwww ? r44.xyzw : r52.xyzw;
+              r58.zw = cmp(r54.ww < float2(0,0.5));
+              r38.w = cmp(1 < r54.w);
+              r38.w = (int)r38.w | (int)r58.z;
+              r38.w = (int)r38.w | (int)r53.w;
+              r38.w = r38.w ? 0.5 : r48.w;
+              r54.xyz = r38.www * r54.xyz + r28.xyz;
+              r68.xyz = -r47.xyz + r32.xyz;
+              r68.xyz = r38.www * r68.xyz + r47.xyz;
+              r39.w = dot(r68.xyz, r68.xyz);
+              r39.w = rsqrt(r39.w);
+              r68.xyz = r68.xyz * r39.www;
+              r69.xyz = -r48.xyz + r33.xyz;
+              r69.xyz = r38.www * r69.xyz + r48.xyz;
+              r39.w = dot(r69.xyz, r69.xyz);
+              r39.w = rsqrt(r39.w);
+              r69.xyz = r69.xyz * r39.www;
+              r70.xyz = -r45.xyz + r30.xyz;
+              r70.xyz = r38.www * r70.xyz + r45.xyz;
+              r39.w = dot(r70.xyz, r70.xyz);
+              r39.w = rsqrt(r39.w);
+              r70.xyz = r70.xyz * r39.www;
+              r65.zw = -r46.xy + r31.xy;
+              r65.zw = r38.ww * r65.zw + r46.xy;
+              r34.xyzw = -r49.xyzw + r34.xyzw;
+              r34.xyzw = r38.wwww * r34.xyzw + r49.xyzw;
+              r49.xyzw = r58.wwww ? r50.xyzw : r35.xyzw;
+              r71.xyzw = r58.wwww ? r52.xyzw : r37.xyzw;
+              r72.xyz = -cb0[3].xyz + r51.xzw;
+              r37.x = dot(r72.xyz, cb0[4].xyz);
+              r72.xyz = -cb0[3].xyz + r53.xyz;
+              r38.w = dot(r72.xyz, cb0[4].xyz);
+              r72.xyz = -cb0[3].xyz + r54.xyz;
+              r39.w = dot(r72.xyz, cb0[4].xyz);
+              r40.w = cmp(abs(r37.x) < 9.99999975e-005);
+              r37.x = r40.w ? abs(r37.x) : r37.x;
+              r40.w = cmp(abs(r38.w) < 9.99999975e-005);
+              r38.w = r40.w ? abs(r38.w) : r38.w;
+              r40.w = cmp(abs(r39.w) < 9.99999975e-005);
+              r39.w = r40.w ? abs(r39.w) : r39.w;
+              r40.w = (int)r18.w + 1;
+              r72.xyz = min(float3(2000,2000,2000), r26.xyz);
+              r72.xyz = f32tof16(r72.xyz);
+              r72.x = mad((int)r72.y, 0x00010000, (int)r72.x);
+              r41.z = (int)r18.w * asint(cb0[7].x);
+              r30.x = min(2000, r30.x);
+              r30.x = f32tof16(r30.x);
+              r72.y = mad((int)r30.x, 0x00010000, (int)r72.z);
+            // No code for instruction (needs manual fix):
+                        store_raw u1.xy, r41.z, r72.xyxx
+              r32.xyz = r32.xyz * float3(127.5,127.5,127.5) + float3(127.5,127.5,127.5);
+              r32.xyz = (uint3)r32.xyz;
+              r30.x = mad((int)r32.y, 256, (int)r32.x);
+              r30.x = mad((int)r32.z, 0x00010000, (int)r30.x);
+              r30.yz = r30.yz * float2(127.5,127.5) + float2(127.5,127.5);
+              r30.yz = (uint2)r30.yz;
+              r30.x = mad((int)r30.y, 0x01000000, (int)r30.x);
+              r32.xyz = mad((int3)r18.www, asint(cb0[7].xxx), asint(cb0[5].yzw));
+            // No code for instruction (needs manual fix):
+                        store_raw u1.x, r32.x, r30.x
+              r33.xyz = r33.xyz * float3(127.5,127.5,127.5) + float3(127.5,127.5,127.5);
+              r33.xyz = (uint3)r33.xyz;
+              r30.x = mad((int)r33.y, 256, (int)r33.x);
+              r30.x = mad((int)r33.z, 0x00010000, (int)r30.x);
+              r30.x = mad((int)r30.z, 0x01000000, (int)r30.x);
+            // No code for instruction (needs manual fix):
+                        store_raw u1.x, r32.y, r30.x
+              r30.xy = min(float2(2000,2000), r31.xy);
+              r30.xy = f32tof16(r30.xy);
+              r30.x = mad((int)r30.y, 0x00010000, (int)r30.x);
+            // No code for instruction (needs manual fix):
+                        store_raw u1.x, r32.z, r30.x
+              if (r13.y != 0) {
+                r30.x = mad((int)r18.w, asint(cb0[7].x), (int)r13.y);
+                r29.w = 1 * r29.w;
+                r29.w = (uint)r29.w;
+                r30.yz = float2(1,1) * r31.zw;
+                r30.yz = (uint2)r30.yz;
+                r29.w = mad((int)r30.y, 256, (int)r29.w);
+                r29.w = mad((int)r30.z, 0x00010000, (int)r29.w);
+                r28.w = 1 * r28.w;
+                r28.w = (uint)r28.w;
+                r28.w = mad((int)r28.w, 0x01000000, (int)r29.w);
+              // No code for instruction (needs manual fix):
+                            store_raw u1.x, r30.x, r28.w
+              }
+              r30.xy = mad((int2)r18.ww, asint(cb0[7].xx), asint(cb0[6].wz));
+            // No code for instruction (needs manual fix):
+                        store_raw u1.x, r30.x, r29.x
+              r31.xyzw = min(float4(2000,2000,2000,2000), r35.xyzw);
+              r31.xyzw = f32tof16(r31.xyzw);
+              r31.xy = mad((int2)r31.yw, int2(0x10000,0x10000), (int2)r31.xz);
+              bitmask.w = ((~(-1 << 24)) << 8) & 0xffffffff;  r28.w = (((uint)r37.y << 8) & bitmask.w) | ((uint)r36.y & ~bitmask.w);
+              r28.w = mad((int)r37.z, 0x00010000, (int)r28.w);
+              bitmask.z = ((~(-1 << 24)) << 0) & 0xffffffff;  r31.z = (((uint)r28.w << 0) & bitmask.z) | ((uint)r36.y & ~bitmask.z);
+            // No code for instruction (needs manual fix):
+                        store_raw u1.xyz, r30.y, r31.xyzx
+              r30.xy = (uint2)r19.xy >> int2(1,1);
+              r30.xy = (uint2)r30.xy << int2(2,2);
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r28.w, r30.x, u3.xxxx
+              r31.xy = (int2)r19.xy & int2(1,1);
+              bitmask.z = ((~(-1 << 16)) << 16) & 0xffffffff;  r31.z = (((uint)r18.w << 16) & bitmask.z) | ((uint)r28.w & ~bitmask.z);
+              bitmask.w = ((~(-1 << 16)) << 0) & 0xffffffff;  r31.w = (((uint)r18.w << 0) & bitmask.w) | ((uint)r28.w & ~bitmask.w);
+              r32.xy = (int2)-r31.xy + int2(1,1);
+              r28.w = (int)r31.w * (int)r32.x;
+              r28.w = mad((int)r31.z, (int)r31.x, (int)r28.w);
+            // No code for instruction (needs manual fix):
+                        store_raw u3.x, r30.x, r28.w
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r28.w, r30.y, u5.xxxx
+              bitmask.x = ((~(-1 << 16)) << 16) & 0xffffffff;  r30.x = (((uint)r18.w << 16) & bitmask.x) | ((uint)r28.w & ~bitmask.x);
+              bitmask.z = ((~(-1 << 16)) << 0) & 0xffffffff;  r30.z = (((uint)r18.w << 0) & bitmask.z) | ((uint)r28.w & ~bitmask.z);
+              r28.w = (int)r32.y * (int)r30.z;
+              r28.w = mad((int)r30.x, (int)r31.y, (int)r28.w);
+            // No code for instruction (needs manual fix):
+                        store_raw u5.x, r30.y, r28.w
+              r31.xyzw = (int4)r19.xyxy + int4(1,1,2,2);
+              r30.xy = (uint2)r20.xy >> int2(1,1);
+              r30.xy = (uint2)r30.xy << int2(2,2);
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r28.w, r30.x, u6.xxxx
+              r32.xy = (int2)r20.xy & int2(1,1);
+              bitmask.x = ((~(-1 << 16)) << 16) & 0xffffffff;  r33.x = (((uint)r18.w << 16) & bitmask.x) | ((uint)r28.w & ~bitmask.x);
+              bitmask.y = ((~(-1 << 16)) << 0) & 0xffffffff;  r33.y = (((uint)r18.w << 0) & bitmask.y) | ((uint)r28.w & ~bitmask.y);
+              r37.yz = (int2)-r32.xy + int2(1,1);
+              r28.w = (int)r33.y * (int)r37.y;
+              r28.w = mad((int)r33.x, (int)r32.x, (int)r28.w);
+            // No code for instruction (needs manual fix):
+                        store_raw u6.x, r30.x, r28.w
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r28.w, r30.y, u7.xxxx
+              bitmask.x = ((~(-1 << 16)) << 16) & 0xffffffff;  r30.x = (((uint)r18.w << 16) & bitmask.x) | ((uint)r28.w & ~bitmask.x);
+              bitmask.z = ((~(-1 << 16)) << 0) & 0xffffffff;  r30.z = (((uint)r18.w << 0) & bitmask.z) | ((uint)r28.w & ~bitmask.z);
+              r28.w = (int)r37.z * (int)r30.z;
+              r28.w = mad((int)r30.x, (int)r32.y, (int)r28.w);
+            // No code for instruction (needs manual fix):
+                        store_raw u7.x, r30.y, r28.w
+              r72.xyzw = (int4)r20.xyxy + int4(1,1,2,2);
+              r28.w = (int)r40.w + 1;
+              r30.xyz = min(float3(2000,2000,2000), r51.xzw);
+              r30.xyz = f32tof16(r30.xyz);
+              r30.x = mad((int)r30.y, 0x00010000, (int)r30.x);
+              r29.w = (int)r40.w * asint(cb0[7].x);
+              r32.x = min(2000, r57.x);
+              r32.x = f32tof16(r32.x);
+              r30.y = mad((int)r32.x, 0x00010000, (int)r30.z);
+            // No code for instruction (needs manual fix):
+                        store_raw u1.xy, r29.w, r30.xyxx
+              r32.xyz = r55.xzw * float3(127.5,127.5,127.5) + float3(127.5,127.5,127.5);
+              r32.xyz = (uint3)r32.xyz;
+              r32.yz = (uint2)r32.yz << int2(8,16);
+              r29.w = (int)r32.y | (int)r32.x;
+              r29.w = (int)r32.z | (int)r29.w;
+              r32.xy = r57.yz * float2(127.5,127.5) + float2(127.5,127.5);
+              r32.xy = (uint2)r32.xy;
+              r32.xy = (uint2)r32.xy << int2(24,24);
+              r29.w = (int)r29.w | (int)r32.x;
+              r33.xyz = mad((int3)r40.www, asint(cb0[7].xxx), asint(cb0[5].yzw));
+            // No code for instruction (needs manual fix):
+                        store_raw u1.x, r33.x, r29.w
+              r51.xzw = r56.xyz * float3(127.5,127.5,127.5) + float3(127.5,127.5,127.5);
+              r51.xzw = (uint3)r51.xzw;
+              r32.xz = (uint2)r51.zw << int2(8,16);
+              r30.z = (int)r32.x | (int)r51.x;
+              r30.z = (int)r32.z | (int)r30.z;
+              r30.z = (int)r32.y | (int)r30.z;
+            // No code for instruction (needs manual fix):
+                        store_raw u1.x, r33.y, r30.z
+              r32.xy = min(float2(2000,2000), r58.xy);
+              r32.xy = f32tof16(r32.xy);
+              r32.x = mad((int)r32.y, 0x00010000, (int)r32.x);
+            // No code for instruction (needs manual fix):
+                        store_raw u1.x, r33.z, r32.x
+              if (r13.y != 0) {
+                r32.y = mad((int)r40.w, asint(cb0[7].x), (int)r13.y);
+                r55.xyzw = float4(255,255,255,255) * r59.xyzw;
+                r55.xyzw = (uint4)r55.xyzw;
+                r33.xyz = (uint3)r55.yzw << int3(8,16,24);
+                r32.z = (int)r33.x | (int)r55.x;
+                r32.z = (int)r33.y | (int)r32.z;
+                r32.z = (int)r33.z | (int)r32.z;
+              // No code for instruction (needs manual fix):
+                            store_raw u1.x, r32.y, r32.z
+              }
+              r32.yz = mad((int2)r40.ww, asint(cb0[7].xx), asint(cb0[6].wz));
+            // No code for instruction (needs manual fix):
+                        store_raw u1.x, r32.y, r37.x
+              r55.xyzw = min(float4(2000,2000,2000,2000), r60.xyzw);
+              r55.xyzw = f32tof16(r55.xyzw);
+              r33.xy = mad((int2)r55.yw, int2(0x10000,0x10000), (int2)r55.xz);
+              r32.y = mad((int)r61.y, 256, (int)r61.x);
+              r32.y = mad((int)r61.z, 0x00010000, (int)r32.y);
+              r33.z = mad((int)r61.w, 0x01000000, (int)r32.y);
+            // No code for instruction (needs manual fix):
+                        store_raw u1.xyz, r32.z, r33.xyzx
+              r55.xyzw = (uint4)r31.xyzw >> int4(1,1,1,1);
+              r55.xyzw = (uint4)r55.xyzw << int4(2,2,2,2);
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r32.y, r55.x, u3.xxxx
+              r31.xyzw = (int4)r31.xyzw & int4(1,1,1,1);
+              bitmask.y = ((~(-1 << 16)) << 16) & 0xffffffff;  r32.y = (((uint)r40.w << 16) & bitmask.y) | ((uint)r32.y & ~bitmask.y);
+              bitmask.z = ((~(-1 << 16)) << 0) & 0xffffffff;  r32.z = (((uint)r40.w << 0) & bitmask.z) | ((uint)r32.y & ~bitmask.z);
+              r56.xyzw = (int4)-r31.xyzw + int4(1,1,1,1);
+              r32.z = (int)r32.z * (int)r56.x;
+              r31.x = mad((int)r32.y, (int)r31.x, (int)r32.z);
+            // No code for instruction (needs manual fix):
+                        store_raw u3.x, r55.x, r31.x
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r31.x, r55.y, u5.xxxx
+              bitmask.y = ((~(-1 << 16)) << 16) & 0xffffffff;  r32.y = (((uint)r40.w << 16) & bitmask.y) | ((uint)r31.x & ~bitmask.y);
+              bitmask.z = ((~(-1 << 16)) << 0) & 0xffffffff;  r32.z = (((uint)r40.w << 0) & bitmask.z) | ((uint)r31.x & ~bitmask.z);
+              r31.x = (int)r56.y * (int)r32.z;
+              r31.x = mad((int)r32.y, (int)r31.y, (int)r31.x);
+            // No code for instruction (needs manual fix):
+                        store_raw u5.x, r55.y, r31.x
+              r57.xyzw = (uint4)r72.xyzw >> int4(1,1,1,1);
+              r57.xyzw = (uint4)r57.xyzw << int4(2,2,2,2);
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r31.x, r57.x, u6.xxxx
+              r58.xyzw = (int4)r72.xyzw & int4(1,1,1,1);
+              bitmask.x = ((~(-1 << 16)) << 16) & 0xffffffff;  r31.x = (((uint)r40.w << 16) & bitmask.x) | ((uint)r31.x & ~bitmask.x);
+              bitmask.y = ((~(-1 << 16)) << 0) & 0xffffffff;  r31.y = (((uint)r40.w << 0) & bitmask.y) | ((uint)r31.x & ~bitmask.y);
+              r60.xyzw = (int4)-r58.xyzw + int4(1,1,1,1);
+              r31.y = (int)r31.y * (int)r60.x;
+              r31.x = mad((int)r31.x, (int)r58.x, (int)r31.y);
+            // No code for instruction (needs manual fix):
+                        store_raw u6.x, r57.x, r31.x
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r31.x, r57.y, u7.xxxx
+              bitmask.x = ((~(-1 << 16)) << 16) & 0xffffffff;  r31.x = (((uint)r40.w << 16) & bitmask.x) | ((uint)r31.x & ~bitmask.x);
+              bitmask.y = ((~(-1 << 16)) << 0) & 0xffffffff;  r31.y = (((uint)r40.w << 0) & bitmask.y) | ((uint)r31.x & ~bitmask.y);
+              r31.y = (int)r60.y * (int)r31.y;
+              r31.x = mad((int)r31.x, (int)r58.y, (int)r31.y);
+            // No code for instruction (needs manual fix):
+                        store_raw u7.x, r57.y, r31.x
+              r31.x = (int)r28.w + 1;
+              r51.xzw = min(float3(2000,2000,2000), r54.xyz);
+              r51.xzw = f32tof16(r51.xzw);
+              r54.x = mad((int)r51.z, 0x00010000, (int)r51.x);
+              r31.y = (int)r28.w * asint(cb0[7].x);
+              r32.y = min(2000, r70.x);
+              r32.y = f32tof16(r32.y);
+              r54.y = mad((int)r32.y, 0x00010000, (int)r51.w);
+            // No code for instruction (needs manual fix):
+                        store_raw u1.xy, r31.y, r54.xyxx
+              r51.xzw = r68.xyz * float3(127.5,127.5,127.5) + float3(127.5,127.5,127.5);
+              r51.xzw = (uint3)r51.xzw;
+              r32.yz = (uint2)r51.zw << int2(8,16);
+              r31.y = (int)r32.y | (int)r51.x;
+              r31.y = (int)r32.z | (int)r31.y;
+              r32.yz = r70.yz * float2(127.5,127.5) + float2(127.5,127.5);
+              r32.yz = (uint2)r32.yz;
+              r32.yz = (uint2)r32.yz << int2(24,24);
+              r31.y = (int)r31.y | (int)r32.y;
+              r51.xzw = mad((int3)r28.www, asint(cb0[7].xxx), asint(cb0[5].yzw));
+            // No code for instruction (needs manual fix):
+                        store_raw u1.x, r51.x, r31.y
+              r61.xyz = r69.xyz * float3(127.5,127.5,127.5) + float3(127.5,127.5,127.5);
+              r61.xyz = (uint3)r61.xyz;
+              r37.yz = (uint2)r61.yz << int2(8,16);
+              r32.y = (int)r37.y | (int)r61.x;
+              r32.y = (int)r37.z | (int)r32.y;
+              r32.y = (int)r32.z | (int)r32.y;
+            // No code for instruction (needs manual fix):
+                        store_raw u1.x, r51.z, r32.y
+              r37.yz = min(float2(2000,2000), r65.zw);
+              r37.yz = f32tof16(r37.yz);
+              r32.z = mad((int)r37.z, 0x00010000, (int)r37.y);
+            // No code for instruction (needs manual fix):
+                        store_raw u1.x, r51.w, r32.z
+              if (r13.y != 0) {
+                r37.y = mad((int)r28.w, asint(cb0[7].x), (int)r13.y);
+                r61.xyzw = float4(255,255,255,255) * r34.xyzw;
+                r61.xyzw = (uint4)r61.xyzw;
+                r51.xzw = (uint3)r61.yzw << int3(8,16,24);
+                r37.z = (int)r51.x | (int)r61.x;
+                r37.z = (int)r51.z | (int)r37.z;
+                r37.z = (int)r51.w | (int)r37.z;
+              // No code for instruction (needs manual fix):
+                            store_raw u1.x, r37.y, r37.z
+              }
+              r37.yz = mad((int2)r28.ww, asint(cb0[7].xx), asint(cb0[6].wz));
+            // No code for instruction (needs manual fix):
+                        store_raw u1.x, r37.y, r39.w
+              r49.xyzw = min(float4(2000,2000,2000,2000), r49.xyzw);
+              r49.xyzw = f32tof16(r49.xyzw);
+              r49.xy = mad((int2)r49.yw, int2(0x10000,0x10000), (int2)r49.xz);
+              r37.y = mad((int)r71.y, 256, (int)r71.x);
+              r37.y = mad((int)r71.z, 0x00010000, (int)r37.y);
+              r49.z = mad((int)r71.w, 0x01000000, (int)r37.y);
+            // No code for instruction (needs manual fix):
+                        store_raw u1.xyz, r37.z, r49.xyzx
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r37.y, r55.z, u3.xxxx
+              bitmask.y = ((~(-1 << 16)) << 16) & 0xffffffff;  r37.y = (((uint)r28.w << 16) & bitmask.y) | ((uint)r37.y & ~bitmask.y);
+              bitmask.z = ((~(-1 << 16)) << 0) & 0xffffffff;  r37.z = (((uint)r28.w << 0) & bitmask.z) | ((uint)r37.y & ~bitmask.z);
+              r37.z = (int)r56.z * (int)r37.z;
+              r31.z = mad((int)r37.y, (int)r31.z, (int)r37.z);
+            // No code for instruction (needs manual fix):
+                        store_raw u3.x, r55.z, r31.z
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r31.z, r55.w, u5.xxxx
+              bitmask.y = ((~(-1 << 16)) << 16) & 0xffffffff;  r37.y = (((uint)r28.w << 16) & bitmask.y) | ((uint)r31.z & ~bitmask.y);
+              bitmask.z = ((~(-1 << 16)) << 0) & 0xffffffff;  r37.z = (((uint)r28.w << 0) & bitmask.z) | ((uint)r31.z & ~bitmask.z);
+              r31.z = (int)r56.w * (int)r37.z;
+              r31.z = mad((int)r37.y, (int)r31.w, (int)r31.z);
+            // No code for instruction (needs manual fix):
+                        store_raw u5.x, r55.w, r31.z
+              r55.xyzw = (int4)r19.xyxy + int4(3,3,4,4);
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r31.z, r57.z, u6.xxxx
+              bitmask.z = ((~(-1 << 16)) << 16) & 0xffffffff;  r31.z = (((uint)r28.w << 16) & bitmask.z) | ((uint)r31.z & ~bitmask.z);
+              bitmask.w = ((~(-1 << 16)) << 0) & 0xffffffff;  r31.w = (((uint)r28.w << 0) & bitmask.w) | ((uint)r31.z & ~bitmask.w);
+              r31.w = (int)r60.z * (int)r31.w;
+              r31.z = mad((int)r31.z, (int)r58.z, (int)r31.w);
+            // No code for instruction (needs manual fix):
+                        store_raw u6.x, r57.z, r31.z
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r31.z, r57.w, u7.xxxx
+              bitmask.z = ((~(-1 << 16)) << 16) & 0xffffffff;  r31.z = (((uint)r28.w << 16) & bitmask.z) | ((uint)r31.z & ~bitmask.z);
+              bitmask.w = ((~(-1 << 16)) << 0) & 0xffffffff;  r31.w = (((uint)r28.w << 0) & bitmask.w) | ((uint)r31.z & ~bitmask.w);
+              r31.w = (int)r60.w * (int)r31.w;
+              r31.z = mad((int)r31.z, (int)r58.w, (int)r31.w);
+            // No code for instruction (needs manual fix):
+                        store_raw u7.x, r57.w, r31.z
+              r56.xyzw = (int4)r20.xyxy + int4(3,3,4,4);
+              r31.z = cmp((int)r40.w == 0x0000ffff);
+              if (r31.z != 0) {
+                r31.z = (int)r31.x + 1;
+                r31.w = (int)r31.x * asint(cb0[7].x);
+              // No code for instruction (needs manual fix):
+                            store_raw u1.xy, r31.w, r30.xyxx
+                r51.xzw = mad((int3)r31.xxx, asint(cb0[7].xxx), asint(cb0[5].yzw));
+              // No code for instruction (needs manual fix):
+                            store_raw u1.x, r51.x, r29.w
+              // No code for instruction (needs manual fix):
+                            store_raw u1.x, r51.z, r30.z
+              // No code for instruction (needs manual fix):
+                            store_raw u1.x, r51.w, r32.x
+                if (r13.y != 0) {
+                  r31.w = mad((int)r31.x, asint(cb0[7].x), (int)r13.y);
+                  r57.xyzw = float4(255,255,255,255) * r59.xyzw;
+                  r57.xyzw = (uint4)r57.xyzw;
+                  r51.xzw = (uint3)r57.yzw << int3(8,16,24);
+                  r37.y = (int)r51.x | (int)r57.x;
+                  r37.y = (int)r51.z | (int)r37.y;
+                  r37.y = (int)r51.w | (int)r37.y;
+                // No code for instruction (needs manual fix):
+                                store_raw u1.x, r31.w, r37.y
+                }
+                r37.yz = mad((int2)r31.xx, asint(cb0[7].xx), asint(cb0[6].wz));
+              // No code for instruction (needs manual fix):
+                            store_raw u1.x, r37.y, r37.x
+              // No code for instruction (needs manual fix):
+                            store_raw u1.xyz, r37.z, r33.xyzx
+                r40.w = r31.x;
+                r31.x = r31.z;
+              }
+              r57.xyzw = (uint4)r55.xyzw >> int4(1,1,1,1);
+              r57.xyzw = (uint4)r57.xyzw << int4(2,2,2,2);
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r31.z, r57.x, u3.xxxx
+              r55.xyzw = (int4)r55.xyzw & int4(1,1,1,1);
+              bitmask.z = ((~(-1 << 16)) << 16) & 0xffffffff;  r31.z = (((uint)r40.w << 16) & bitmask.z) | ((uint)r31.z & ~bitmask.z);
+              bitmask.w = ((~(-1 << 16)) << 0) & 0xffffffff;  r31.w = (((uint)r40.w << 0) & bitmask.w) | ((uint)r31.z & ~bitmask.w);
+              r58.xyzw = (int4)-r55.xyzw + int4(1,1,1,1);
+              r31.w = (int)r31.w * (int)r58.x;
+              r31.z = mad((int)r31.z, (int)r55.x, (int)r31.w);
+            // No code for instruction (needs manual fix):
+                        store_raw u3.x, r57.x, r31.z
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r31.z, r57.y, u5.xxxx
+              bitmask.z = ((~(-1 << 16)) << 16) & 0xffffffff;  r31.z = (((uint)r40.w << 16) & bitmask.z) | ((uint)r31.z & ~bitmask.z);
+              bitmask.w = ((~(-1 << 16)) << 0) & 0xffffffff;  r31.w = (((uint)r40.w << 0) & bitmask.w) | ((uint)r31.z & ~bitmask.w);
+              r31.w = (int)r58.y * (int)r31.w;
+              r31.z = mad((int)r31.z, (int)r55.y, (int)r31.w);
+            // No code for instruction (needs manual fix):
+                        store_raw u5.x, r57.y, r31.z
+              r60.xyzw = (uint4)r56.xyzw >> int4(1,1,1,1);
+              r60.xyzw = (uint4)r60.xyzw << int4(2,2,2,2);
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r31.z, r60.x, u6.xxxx
+              r56.xyzw = (int4)r56.xyzw & int4(1,1,1,1);
+              bitmask.z = ((~(-1 << 16)) << 16) & 0xffffffff;  r31.z = (((uint)r40.w << 16) & bitmask.z) | ((uint)r31.z & ~bitmask.z);
+              bitmask.w = ((~(-1 << 16)) << 0) & 0xffffffff;  r31.w = (((uint)r40.w << 0) & bitmask.w) | ((uint)r31.z & ~bitmask.w);
+              r61.xyzw = (int4)-r56.xyzw + int4(1,1,1,1);
+              r31.w = (int)r31.w * (int)r61.x;
+              r31.z = mad((int)r31.z, (int)r56.x, (int)r31.w);
+            // No code for instruction (needs manual fix):
+                        store_raw u6.x, r60.x, r31.z
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r31.z, r60.y, u7.xxxx
+              bitmask.z = ((~(-1 << 16)) << 16) & 0xffffffff;  r31.z = (((uint)r40.w << 16) & bitmask.z) | ((uint)r31.z & ~bitmask.z);
+              bitmask.w = ((~(-1 << 16)) << 0) & 0xffffffff;  r31.w = (((uint)r40.w << 0) & bitmask.w) | ((uint)r31.z & ~bitmask.w);
+              r31.w = (int)r61.y * (int)r31.w;
+              r31.z = mad((int)r31.z, (int)r56.y, (int)r31.w);
+            // No code for instruction (needs manual fix):
+                        store_raw u7.x, r60.y, r31.z
+              r31.z = (int)r31.x + 1;
+              r51.xzw = min(float3(2000,2000,2000), r27.xyz);
+              r51.xzw = f32tof16(r51.xzw);
+              r55.x = mad((int)r51.z, 0x00010000, (int)r51.x);
+              r31.w = (int)r31.x * asint(cb0[7].x);
+              r37.y = min(2000, r38.x);
+              r37.y = f32tof16(r37.y);
+              r55.y = mad((int)r37.y, 0x00010000, (int)r51.w);
+            // No code for instruction (needs manual fix):
+                        store_raw u1.xy, r31.w, r55.xyxx
+              r39.xyz = r39.xyz * float3(127.5,127.5,127.5) + float3(127.5,127.5,127.5);
+              r39.xyz = (uint3)r39.xyz;
+              r31.w = mad((int)r39.y, 256, (int)r39.x);
+              r31.w = mad((int)r39.z, 0x00010000, (int)r31.w);
+              r37.yz = r38.yz * float2(127.5,127.5) + float2(127.5,127.5);
+              r37.yz = (uint2)r37.yz;
+              r31.w = mad((int)r37.y, 0x01000000, (int)r31.w);
+              r38.xyz = mad((int3)r31.xxx, asint(cb0[7].xxx), asint(cb0[5].yzw));
+            // No code for instruction (needs manual fix):
+                        store_raw u1.x, r38.x, r31.w
+              r39.xyz = r40.xyz * float3(127.5,127.5,127.5) + float3(127.5,127.5,127.5);
+              r39.xyz = (uint3)r39.xyz;
+              r31.w = mad((int)r39.y, 256, (int)r39.x);
+              r31.w = mad((int)r39.z, 0x00010000, (int)r31.w);
+              r31.w = mad((int)r37.z, 0x01000000, (int)r31.w);
+            // No code for instruction (needs manual fix):
+                        store_raw u1.x, r38.y, r31.w
+              r37.yz = min(float2(2000,2000), r41.xy);
+              r37.yz = f32tof16(r37.yz);
+              r31.w = mad((int)r37.z, 0x00010000, (int)r37.y);
+            // No code for instruction (needs manual fix):
+                        store_raw u1.x, r38.z, r31.w
+              if (r13.y != 0) {
+                r31.w = mad((int)r31.x, asint(cb0[7].x), (int)r13.y);
+                r32.w = 1 * r32.w;
+                r32.w = (uint)r32.w;
+                r36.xz = float2(1,1) * r36.xz;
+                r36.xz = (uint2)r36.xz;
+                r32.w = mad((int)r36.x, 256, (int)r32.w);
+                r32.w = mad((int)r36.z, 0x00010000, (int)r32.w);
+                r30.w = 1 * r30.w;
+                r30.w = (uint)r30.w;
+                r30.w = mad((int)r30.w, 0x01000000, (int)r32.w);
+              // No code for instruction (needs manual fix):
+                            store_raw u1.x, r31.w, r30.w
+              }
+              r36.xz = mad((int2)r31.xx, asint(cb0[7].xx), asint(cb0[6].wz));
+            // No code for instruction (needs manual fix):
+                        store_raw u1.x, r36.x, r29.y
+              r68.xyzw = min(float4(2000,2000,2000,2000), r43.xyzw);
+              r68.xyzw = f32tof16(r68.xyzw);
+              r38.xy = mad((int2)r68.yw, int2(0x10000,0x10000), (int2)r68.xz);
+              bitmask.w = ((~(-1 << 24)) << 8) & 0xffffffff;  r30.w = (((uint)r44.y << 8) & bitmask.w) | ((uint)r41.w & ~bitmask.w);
+              r30.w = mad((int)r44.z, 0x00010000, (int)r30.w);
+              bitmask.z = ((~(-1 << 24)) << 0) & 0xffffffff;  r38.z = (((uint)r30.w << 0) & bitmask.z) | ((uint)r41.w & ~bitmask.z);
+            // No code for instruction (needs manual fix):
+                        store_raw u1.xyz, r36.z, r38.xyzx
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r30.w, r57.z, u3.xxxx
+              bitmask.x = ((~(-1 << 16)) << 16) & 0xffffffff;  r36.x = (((uint)r31.x << 16) & bitmask.x) | ((uint)r30.w & ~bitmask.x);
+              bitmask.z = ((~(-1 << 16)) << 0) & 0xffffffff;  r36.z = (((uint)r31.x << 0) & bitmask.z) | ((uint)r30.w & ~bitmask.z);
+              r30.w = (int)r58.z * (int)r36.z;
+              r30.w = mad((int)r36.x, (int)r55.z, (int)r30.w);
+            // No code for instruction (needs manual fix):
+                        store_raw u3.x, r57.z, r30.w
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r30.w, r57.w, u5.xxxx
+              bitmask.x = ((~(-1 << 16)) << 16) & 0xffffffff;  r36.x = (((uint)r31.x << 16) & bitmask.x) | ((uint)r30.w & ~bitmask.x);
+              bitmask.z = ((~(-1 << 16)) << 0) & 0xffffffff;  r36.z = (((uint)r31.x << 0) & bitmask.z) | ((uint)r30.w & ~bitmask.z);
+              r30.w = (int)r58.w * (int)r36.z;
+              r30.w = mad((int)r36.x, (int)r55.w, (int)r30.w);
+            // No code for instruction (needs manual fix):
+                        store_raw u5.x, r57.w, r30.w
+              r55.xyzw = (int4)r19.xyxy + int4(5,5,6,6);
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r30.w, r60.z, u6.xxxx
+              bitmask.x = ((~(-1 << 16)) << 16) & 0xffffffff;  r36.x = (((uint)r31.x << 16) & bitmask.x) | ((uint)r30.w & ~bitmask.x);
+              bitmask.z = ((~(-1 << 16)) << 0) & 0xffffffff;  r36.z = (((uint)r31.x << 0) & bitmask.z) | ((uint)r30.w & ~bitmask.z);
+              r30.w = (int)r61.z * (int)r36.z;
+              r30.w = mad((int)r36.x, (int)r56.z, (int)r30.w);
+            // No code for instruction (needs manual fix):
+                        store_raw u6.x, r60.z, r30.w
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r30.w, r60.w, u7.xxxx
+              bitmask.x = ((~(-1 << 16)) << 16) & 0xffffffff;  r31.x = (((uint)r31.x << 16) & bitmask.x) | ((uint)r30.w & ~bitmask.x);
+              bitmask.w = ((~(-1 << 16)) << 0) & 0xffffffff;  r31.w = (((uint)r31.x << 0) & bitmask.w) | ((uint)r30.w & ~bitmask.w);
+              r30.w = (int)r61.w * (int)r31.w;
+              r30.w = mad((int)r31.x, (int)r56.w, (int)r30.w);
+            // No code for instruction (needs manual fix):
+                        store_raw u7.x, r60.w, r30.w
+              r56.xyzw = (int4)r20.xyxy + int4(5,5,6,6);
+              r30.w = (int)r31.z + 1;
+              r38.xyz = min(float3(2000,2000,2000), r53.xyz);
+              r38.xyz = f32tof16(r38.xyz);
+              r38.x = mad((int)r38.y, 0x00010000, (int)r38.x);
+              r31.x = (int)r31.z * asint(cb0[7].x);
+              r31.w = min(2000, r64.x);
+              r31.w = f32tof16(r31.w);
+              r38.y = mad((int)r31.w, 0x00010000, (int)r38.z);
+            // No code for instruction (needs manual fix):
+                        store_raw u1.xy, r31.x, r38.xyxx
+              r39.xyz = r62.xyz * float3(127.5,127.5,127.5) + float3(127.5,127.5,127.5);
+              r39.xyz = (uint3)r39.xyz;
+              r31.xw = (uint2)r39.yz << int2(8,16);
+              r31.x = (int)r31.x | (int)r39.x;
+              r31.x = (int)r31.w | (int)r31.x;
+              r36.xz = r64.yz * float2(127.5,127.5) + float2(127.5,127.5);
+              r36.xz = (uint2)r36.xz;
+              r36.xz = (uint2)r36.xz << int2(24,24);
+              r31.x = (int)r31.x | (int)r36.x;
+              r39.xyz = mad((int3)r31.zzz, asint(cb0[7].xxx), asint(cb0[5].yzw));
+            // No code for instruction (needs manual fix):
+                        store_raw u1.x, r39.x, r31.x
+              r40.xyz = r63.xyz * float3(127.5,127.5,127.5) + float3(127.5,127.5,127.5);
+              r40.xyz = (uint3)r40.xyz;
+              r37.yz = (uint2)r40.yz << int2(8,16);
+              r31.w = (int)r37.y | (int)r40.x;
+              r31.w = (int)r37.z | (int)r31.w;
+              r31.w = (int)r36.z | (int)r31.w;
+            // No code for instruction (needs manual fix):
+                        store_raw u1.x, r39.y, r31.w
+              r36.xz = min(float2(2000,2000), r65.xy);
+              r36.xz = f32tof16(r36.xz);
+              r32.w = mad((int)r36.z, 0x00010000, (int)r36.x);
+            // No code for instruction (needs manual fix):
+                        store_raw u1.x, r39.z, r32.w
+              if (r13.y != 0) {
+                r36.x = mad((int)r31.z, asint(cb0[7].x), (int)r13.y);
+                r53.xyzw = float4(255,255,255,255) * r42.xyzw;
+                r53.xyzw = (uint4)r53.xyzw;
+                r39.xyz = (uint3)r53.yzw << int3(8,16,24);
+                r36.z = (int)r39.x | (int)r53.x;
+                r36.z = (int)r39.y | (int)r36.z;
+                r36.z = (int)r39.z | (int)r36.z;
+              // No code for instruction (needs manual fix):
+                            store_raw u1.x, r36.x, r36.z
+              }
+              r36.xz = mad((int2)r31.zz, asint(cb0[7].xx), asint(cb0[6].wz));
+            // No code for instruction (needs manual fix):
+                        store_raw u1.x, r36.x, r38.w
+              r53.xyzw = min(float4(2000,2000,2000,2000), r66.xyzw);
+              r53.xyzw = f32tof16(r53.xyzw);
+              r39.xy = mad((int2)r53.yw, int2(0x10000,0x10000), (int2)r53.xz);
+              r36.x = mad((int)r67.y, 256, (int)r67.x);
+              r36.x = mad((int)r67.z, 0x00010000, (int)r36.x);
+              r39.z = mad((int)r67.w, 0x01000000, (int)r36.x);
+            // No code for instruction (needs manual fix):
+                        store_raw u1.xyz, r36.z, r39.xyzx
+              r53.xyzw = (uint4)r55.xyzw >> int4(1,1,1,1);
+              r53.xyzw = (uint4)r53.xyzw << int4(2,2,2,2);
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r36.x, r53.x, u3.xxxx
+              r55.xyzw = (int4)r55.xyzw & int4(1,1,1,1);
+              bitmask.x = ((~(-1 << 16)) << 16) & 0xffffffff;  r36.x = (((uint)r31.z << 16) & bitmask.x) | ((uint)r36.x & ~bitmask.x);
+              bitmask.z = ((~(-1 << 16)) << 0) & 0xffffffff;  r36.z = (((uint)r31.z << 0) & bitmask.z) | ((uint)r36.x & ~bitmask.z);
+              r57.xyzw = (int4)-r55.xyzw + int4(1,1,1,1);
+              r36.z = (int)r36.z * (int)r57.x;
+              r36.x = mad((int)r36.x, (int)r55.x, (int)r36.z);
+            // No code for instruction (needs manual fix):
+                        store_raw u3.x, r53.x, r36.x
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r36.x, r53.y, u5.xxxx
+              bitmask.x = ((~(-1 << 16)) << 16) & 0xffffffff;  r36.x = (((uint)r31.z << 16) & bitmask.x) | ((uint)r36.x & ~bitmask.x);
+              bitmask.z = ((~(-1 << 16)) << 0) & 0xffffffff;  r36.z = (((uint)r31.z << 0) & bitmask.z) | ((uint)r36.x & ~bitmask.z);
+              r36.z = (int)r57.y * (int)r36.z;
+              r36.x = mad((int)r36.x, (int)r55.y, (int)r36.z);
+            // No code for instruction (needs manual fix):
+                        store_raw u5.x, r53.y, r36.x
+              r58.xyzw = (uint4)r56.xyzw >> int4(1,1,1,1);
+              r58.xyzw = (uint4)r58.xyzw << int4(2,2,2,2);
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r36.x, r58.x, u6.xxxx
+              r56.xyzw = (int4)r56.xyzw & int4(1,1,1,1);
+              bitmask.x = ((~(-1 << 16)) << 16) & 0xffffffff;  r36.x = (((uint)r31.z << 16) & bitmask.x) | ((uint)r36.x & ~bitmask.x);
+              bitmask.z = ((~(-1 << 16)) << 0) & 0xffffffff;  r36.z = (((uint)r31.z << 0) & bitmask.z) | ((uint)r36.x & ~bitmask.z);
+              r60.xyzw = (int4)-r56.xyzw + int4(1,1,1,1);
+              r36.z = (int)r36.z * (int)r60.x;
+              r36.x = mad((int)r36.x, (int)r56.x, (int)r36.z);
+            // No code for instruction (needs manual fix):
+                        store_raw u6.x, r58.x, r36.x
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r36.x, r58.y, u7.xxxx
+              bitmask.x = ((~(-1 << 16)) << 16) & 0xffffffff;  r36.x = (((uint)r31.z << 16) & bitmask.x) | ((uint)r36.x & ~bitmask.x);
+              bitmask.z = ((~(-1 << 16)) << 0) & 0xffffffff;  r36.z = (((uint)r31.z << 0) & bitmask.z) | ((uint)r36.x & ~bitmask.z);
+              r36.z = (int)r60.y * (int)r36.z;
+              r36.x = mad((int)r36.x, (int)r56.y, (int)r36.z);
+            // No code for instruction (needs manual fix):
+                        store_raw u7.x, r58.y, r36.x
+              r36.x = cmp((int)r28.w == 0x0000ffff);
+              if (r36.x != 0) {
+                r36.x = (int)r30.w + 1;
+                r36.z = (int)r30.w * asint(cb0[7].x);
+              // No code for instruction (needs manual fix):
+                            store_raw u1.xy, r36.z, r54.xyxx
+                r40.xyz = mad((int3)r30.www, asint(cb0[7].xxx), asint(cb0[5].yzw));
+              // No code for instruction (needs manual fix):
+                            store_raw u1.x, r40.x, r31.y
+              // No code for instruction (needs manual fix):
+                            store_raw u1.x, r40.y, r32.y
+              // No code for instruction (needs manual fix):
+                            store_raw u1.x, r40.z, r32.z
+                if (r13.y != 0) {
+                  r36.z = mad((int)r30.w, asint(cb0[7].x), (int)r13.y);
+                  r61.xyzw = float4(255,255,255,255) * r34.xyzw;
+                  r61.xyzw = (uint4)r61.xyzw;
+                  r40.xyz = (uint3)r61.yzw << int3(8,16,24);
+                  r37.y = (int)r40.x | (int)r61.x;
+                  r37.y = (int)r40.y | (int)r37.y;
+                  r37.y = (int)r40.z | (int)r37.y;
+                // No code for instruction (needs manual fix):
+                                store_raw u1.x, r36.z, r37.y
+                }
+                r37.yz = mad((int2)r30.ww, asint(cb0[7].xx), asint(cb0[6].wz));
+              // No code for instruction (needs manual fix):
+                            store_raw u1.x, r37.y, r39.w
+              // No code for instruction (needs manual fix):
+                            store_raw u1.xyz, r37.z, r49.xyzx
+                r28.w = r30.w;
+                r30.w = r36.x;
+              }
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r36.x, r53.z, u3.xxxx
+              bitmask.x = ((~(-1 << 16)) << 16) & 0xffffffff;  r36.x = (((uint)r28.w << 16) & bitmask.x) | ((uint)r36.x & ~bitmask.x);
+              bitmask.z = ((~(-1 << 16)) << 0) & 0xffffffff;  r36.z = (((uint)r28.w << 0) & bitmask.z) | ((uint)r36.x & ~bitmask.z);
+              r36.z = (int)r57.z * (int)r36.z;
+              r36.x = mad((int)r36.x, (int)r55.z, (int)r36.z);
+            // No code for instruction (needs manual fix):
+                        store_raw u3.x, r53.z, r36.x
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r36.x, r53.w, u5.xxxx
+              bitmask.x = ((~(-1 << 16)) << 16) & 0xffffffff;  r36.x = (((uint)r28.w << 16) & bitmask.x) | ((uint)r36.x & ~bitmask.x);
+              bitmask.z = ((~(-1 << 16)) << 0) & 0xffffffff;  r36.z = (((uint)r28.w << 0) & bitmask.z) | ((uint)r36.x & ~bitmask.z);
+              r36.z = (int)r57.w * (int)r36.z;
+              r36.x = mad((int)r36.x, (int)r55.w, (int)r36.z);
+            // No code for instruction (needs manual fix):
+                        store_raw u5.x, r53.w, r36.x
+              r53.xyzw = (int4)r19.xyxy + int4(7,7,8,8);
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r36.x, r58.z, u6.xxxx
+              bitmask.x = ((~(-1 << 16)) << 16) & 0xffffffff;  r36.x = (((uint)r28.w << 16) & bitmask.x) | ((uint)r36.x & ~bitmask.x);
+              bitmask.z = ((~(-1 << 16)) << 0) & 0xffffffff;  r36.z = (((uint)r28.w << 0) & bitmask.z) | ((uint)r36.x & ~bitmask.z);
+              r36.z = (int)r60.z * (int)r36.z;
+              r36.x = mad((int)r36.x, (int)r56.z, (int)r36.z);
+            // No code for instruction (needs manual fix):
+                        store_raw u6.x, r58.z, r36.x
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r36.x, r58.w, u7.xxxx
+              bitmask.x = ((~(-1 << 16)) << 16) & 0xffffffff;  r36.x = (((uint)r28.w << 16) & bitmask.x) | ((uint)r36.x & ~bitmask.x);
+              bitmask.z = ((~(-1 << 16)) << 0) & 0xffffffff;  r36.z = (((uint)r28.w << 0) & bitmask.z) | ((uint)r36.x & ~bitmask.z);
+              r36.z = (int)r60.w * (int)r36.z;
+              r36.x = mad((int)r36.x, (int)r56.w, (int)r36.z);
+            // No code for instruction (needs manual fix):
+                        store_raw u7.x, r58.w, r36.x
+              r55.xyzw = (int4)r20.xyxy + int4(7,7,8,8);
+              r36.x = cmp((int)r31.z == 0x0000ffff);
+              if (r36.x != 0) {
+                r36.x = (int)r30.w + 1;
+                r36.z = (int)r30.w * asint(cb0[7].x);
+              // No code for instruction (needs manual fix):
+                            store_raw u1.xy, r36.z, r38.xyxx
+                r40.xyz = mad((int3)r30.www, asint(cb0[7].xxx), asint(cb0[5].yzw));
+              // No code for instruction (needs manual fix):
+                            store_raw u1.x, r40.x, r31.x
+              // No code for instruction (needs manual fix):
+                            store_raw u1.x, r40.y, r31.w
+              // No code for instruction (needs manual fix):
+                            store_raw u1.x, r40.z, r32.w
+                if (r13.y != 0) {
+                  r36.z = mad((int)r30.w, asint(cb0[7].x), (int)r13.y);
+                  r56.xyzw = float4(255,255,255,255) * r42.xyzw;
+                  r56.xyzw = (uint4)r56.xyzw;
+                  r40.xyz = (uint3)r56.yzw << int3(8,16,24);
+                  r37.y = (int)r40.x | (int)r56.x;
+                  r37.y = (int)r40.y | (int)r37.y;
+                  r37.y = (int)r40.z | (int)r37.y;
+                // No code for instruction (needs manual fix):
+                                store_raw u1.x, r36.z, r37.y
+                }
+                r37.yz = mad((int2)r30.ww, asint(cb0[7].xx), asint(cb0[6].wz));
+              // No code for instruction (needs manual fix):
+                            store_raw u1.x, r37.y, r38.w
+              // No code for instruction (needs manual fix):
+                            store_raw u1.xyz, r37.z, r39.xyzx
+                r31.z = r30.w;
+                r30.w = r36.x;
+              }
+              r56.xyzw = (uint4)r53.xyzw >> int4(1,1,1,1);
+              r56.xyzw = (uint4)r56.xyzw << int4(2,2,2,2);
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r36.x, r56.x, u3.xxxx
+              r53.xyzw = (int4)r53.xyzw & int4(1,1,1,1);
+              bitmask.x = ((~(-1 << 16)) << 16) & 0xffffffff;  r36.x = (((uint)r31.z << 16) & bitmask.x) | ((uint)r36.x & ~bitmask.x);
+              bitmask.z = ((~(-1 << 16)) << 0) & 0xffffffff;  r36.z = (((uint)r31.z << 0) & bitmask.z) | ((uint)r36.x & ~bitmask.z);
+              r57.xyzw = (int4)-r53.xyzw + int4(1,1,1,1);
+              r36.z = (int)r36.z * (int)r57.x;
+              r36.x = mad((int)r36.x, (int)r53.x, (int)r36.z);
+            // No code for instruction (needs manual fix):
+                        store_raw u3.x, r56.x, r36.x
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r36.x, r56.y, u5.xxxx
+              bitmask.x = ((~(-1 << 16)) << 16) & 0xffffffff;  r36.x = (((uint)r31.z << 16) & bitmask.x) | ((uint)r36.x & ~bitmask.x);
+              bitmask.z = ((~(-1 << 16)) << 0) & 0xffffffff;  r36.z = (((uint)r31.z << 0) & bitmask.z) | ((uint)r36.x & ~bitmask.z);
+              r36.z = (int)r57.y * (int)r36.z;
+              r36.x = mad((int)r36.x, (int)r53.y, (int)r36.z);
+            // No code for instruction (needs manual fix):
+                        store_raw u5.x, r56.y, r36.x
+              r58.xyzw = (uint4)r55.xyzw >> int4(1,1,1,1);
+              r58.xyzw = (uint4)r58.xyzw << int4(2,2,2,2);
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r36.x, r58.x, u6.xxxx
+              r55.xyzw = (int4)r55.xyzw & int4(1,1,1,1);
+              bitmask.x = ((~(-1 << 16)) << 16) & 0xffffffff;  r36.x = (((uint)r31.z << 16) & bitmask.x) | ((uint)r36.x & ~bitmask.x);
+              bitmask.z = ((~(-1 << 16)) << 0) & 0xffffffff;  r36.z = (((uint)r31.z << 0) & bitmask.z) | ((uint)r36.x & ~bitmask.z);
+              r60.xyzw = (int4)-r55.xyzw + int4(1,1,1,1);
+              r36.z = (int)r36.z * (int)r60.x;
+              r36.x = mad((int)r36.x, (int)r55.x, (int)r36.z);
+            // No code for instruction (needs manual fix):
+                        store_raw u6.x, r58.x, r36.x
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r36.x, r58.y, u7.xxxx
+              bitmask.x = ((~(-1 << 16)) << 16) & 0xffffffff;  r36.x = (((uint)r31.z << 16) & bitmask.x) | ((uint)r36.x & ~bitmask.x);
+              bitmask.z = ((~(-1 << 16)) << 0) & 0xffffffff;  r36.z = (((uint)r31.z << 0) & bitmask.z) | ((uint)r36.x & ~bitmask.z);
+              r36.z = (int)r60.y * (int)r36.z;
+              r36.x = mad((int)r36.x, (int)r55.y, (int)r36.z);
+            // No code for instruction (needs manual fix):
+                        store_raw u7.x, r58.y, r36.x
+              r18.w = (int)r30.w + 1;
+              r40.xyz = min(float3(2000,2000,2000), r28.xyz);
+              r40.xyz = f32tof16(r40.xyz);
+              r40.x = mad((int)r40.y, 0x00010000, (int)r40.x);
+              r36.x = (int)r30.w * asint(cb0[7].x);
+              r36.z = min(2000, r45.x);
+              r36.z = f32tof16(r36.z);
+              r40.y = mad((int)r36.z, 0x00010000, (int)r40.z);
+            // No code for instruction (needs manual fix):
+                        store_raw u1.xy, r36.x, r40.xyxx
+              r40.xyz = r47.xyz * float3(127.5,127.5,127.5) + float3(127.5,127.5,127.5);
+              r40.xyz = (uint3)r40.xyz;
+              r36.x = mad((int)r40.y, 256, (int)r40.x);
+              r36.x = mad((int)r40.z, 0x00010000, (int)r36.x);
+              r37.yz = r45.yz * float2(127.5,127.5) + float2(127.5,127.5);
+              r37.yz = (uint2)r37.yz;
+              r36.x = mad((int)r37.y, 0x01000000, (int)r36.x);
+              r40.xyz = mad((int3)r30.www, asint(cb0[7].xxx), asint(cb0[5].yzw));
+            // No code for instruction (needs manual fix):
+                        store_raw u1.x, r40.x, r36.x
+              r41.xyz = r48.xyz * float3(127.5,127.5,127.5) + float3(127.5,127.5,127.5);
+              r41.xyz = (uint3)r41.xyz;
+              r36.x = mad((int)r41.y, 256, (int)r41.x);
+              r36.x = mad((int)r41.z, 0x00010000, (int)r36.x);
+              r36.x = mad((int)r37.z, 0x01000000, (int)r36.x);
+            // No code for instruction (needs manual fix):
+                        store_raw u1.x, r40.y, r36.x
+              r36.xz = min(float2(2000,2000), r46.xy);
+              r36.xz = f32tof16(r36.xz);
+              r36.x = mad((int)r36.z, 0x00010000, (int)r36.x);
+            // No code for instruction (needs manual fix):
+                        store_raw u1.x, r40.z, r36.x
+              if (r13.y != 0) {
+                r36.x = mad((int)r30.w, asint(cb0[7].x), (int)r13.y);
+                r36.z = 1 * r36.w;
+                r36.z = (uint)r36.z;
+                r37.yz = float2(1,1) * r46.zw;
+                r37.yz = (uint2)r37.yz;
+                r36.z = mad((int)r37.y, 256, (int)r36.z);
+                r36.z = mad((int)r37.z, 0x00010000, (int)r36.z);
+                r33.w = 1 * r33.w;
+                r33.w = (uint)r33.w;
+                r33.w = mad((int)r33.w, 0x01000000, (int)r36.z);
+              // No code for instruction (needs manual fix):
+                            store_raw u1.x, r36.x, r33.w
+              }
+              r36.xz = mad((int2)r30.ww, asint(cb0[7].xx), asint(cb0[6].wz));
+            // No code for instruction (needs manual fix):
+                        store_raw u1.x, r36.x, r29.z
+              r45.xyzw = min(float4(2000,2000,2000,2000), r50.xyzw);
+              r45.xyzw = f32tof16(r45.xyzw);
+              r40.xy = mad((int2)r45.yw, int2(0x10000,0x10000), (int2)r45.xz);
+              bitmask.w = ((~(-1 << 24)) << 8) & 0xffffffff;  r33.w = (((uint)r52.y << 8) & bitmask.w) | ((uint)r51.y & ~bitmask.w);
+              r33.w = mad((int)r52.z, 0x00010000, (int)r33.w);
+              bitmask.z = ((~(-1 << 24)) << 0) & 0xffffffff;  r40.z = (((uint)r33.w << 0) & bitmask.z) | ((uint)r51.y & ~bitmask.z);
+            // No code for instruction (needs manual fix):
+                        store_raw u1.xyz, r36.z, r40.xyzx
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r33.w, r56.z, u3.xxxx
+              bitmask.x = ((~(-1 << 16)) << 16) & 0xffffffff;  r36.x = (((uint)r30.w << 16) & bitmask.x) | ((uint)r33.w & ~bitmask.x);
+              bitmask.z = ((~(-1 << 16)) << 0) & 0xffffffff;  r36.z = (((uint)r30.w << 0) & bitmask.z) | ((uint)r33.w & ~bitmask.z);
+              r33.w = (int)r57.z * (int)r36.z;
+              r33.w = mad((int)r36.x, (int)r53.z, (int)r33.w);
+            // No code for instruction (needs manual fix):
+                        store_raw u3.x, r56.z, r33.w
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r33.w, r56.w, u5.xxxx
+              bitmask.x = ((~(-1 << 16)) << 16) & 0xffffffff;  r36.x = (((uint)r30.w << 16) & bitmask.x) | ((uint)r33.w & ~bitmask.x);
+              bitmask.z = ((~(-1 << 16)) << 0) & 0xffffffff;  r36.z = (((uint)r30.w << 0) & bitmask.z) | ((uint)r33.w & ~bitmask.z);
+              r33.w = (int)r57.w * (int)r36.z;
+              r33.w = mad((int)r36.x, (int)r53.w, (int)r33.w);
+            // No code for instruction (needs manual fix):
+                        store_raw u5.x, r56.w, r33.w
+              r45.xyzw = (int4)r19.xyxy + int4(9,9,10,10);
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r33.w, r58.z, u6.xxxx
+              bitmask.x = ((~(-1 << 16)) << 16) & 0xffffffff;  r36.x = (((uint)r30.w << 16) & bitmask.x) | ((uint)r33.w & ~bitmask.x);
+              bitmask.z = ((~(-1 << 16)) << 0) & 0xffffffff;  r36.z = (((uint)r30.w << 0) & bitmask.z) | ((uint)r33.w & ~bitmask.z);
+              r33.w = (int)r60.z * (int)r36.z;
+              r33.w = mad((int)r36.x, (int)r55.z, (int)r33.w);
+            // No code for instruction (needs manual fix):
+                        store_raw u6.x, r58.z, r33.w
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r33.w, r58.w, u7.xxxx
+              bitmask.x = ((~(-1 << 16)) << 16) & 0xffffffff;  r36.x = (((uint)r30.w << 16) & bitmask.x) | ((uint)r33.w & ~bitmask.x);
+              bitmask.z = ((~(-1 << 16)) << 0) & 0xffffffff;  r36.z = (((uint)r30.w << 0) & bitmask.z) | ((uint)r33.w & ~bitmask.z);
+              r30.w = (int)r60.w * (int)r36.z;
+              r30.w = mad((int)r36.x, (int)r55.w, (int)r30.w);
+            // No code for instruction (needs manual fix):
+                        store_raw u7.x, r58.w, r30.w
+              r46.xyzw = (int4)r20.xyxy + int4(9,9,10,10);
+              r30.w = cmp((int)r40.w == 0x0000ffff);
+              if (r30.w != 0) {
+                r30.w = (int)r18.w + 1;
+                r33.w = (int)r18.w * asint(cb0[7].x);
+              // No code for instruction (needs manual fix):
+                            store_raw u1.xy, r33.w, r30.xyxx
+                r36.xzw = mad((int3)r18.www, asint(cb0[7].xxx), asint(cb0[5].yzw));
+              // No code for instruction (needs manual fix):
+                            store_raw u1.x, r36.x, r29.w
+              // No code for instruction (needs manual fix):
+                            store_raw u1.x, r36.z, r30.z
+              // No code for instruction (needs manual fix):
+                            store_raw u1.x, r36.w, r32.x
+                if (r13.y != 0) {
+                  r29.w = mad((int)r18.w, asint(cb0[7].x), (int)r13.y);
+                  r47.xyzw = float4(255,255,255,255) * r59.xyzw;
+                  r47.xyzw = (uint4)r47.xyzw;
+                  r30.xyz = (uint3)r47.yzw << int3(8,16,24);
+                  r30.x = (int)r30.x | (int)r47.x;
+                  r30.x = (int)r30.y | (int)r30.x;
+                  r30.x = (int)r30.z | (int)r30.x;
+                // No code for instruction (needs manual fix):
+                                store_raw u1.x, r29.w, r30.x
+                }
+                r30.xy = mad((int2)r18.ww, asint(cb0[7].xx), asint(cb0[6].wz));
+              // No code for instruction (needs manual fix):
+                            store_raw u1.x, r30.x, r37.x
+              // No code for instruction (needs manual fix):
+                            store_raw u1.xyz, r30.y, r33.xyzx
+                r40.w = r18.w;
+                r18.w = r30.w;
+              }
+              r30.xyzw = (uint4)r45.xyzw >> int4(1,1,1,1);
+              r30.xyzw = (uint4)r30.xyzw << int4(2,2,2,2);
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r29.w, r30.x, u3.xxxx
+              r33.xyzw = (int4)r45.xyzw & int4(1,1,1,1);
+              bitmask.x = ((~(-1 << 16)) << 16) & 0xffffffff;  r36.x = (((uint)r40.w << 16) & bitmask.x) | ((uint)r29.w & ~bitmask.x);
+              bitmask.z = ((~(-1 << 16)) << 0) & 0xffffffff;  r36.z = (((uint)r40.w << 0) & bitmask.z) | ((uint)r29.w & ~bitmask.z);
+              r45.xyzw = (int4)-r33.xyzw + int4(1,1,1,1);
+              r29.w = (int)r36.z * (int)r45.x;
+              r29.w = mad((int)r36.x, (int)r33.x, (int)r29.w);
+            // No code for instruction (needs manual fix):
+                        store_raw u3.x, r30.x, r29.w
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r29.w, r30.y, u5.xxxx
+              bitmask.x = ((~(-1 << 16)) << 16) & 0xffffffff;  r36.x = (((uint)r40.w << 16) & bitmask.x) | ((uint)r29.w & ~bitmask.x);
+              bitmask.z = ((~(-1 << 16)) << 0) & 0xffffffff;  r36.z = (((uint)r40.w << 0) & bitmask.z) | ((uint)r29.w & ~bitmask.z);
+              r29.w = (int)r45.y * (int)r36.z;
+              r29.w = mad((int)r36.x, (int)r33.y, (int)r29.w);
+            // No code for instruction (needs manual fix):
+                        store_raw u5.x, r30.y, r29.w
+              r47.xyzw = (uint4)r46.xyzw >> int4(1,1,1,1);
+              r47.xyzw = (uint4)r47.xyzw << int4(2,2,2,2);
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r29.w, r47.x, u6.xxxx
+              r46.xyzw = (int4)r46.xyzw & int4(1,1,1,1);
+              bitmask.x = ((~(-1 << 16)) << 16) & 0xffffffff;  r30.x = (((uint)r40.w << 16) & bitmask.x) | ((uint)r29.w & ~bitmask.x);
+              bitmask.y = ((~(-1 << 16)) << 0) & 0xffffffff;  r30.y = (((uint)r40.w << 0) & bitmask.y) | ((uint)r29.w & ~bitmask.y);
+              r48.xyzw = (int4)-r46.xyzw + int4(1,1,1,1);
+              r29.w = (int)r30.y * (int)r48.x;
+              r29.w = mad((int)r30.x, (int)r46.x, (int)r29.w);
+            // No code for instruction (needs manual fix):
+                        store_raw u6.x, r47.x, r29.w
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r29.w, r47.y, u7.xxxx
+              bitmask.x = ((~(-1 << 16)) << 16) & 0xffffffff;  r30.x = (((uint)r40.w << 16) & bitmask.x) | ((uint)r29.w & ~bitmask.x);
+              bitmask.y = ((~(-1 << 16)) << 0) & 0xffffffff;  r30.y = (((uint)r40.w << 0) & bitmask.y) | ((uint)r29.w & ~bitmask.y);
+              r29.w = (int)r48.y * (int)r30.y;
+              r29.w = mad((int)r30.x, (int)r46.y, (int)r29.w);
+            // No code for instruction (needs manual fix):
+                        store_raw u7.x, r47.y, r29.w
+              r29.w = cmp((int)r31.z == 0x0000ffff);
+              if (r29.w != 0) {
+                r29.w = (int)r18.w + 1;
+                r30.x = (int)r18.w * asint(cb0[7].x);
+              // No code for instruction (needs manual fix):
+                            store_raw u1.xy, r30.x, r38.xyxx
+                r36.xzw = mad((int3)r18.www, asint(cb0[7].xxx), asint(cb0[5].yzw));
+              // No code for instruction (needs manual fix):
+                            store_raw u1.x, r36.x, r31.x
+              // No code for instruction (needs manual fix):
+                            store_raw u1.x, r36.z, r31.w
+              // No code for instruction (needs manual fix):
+                            store_raw u1.x, r36.w, r32.w
+                if (r13.y != 0) {
+                  r30.x = mad((int)r18.w, asint(cb0[7].x), (int)r13.y);
+                  r40.xyzw = float4(255,255,255,255) * r42.xyzw;
+                  r40.xyzw = (uint4)r40.xyzw;
+                  r36.xzw = (uint3)r40.yzw << int3(8,16,24);
+                  r30.y = (int)r36.x | (int)r40.x;
+                  r30.y = (int)r36.z | (int)r30.y;
+                  r30.y = (int)r36.w | (int)r30.y;
+                // No code for instruction (needs manual fix):
+                                store_raw u1.x, r30.x, r30.y
+                }
+                r30.xy = mad((int2)r18.ww, asint(cb0[7].xx), asint(cb0[6].wz));
+              // No code for instruction (needs manual fix):
+                            store_raw u1.x, r30.x, r38.w
+              // No code for instruction (needs manual fix):
+                            store_raw u1.xyz, r30.y, r39.xyzx
+                r31.z = r18.w;
+                r18.w = r29.w;
+              }
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r29.w, r30.z, u3.xxxx
+              bitmask.x = ((~(-1 << 16)) << 16) & 0xffffffff;  r30.x = (((uint)r31.z << 16) & bitmask.x) | ((uint)r29.w & ~bitmask.x);
+              bitmask.y = ((~(-1 << 16)) << 0) & 0xffffffff;  r30.y = (((uint)r31.z << 0) & bitmask.y) | ((uint)r29.w & ~bitmask.y);
+              r29.w = (int)r45.z * (int)r30.y;
+              r29.w = mad((int)r30.x, (int)r33.z, (int)r29.w);
+            // No code for instruction (needs manual fix):
+                        store_raw u3.x, r30.z, r29.w
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r29.w, r30.w, u5.xxxx
+              bitmask.x = ((~(-1 << 16)) << 16) & 0xffffffff;  r30.x = (((uint)r31.z << 16) & bitmask.x) | ((uint)r29.w & ~bitmask.x);
+              bitmask.y = ((~(-1 << 16)) << 0) & 0xffffffff;  r30.y = (((uint)r31.z << 0) & bitmask.y) | ((uint)r29.w & ~bitmask.y);
+              r29.w = (int)r45.w * (int)r30.y;
+              r29.w = mad((int)r30.x, (int)r33.w, (int)r29.w);
+            // No code for instruction (needs manual fix):
+                        store_raw u5.x, r30.w, r29.w
+              r19.xyzw = (int4)r19.xyxy + int4(12,12,11,11);
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r29.w, r47.z, u6.xxxx
+              bitmask.x = ((~(-1 << 16)) << 16) & 0xffffffff;  r30.x = (((uint)r31.z << 16) & bitmask.x) | ((uint)r29.w & ~bitmask.x);
+              bitmask.y = ((~(-1 << 16)) << 0) & 0xffffffff;  r30.y = (((uint)r31.z << 0) & bitmask.y) | ((uint)r29.w & ~bitmask.y);
+              r29.w = (int)r48.z * (int)r30.y;
+              r29.w = mad((int)r30.x, (int)r46.z, (int)r29.w);
+            // No code for instruction (needs manual fix):
+                        store_raw u6.x, r47.z, r29.w
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r29.w, r47.w, u7.xxxx
+              bitmask.x = ((~(-1 << 16)) << 16) & 0xffffffff;  r30.x = (((uint)r31.z << 16) & bitmask.x) | ((uint)r29.w & ~bitmask.x);
+              bitmask.y = ((~(-1 << 16)) << 0) & 0xffffffff;  r30.y = (((uint)r31.z << 0) & bitmask.y) | ((uint)r29.w & ~bitmask.y);
+              r29.w = (int)r48.w * (int)r30.y;
+              r29.w = mad((int)r30.x, (int)r46.w, (int)r29.w);
+            // No code for instruction (needs manual fix):
+                        store_raw u7.x, r47.w, r29.w
+              r20.xyzw = (int4)r20.xyxy + int4(12,12,11,11);
+              r29.w = cmp((int)r28.w == 0x0000ffff);
+              if (r29.w != 0) {
+                r29.w = (int)r18.w + 1;
+                r30.x = (int)r18.w * asint(cb0[7].x);
+              // No code for instruction (needs manual fix):
+                            store_raw u1.xy, r30.x, r54.xyxx
+                r30.xyz = mad((int3)r18.www, asint(cb0[7].xxx), asint(cb0[5].yzw));
+              // No code for instruction (needs manual fix):
+                            store_raw u1.x, r30.x, r31.y
+              // No code for instruction (needs manual fix):
+                            store_raw u1.x, r30.y, r32.y
+              // No code for instruction (needs manual fix):
+                            store_raw u1.x, r30.z, r32.z
+                if (r13.y != 0) {
+                  r30.x = mad((int)r18.w, asint(cb0[7].x), (int)r13.y);
+                  r31.xyzw = float4(255,255,255,255) * r34.xyzw;
+                  r31.xyzw = (uint4)r31.xyzw;
+                  r30.yzw = (uint3)r31.yzw << int3(8,16,24);
+                  r30.y = (int)r30.y | (int)r31.x;
+                  r30.y = (int)r30.z | (int)r30.y;
+                  r30.y = (int)r30.w | (int)r30.y;
+                // No code for instruction (needs manual fix):
+                                store_raw u1.x, r30.x, r30.y
+                }
+                r30.xy = mad((int2)r18.ww, asint(cb0[7].xx), asint(cb0[6].wz));
+              // No code for instruction (needs manual fix):
+                            store_raw u1.x, r30.x, r39.w
+              // No code for instruction (needs manual fix):
+                            store_raw u1.xyz, r30.y, r49.xyzx
+                r28.w = r18.w;
+                r18.w = r29.w;
+              }
+              r30.xy = (uint2)r19.zw >> int2(1,1);
+              r30.xy = (uint2)r30.xy << int2(2,2);
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r29.w, r30.x, u3.xxxx
+              r19.zw = (int2)r19.zw & int2(1,1);
+              bitmask.z = ((~(-1 << 16)) << 16) & 0xffffffff;  r30.z = (((uint)r28.w << 16) & bitmask.z) | ((uint)r29.w & ~bitmask.z);
+              bitmask.w = ((~(-1 << 16)) << 0) & 0xffffffff;  r30.w = (((uint)r28.w << 0) & bitmask.w) | ((uint)r29.w & ~bitmask.w);
+              r31.xy = (int2)-r19.zw + int2(1,1);
+              r29.w = (int)r30.w * (int)r31.x;
+              r19.z = mad((int)r30.z, (int)r19.z, (int)r29.w);
+            // No code for instruction (needs manual fix):
+                        store_raw u3.x, r30.x, r19.z
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r19.z, r30.y, u5.xxxx
+              bitmask.x = ((~(-1 << 16)) << 16) & 0xffffffff;  r30.x = (((uint)r28.w << 16) & bitmask.x) | ((uint)r19.z & ~bitmask.x);
+              bitmask.z = ((~(-1 << 16)) << 0) & 0xffffffff;  r30.z = (((uint)r28.w << 0) & bitmask.z) | ((uint)r19.z & ~bitmask.z);
+              r19.z = (int)r31.y * (int)r30.z;
+              r19.z = mad((int)r30.x, (int)r19.w, (int)r19.z);
+            // No code for instruction (needs manual fix):
+                        store_raw u5.x, r30.y, r19.z
+              r19.zw = (uint2)r20.zw >> int2(1,1);
+              r19.zw = (uint2)r19.zw << int2(2,2);
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r29.w, r19.z, u6.xxxx
+              r30.xy = (int2)r20.zw & int2(1,1);
+              bitmask.z = ((~(-1 << 16)) << 16) & 0xffffffff;  r30.z = (((uint)r28.w << 16) & bitmask.z) | ((uint)r29.w & ~bitmask.z);
+              bitmask.w = ((~(-1 << 16)) << 0) & 0xffffffff;  r30.w = (((uint)r28.w << 0) & bitmask.w) | ((uint)r29.w & ~bitmask.w);
+              r31.xy = (int2)-r30.xy + int2(1,1);
+              r29.w = (int)r30.w * (int)r31.x;
+              r29.w = mad((int)r30.z, (int)r30.x, (int)r29.w);
+            // No code for instruction (needs manual fix):
+                        store_raw u6.x, r19.z, r29.w
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r19.z, r19.w, u7.xxxx
+              bitmask.x = ((~(-1 << 16)) << 16) & 0xffffffff;  r30.x = (((uint)r28.w << 16) & bitmask.x) | ((uint)r19.z & ~bitmask.x);
+              bitmask.z = ((~(-1 << 16)) << 0) & 0xffffffff;  r30.z = (((uint)r28.w << 0) & bitmask.z) | ((uint)r19.z & ~bitmask.z);
+              r19.z = (int)r31.y * (int)r30.z;
+              r19.z = mad((int)r30.x, (int)r30.y, (int)r19.z);
+            // No code for instruction (needs manual fix):
+                        store_raw u7.x, r19.w, r19.z
+              r30.xyzw = cmp(float4(0,0,0,0) < r35.xyzw);
+              if (r30.x != 0) {
+                if (3 == 0) r19.z = 0; else if (3+5 < 32) {                 r19.z = (uint)r36.y << (32-(3 + 5)); r19.z = (uint)r19.z >> (32-3);                } else r19.z = (uint)r36.y >> 5;
+                r31.xyzw = cmp((int4)r19.zzzz == int4(0,1,2,3));
+                r32.xyzw = cmp((int4)r19.zzzz == int4(4,5,6,7));
+                r31.xyzw = r31.xyzw ? r15.xyzw : 0;
+                r19.w = (int)r31.x | (int)r31.y;
+                r19.w = (int)r19.w | (int)r31.z;
+                r19.w = (int)r19.w | (int)r31.w;
+                r31.xyzw = r32.xyzw ? r16.xyzw : 0;
+                r19.w = (int)r19.w | (int)r31.x;
+                r19.w = (int)r19.w | (int)r31.y;
+                r19.w = (int)r19.w | (int)r31.z;
+                r19.w = (int)r19.w | (int)r31.w;
+                bitmask.w = ((~(-1 << 1)) << r36.y) & 0xffffffff;  r19.w = (((uint)1 << r36.y) & bitmask.w) | ((uint)r19.w & ~bitmask.w);
+                r19.z = 1 << (int)r19.z;
+                r31.xyzw = (int4)r19.zzzz & int4(1,2,4,8);
+                r31.xyzw = r31.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                r31.xyzw = (int4)r19.wwww * (int4)r31.xyzw;
+                r15.xyzw = (int4)r15.xyzw | (int4)r31.xyzw;
+                r31.xyzw = (int4)r19.zzzz & int4(16,32,64,128);
+                r31.xyzw = r31.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                r31.xyzw = (int4)r19.wwww * (int4)r31.xyzw;
+                r16.xyzw = (int4)r16.xyzw | (int4)r31.xyzw;
+              }
+              if (r30.y != 0) {
+                r19.z = (uint)r36.y >> 8;
+                if (3 == 0) r19.w = 0; else if (3+13 < 32) {                 r19.w = (uint)r36.y << (32-(3 + 13)); r19.w = (uint)r19.w >> (32-3);                } else r19.w = (uint)r36.y >> 13;
+                r31.xyzw = cmp((int4)r19.wwww == int4(0,1,2,3));
+                r32.xyzw = cmp((int4)r19.wwww == int4(4,5,6,7));
+                r31.xyzw = r31.xyzw ? r15.xyzw : 0;
+                r28.w = (int)r31.x | (int)r31.y;
+                r28.w = (int)r28.w | (int)r31.z;
+                r28.w = (int)r28.w | (int)r31.w;
+                r31.xyzw = r32.xyzw ? r16.xyzw : 0;
+                r28.w = (int)r28.w | (int)r31.x;
+                r28.w = (int)r28.w | (int)r31.y;
+                r28.w = (int)r28.w | (int)r31.z;
+                r28.w = (int)r28.w | (int)r31.w;
+                bitmask.z = ((~(-1 << 1)) << r19.z) & 0xffffffff;  r19.z = (((uint)1 << r19.z) & bitmask.z) | ((uint)r28.w & ~bitmask.z);
+                r19.w = 1 << (int)r19.w;
+                r31.xyzw = (int4)r19.wwww & int4(1,2,4,8);
+                r31.xyzw = r31.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                r31.xyzw = (int4)r19.zzzz * (int4)r31.xyzw;
+                r15.xyzw = (int4)r15.xyzw | (int4)r31.xyzw;
+                r31.xyzw = (int4)r19.wwww & int4(16,32,64,128);
+                r31.xyzw = r31.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                r31.xyzw = (int4)r19.zzzz * (int4)r31.xyzw;
+                r16.xyzw = (int4)r16.xyzw | (int4)r31.xyzw;
+              }
+              if (r30.z != 0) {
+                r19.z = (uint)r36.y >> 16;
+                if (3 == 0) r19.w = 0; else if (3+21 < 32) {                 r19.w = (uint)r36.y << (32-(3 + 21)); r19.w = (uint)r19.w >> (32-3);                } else r19.w = (uint)r36.y >> 21;
+                r31.xyzw = cmp((int4)r19.wwww == int4(0,1,2,3));
+                r32.xyzw = cmp((int4)r19.wwww == int4(4,5,6,7));
+                r31.xyzw = r31.xyzw ? r15.xyzw : 0;
+                r28.w = (int)r31.x | (int)r31.y;
+                r28.w = (int)r28.w | (int)r31.z;
+                r28.w = (int)r28.w | (int)r31.w;
+                r31.xyzw = r32.xyzw ? r16.xyzw : 0;
+                r28.w = (int)r28.w | (int)r31.x;
+                r28.w = (int)r28.w | (int)r31.y;
+                r28.w = (int)r28.w | (int)r31.z;
+                r28.w = (int)r28.w | (int)r31.w;
+                bitmask.z = ((~(-1 << 1)) << r19.z) & 0xffffffff;  r19.z = (((uint)1 << r19.z) & bitmask.z) | ((uint)r28.w & ~bitmask.z);
+                r19.w = 1 << (int)r19.w;
+                r31.xyzw = (int4)r19.wwww & int4(1,2,4,8);
+                r31.xyzw = r31.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                r31.xyzw = (int4)r19.zzzz * (int4)r31.xyzw;
+                r15.xyzw = (int4)r15.xyzw | (int4)r31.xyzw;
+                r31.xyzw = (int4)r19.wwww & int4(16,32,64,128);
+                r31.xyzw = r31.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                r31.xyzw = (int4)r19.zzzz * (int4)r31.xyzw;
+                r16.xyzw = (int4)r16.xyzw | (int4)r31.xyzw;
+              }
+              if (r30.w != 0) {
+                r19.z = (uint)r37.w >> 5;
+                r30.xyzw = cmp((int4)r19.zzzz == int4(0,1,2,3));
+                r31.xyzw = cmp((int4)r19.zzzz == int4(4,5,6,7));
+                r30.xyzw = r30.xyzw ? r15.xyzw : 0;
+                r19.w = (int)r30.x | (int)r30.y;
+                r19.w = (int)r19.w | (int)r30.z;
+                r19.w = (int)r19.w | (int)r30.w;
+                r30.xyzw = r31.xyzw ? r16.xyzw : 0;
+                r19.w = (int)r19.w | (int)r30.x;
+                r19.w = (int)r19.w | (int)r30.y;
+                r19.w = (int)r19.w | (int)r30.z;
+                r19.w = (int)r19.w | (int)r30.w;
+                bitmask.w = ((~(-1 << 1)) << r37.w) & 0xffffffff;  r19.w = (((uint)1 << r37.w) & bitmask.w) | ((uint)r19.w & ~bitmask.w);
+                r19.z = 1 << (int)r19.z;
+                r30.xyzw = (int4)r19.zzzz & int4(1,2,4,8);
+                r30.xyzw = r30.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                r30.xyzw = (int4)r19.wwww * (int4)r30.xyzw;
+                r15.xyzw = (int4)r15.xyzw | (int4)r30.xyzw;
+                r30.xyzw = (int4)r19.zzzz & int4(16,32,64,128);
+                r30.xyzw = r30.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                r30.xyzw = (int4)r19.wwww * (int4)r30.xyzw;
+                r16.xyzw = (int4)r16.xyzw | (int4)r30.xyzw;
+              }
+              r30.xyzw = cmp(float4(0,0,0,0) < r43.xyzw);
+              if (r30.x != 0) {
+                if (3 == 0) r19.z = 0; else if (3+5 < 32) {                 r19.z = (uint)r41.w << (32-(3 + 5)); r19.z = (uint)r19.z >> (32-3);                } else r19.z = (uint)r41.w >> 5;
+                r31.xyzw = cmp((int4)r19.zzzz == int4(0,1,2,3));
+                r32.xyzw = cmp((int4)r19.zzzz == int4(4,5,6,7));
+                r31.xyzw = r31.xyzw ? r15.xyzw : 0;
+                r19.w = (int)r31.x | (int)r31.y;
+                r19.w = (int)r19.w | (int)r31.z;
+                r19.w = (int)r19.w | (int)r31.w;
+                r31.xyzw = r32.xyzw ? r16.xyzw : 0;
+                r19.w = (int)r19.w | (int)r31.x;
+                r19.w = (int)r19.w | (int)r31.y;
+                r19.w = (int)r19.w | (int)r31.z;
+                r19.w = (int)r19.w | (int)r31.w;
+                bitmask.w = ((~(-1 << 1)) << r41.w) & 0xffffffff;  r19.w = (((uint)1 << r41.w) & bitmask.w) | ((uint)r19.w & ~bitmask.w);
+                r19.z = 1 << (int)r19.z;
+                r31.xyzw = (int4)r19.zzzz & int4(1,2,4,8);
+                r31.xyzw = r31.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                r31.xyzw = (int4)r19.wwww * (int4)r31.xyzw;
+                r15.xyzw = (int4)r15.xyzw | (int4)r31.xyzw;
+                r31.xyzw = (int4)r19.zzzz & int4(16,32,64,128);
+                r31.xyzw = r31.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                r31.xyzw = (int4)r19.wwww * (int4)r31.xyzw;
+                r16.xyzw = (int4)r16.xyzw | (int4)r31.xyzw;
+              }
+              if (r30.y != 0) {
+                r19.z = (uint)r41.w >> 8;
+                if (3 == 0) r19.w = 0; else if (3+13 < 32) {                 r19.w = (uint)r41.w << (32-(3 + 13)); r19.w = (uint)r19.w >> (32-3);                } else r19.w = (uint)r41.w >> 13;
+                r31.xyzw = cmp((int4)r19.wwww == int4(0,1,2,3));
+                r32.xyzw = cmp((int4)r19.wwww == int4(4,5,6,7));
+                r31.xyzw = r31.xyzw ? r15.xyzw : 0;
+                r28.w = (int)r31.x | (int)r31.y;
+                r28.w = (int)r28.w | (int)r31.z;
+                r28.w = (int)r28.w | (int)r31.w;
+                r31.xyzw = r32.xyzw ? r16.xyzw : 0;
+                r28.w = (int)r28.w | (int)r31.x;
+                r28.w = (int)r28.w | (int)r31.y;
+                r28.w = (int)r28.w | (int)r31.z;
+                r28.w = (int)r28.w | (int)r31.w;
+                bitmask.z = ((~(-1 << 1)) << r19.z) & 0xffffffff;  r19.z = (((uint)1 << r19.z) & bitmask.z) | ((uint)r28.w & ~bitmask.z);
+                r19.w = 1 << (int)r19.w;
+                r31.xyzw = (int4)r19.wwww & int4(1,2,4,8);
+                r31.xyzw = r31.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                r31.xyzw = (int4)r19.zzzz * (int4)r31.xyzw;
+                r15.xyzw = (int4)r15.xyzw | (int4)r31.xyzw;
+                r31.xyzw = (int4)r19.wwww & int4(16,32,64,128);
+                r31.xyzw = r31.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                r31.xyzw = (int4)r19.zzzz * (int4)r31.xyzw;
+                r16.xyzw = (int4)r16.xyzw | (int4)r31.xyzw;
+              }
+              if (r30.z != 0) {
+                r19.z = (uint)r41.w >> 16;
+                if (3 == 0) r19.w = 0; else if (3+21 < 32) {                 r19.w = (uint)r41.w << (32-(3 + 21)); r19.w = (uint)r19.w >> (32-3);                } else r19.w = (uint)r41.w >> 21;
+                r31.xyzw = cmp((int4)r19.wwww == int4(0,1,2,3));
+                r32.xyzw = cmp((int4)r19.wwww == int4(4,5,6,7));
+                r31.xyzw = r31.xyzw ? r15.xyzw : 0;
+                r28.w = (int)r31.x | (int)r31.y;
+                r28.w = (int)r28.w | (int)r31.z;
+                r28.w = (int)r28.w | (int)r31.w;
+                r31.xyzw = r32.xyzw ? r16.xyzw : 0;
+                r28.w = (int)r28.w | (int)r31.x;
+                r28.w = (int)r28.w | (int)r31.y;
+                r28.w = (int)r28.w | (int)r31.z;
+                r28.w = (int)r28.w | (int)r31.w;
+                bitmask.z = ((~(-1 << 1)) << r19.z) & 0xffffffff;  r19.z = (((uint)1 << r19.z) & bitmask.z) | ((uint)r28.w & ~bitmask.z);
+                r19.w = 1 << (int)r19.w;
+                r31.xyzw = (int4)r19.wwww & int4(1,2,4,8);
+                r31.xyzw = r31.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                r31.xyzw = (int4)r19.zzzz * (int4)r31.xyzw;
+                r15.xyzw = (int4)r15.xyzw | (int4)r31.xyzw;
+                r31.xyzw = (int4)r19.wwww & int4(16,32,64,128);
+                r31.xyzw = r31.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                r31.xyzw = (int4)r19.zzzz * (int4)r31.xyzw;
+                r16.xyzw = (int4)r16.xyzw | (int4)r31.xyzw;
+              }
+              if (r30.w != 0) {
+                r19.z = (uint)r44.w >> 5;
+                r30.xyzw = cmp((int4)r19.zzzz == int4(0,1,2,3));
+                r31.xyzw = cmp((int4)r19.zzzz == int4(4,5,6,7));
+                r30.xyzw = r30.xyzw ? r15.xyzw : 0;
+                r19.w = (int)r30.x | (int)r30.y;
+                r19.w = (int)r19.w | (int)r30.z;
+                r19.w = (int)r19.w | (int)r30.w;
+                r30.xyzw = r31.xyzw ? r16.xyzw : 0;
+                r19.w = (int)r19.w | (int)r30.x;
+                r19.w = (int)r19.w | (int)r30.y;
+                r19.w = (int)r19.w | (int)r30.z;
+                r19.w = (int)r19.w | (int)r30.w;
+                bitmask.w = ((~(-1 << 1)) << r44.w) & 0xffffffff;  r19.w = (((uint)1 << r44.w) & bitmask.w) | ((uint)r19.w & ~bitmask.w);
+                r19.z = 1 << (int)r19.z;
+                r30.xyzw = (int4)r19.zzzz & int4(1,2,4,8);
+                r30.xyzw = r30.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                r30.xyzw = (int4)r19.wwww * (int4)r30.xyzw;
+                r15.xyzw = (int4)r15.xyzw | (int4)r30.xyzw;
+                r30.xyzw = (int4)r19.zzzz & int4(16,32,64,128);
+                r30.xyzw = r30.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                r30.xyzw = (int4)r19.wwww * (int4)r30.xyzw;
+                r16.xyzw = (int4)r16.xyzw | (int4)r30.xyzw;
+              }
+              r30.xyzw = cmp(float4(0,0,0,0) < r50.xyzw);
+              if (r30.x != 0) {
+                if (3 == 0) r19.z = 0; else if (3+5 < 32) {                 r19.z = (uint)r51.y << (32-(3 + 5)); r19.z = (uint)r19.z >> (32-3);                } else r19.z = (uint)r51.y >> 5;
+                r31.xyzw = cmp((int4)r19.zzzz == int4(0,1,2,3));
+                r32.xyzw = cmp((int4)r19.zzzz == int4(4,5,6,7));
+                r31.xyzw = r31.xyzw ? r15.xyzw : 0;
+                r19.w = (int)r31.x | (int)r31.y;
+                r19.w = (int)r19.w | (int)r31.z;
+                r19.w = (int)r19.w | (int)r31.w;
+                r31.xyzw = r32.xyzw ? r16.xyzw : 0;
+                r19.w = (int)r19.w | (int)r31.x;
+                r19.w = (int)r19.w | (int)r31.y;
+                r19.w = (int)r19.w | (int)r31.z;
+                r19.w = (int)r19.w | (int)r31.w;
+                bitmask.w = ((~(-1 << 1)) << r51.y) & 0xffffffff;  r19.w = (((uint)1 << r51.y) & bitmask.w) | ((uint)r19.w & ~bitmask.w);
+                r19.z = 1 << (int)r19.z;
+                r31.xyzw = (int4)r19.zzzz & int4(1,2,4,8);
+                r31.xyzw = r31.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                r31.xyzw = (int4)r19.wwww * (int4)r31.xyzw;
+                r15.xyzw = (int4)r15.xyzw | (int4)r31.xyzw;
+                r31.xyzw = (int4)r19.zzzz & int4(16,32,64,128);
+                r31.xyzw = r31.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                r31.xyzw = (int4)r19.wwww * (int4)r31.xyzw;
+                r16.xyzw = (int4)r16.xyzw | (int4)r31.xyzw;
+              }
+              if (r30.y != 0) {
+                r19.z = (uint)r51.y >> 8;
+                if (3 == 0) r19.w = 0; else if (3+13 < 32) {                 r19.w = (uint)r51.y << (32-(3 + 13)); r19.w = (uint)r19.w >> (32-3);                } else r19.w = (uint)r51.y >> 13;
+                r31.xyzw = cmp((int4)r19.wwww == int4(0,1,2,3));
+                r32.xyzw = cmp((int4)r19.wwww == int4(4,5,6,7));
+                r31.xyzw = r31.xyzw ? r15.xyzw : 0;
+                r28.w = (int)r31.x | (int)r31.y;
+                r28.w = (int)r28.w | (int)r31.z;
+                r28.w = (int)r28.w | (int)r31.w;
+                r31.xyzw = r32.xyzw ? r16.xyzw : 0;
+                r28.w = (int)r28.w | (int)r31.x;
+                r28.w = (int)r28.w | (int)r31.y;
+                r28.w = (int)r28.w | (int)r31.z;
+                r28.w = (int)r28.w | (int)r31.w;
+                bitmask.z = ((~(-1 << 1)) << r19.z) & 0xffffffff;  r19.z = (((uint)1 << r19.z) & bitmask.z) | ((uint)r28.w & ~bitmask.z);
+                r19.w = 1 << (int)r19.w;
+                r31.xyzw = (int4)r19.wwww & int4(1,2,4,8);
+                r31.xyzw = r31.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                r31.xyzw = (int4)r19.zzzz * (int4)r31.xyzw;
+                r15.xyzw = (int4)r15.xyzw | (int4)r31.xyzw;
+                r31.xyzw = (int4)r19.wwww & int4(16,32,64,128);
+                r31.xyzw = r31.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                r31.xyzw = (int4)r19.zzzz * (int4)r31.xyzw;
+                r16.xyzw = (int4)r16.xyzw | (int4)r31.xyzw;
+              }
+              if (r30.z != 0) {
+                r19.z = (uint)r51.y >> 16;
+                if (3 == 0) r19.w = 0; else if (3+21 < 32) {                 r19.w = (uint)r51.y << (32-(3 + 21)); r19.w = (uint)r19.w >> (32-3);                } else r19.w = (uint)r51.y >> 21;
+                r31.xyzw = cmp((int4)r19.wwww == int4(0,1,2,3));
+                r32.xyzw = cmp((int4)r19.wwww == int4(4,5,6,7));
+                r31.xyzw = r31.xyzw ? r15.xyzw : 0;
+                r28.w = (int)r31.x | (int)r31.y;
+                r28.w = (int)r28.w | (int)r31.z;
+                r28.w = (int)r28.w | (int)r31.w;
+                r31.xyzw = r32.xyzw ? r16.xyzw : 0;
+                r28.w = (int)r28.w | (int)r31.x;
+                r28.w = (int)r28.w | (int)r31.y;
+                r28.w = (int)r28.w | (int)r31.z;
+                r28.w = (int)r28.w | (int)r31.w;
+                bitmask.z = ((~(-1 << 1)) << r19.z) & 0xffffffff;  r19.z = (((uint)1 << r19.z) & bitmask.z) | ((uint)r28.w & ~bitmask.z);
+                r19.w = 1 << (int)r19.w;
+                r31.xyzw = (int4)r19.wwww & int4(1,2,4,8);
+                r31.xyzw = r31.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                r31.xyzw = (int4)r19.zzzz * (int4)r31.xyzw;
+                r15.xyzw = (int4)r15.xyzw | (int4)r31.xyzw;
+                r31.xyzw = (int4)r19.wwww & int4(16,32,64,128);
+                r31.xyzw = r31.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                r31.xyzw = (int4)r19.zzzz * (int4)r31.xyzw;
+                r16.xyzw = (int4)r16.xyzw | (int4)r31.xyzw;
+              }
+              if (r30.w != 0) {
+                r19.z = (uint)r52.w >> 5;
+                r30.xyzw = cmp((int4)r19.zzzz == int4(0,1,2,3));
+                r31.xyzw = cmp((int4)r19.zzzz == int4(4,5,6,7));
+                r30.xyzw = r30.xyzw ? r15.xyzw : 0;
+                r19.w = (int)r30.x | (int)r30.y;
+                r19.w = (int)r19.w | (int)r30.z;
+                r19.w = (int)r19.w | (int)r30.w;
+                r30.xyzw = r31.xyzw ? r16.xyzw : 0;
+                r19.w = (int)r19.w | (int)r30.x;
+                r19.w = (int)r19.w | (int)r30.y;
+                r19.w = (int)r19.w | (int)r30.z;
+                r19.w = (int)r19.w | (int)r30.w;
+                bitmask.w = ((~(-1 << 1)) << r52.w) & 0xffffffff;  r19.w = (((uint)1 << r52.w) & bitmask.w) | ((uint)r19.w & ~bitmask.w);
+                r19.z = 1 << (int)r19.z;
+                r30.xyzw = (int4)r19.zzzz & int4(1,2,4,8);
+                r30.xyzw = r30.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                r30.xyzw = (int4)r19.wwww * (int4)r30.xyzw;
+                r15.xyzw = (int4)r15.xyzw | (int4)r30.xyzw;
+                r30.xyzw = (int4)r19.zzzz & int4(16,32,64,128);
+                r30.xyzw = r30.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                r30.xyzw = (int4)r19.wwww * (int4)r30.xyzw;
+                r16.xyzw = (int4)r16.xyzw | (int4)r30.xyzw;
+              }
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r19.z, r23.x, u2.xxxx
+              r19.zw = (int2)r19.zz & int2(0xffff,0xffff0000);
+              r19.w = (int)r23.w * (int)r19.w;
+              r19.z = mad((int)r19.z, (int)r22.w, (int)r19.w);
+            // No code for instruction (needs manual fix):
+                        store_raw u2.x, r23.x, r19.z
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r19.z, r22.y, u2.xxxx
+              r19.zw = (int2)r19.zz & int2(0xffff,0xffff0000);
+              r19.w = (int)r25.x * (int)r19.w;
+              r19.z = mad((int)r19.z, (int)r24.x, (int)r19.w);
+            // No code for instruction (needs manual fix):
+                        store_raw u2.x, r22.y, r19.z
+            // No code for instruction (needs manual fix):
+                        ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r19.z, r22.z, u2.xxxx
+              r19.zw = (int2)r19.zz & int2(0xffff,0xffff0000);
+              r19.w = (int)r25.y * (int)r19.w;
+              r19.z = mad((int)r19.z, (int)r24.y, (int)r19.w);
+            // No code for instruction (needs manual fix):
+                        store_raw u2.x, r22.z, r19.z
+              r17.w = r12.w;
+            } else {
+              r30.xyz = cmp(r29.xyz < float3(5,5,5));
+              r19.z = (int)r30.y | (int)r30.x;
+              r19.z = (int)r30.z | (int)r19.z;
+              r30.xyz = cmp(float3(-5,-5,-5) < r29.xyz);
+              r19.w = (int)r30.y | (int)r30.x;
+              r19.w = (int)r30.z | (int)r19.w;
+              r19.z = (int)r19.z & (int)r26.w;
+              r19.w = (int)r19.w & (int)r27.w;
+              r19.z = (int)r19.w | (int)r19.z;
+              if (r19.z != 0) {
+                r19.z = (uint)r24.w >> 16;
+                r19.z = f16tof32(r19.z);
+                r30.xyz = mad((int3)r23.yyy, asint(cb0[5].xxx), asint(cb0[5].yzw));
+              // No code for instruction (needs manual fix):
+                            ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r19.w, r30.x, t1.xxxx
+                r24.w = (int)r19.w & 255;
+                r24.w = (uint)r24.w;
+                r24.w = r24.w * 0.00784313772 + -1;
+                if (8 == 0) r30.x = 0; else if (8+8 < 32) {                 r30.x = (uint)r19.w << (32-(8 + 8)); r30.x = (uint)r30.x >> (32-8);                } else r30.x = (uint)r19.w >> 8;
+                if (8 == 0) r30.w = 0; else if (8+16 < 32) {                 r30.w = (uint)r19.w << (32-(8 + 16)); r30.w = (uint)r30.w >> (32-8);                } else r30.w = (uint)r19.w >> 16;
+                r30.xw = (uint2)r30.xw;
+                r30.xw = r30.xw * float2(0.00784313772,0.00784313772) + float2(-1,-1);
+                r19.w = (uint)r19.w >> 24;
+                r19.w = (uint)r19.w;
+                r19.w = r19.w * 0.00784313772 + -1;
+              // No code for instruction (needs manual fix):
+                            ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r28.w, r30.y, t1.xxxx
+                r29.w = (int)r28.w & 255;
+                r29.w = (uint)r29.w;
+                r29.w = r29.w * 0.00784313772 + -1;
+                if (8 == 0) r31.x = 0; else if (8+8 < 32) {                 r31.x = (uint)r28.w << (32-(8 + 8)); r31.x = (uint)r31.x >> (32-8);                } else r31.x = (uint)r28.w >> 8;
+                if (8 == 0) r31.y = 0; else if (8+16 < 32) {                 r31.y = (uint)r28.w << (32-(8 + 16)); r31.y = (uint)r31.y >> (32-8);                } else r31.y = (uint)r28.w >> 16;
+                r31.xy = (uint2)r31.xy;
+                r31.xy = r31.xy * float2(0.00784313772,0.00784313772) + float2(-1,-1);
+                r28.w = (uint)r28.w >> 24;
+                r28.w = (uint)r28.w;
+                r28.w = r28.w * 0.00784313772 + -1;
+              // No code for instruction (needs manual fix):
+                            ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r30.y, r30.z, t1.xxxx
+                r30.z = f16tof32(r30.y);
+                r30.y = (uint)r30.y >> 16;
+                r30.y = f16tof32(r30.y);
+                r31.z = mad((int)r23.y, asint(cb0[5].x), (int)r13.y);
+              // No code for instruction (needs manual fix):
+                            ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r31.z, r31.z, t1.xxxx
+                r31.w = (int)r31.z & 255;
+                if (8 == 0) r32.x = 0; else if (8+8 < 32) {                 r32.x = (uint)r31.z << (32-(8 + 8)); r32.x = (uint)r32.x >> (32-8);                } else r32.x = (uint)r31.z >> 8;
+                if (8 == 0) r32.y = 0; else if (8+16 < 32) {                 r32.y = (uint)r31.z << (32-(8 + 16)); r32.y = (uint)r32.y >> (32-8);                } else r32.y = (uint)r31.z >> 16;
+                r32.xy = (uint2)r32.xy;
+                r31.z = (uint)r31.z >> 24;
+                r31.zw = (uint2)r31.zw;
+                r32.z = mad((int)r23.y, asint(cb0[5].x), asint(cb0[6].z));
+              // No code for instruction (needs manual fix):
+                            ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r32.w, r32.z, t1.xxxx
+                r33.x = f16tof32(r32.w);
+                r32.w = (uint)r32.w >> 16;
+                r32.w = f16tof32(r32.w);
+                r32.z = (int)r32.z + 4;
+              // No code for instruction (needs manual fix):
+                            ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r33.yz, r32.z, t1.xxyx
+                r32.z = f16tof32(r33.y);
+                r33.y = (uint)r33.y >> 16;
+                r33.y = f16tof32(r33.y);
+                if (8 == 0) r34.x = 0; else if (8+8 < 32) {                 r34.x = (uint)r33.z << (32-(8 + 8)); r34.x = (uint)r34.x >> (32-8);                } else r34.x = (uint)r33.z >> 8;
+                if (8 == 0) r34.y = 0; else if (8+16 < 32) {                 r34.y = (uint)r33.z << (32-(8 + 16)); r34.y = (uint)r34.y >> (32-8);                } else r34.y = (uint)r33.z >> 16;
+                r25.zw = (uint2)r25.zw >> int2(16,16);
+                r35.xyz = mad((int3)r23.zzz, asint(cb0[5].xxx), asint(cb0[5].yzw));
+              // No code for instruction (needs manual fix):
+                            ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r33.w, r35.x, t1.xxxx
+                r34.z = (int)r33.w & 255;
+                r34.z = (uint)r34.z;
+                r34.z = r34.z * 0.00784313772 + -1;
+                if (8 == 0) r35.x = 0; else if (8+8 < 32) {                 r35.x = (uint)r33.w << (32-(8 + 8)); r35.x = (uint)r35.x >> (32-8);                } else r35.x = (uint)r33.w >> 8;
+                if (8 == 0) r35.w = 0; else if (8+16 < 32) {                 r35.w = (uint)r33.w << (32-(8 + 16)); r35.w = (uint)r35.w >> (32-8);                } else r35.w = (uint)r33.w >> 16;
+                r35.xw = (uint2)r35.xw;
+                r35.xw = r35.xw * float2(0.00784313772,0.00784313772) + float2(-1,-1);
+                r33.w = (uint)r33.w >> 24;
+                r33.w = (uint)r33.w;
+                r33.w = r33.w * 0.00784313772 + -1;
+              // No code for instruction (needs manual fix):
+                            ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r34.w, r35.y, t1.xxxx
+                r35.y = (int)r34.w & 255;
+                r35.y = (uint)r35.y;
+                r35.y = r35.y * 0.00784313772 + -1;
+                if (8 == 0) r36.x = 0; else if (8+8 < 32) {                 r36.x = (uint)r34.w << (32-(8 + 8)); r36.x = (uint)r36.x >> (32-8);                } else r36.x = (uint)r34.w >> 8;
+                if (8 == 0) r36.y = 0; else if (8+16 < 32) {                 r36.y = (uint)r34.w << (32-(8 + 16)); r36.y = (uint)r36.y >> (32-8);                } else r36.y = (uint)r34.w >> 16;
+                r36.xy = (uint2)r36.xy;
+                r36.xy = r36.xy * float2(0.00784313772,0.00784313772) + float2(-1,-1);
+                r34.w = (uint)r34.w >> 24;
+                r34.w = (uint)r34.w;
+                r34.w = r34.w * 0.00784313772 + -1;
+              // No code for instruction (needs manual fix):
+                            ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r35.z, r35.z, t1.xxxx
+                r36.z = f16tof32(r35.z);
+                r35.z = (uint)r35.z >> 16;
+                r35.z = f16tof32(r35.z);
+                r36.w = mad((int)r23.z, asint(cb0[5].x), (int)r13.y);
+              // No code for instruction (needs manual fix):
+                            ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r36.w, r36.w, t1.xxxx
+                r37.x = (int)r36.w & 255;
+                if (8 == 0) r37.y = 0; else if (8+8 < 32) {                 r37.y = (uint)r36.w << (32-(8 + 8)); r37.y = (uint)r37.y >> (32-8);                } else r37.y = (uint)r36.w >> 8;
+                if (8 == 0) r37.z = 0; else if (8+16 < 32) {                 r37.z = (uint)r36.w << (32-(8 + 16)); r37.z = (uint)r37.z >> (32-8);                } else r37.z = (uint)r36.w >> 16;
+                r37.xyz = (uint3)r37.xyz;
+                r36.w = (uint)r36.w >> 24;
+                r36.w = (uint)r36.w;
+                r37.w = mad((int)r23.z, asint(cb0[5].x), asint(cb0[6].z));
+              // No code for instruction (needs manual fix):
+                            ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r38.x, r37.w, t1.xxxx
+                r38.y = f16tof32(r38.x);
+                r37.w = (int)r37.w + 4;
+              // No code for instruction (needs manual fix):
+                            ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r38.zw, r37.w, t1.xxxy
+                r37.w = f16tof32(r38.z);
+                r38.xz = (uint2)r38.xz >> int2(16,16);
+                r38.xz = f16tof32(r38.xz);
+                if (8 == 0) r39.x = 0; else if (8+8 < 32) {                 r39.x = (uint)r38.w << (32-(8 + 8)); r39.x = (uint)r39.x >> (32-8);                } else r39.x = (uint)r38.w >> 8;
+                if (8 == 0) r39.y = 0; else if (8+16 < 32) {                 r39.y = (uint)r38.w << (32-(8 + 16)); r39.y = (uint)r39.y >> (32-8);                } else r39.y = (uint)r38.w >> 16;
+                r25.zw = f16tof32(r25.zw);
+                r40.xyz = mad((int3)r24.zzz, asint(cb0[5].xxx), asint(cb0[5].yzw));
+              // No code for instruction (needs manual fix):
+                            ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r39.z, r40.x, t1.xxxx
+                r39.w = (int)r39.z & 255;
+                r39.w = (uint)r39.w;
+                r39.w = r39.w * 0.00784313772 + -1;
+                if (8 == 0) r40.x = 0; else if (8+8 < 32) {                 r40.x = (uint)r39.z << (32-(8 + 8)); r40.x = (uint)r40.x >> (32-8);                } else r40.x = (uint)r39.z >> 8;
+                if (8 == 0) r40.w = 0; else if (8+16 < 32) {                 r40.w = (uint)r39.z << (32-(8 + 16)); r40.w = (uint)r40.w >> (32-8);                } else r40.w = (uint)r39.z >> 16;
+                r40.xw = (uint2)r40.xw;
+                r40.xw = r40.xw * float2(0.00784313772,0.00784313772) + float2(-1,-1);
+                r39.z = (uint)r39.z >> 24;
+                r39.z = (uint)r39.z;
+                r39.z = r39.z * 0.00784313772 + -1;
+              // No code for instruction (needs manual fix):
+                            ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r40.y, r40.y, t1.xxxx
+                r41.x = (int)r40.y & 255;
+                r41.x = (uint)r41.x;
+                r41.x = r41.x * 0.00784313772 + -1;
+                if (8 == 0) r41.y = 0; else if (8+8 < 32) {                 r41.y = (uint)r40.y << (32-(8 + 8)); r41.y = (uint)r41.y >> (32-8);                } else r41.y = (uint)r40.y >> 8;
+                if (8 == 0) r41.z = 0; else if (8+16 < 32) {                 r41.z = (uint)r40.y << (32-(8 + 16)); r41.z = (uint)r41.z >> (32-8);                } else r41.z = (uint)r40.y >> 16;
+                r41.yz = (uint2)r41.yz;
+                r41.yz = r41.yz * float2(0.00784313772,0.00784313772) + float2(-1,-1);
+                r40.y = (uint)r40.y >> 24;
+                r40.y = (uint)r40.y;
+                r40.y = r40.y * 0.00784313772 + -1;
+              // No code for instruction (needs manual fix):
+                            ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r40.z, r40.z, t1.xxxx
+                r41.w = f16tof32(r40.z);
+                r40.z = (uint)r40.z >> 16;
+                r40.z = f16tof32(r40.z);
+                r42.x = mad((int)r24.z, asint(cb0[5].x), (int)r13.y);
+              // No code for instruction (needs manual fix):
+                            ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r42.x, r42.x, t1.xxxx
+                r42.y = (int)r42.x & 255;
+                if (8 == 0) r42.z = 0; else if (8+8 < 32) {                 r42.z = (uint)r42.x << (32-(8 + 8)); r42.z = (uint)r42.z >> (32-8);                } else r42.z = (uint)r42.x >> 8;
+                if (8 == 0) r42.w = 0; else if (8+16 < 32) {                 r42.w = (uint)r42.x << (32-(8 + 16)); r42.w = (uint)r42.w >> (32-8);                } else r42.w = (uint)r42.x >> 16;
+                r42.x = (uint)r42.x >> 24;
+                r42.xyzw = (uint4)r42.xyzw;
+                r43.x = mad((int)r24.z, asint(cb0[5].x), asint(cb0[6].z));
+              // No code for instruction (needs manual fix):
+                            ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r43.y, r43.x, t1.xxxx
+                r43.z = f16tof32(r43.y);
+                r43.y = (uint)r43.y >> 16;
+                r43.x = (int)r43.x + 4;
+              // No code for instruction (needs manual fix):
+                            ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r43.xw, r43.x, t1.xxxy
+                r44.x = f16tof32(r43.x);
+                r43.x = (uint)r43.x >> 16;
+                r43.xy = f16tof32(r43.xy);
+                if (8 == 0) r44.y = 0; else if (8+8 < 32) {                 r44.y = (uint)r43.w << (32-(8 + 8)); r44.y = (uint)r44.y >> (32-8);                } else r44.y = (uint)r43.w >> 8;
+                if (8 == 0) r44.z = 0; else if (8+16 < 32) {                 r44.z = (uint)r43.w << (32-(8 + 16)); r44.z = (uint)r44.z >> (32-8);                } else r44.z = (uint)r43.w >> 16;
+                if (r26.w != 0) {
+                  r44.w = (int)r18.w + 1;
+                  r45.xyz = min(float3(2000,2000,2000), r26.xyz);
+                  r45.xyz = f32tof16(r45.xyz);
+                  r45.x = mad((int)r45.y, 0x00010000, (int)r45.x);
+                  r45.w = (int)r18.w * asint(cb0[7].x);
+                  r46.x = min(2000, r19.z);
+                  r46.x = f32tof16(r46.x);
+                  r45.y = mad((int)r46.x, 0x00010000, (int)r45.z);
+                // No code for instruction (needs manual fix):
+                                store_raw u1.xy, r45.w, r45.xyxx
+                  r45.x = r24.w * 127.5 + 127.5;
+                  r45.yz = r30.xw * float2(127.5,127.5) + float2(127.5,127.5);
+                  r45.xyz = (uint3)r45.xyz;
+                  r45.x = mad((int)r45.y, 256, (int)r45.x);
+                  r45.x = mad((int)r45.z, 0x00010000, (int)r45.x);
+                  r45.y = r19.w * 127.5 + 127.5;
+                  r45.y = (uint)r45.y;
+                  r45.x = mad((int)r45.y, 0x01000000, (int)r45.x);
+                  r45.yzw = mad((int3)r18.www, asint(cb0[7].xxx), asint(cb0[5].yzw));
+                // No code for instruction (needs manual fix):
+                                store_raw u1.x, r45.y, r45.x
+                  r45.x = r29.w * 127.5 + 127.5;
+                  r45.x = (uint)r45.x;
+                  r46.xy = r31.xy * float2(127.5,127.5) + float2(127.5,127.5);
+                  r46.xy = (uint2)r46.xy;
+                  r45.x = mad((int)r46.x, 256, (int)r45.x);
+                  r45.x = mad((int)r46.y, 0x00010000, (int)r45.x);
+                  r45.y = r28.w * 127.5 + 127.5;
+                  r45.y = (uint)r45.y;
+                  r45.x = mad((int)r45.y, 0x01000000, (int)r45.x);
+                // No code for instruction (needs manual fix):
+                                store_raw u1.x, r45.z, r45.x
+                  r45.xy = min(float2(2000,2000), r30.zy);
+                  r45.xy = f32tof16(r45.xy);
+                  r45.x = mad((int)r45.y, 0x00010000, (int)r45.x);
+                // No code for instruction (needs manual fix):
+                                store_raw u1.x, r45.w, r45.x
+                  if (r13.y != 0) {
+                    r45.x = mad((int)r18.w, asint(cb0[7].x), (int)r13.y);
+                    r45.y = 1 * r31.w;
+                    r45.zw = float2(1,1) * r32.xy;
+                    r45.yzw = (uint3)r45.yzw;
+                    r45.y = mad((int)r45.z, 256, (int)r45.y);
+                    r45.y = mad((int)r45.w, 0x00010000, (int)r45.y);
+                    r45.z = 1 * r31.z;
+                    r45.z = (uint)r45.z;
+                    r45.y = mad((int)r45.z, 0x01000000, (int)r45.y);
+                  // No code for instruction (needs manual fix):
+                                    store_raw u1.x, r45.x, r45.y
+                  }
+                  r45.xy = mad((int2)r18.ww, asint(cb0[7].xx), asint(cb0[6].wz));
+                // No code for instruction (needs manual fix):
+                                store_raw u1.x, r45.x, r29.x
+                  r45.x = min(2000, r33.x);
+                  r45.z = min(2000, r32.w);
+                  r45.xz = f32tof16(r45.xz);
+                  r46.x = mad((int)r45.z, 0x00010000, (int)r45.x);
+                  r45.x = min(2000, r32.z);
+                  r45.z = min(2000, r33.y);
+                  r45.xz = f32tof16(r45.xz);
+                  r46.y = mad((int)r45.z, 0x00010000, (int)r45.x);
+                  bitmask.x = ((~(-1 << 24)) << 8) & 0xffffffff;  r45.x = (((uint)r34.x << 8) & bitmask.x) | ((uint)r33.z & ~bitmask.x);
+                  r45.x = mad((int)r34.y, 0x00010000, (int)r45.x);
+                  bitmask.z = ((~(-1 << 24)) << 0) & 0xffffffff;  r46.z = (((uint)r45.x << 0) & bitmask.z) | ((uint)r33.z & ~bitmask.z);
+                // No code for instruction (needs manual fix):
+                                store_raw u1.xyz, r45.y, r46.xyzx
+                  r45.x = (uint)r20.x >> 1;
+                  r45.x = (uint)r45.x << 2;
+                // No code for instruction (needs manual fix):
+                                ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r45.y, r45.x, u6.xxxx
+                  r45.z = (int)r20.x & 1;
+                  bitmask.y = ((~(-1 << 16)) << 16) & 0xffffffff;  r45.y = (((uint)r18.w << 16) & bitmask.y) | ((uint)r45.y & ~bitmask.y);
+                  bitmask.w = ((~(-1 << 16)) << 0) & 0xffffffff;  r45.w = (((uint)r18.w << 0) & bitmask.w) | ((uint)r45.y & ~bitmask.w);
+                  r46.x = (int)-r45.z + 1;
+                  r45.w = (int)r45.w * (int)r46.x;
+                  r45.y = mad((int)r45.y, (int)r45.z, (int)r45.w);
+                // No code for instruction (needs manual fix):
+                                store_raw u6.x, r45.x, r45.y
+                  r20.xzw = (int3)r20.xxx + int3(3,1,2);
+                  r45.x = (int)r44.w + 1;
+                  r45.yzw = min(float3(2000,2000,2000), r27.xyz);
+                  r45.yzw = f32tof16(r45.yzw);
+                  r46.x = mad((int)r45.z, 0x00010000, (int)r45.y);
+                  r45.y = (int)r44.w * asint(cb0[7].x);
+                  r45.z = min(2000, r25.z);
+                  r45.z = f32tof16(r45.z);
+                  r46.y = mad((int)r45.z, 0x00010000, (int)r45.w);
+                // No code for instruction (needs manual fix):
+                                store_raw u1.xy, r45.y, r46.xyxx
+                  r45.y = r34.z * 127.5 + 127.5;
+                  r45.zw = r35.xw * float2(127.5,127.5) + float2(127.5,127.5);
+                  r45.yzw = (uint3)r45.yzw;
+                  r45.y = mad((int)r45.z, 256, (int)r45.y);
+                  r45.y = mad((int)r45.w, 0x00010000, (int)r45.y);
+                  r45.z = r33.w * 127.5 + 127.5;
+                  r45.z = (uint)r45.z;
+                  r45.y = mad((int)r45.z, 0x01000000, (int)r45.y);
+                  r46.xyz = mad((int3)r44.www, asint(cb0[7].xxx), asint(cb0[5].yzw));
+                // No code for instruction (needs manual fix):
+                                store_raw u1.x, r46.x, r45.y
+                  r45.y = r35.y * 127.5 + 127.5;
+                  r45.zw = r36.xy * float2(127.5,127.5) + float2(127.5,127.5);
+                  r45.yzw = (uint3)r45.yzw;
+                  r45.y = mad((int)r45.z, 256, (int)r45.y);
+                  r45.y = mad((int)r45.w, 0x00010000, (int)r45.y);
+                  r45.z = r34.w * 127.5 + 127.5;
+                  r45.z = (uint)r45.z;
+                  r45.y = mad((int)r45.z, 0x01000000, (int)r45.y);
+                // No code for instruction (needs manual fix):
+                                store_raw u1.x, r46.y, r45.y
+                  r45.y = min(2000, r36.z);
+                  r45.z = min(2000, r35.z);
+                  r45.yz = f32tof16(r45.yz);
+                  r45.y = mad((int)r45.z, 0x00010000, (int)r45.y);
+                // No code for instruction (needs manual fix):
+                                store_raw u1.x, r46.z, r45.y
+                  if (r13.y != 0) {
+                    r45.y = mad((int)r44.w, asint(cb0[7].x), (int)r13.y);
+                    r45.z = 1 * r37.x;
+                    r45.z = (uint)r45.z;
+                    r46.xy = float2(1,1) * r37.yz;
+                    r46.xy = (uint2)r46.xy;
+                    r45.z = mad((int)r46.x, 256, (int)r45.z);
+                    r45.z = mad((int)r46.y, 0x00010000, (int)r45.z);
+                    r45.w = 1 * r36.w;
+                    r45.w = (uint)r45.w;
+                    r45.z = mad((int)r45.w, 0x01000000, (int)r45.z);
+                  // No code for instruction (needs manual fix):
+                                    store_raw u1.x, r45.y, r45.z
+                  }
+                  r45.yz = mad((int2)r44.ww, asint(cb0[7].xx), asint(cb0[6].wz));
+                // No code for instruction (needs manual fix):
+                                store_raw u1.x, r45.y, r29.y
+                  r45.yw = min(float2(2000,2000), r38.yx);
+                  r45.yw = f32tof16(r45.yw);
+                  r46.x = mad((int)r45.w, 0x00010000, (int)r45.y);
+                  r45.y = min(2000, r37.w);
+                  r45.w = min(2000, r38.z);
+                  r45.yw = f32tof16(r45.yw);
+                  r46.y = mad((int)r45.w, 0x00010000, (int)r45.y);
+                  bitmask.y = ((~(-1 << 24)) << 8) & 0xffffffff;  r45.y = (((uint)r39.x << 8) & bitmask.y) | ((uint)r38.w & ~bitmask.y);
+                  r45.y = mad((int)r39.y, 0x00010000, (int)r45.y);
+                  bitmask.z = ((~(-1 << 24)) << 0) & 0xffffffff;  r46.z = (((uint)r45.y << 0) & bitmask.z) | ((uint)r38.w & ~bitmask.z);
+                // No code for instruction (needs manual fix):
+                                store_raw u1.xyz, r45.z, r46.xyzx
+                  r45.yz = (uint2)r20.zw >> int2(1,1);
+                  r45.yz = (uint2)r45.yz << int2(2,2);
+                // No code for instruction (needs manual fix):
+                                ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r45.w, r45.y, u6.xxxx
+                  r46.xy = (int2)r20.zw & int2(1,1);
+                  bitmask.z = ((~(-1 << 16)) << 16) & 0xffffffff;  r46.z = (((uint)r44.w << 16) & bitmask.z) | ((uint)r45.w & ~bitmask.z);
+                  bitmask.w = ((~(-1 << 16)) << 0) & 0xffffffff;  r46.w = (((uint)r44.w << 0) & bitmask.w) | ((uint)r45.w & ~bitmask.w);
+                  r47.xy = (int2)-r46.xy + int2(1,1);
+                  r44.w = (int)r46.w * (int)r47.x;
+                  r44.w = mad((int)r46.z, (int)r46.x, (int)r44.w);
+                // No code for instruction (needs manual fix):
+                                store_raw u6.x, r45.y, r44.w
+                  r18.w = (int)r45.x + 1;
+                  r46.xzw = min(float3(2000,2000,2000), r28.xyz);
+                  r46.xzw = f32tof16(r46.xzw);
+                  r48.x = mad((int)r46.z, 0x00010000, (int)r46.x);
+                  r44.w = (int)r45.x * asint(cb0[7].x);
+                  r45.y = min(2000, r25.w);
+                  r45.y = f32tof16(r45.y);
+                  r48.y = mad((int)r45.y, 0x00010000, (int)r46.w);
+                // No code for instruction (needs manual fix):
+                                store_raw u1.xy, r44.w, r48.xyxx
+                  r44.w = r39.w * 127.5 + 127.5;
+                  r44.w = (uint)r44.w;
+                  r45.yw = r40.xw * float2(127.5,127.5) + float2(127.5,127.5);
+                  r45.yw = (uint2)r45.yw;
+                  r44.w = mad((int)r45.y, 256, (int)r44.w);
+                  r44.w = mad((int)r45.w, 0x00010000, (int)r44.w);
+                  r45.y = r39.z * 127.5 + 127.5;
+                  r45.y = (uint)r45.y;
+                  r44.w = mad((int)r45.y, 0x01000000, (int)r44.w);
+                  r46.xzw = mad((int3)r45.xxx, asint(cb0[7].xxx), asint(cb0[5].yzw));
+                // No code for instruction (needs manual fix):
+                                store_raw u1.x, r46.x, r44.w
+                  r44.w = r41.x * 127.5 + 127.5;
+                  r44.w = (uint)r44.w;
+                  r45.yw = r41.yz * float2(127.5,127.5) + float2(127.5,127.5);
+                  r45.yw = (uint2)r45.yw;
+                  r44.w = mad((int)r45.y, 256, (int)r44.w);
+                  r44.w = mad((int)r45.w, 0x00010000, (int)r44.w);
+                  r45.y = r40.y * 127.5 + 127.5;
+                  r45.y = (uint)r45.y;
+                  r44.w = mad((int)r45.y, 0x01000000, (int)r44.w);
+                // No code for instruction (needs manual fix):
+                                store_raw u1.x, r46.z, r44.w
+                  r44.w = min(2000, r41.w);
+                  r44.w = f32tof16(r44.w);
+                  r45.y = min(2000, r40.z);
+                  r45.y = f32tof16(r45.y);
+                  r44.w = mad((int)r45.y, 0x00010000, (int)r44.w);
+                // No code for instruction (needs manual fix):
+                                store_raw u1.x, r46.w, r44.w
+                  if (r13.y != 0) {
+                    r44.w = mad((int)r45.x, asint(cb0[7].x), (int)r13.y);
+                    r45.yw = float2(1,1) * r42.yx;
+                    r45.yw = (uint2)r45.yw;
+                    r46.xz = float2(1,1) * r42.zw;
+                    r46.xz = (uint2)r46.xz;
+                    r45.y = mad((int)r46.x, 256, (int)r45.y);
+                    r45.y = mad((int)r46.z, 0x00010000, (int)r45.y);
+                    r45.y = mad((int)r45.w, 0x01000000, (int)r45.y);
+                  // No code for instruction (needs manual fix):
+                                    store_raw u1.x, r44.w, r45.y
+                  }
+                  r45.yw = mad((int2)r45.xx, asint(cb0[7].xx), asint(cb0[6].wz));
+                // No code for instruction (needs manual fix):
+                                store_raw u1.x, r45.y, r29.z
+                  r44.w = min(2000, r43.z);
+                  r44.w = f32tof16(r44.w);
+                  r45.y = min(2000, r43.y);
+                  r45.y = f32tof16(r45.y);
+                  r48.x = mad((int)r45.y, 0x00010000, (int)r44.w);
+                  r44.w = min(2000, r44.x);
+                  r44.w = f32tof16(r44.w);
+                  r45.y = min(2000, r43.x);
+                  r45.y = f32tof16(r45.y);
+                  r48.y = mad((int)r45.y, 0x00010000, (int)r44.w);
+                  bitmask.w = ((~(-1 << 24)) << 8) & 0xffffffff;  r44.w = (((uint)r44.y << 8) & bitmask.w) | ((uint)r43.w & ~bitmask.w);
+                  r44.w = mad((int)r44.z, 0x00010000, (int)r44.w);
+                  bitmask.z = ((~(-1 << 24)) << 0) & 0xffffffff;  r48.z = (((uint)r44.w << 0) & bitmask.z) | ((uint)r43.w & ~bitmask.z);
+                // No code for instruction (needs manual fix):
+                                store_raw u1.xyz, r45.w, r48.xyzx
+                // No code for instruction (needs manual fix):
+                                ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r44.w, r45.z, u6.xxxx
+                  bitmask.x = ((~(-1 << 16)) << 16) & 0xffffffff;  r45.x = (((uint)r45.x << 16) & bitmask.x) | ((uint)r44.w & ~bitmask.x);
+                  bitmask.y = ((~(-1 << 16)) << 0) & 0xffffffff;  r45.y = (((uint)r45.x << 0) & bitmask.y) | ((uint)r44.w & ~bitmask.y);
+                  r44.w = (int)r47.y * (int)r45.y;
+                  r44.w = mad((int)r45.x, (int)r46.y, (int)r44.w);
+                // No code for instruction (needs manual fix):
+                                store_raw u6.x, r45.z, r44.w
+                  r44.w = cmp(0 < r33.x);
+                  if (r44.w != 0) {
+                    if (3 == 0) r44.w = 0; else if (3+5 < 32) {                     r44.w = (uint)r33.z << (32-(3 + 5)); r44.w = (uint)r44.w >> (32-3);                    } else r44.w = (uint)r33.z >> 5;
+                    r45.xyzw = cmp((int4)r44.wwww == int4(0,1,2,3));
+                    r46.xyzw = cmp((int4)r44.wwww == int4(4,5,6,7));
+                    r45.xyzw = r45.xyzw ? r15.xyzw : 0;
+                    r45.x = (int)r45.x | (int)r45.y;
+                    r45.x = (int)r45.x | (int)r45.z;
+                    r45.x = (int)r45.x | (int)r45.w;
+                    r46.xyzw = r46.xyzw ? r16.xyzw : 0;
+                    r45.x = (int)r45.x | (int)r46.x;
+                    r45.x = (int)r45.x | (int)r46.y;
+                    r45.x = (int)r45.x | (int)r46.z;
+                    r45.x = (int)r45.x | (int)r46.w;
+                    bitmask.x = ((~(-1 << 1)) << r33.z) & 0xffffffff;  r45.x = (((uint)1 << r33.z) & bitmask.x) | ((uint)r45.x & ~bitmask.x);
+                    r44.w = 1 << (int)r44.w;
+                    r46.xyzw = (int4)r44.wwww & int4(1,2,4,8);
+                    r46.xyzw = r46.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                    r46.xyzw = (int4)r45.xxxx * (int4)r46.xyzw;
+                    r15.xyzw = (int4)r15.xyzw | (int4)r46.xyzw;
+                    r46.xyzw = (int4)r44.wwww & int4(16,32,64,128);
+                    r46.xyzw = r46.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                    r45.xyzw = (int4)r45.xxxx * (int4)r46.xyzw;
+                    r16.xyzw = (int4)r16.xyzw | (int4)r45.xyzw;
+                  }
+                  r44.w = cmp(0 < r32.w);
+                  if (r44.w != 0) {
+                    r44.w = (uint)r33.z >> 8;
+                    if (3 == 0) r45.x = 0; else if (3+13 < 32) {                     r45.x = (uint)r33.z << (32-(3 + 13)); r45.x = (uint)r45.x >> (32-3);                    } else r45.x = (uint)r33.z >> 13;
+                    r46.xyzw = cmp((int4)r45.xxxx == int4(0,1,2,3));
+                    r47.xyzw = cmp((int4)r45.xxxx == int4(4,5,6,7));
+                    r46.xyzw = r46.xyzw ? r15.xyzw : 0;
+                    r45.y = (int)r46.x | (int)r46.y;
+                    r45.y = (int)r45.y | (int)r46.z;
+                    r45.y = (int)r45.y | (int)r46.w;
+                    r46.xyzw = r47.xyzw ? r16.xyzw : 0;
+                    r45.y = (int)r45.y | (int)r46.x;
+                    r45.y = (int)r45.y | (int)r46.y;
+                    r45.y = (int)r45.y | (int)r46.z;
+                    r45.y = (int)r45.y | (int)r46.w;
+                    bitmask.w = ((~(-1 << 1)) << r44.w) & 0xffffffff;  r44.w = (((uint)1 << r44.w) & bitmask.w) | ((uint)r45.y & ~bitmask.w);
+                    r45.x = 1 << (int)r45.x;
+                    r46.xyzw = (int4)r45.xxxx & int4(1,2,4,8);
+                    r46.xyzw = r46.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                    r46.xyzw = (int4)r44.wwww * (int4)r46.xyzw;
+                    r15.xyzw = (int4)r15.xyzw | (int4)r46.xyzw;
+                    r45.xyzw = (int4)r45.xxxx & int4(16,32,64,128);
+                    r45.xyzw = r45.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                    r45.xyzw = (int4)r44.wwww * (int4)r45.xyzw;
+                    r16.xyzw = (int4)r16.xyzw | (int4)r45.xyzw;
+                  }
+                  r44.w = cmp(0 < r32.z);
+                  if (r44.w != 0) {
+                    r44.w = (uint)r33.z >> 16;
+                    if (3 == 0) r45.x = 0; else if (3+21 < 32) {                     r45.x = (uint)r33.z << (32-(3 + 21)); r45.x = (uint)r45.x >> (32-3);                    } else r45.x = (uint)r33.z >> 21;
+                    r46.xyzw = cmp((int4)r45.xxxx == int4(0,1,2,3));
+                    r47.xyzw = cmp((int4)r45.xxxx == int4(4,5,6,7));
+                    r46.xyzw = r46.xyzw ? r15.xyzw : 0;
+                    r45.y = (int)r46.x | (int)r46.y;
+                    r45.y = (int)r45.y | (int)r46.z;
+                    r45.y = (int)r45.y | (int)r46.w;
+                    r46.xyzw = r47.xyzw ? r16.xyzw : 0;
+                    r45.y = (int)r45.y | (int)r46.x;
+                    r45.y = (int)r45.y | (int)r46.y;
+                    r45.y = (int)r45.y | (int)r46.z;
+                    r45.y = (int)r45.y | (int)r46.w;
+                    bitmask.w = ((~(-1 << 1)) << r44.w) & 0xffffffff;  r44.w = (((uint)1 << r44.w) & bitmask.w) | ((uint)r45.y & ~bitmask.w);
+                    r45.x = 1 << (int)r45.x;
+                    r46.xyzw = (int4)r45.xxxx & int4(1,2,4,8);
+                    r46.xyzw = r46.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                    r46.xyzw = (int4)r44.wwww * (int4)r46.xyzw;
+                    r15.xyzw = (int4)r15.xyzw | (int4)r46.xyzw;
+                    r45.xyzw = (int4)r45.xxxx & int4(16,32,64,128);
+                    r45.xyzw = r45.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                    r45.xyzw = (int4)r44.wwww * (int4)r45.xyzw;
+                    r16.xyzw = (int4)r16.xyzw | (int4)r45.xyzw;
+                  }
+                  r44.w = cmp(0 < r33.y);
+                  if (r44.w != 0) {
+                    r44.w = (uint)r33.z >> 24;
+                    r45.x = (uint)r44.w >> 5;
+                    r46.xyzw = cmp((int4)r45.xxxx == int4(0,1,2,3));
+                    r47.xyzw = cmp((int4)r45.xxxx == int4(4,5,6,7));
+                    r46.xyzw = r46.xyzw ? r15.xyzw : 0;
+                    r45.y = (int)r46.x | (int)r46.y;
+                    r45.y = (int)r45.y | (int)r46.z;
+                    r45.y = (int)r45.y | (int)r46.w;
+                    r46.xyzw = r47.xyzw ? r16.xyzw : 0;
+                    r45.y = (int)r45.y | (int)r46.x;
+                    r45.y = (int)r45.y | (int)r46.y;
+                    r45.y = (int)r45.y | (int)r46.z;
+                    r45.y = (int)r45.y | (int)r46.w;
+                    bitmask.w = ((~(-1 << 1)) << r44.w) & 0xffffffff;  r44.w = (((uint)1 << r44.w) & bitmask.w) | ((uint)r45.y & ~bitmask.w);
+                    r45.x = 1 << (int)r45.x;
+                    r46.xyzw = (int4)r45.xxxx & int4(1,2,4,8);
+                    r46.xyzw = r46.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                    r46.xyzw = (int4)r44.wwww * (int4)r46.xyzw;
+                    r15.xyzw = (int4)r15.xyzw | (int4)r46.xyzw;
+                    r45.xyzw = (int4)r45.xxxx & int4(16,32,64,128);
+                    r45.xyzw = r45.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                    r45.xyzw = (int4)r44.wwww * (int4)r45.xyzw;
+                    r16.xyzw = (int4)r16.xyzw | (int4)r45.xyzw;
+                  }
+                  r44.w = cmp(0 < r38.y);
+                  if (r44.w != 0) {
+                    if (3 == 0) r44.w = 0; else if (3+5 < 32) {                     r44.w = (uint)r38.w << (32-(3 + 5)); r44.w = (uint)r44.w >> (32-3);                    } else r44.w = (uint)r38.w >> 5;
+                    r45.xyzw = cmp((int4)r44.wwww == int4(0,1,2,3));
+                    r46.xyzw = cmp((int4)r44.wwww == int4(4,5,6,7));
+                    r45.xyzw = r45.xyzw ? r15.xyzw : 0;
+                    r45.x = (int)r45.x | (int)r45.y;
+                    r45.x = (int)r45.x | (int)r45.z;
+                    r45.x = (int)r45.x | (int)r45.w;
+                    r46.xyzw = r46.xyzw ? r16.xyzw : 0;
+                    r45.x = (int)r45.x | (int)r46.x;
+                    r45.x = (int)r45.x | (int)r46.y;
+                    r45.x = (int)r45.x | (int)r46.z;
+                    r45.x = (int)r45.x | (int)r46.w;
+                    bitmask.x = ((~(-1 << 1)) << r38.w) & 0xffffffff;  r45.x = (((uint)1 << r38.w) & bitmask.x) | ((uint)r45.x & ~bitmask.x);
+                    r44.w = 1 << (int)r44.w;
+                    r46.xyzw = (int4)r44.wwww & int4(1,2,4,8);
+                    r46.xyzw = r46.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                    r46.xyzw = (int4)r45.xxxx * (int4)r46.xyzw;
+                    r15.xyzw = (int4)r15.xyzw | (int4)r46.xyzw;
+                    r46.xyzw = (int4)r44.wwww & int4(16,32,64,128);
+                    r46.xyzw = r46.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                    r45.xyzw = (int4)r45.xxxx * (int4)r46.xyzw;
+                    r16.xyzw = (int4)r16.xyzw | (int4)r45.xyzw;
+                  }
+                  r44.w = cmp(0 < r38.x);
+                  if (r44.w != 0) {
+                    r44.w = (uint)r38.w >> 8;
+                    if (3 == 0) r45.x = 0; else if (3+13 < 32) {                     r45.x = (uint)r38.w << (32-(3 + 13)); r45.x = (uint)r45.x >> (32-3);                    } else r45.x = (uint)r38.w >> 13;
+                    r46.xyzw = cmp((int4)r45.xxxx == int4(0,1,2,3));
+                    r47.xyzw = cmp((int4)r45.xxxx == int4(4,5,6,7));
+                    r46.xyzw = r46.xyzw ? r15.xyzw : 0;
+                    r45.y = (int)r46.x | (int)r46.y;
+                    r45.y = (int)r45.y | (int)r46.z;
+                    r45.y = (int)r45.y | (int)r46.w;
+                    r46.xyzw = r47.xyzw ? r16.xyzw : 0;
+                    r45.y = (int)r45.y | (int)r46.x;
+                    r45.y = (int)r45.y | (int)r46.y;
+                    r45.y = (int)r45.y | (int)r46.z;
+                    r45.y = (int)r45.y | (int)r46.w;
+                    bitmask.w = ((~(-1 << 1)) << r44.w) & 0xffffffff;  r44.w = (((uint)1 << r44.w) & bitmask.w) | ((uint)r45.y & ~bitmask.w);
+                    r45.x = 1 << (int)r45.x;
+                    r46.xyzw = (int4)r45.xxxx & int4(1,2,4,8);
+                    r46.xyzw = r46.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                    r46.xyzw = (int4)r44.wwww * (int4)r46.xyzw;
+                    r15.xyzw = (int4)r15.xyzw | (int4)r46.xyzw;
+                    r45.xyzw = (int4)r45.xxxx & int4(16,32,64,128);
+                    r45.xyzw = r45.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                    r45.xyzw = (int4)r44.wwww * (int4)r45.xyzw;
+                    r16.xyzw = (int4)r16.xyzw | (int4)r45.xyzw;
+                  }
+                  r44.w = cmp(0 < r37.w);
+                  if (r44.w != 0) {
+                    r44.w = (uint)r38.w >> 16;
+                    if (3 == 0) r45.x = 0; else if (3+21 < 32) {                     r45.x = (uint)r38.w << (32-(3 + 21)); r45.x = (uint)r45.x >> (32-3);                    } else r45.x = (uint)r38.w >> 21;
+                    r46.xyzw = cmp((int4)r45.xxxx == int4(0,1,2,3));
+                    r47.xyzw = cmp((int4)r45.xxxx == int4(4,5,6,7));
+                    r46.xyzw = r46.xyzw ? r15.xyzw : 0;
+                    r45.y = (int)r46.x | (int)r46.y;
+                    r45.y = (int)r45.y | (int)r46.z;
+                    r45.y = (int)r45.y | (int)r46.w;
+                    r46.xyzw = r47.xyzw ? r16.xyzw : 0;
+                    r45.y = (int)r45.y | (int)r46.x;
+                    r45.y = (int)r45.y | (int)r46.y;
+                    r45.y = (int)r45.y | (int)r46.z;
+                    r45.y = (int)r45.y | (int)r46.w;
+                    bitmask.w = ((~(-1 << 1)) << r44.w) & 0xffffffff;  r44.w = (((uint)1 << r44.w) & bitmask.w) | ((uint)r45.y & ~bitmask.w);
+                    r45.x = 1 << (int)r45.x;
+                    r46.xyzw = (int4)r45.xxxx & int4(1,2,4,8);
+                    r46.xyzw = r46.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                    r46.xyzw = (int4)r44.wwww * (int4)r46.xyzw;
+                    r15.xyzw = (int4)r15.xyzw | (int4)r46.xyzw;
+                    r45.xyzw = (int4)r45.xxxx & int4(16,32,64,128);
+                    r45.xyzw = r45.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                    r45.xyzw = (int4)r44.wwww * (int4)r45.xyzw;
+                    r16.xyzw = (int4)r16.xyzw | (int4)r45.xyzw;
+                  }
+                  r44.w = cmp(0 < r38.z);
+                  if (r44.w != 0) {
+                    r44.w = (uint)r38.w >> 24;
+                    r45.x = (uint)r44.w >> 5;
+                    r46.xyzw = cmp((int4)r45.xxxx == int4(0,1,2,3));
+                    r47.xyzw = cmp((int4)r45.xxxx == int4(4,5,6,7));
+                    r46.xyzw = r46.xyzw ? r15.xyzw : 0;
+                    r45.y = (int)r46.x | (int)r46.y;
+                    r45.y = (int)r45.y | (int)r46.z;
+                    r45.y = (int)r45.y | (int)r46.w;
+                    r46.xyzw = r47.xyzw ? r16.xyzw : 0;
+                    r45.y = (int)r45.y | (int)r46.x;
+                    r45.y = (int)r45.y | (int)r46.y;
+                    r45.y = (int)r45.y | (int)r46.z;
+                    r45.y = (int)r45.y | (int)r46.w;
+                    bitmask.w = ((~(-1 << 1)) << r44.w) & 0xffffffff;  r44.w = (((uint)1 << r44.w) & bitmask.w) | ((uint)r45.y & ~bitmask.w);
+                    r45.x = 1 << (int)r45.x;
+                    r46.xyzw = (int4)r45.xxxx & int4(1,2,4,8);
+                    r46.xyzw = r46.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                    r46.xyzw = (int4)r44.wwww * (int4)r46.xyzw;
+                    r15.xyzw = (int4)r15.xyzw | (int4)r46.xyzw;
+                    r45.xyzw = (int4)r45.xxxx & int4(16,32,64,128);
+                    r45.xyzw = r45.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                    r45.xyzw = (int4)r44.wwww * (int4)r45.xyzw;
+                    r16.xyzw = (int4)r16.xyzw | (int4)r45.xyzw;
+                  }
+                  r44.w = cmp(0 < r43.z);
+                  if (r44.w != 0) {
+                    if (3 == 0) r44.w = 0; else if (3+5 < 32) {                     r44.w = (uint)r43.w << (32-(3 + 5)); r44.w = (uint)r44.w >> (32-3);                    } else r44.w = (uint)r43.w >> 5;
+                    r45.xyzw = cmp((int4)r44.wwww == int4(0,1,2,3));
+                    r46.xyzw = cmp((int4)r44.wwww == int4(4,5,6,7));
+                    r45.xyzw = r45.xyzw ? r15.xyzw : 0;
+                    r45.x = (int)r45.x | (int)r45.y;
+                    r45.x = (int)r45.x | (int)r45.z;
+                    r45.x = (int)r45.x | (int)r45.w;
+                    r46.xyzw = r46.xyzw ? r16.xyzw : 0;
+                    r45.x = (int)r45.x | (int)r46.x;
+                    r45.x = (int)r45.x | (int)r46.y;
+                    r45.x = (int)r45.x | (int)r46.z;
+                    r45.x = (int)r45.x | (int)r46.w;
+                    bitmask.x = ((~(-1 << 1)) << r43.w) & 0xffffffff;  r45.x = (((uint)1 << r43.w) & bitmask.x) | ((uint)r45.x & ~bitmask.x);
+                    r44.w = 1 << (int)r44.w;
+                    r46.xyzw = (int4)r44.wwww & int4(1,2,4,8);
+                    r46.xyzw = r46.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                    r46.xyzw = (int4)r45.xxxx * (int4)r46.xyzw;
+                    r15.xyzw = (int4)r15.xyzw | (int4)r46.xyzw;
+                    r46.xyzw = (int4)r44.wwww & int4(16,32,64,128);
+                    r46.xyzw = r46.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                    r45.xyzw = (int4)r45.xxxx * (int4)r46.xyzw;
+                    r16.xyzw = (int4)r16.xyzw | (int4)r45.xyzw;
+                  }
+                  r44.w = cmp(0 < r43.y);
+                  if (r44.w != 0) {
+                    r44.w = (uint)r43.w >> 8;
+                    if (3 == 0) r45.x = 0; else if (3+13 < 32) {                     r45.x = (uint)r43.w << (32-(3 + 13)); r45.x = (uint)r45.x >> (32-3);                    } else r45.x = (uint)r43.w >> 13;
+                    r46.xyzw = cmp((int4)r45.xxxx == int4(0,1,2,3));
+                    r47.xyzw = cmp((int4)r45.xxxx == int4(4,5,6,7));
+                    r46.xyzw = r46.xyzw ? r15.xyzw : 0;
+                    r45.y = (int)r46.x | (int)r46.y;
+                    r45.y = (int)r45.y | (int)r46.z;
+                    r45.y = (int)r45.y | (int)r46.w;
+                    r46.xyzw = r47.xyzw ? r16.xyzw : 0;
+                    r45.y = (int)r45.y | (int)r46.x;
+                    r45.y = (int)r45.y | (int)r46.y;
+                    r45.y = (int)r45.y | (int)r46.z;
+                    r45.y = (int)r45.y | (int)r46.w;
+                    bitmask.w = ((~(-1 << 1)) << r44.w) & 0xffffffff;  r44.w = (((uint)1 << r44.w) & bitmask.w) | ((uint)r45.y & ~bitmask.w);
+                    r45.x = 1 << (int)r45.x;
+                    r46.xyzw = (int4)r45.xxxx & int4(1,2,4,8);
+                    r46.xyzw = r46.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                    r46.xyzw = (int4)r44.wwww * (int4)r46.xyzw;
+                    r15.xyzw = (int4)r15.xyzw | (int4)r46.xyzw;
+                    r45.xyzw = (int4)r45.xxxx & int4(16,32,64,128);
+                    r45.xyzw = r45.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                    r45.xyzw = (int4)r44.wwww * (int4)r45.xyzw;
+                    r16.xyzw = (int4)r16.xyzw | (int4)r45.xyzw;
+                  }
+                  r44.w = cmp(0 < r44.x);
+                  if (r44.w != 0) {
+                    r44.w = (uint)r43.w >> 16;
+                    if (3 == 0) r45.x = 0; else if (3+21 < 32) {                     r45.x = (uint)r43.w << (32-(3 + 21)); r45.x = (uint)r45.x >> (32-3);                    } else r45.x = (uint)r43.w >> 21;
+                    r46.xyzw = cmp((int4)r45.xxxx == int4(0,1,2,3));
+                    r47.xyzw = cmp((int4)r45.xxxx == int4(4,5,6,7));
+                    r46.xyzw = r46.xyzw ? r15.xyzw : 0;
+                    r45.y = (int)r46.x | (int)r46.y;
+                    r45.y = (int)r45.y | (int)r46.z;
+                    r45.y = (int)r45.y | (int)r46.w;
+                    r46.xyzw = r47.xyzw ? r16.xyzw : 0;
+                    r45.y = (int)r45.y | (int)r46.x;
+                    r45.y = (int)r45.y | (int)r46.y;
+                    r45.y = (int)r45.y | (int)r46.z;
+                    r45.y = (int)r45.y | (int)r46.w;
+                    bitmask.w = ((~(-1 << 1)) << r44.w) & 0xffffffff;  r44.w = (((uint)1 << r44.w) & bitmask.w) | ((uint)r45.y & ~bitmask.w);
+                    r45.x = 1 << (int)r45.x;
+                    r46.xyzw = (int4)r45.xxxx & int4(1,2,4,8);
+                    r46.xyzw = r46.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                    r46.xyzw = (int4)r44.wwww * (int4)r46.xyzw;
+                    r15.xyzw = (int4)r15.xyzw | (int4)r46.xyzw;
+                    r45.xyzw = (int4)r45.xxxx & int4(16,32,64,128);
+                    r45.xyzw = r45.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                    r45.xyzw = (int4)r44.wwww * (int4)r45.xyzw;
+                    r16.xyzw = (int4)r16.xyzw | (int4)r45.xyzw;
+                  }
+                  r44.w = cmp(0 < r43.x);
+                  if (r44.w != 0) {
+                    r44.w = (uint)r43.w >> 24;
+                    r45.x = (uint)r44.w >> 5;
+                    r46.xyzw = cmp((int4)r45.xxxx == int4(0,1,2,3));
+                    r47.xyzw = cmp((int4)r45.xxxx == int4(4,5,6,7));
+                    r46.xyzw = r46.xyzw ? r15.xyzw : 0;
+                    r45.y = (int)r46.x | (int)r46.y;
+                    r45.y = (int)r45.y | (int)r46.z;
+                    r45.y = (int)r45.y | (int)r46.w;
+                    r46.xyzw = r47.xyzw ? r16.xyzw : 0;
+                    r45.y = (int)r45.y | (int)r46.x;
+                    r45.y = (int)r45.y | (int)r46.y;
+                    r45.y = (int)r45.y | (int)r46.z;
+                    r45.y = (int)r45.y | (int)r46.w;
+                    bitmask.w = ((~(-1 << 1)) << r44.w) & 0xffffffff;  r44.w = (((uint)1 << r44.w) & bitmask.w) | ((uint)r45.y & ~bitmask.w);
+                    r45.x = 1 << (int)r45.x;
+                    r46.xyzw = (int4)r45.xxxx & int4(1,2,4,8);
+                    r46.xyzw = r46.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                    r46.xyzw = (int4)r44.wwww * (int4)r46.xyzw;
+                    r15.xyzw = (int4)r15.xyzw | (int4)r46.xyzw;
+                    r45.xyzw = (int4)r45.xxxx & int4(16,32,64,128);
+                    r45.xyzw = r45.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+                    r45.xyzw = (int4)r44.wwww * (int4)r45.xyzw;
+                    r16.xyzw = (int4)r16.xyzw | (int4)r45.xyzw;
+                  }
+                } else {
+                  r44.w = (int)r18.w + 1;
+                  r26.xyz = min(float3(2000,2000,2000), r26.xyz);
+                  r26.xyz = f32tof16(r26.xyz);
+                  r26.x = mad((int)r26.y, 0x00010000, (int)r26.x);
+                  r45.x = (int)r18.w * asint(cb0[7].x);
+                  r19.z = min(2000, r19.z);
+                  r19.z = f32tof16(r19.z);
+                  r26.y = mad((int)r19.z, 0x00010000, (int)r26.z);
+                // No code for instruction (needs manual fix):
+                                store_raw u1.xy, r45.x, r26.xyxx
+                  r19.z = r24.w * 127.5 + 127.5;
+                  r19.z = (uint)r19.z;
+                  r26.xy = r30.xw * float2(127.5,127.5) + float2(127.5,127.5);
+                  r26.xy = (uint2)r26.xy;
+                  r19.z = mad((int)r26.x, 256, (int)r19.z);
+                  r19.z = mad((int)r26.y, 0x00010000, (int)r19.z);
+                  r19.w = r19.w * 127.5 + 127.5;
+                  r19.w = (uint)r19.w;
+                  r19.z = mad((int)r19.w, 0x01000000, (int)r19.z);
+                  r26.xyz = mad((int3)r18.www, asint(cb0[7].xxx), asint(cb0[5].yzw));
+                // No code for instruction (needs manual fix):
+                                store_raw u1.x, r26.x, r19.z
+                  r19.z = r29.w * 127.5 + 127.5;
+                  r19.z = (uint)r19.z;
+                  r30.xw = r31.xy * float2(127.5,127.5) + float2(127.5,127.5);
+                  r30.xw = (uint2)r30.xw;
+                  r19.z = mad((int)r30.x, 256, (int)r19.z);
+                  r19.z = mad((int)r30.w, 0x00010000, (int)r19.z);
+                  r19.w = r28.w * 127.5 + 127.5;
+                  r19.w = (uint)r19.w;
+                  r19.z = mad((int)r19.w, 0x01000000, (int)r19.z);
+                // No code for instruction (needs manual fix):
+                                store_raw u1.x, r26.y, r19.z
+                  r19.zw = min(float2(2000,2000), r30.zy);
+                  r19.zw = f32tof16(r19.zw);
+                  r19.z = mad((int)r19.w, 0x00010000, (int)r19.z);
+                // No code for instruction (needs manual fix):
+                                store_raw u1.x, r26.z, r19.z
+                  if (r13.y != 0) {
+                    r19.z = mad((int)r18.w, asint(cb0[7].x), (int)r13.y);
+                    r19.w = 1 * r31.w;
+                    r19.w = (uint)r19.w;
+                    r26.xy = float2(1,1) * r32.xy;
+                    r26.xy = (uint2)r26.xy;
+                    r19.w = mad((int)r26.x, 256, (int)r19.w);
+                    r19.w = mad((int)r26.y, 0x00010000, (int)r19.w);
+                    r24.w = 1 * r31.z;
+                    r24.w = (uint)r24.w;
+                    r19.w = mad((int)r24.w, 0x01000000, (int)r19.w);
+                  // No code for instruction (needs manual fix):
+                                    store_raw u1.x, r19.z, r19.w
+                  }
+                  r19.zw = mad((int2)r18.ww, asint(cb0[7].xx), asint(cb0[6].wz));
+                // No code for instruction (needs manual fix):
+                                store_raw u1.x, r19.z, r29.x
+                  r19.z = min(2000, r33.x);
+                  r19.z = f32tof16(r19.z);
+                  r24.w = min(2000, r32.w);
+                  r24.w = f32tof16(r24.w);
+                  r26.x = mad((int)r24.w, 0x00010000, (int)r19.z);
+                  r19.z = min(2000, r32.z);
+                  r19.z = f32tof16(r19.z);
+                  r24.w = min(2000, r33.y);
+                  r24.w = f32tof16(r24.w);
+                  r26.y = mad((int)r24.w, 0x00010000, (int)r19.z);
+                  bitmask.z = ((~(-1 << 24)) << 8) & 0xffffffff;  r19.z = (((uint)r34.x << 8) & bitmask.z) | ((uint)r33.z & ~bitmask.z);
+                  r19.z = mad((int)r34.y, 0x00010000, (int)r19.z);
+                  bitmask.z = ((~(-1 << 24)) << 0) & 0xffffffff;  r26.z = (((uint)r19.z << 0) & bitmask.z) | ((uint)r33.z & ~bitmask.z);
+                // No code for instruction (needs manual fix):
+                                store_raw u1.xyz, r19.w, r26.xyzx
+                  r19.z = (uint)r20.y >> 1;
+                  r19.z = (uint)r19.z << 2;
+                // No code for instruction (needs manual fix):
+                                ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r19.w, r19.z, u7.xxxx
+                  r24.w = (int)r20.y & 1;
+                  bitmask.x = ((~(-1 << 16)) << 16) & 0xffffffff;  r26.x = (((uint)r18.w << 16) & bitmask.x) | ((uint)r19.w & ~bitmask.x);
+                  bitmask.y = ((~(-1 << 16)) << 0) & 0xffffffff;  r26.y = (((uint)r18.w << 0) & bitmask.y) | ((uint)r19.w & ~bitmask.y);
+                  r19.w = (int)-r24.w + 1;
+                  r19.w = (int)r19.w * (int)r26.y;
+                  r19.w = mad((int)r26.x, (int)r24.w, (int)r19.w);
+                // No code for instruction (needs manual fix):
+                                store_raw u7.x, r19.z, r19.w
+                  r20.yzw = (int3)r20.yyy + int3(3,1,2);
+                  r19.z = (int)r44.w + 1;
+                  r26.xyz = min(float3(2000,2000,2000), r27.xyz);
+                  r26.xyz = f32tof16(r26.xyz);
+                  r26.x = mad((int)r26.y, 0x00010000, (int)r26.x);
+                  r19.w = (int)r44.w * asint(cb0[7].x);
+                  r24.w = min(2000, r25.z);
+                  r24.w = f32tof16(r24.w);
+                  r26.y = mad((int)r24.w, 0x00010000, (int)r26.z);
+                // No code for instruction (needs manual fix):
+                                store_raw u1.xy, r19.w, r26.xyxx
+                  r19.w = r34.z * 127.5 + 127.5;
+                  r19.w = (uint)r19.w;
+                  r26.xy = r35.xw * float2(127.5,127.5) + float2(127.5,127.5);
+                  r26.xy = (uint2)r26.xy;
+                  r19.w = mad((int)r26.x, 256, (int)r19.w);
+                  r19.w = mad((int)r26.y, 0x00010000, (int)r19.w);
+                  r24.w = r33.w * 127.5 + 127.5;
+                  r24.w = (uint)r24.w;
+                  r19.w = mad((int)r24.w, 0x01000000, (int)r19.w);
+                  r26.xyz = mad((int3)r44.www, asint(cb0[7].xxx), asint(cb0[5].yzw));
+                // No code for instruction (needs manual fix):
+                                store_raw u1.x, r26.x, r19.w
+                  r19.w = r35.y * 127.5 + 127.5;
+                  r19.w = (uint)r19.w;
+                  r27.xy = r36.xy * float2(127.5,127.5) + float2(127.5,127.5);
+                  r27.xy = (uint2)r27.xy;
+                  r19.w = mad((int)r27.x, 256, (int)r19.w);
+                  r19.w = mad((int)r27.y, 0x00010000, (int)r19.w);
+                  r24.w = r34.w * 127.5 + 127.5;
+                  r24.w = (uint)r24.w;
+                  r19.w = mad((int)r24.w, 0x01000000, (int)r19.w);
+                // No code for instruction (needs manual fix):
+                                store_raw u1.x, r26.y, r19.w
+                  r19.w = min(2000, r36.z);
+                  r19.w = f32tof16(r19.w);
+                  r24.w = min(2000, r35.z);
+                  r24.w = f32tof16(r24.w);
+                  r19.w = mad((int)r24.w, 0x00010000, (int)r19.w);
+                // No code for instruction (needs manual fix):
+                                store_raw u1.x, r26.z, r19.w
+                  if (r13.y != 0) {
+                    r19.w = mad((int)r44.w, asint(cb0[7].x), (int)r13.y);
+                    r24.w = 1 * r37.x;
+                    r24.w = (uint)r24.w;
+                    r26.xy = float2(1,1) * r37.yz;
+                    r26.xy = (uint2)r26.xy;
+                    r24.w = mad((int)r26.x, 256, (int)r24.w);
+                    r24.w = mad((int)r26.y, 0x00010000, (int)r24.w);
+                    r25.z = 1 * r36.w;
+                    r25.z = (uint)r25.z;
+                    r24.w = mad((int)r25.z, 0x01000000, (int)r24.w);
+                  // No code for instruction (needs manual fix):
+                                    store_raw u1.x, r19.w, r24.w
+                  }
+                  r26.xy = mad((int2)r44.ww, asint(cb0[7].xx), asint(cb0[6].wz));
+                // No code for instruction (needs manual fix):
+                                store_raw u1.x, r26.x, r29.y
+                  r19.w = min(2000, r38.y);
+                  r19.w = f32tof16(r19.w);
+                  r24.w = min(2000, r38.x);
+                  r24.w = f32tof16(r24.w);
+                  r27.x = mad((int)r24.w, 0x00010000, (int)r19.w);
+                  r19.w = min(2000, r37.w);
+                  r19.w = f32tof16(r19.w);
+                  r24.w = min(2000, r38.z);
+                  r24.w = f32tof16(r24.w);
+                  r27.y = mad((int)r24.w, 0x00010000, (int)r19.w);
+                  bitmask.w = ((~(-1 << 24)) << 8) & 0xffffffff;  r19.w = (((uint)r39.x << 8) & bitmask.w) | ((uint)r38.w & ~bitmask.w);
+                  r19.w = mad((int)r39.y, 0x00010000, (int)r19.w);
+                  bitmask.z = ((~(-1 << 24)) << 0) & 0xffffffff;  r27.z = (((uint)r19.w << 0) & bitmask.z) | ((uint)r38.w & ~bitmask.z);
+                // No code for instruction (needs manual fix):
+                                store_raw u1.xyz, r26.y, r27.xyzx
+                  r26.xy = (uint2)r20.zw >> int2(1,1);
+                  r26.xy = (uint2)r26.xy << int2(2,2);
+                // No code for instruction (needs manual fix):
+                                ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r19.w, r26.x, u7.xxxx
+                  r20.zw = (int2)r20.zw & int2(1,1);
+                  bitmask.x = ((~(-1 << 16)) << 16) & 0xffffffff;  r27.x = (((uint)r44.w << 16) & bitmask.x) | ((uint)r19.w & ~bitmask.x);
+                  bitmask.y = ((~(-1 << 16)) << 0) & 0xffffffff;  r27.y = (((uint)r44.w << 0) & bitmask.y) | ((uint)r19.w & ~bitmask.y);
+                  r29.xy = (int2)-r20.zw + int2(1,1);
+                  r19.w = (int)r27.y * (int)r29.x;
+                  r19.w = mad((int)r27.x, (int)r20.z, (int)r19.w);
+                // No code for instruction (needs manual fix):
+                                store_raw u7.x, r26.x, r19.w
+                  r18.w = (int)r19.z + 1;
+                  r27.xyz = min(float3(2000,2000,2000), r28.xyz);
+                  r27.xyz = f32tof16(r27.xyz);
+                  r27.x = mad((int)r27.y, 0x00010000, (int)r27.x);
+                  r19.w = (int)r19.z * asint(cb0[7].x);
+                  r20.z = min(2000, r25.w);
+                  r20.z = f32tof16(r20.z);
+                  r27.y = mad((int)r20.z, 0x00010000, (int)r27.z);
+                // No code for instruction (needs manual fix):
+                                store_raw u1.xy, r19.w, r27.xyxx
+                  r19.w = r39.w * 127.5 + 127.5;
+                  r19.w = (uint)r19.w;
+                  r25.zw = r40.xw * float2(127.5,127.5) + float2(127.5,127.5);
+                  r25.zw = (uint2)r25.zw;
+                  r19.w = mad((int)r25.z, 256, (int)r19.w);
+                  r19.w = mad((int)r25.w, 0x00010000, (int)r19.w);
+                  r20.z = r39.z * 127.5 + 127.5;
+                  r20.z = (uint)r20.z;
+                  r19.w = mad((int)r20.z, 0x01000000, (int)r19.w);
+                  r27.xyz = mad((int3)r19.zzz, asint(cb0[7].xxx), asint(cb0[5].yzw));
+                // No code for instruction (needs manual fix):
+                                store_raw u1.x, r27.x, r19.w
+                  r19.w = r41.x * 127.5 + 127.5;
+                  r19.w = (uint)r19.w;
+                  r25.zw = r41.yz * float2(127.5,127.5) + float2(127.5,127.5);
+                  r25.zw = (uint2)r25.zw;
+                  r19.w = mad((int)r25.z, 256, (int)r19.w);
+                  r19.w = mad((int)r25.w, 0x00010000, (int)r19.w);
+                  r20.z = r40.y * 127.5 + 127.5;
+                  r20.z = (uint)r20.z;
+                  r19.w = mad((int)r20.z, 0x01000000, (int)r19.w);
+                // No code for instruction (needs manual fix):
+                                store_raw u1.x, r27.y, r19.w
+                  r19.w = min(2000, r41.w);
+                  r19.w = f32tof16(r19.w);
+                  r20.z = min(2000, r40.z);
+                  r20.z = f32tof16(r20.z);
+                  r19.w = mad((int)r20.z, 0x00010000, (int)r19.w);
+                // No code for instruction (needs manual fix):
+                                store_raw u1.x, r27.z, r19.w
+                  if (r13.y != 0) {
+                    r19.w = mad((int)r19.z, asint(cb0[7].x), (int)r13.y);
+                    r20.z = 1 * r42.y;
+                    r20.z = (uint)r20.z;
+                    r25.zw = float2(1,1) * r42.zw;
+                    r25.zw = (uint2)r25.zw;
+                    r20.z = mad((int)r25.z, 256, (int)r20.z);
+                    r20.z = mad((int)r25.w, 0x00010000, (int)r20.z);
+                    r24.w = 1 * r42.x;
+                    r24.w = (uint)r24.w;
+                    r20.z = mad((int)r24.w, 0x01000000, (int)r20.z);
+                  // No code for instruction (needs manual fix):
+                                    store_raw u1.x, r19.w, r20.z
+                  }
+                  r25.zw = mad((int2)r19.zz, asint(cb0[7].xx), asint(cb0[6].wz));
+                // No code for instruction (needs manual fix):
+                                store_raw u1.x, r25.z, r29.z
+                  r19.w = min(2000, r43.z);
+                  r19.w = f32tof16(r19.w);
+                  r20.z = min(2000, r43.y);
+                  r20.z = f32tof16(r20.z);
+                  r27.x = mad((int)r20.z, 0x00010000, (int)r19.w);
+                  r19.w = min(2000, r44.x);
+                  r19.w = f32tof16(r19.w);
+                  r20.z = min(2000, r43.x);
+                  r20.z = f32tof16(r20.z);
+                  r27.y = mad((int)r20.z, 0x00010000, (int)r19.w);
+                  bitmask.w = ((~(-1 << 24)) << 8) & 0xffffffff;  r19.w = (((uint)r44.y << 8) & bitmask.w) | ((uint)r43.w & ~bitmask.w);
+                  r19.w = mad((int)r44.z, 0x00010000, (int)r19.w);
+                  bitmask.z = ((~(-1 << 24)) << 0) & 0xffffffff;  r27.z = (((uint)r19.w << 0) & bitmask.z) | ((uint)r43.w & ~bitmask.z);
+                // No code for instruction (needs manual fix):
+                                store_raw u1.xyz, r25.w, r27.xyzx
+                // No code for instruction (needs manual fix):
+                                ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r19.w, r26.y, u7.xxxx
+                  bitmask.z = ((~(-1 << 16)) << 16) & 0xffffffff;  r19.z = (((uint)r19.z << 16) & bitmask.z) | ((uint)r19.w & ~bitmask.z);
+                  bitmask.w = ((~(-1 << 16)) << 0) & 0xffffffff;  r19.w = (((uint)r19.z << 0) & bitmask.w) | ((uint)r19.w & ~bitmask.w);
+                  r19.w = (int)r29.y * (int)r19.w;
+                  r19.z = mad((int)r19.z, (int)r20.w, (int)r19.w);
+                // No code for instruction (needs manual fix):
+                                store_raw u7.x, r26.y, r19.z
+                }
+              }
+            }
+          }
+        } else {
+          r26.w = r14.y;
+          r27.w = r14.z;
+        }
+        r19.z = ~(int)r27.w;
+        r19.z = (int)r19.z & (int)r26.w;
+        r19.w = (int)r13.z + 3;
+        r13.z = r19.z ? r19.w : r13.z;
+        r19.z = ~(int)r26.w;
+        r19.z = (int)r27.w & (int)r19.z;
+        if (r19.z != 0) {
+          r19.z = (uint)r21.x >> 1;
+          r19.z = (uint)r19.z << 2;
+        // No code for instruction (needs manual fix):
+                ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r19.w, r19.z, u4.xxxx
+          r20.z = (int)r21.x & 1;
+          bitmask.z = ((~(-1 << 16)) << 16) & 0xffffffff;  r25.z = (((uint)r23.y << 16) & bitmask.z) | ((uint)r19.w & ~bitmask.z);
+          bitmask.w = ((~(-1 << 16)) << 0) & 0xffffffff;  r25.w = (((uint)r23.y << 0) & bitmask.w) | ((uint)r19.w & ~bitmask.w);
+          r19.w = (int)-r20.z + 1;
+          r19.w = (int)r19.w * (int)r25.w;
+          r19.w = mad((int)r25.z, (int)r20.z, (int)r19.w);
+        // No code for instruction (needs manual fix):
+                store_raw u4.x, r19.z, r19.w
+          r21.xyz = (int3)r21.xxx + int3(3,1,2);
+          r19.zw = (uint2)r21.yz >> int2(1,1);
+          r19.zw = (uint2)r19.zw << int2(2,2);
+        // No code for instruction (needs manual fix):
+                ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r20.z, r19.z, u4.xxxx
+          r21.yz = (int2)r21.yz & int2(1,1);
+          bitmask.z = ((~(-1 << 16)) << 16) & 0xffffffff;  r20.z = (((uint)r23.z << 16) & bitmask.z) | ((uint)r20.z & ~bitmask.z);
+          bitmask.w = ((~(-1 << 16)) << 0) & 0xffffffff;  r20.w = (((uint)r23.z << 0) & bitmask.w) | ((uint)r20.z & ~bitmask.w);
+          r25.zw = (int2)-r21.yz + int2(1,1);
+          r20.w = (int)r20.w * (int)r25.z;
+          r20.z = mad((int)r20.z, (int)r21.y, (int)r20.w);
+        // No code for instruction (needs manual fix):
+                store_raw u4.x, r19.z, r20.z
+        // No code for instruction (needs manual fix):
+                ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r19.z, r19.w, u4.xxxx
+          bitmask.z = ((~(-1 << 16)) << 16) & 0xffffffff;  r20.z = (((uint)r24.z << 16) & bitmask.z) | ((uint)r19.z & ~bitmask.z);
+          bitmask.w = ((~(-1 << 16)) << 0) & 0xffffffff;  r20.w = (((uint)r24.z << 0) & bitmask.w) | ((uint)r19.z & ~bitmask.w);
+          r19.z = (int)r25.w * (int)r20.w;
+          r19.z = mad((int)r20.z, (int)r21.z, (int)r19.z);
+        // No code for instruction (needs manual fix):
+                store_raw u4.x, r19.w, r19.z
+          r19.z = mad((int)r23.y, asint(cb0[5].x), asint(cb0[6].z));
+        // No code for instruction (needs manual fix):
+                ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r19.w, r19.z, t1.xxxx
+          r20.z = f16tof32(r19.w);
+          r19.w = (uint)r19.w >> 16;
+          r19.w = f16tof32(r19.w);
+          r19.z = (int)r19.z + 4;
+        // No code for instruction (needs manual fix):
+                ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r21.yz, r19.z, t1.xxyx
+          r19.z = f16tof32(r21.y);
+          r20.w = (uint)r21.y >> 16;
+          r20.w = f16tof32(r20.w);
+          r20.z = cmp(0 < r20.z);
+          if (r20.z != 0) {
+            if (3 == 0) r20.z = 0; else if (3+5 < 32) {             r20.z = (uint)r21.z << (32-(3 + 5)); r20.z = (uint)r20.z >> (32-3);            } else r20.z = (uint)r21.z >> 5;
+            r27.xyzw = cmp((int4)r20.zzzz == int4(0,1,2,3));
+            r28.xyzw = cmp((int4)r20.zzzz == int4(4,5,6,7));
+            r27.xyzw = r27.xyzw ? r15.xyzw : 0;
+            r21.y = (int)r27.x | (int)r27.y;
+            r21.y = (int)r21.y | (int)r27.z;
+            r21.y = (int)r21.y | (int)r27.w;
+            r27.xyzw = r28.xyzw ? r16.xyzw : 0;
+            r21.y = (int)r21.y | (int)r27.x;
+            r21.y = (int)r21.y | (int)r27.y;
+            r21.y = (int)r21.y | (int)r27.z;
+            r21.y = (int)r21.y | (int)r27.w;
+            bitmask.y = ((~(-1 << 1)) << r21.z) & 0xffffffff;  r21.y = (((uint)1 << r21.z) & bitmask.y) | ((uint)r21.y & ~bitmask.y);
+            r20.z = 1 << (int)r20.z;
+            r27.xyzw = (int4)r20.zzzz & int4(1,2,4,8);
+            r27.xyzw = r27.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+            r27.xyzw = (int4)r21.yyyy * (int4)r27.xyzw;
+            r15.xyzw = (int4)r15.xyzw | (int4)r27.xyzw;
+            r27.xyzw = (int4)r20.zzzz & int4(16,32,64,128);
+            r27.xyzw = r27.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+            r27.xyzw = (int4)r21.yyyy * (int4)r27.xyzw;
+            r16.xyzw = (int4)r16.xyzw | (int4)r27.xyzw;
+          }
+          r19.zw = cmp(float2(0,0) < r19.zw);
+          if (r19.w != 0) {
+            r19.w = (uint)r21.z >> 8;
+            if (3 == 0) r20.z = 0; else if (3+13 < 32) {             r20.z = (uint)r21.z << (32-(3 + 13)); r20.z = (uint)r20.z >> (32-3);            } else r20.z = (uint)r21.z >> 13;
+            r27.xyzw = cmp((int4)r20.zzzz == int4(0,1,2,3));
+            r28.xyzw = cmp((int4)r20.zzzz == int4(4,5,6,7));
+            r27.xyzw = r27.xyzw ? r15.xyzw : 0;
+            r21.y = (int)r27.x | (int)r27.y;
+            r21.y = (int)r21.y | (int)r27.z;
+            r21.y = (int)r21.y | (int)r27.w;
+            r27.xyzw = r28.xyzw ? r16.xyzw : 0;
+            r21.y = (int)r21.y | (int)r27.x;
+            r21.y = (int)r21.y | (int)r27.y;
+            r21.y = (int)r21.y | (int)r27.z;
+            r21.y = (int)r21.y | (int)r27.w;
+            bitmask.w = ((~(-1 << 1)) << r19.w) & 0xffffffff;  r19.w = (((uint)1 << r19.w) & bitmask.w) | ((uint)r21.y & ~bitmask.w);
+            r20.z = 1 << (int)r20.z;
+            r27.xyzw = (int4)r20.zzzz & int4(1,2,4,8);
+            r27.xyzw = r27.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+            r27.xyzw = (int4)r19.wwww * (int4)r27.xyzw;
+            r15.xyzw = (int4)r15.xyzw | (int4)r27.xyzw;
+            r27.xyzw = (int4)r20.zzzz & int4(16,32,64,128);
+            r27.xyzw = r27.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+            r27.xyzw = (int4)r19.wwww * (int4)r27.xyzw;
+            r16.xyzw = (int4)r16.xyzw | (int4)r27.xyzw;
+          }
+          if (r19.z != 0) {
+            r19.z = (uint)r21.z >> 16;
+            if (3 == 0) r19.w = 0; else if (3+21 < 32) {             r19.w = (uint)r21.z << (32-(3 + 21)); r19.w = (uint)r19.w >> (32-3);            } else r19.w = (uint)r21.z >> 21;
+            r27.xyzw = cmp((int4)r19.wwww == int4(0,1,2,3));
+            r28.xyzw = cmp((int4)r19.wwww == int4(4,5,6,7));
+            r27.xyzw = r27.xyzw ? r15.xyzw : 0;
+            r20.z = (int)r27.x | (int)r27.y;
+            r20.z = (int)r20.z | (int)r27.z;
+            r20.z = (int)r20.z | (int)r27.w;
+            r27.xyzw = r28.xyzw ? r16.xyzw : 0;
+            r20.z = (int)r20.z | (int)r27.x;
+            r20.z = (int)r20.z | (int)r27.y;
+            r20.z = (int)r20.z | (int)r27.z;
+            r20.z = (int)r20.z | (int)r27.w;
+            bitmask.z = ((~(-1 << 1)) << r19.z) & 0xffffffff;  r19.z = (((uint)1 << r19.z) & bitmask.z) | ((uint)r20.z & ~bitmask.z);
+            r19.w = 1 << (int)r19.w;
+            r27.xyzw = (int4)r19.wwww & int4(1,2,4,8);
+            r27.xyzw = r27.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+            r27.xyzw = (int4)r19.zzzz * (int4)r27.xyzw;
+            r15.xyzw = (int4)r15.xyzw | (int4)r27.xyzw;
+            r27.xyzw = (int4)r19.wwww & int4(16,32,64,128);
+            r27.xyzw = r27.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+            r27.xyzw = (int4)r19.zzzz * (int4)r27.xyzw;
+            r16.xyzw = (int4)r16.xyzw | (int4)r27.xyzw;
+          }
+          r19.z = cmp(0 < r20.w);
+          if (r19.z != 0) {
+            r19.z = (uint)r21.z >> 24;
+            r19.w = (uint)r19.z >> 5;
+            r27.xyzw = cmp((int4)r19.wwww == int4(0,1,2,3));
+            r28.xyzw = cmp((int4)r19.wwww == int4(4,5,6,7));
+            r27.xyzw = r27.xyzw ? r15.xyzw : 0;
+            r20.z = (int)r27.x | (int)r27.y;
+            r20.z = (int)r20.z | (int)r27.z;
+            r20.z = (int)r20.z | (int)r27.w;
+            r27.xyzw = r28.xyzw ? r16.xyzw : 0;
+            r20.z = (int)r20.z | (int)r27.x;
+            r20.z = (int)r20.z | (int)r27.y;
+            r20.z = (int)r20.z | (int)r27.z;
+            r20.z = (int)r20.z | (int)r27.w;
+            bitmask.z = ((~(-1 << 1)) << r19.z) & 0xffffffff;  r19.z = (((uint)1 << r19.z) & bitmask.z) | ((uint)r20.z & ~bitmask.z);
+            r19.w = 1 << (int)r19.w;
+            r27.xyzw = (int4)r19.wwww & int4(1,2,4,8);
+            r27.xyzw = r27.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+            r27.xyzw = (int4)r19.zzzz * (int4)r27.xyzw;
+            r15.xyzw = (int4)r15.xyzw | (int4)r27.xyzw;
+            r27.xyzw = (int4)r19.wwww & int4(16,32,64,128);
+            r27.xyzw = r27.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+            r27.xyzw = (int4)r19.zzzz * (int4)r27.xyzw;
+            r16.xyzw = (int4)r16.xyzw | (int4)r27.xyzw;
+          }
+          r19.z = mad((int)r23.z, asint(cb0[5].x), asint(cb0[6].z));
+        // No code for instruction (needs manual fix):
+                ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r19.w, r19.z, t1.xxxx
+          r20.z = f16tof32(r19.w);
+          r19.w = (uint)r19.w >> 16;
+          r19.w = f16tof32(r19.w);
+          r19.z = (int)r19.z + 4;
+        // No code for instruction (needs manual fix):
+                ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r21.yz, r19.z, t1.xxyx
+          r19.z = f16tof32(r21.y);
+          r20.w = (uint)r21.y >> 16;
+          r20.w = f16tof32(r20.w);
+          r20.z = cmp(0 < r20.z);
+          if (r20.z != 0) {
+            if (3 == 0) r20.z = 0; else if (3+5 < 32) {             r20.z = (uint)r21.z << (32-(3 + 5)); r20.z = (uint)r20.z >> (32-3);            } else r20.z = (uint)r21.z >> 5;
+            r27.xyzw = cmp((int4)r20.zzzz == int4(0,1,2,3));
+            r28.xyzw = cmp((int4)r20.zzzz == int4(4,5,6,7));
+            r27.xyzw = r27.xyzw ? r15.xyzw : 0;
+            r21.y = (int)r27.x | (int)r27.y;
+            r21.y = (int)r21.y | (int)r27.z;
+            r21.y = (int)r21.y | (int)r27.w;
+            r27.xyzw = r28.xyzw ? r16.xyzw : 0;
+            r21.y = (int)r21.y | (int)r27.x;
+            r21.y = (int)r21.y | (int)r27.y;
+            r21.y = (int)r21.y | (int)r27.z;
+            r21.y = (int)r21.y | (int)r27.w;
+            bitmask.y = ((~(-1 << 1)) << r21.z) & 0xffffffff;  r21.y = (((uint)1 << r21.z) & bitmask.y) | ((uint)r21.y & ~bitmask.y);
+            r20.z = 1 << (int)r20.z;
+            r27.xyzw = (int4)r20.zzzz & int4(1,2,4,8);
+            r27.xyzw = r27.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+            r27.xyzw = (int4)r21.yyyy * (int4)r27.xyzw;
+            r15.xyzw = (int4)r15.xyzw | (int4)r27.xyzw;
+            r27.xyzw = (int4)r20.zzzz & int4(16,32,64,128);
+            r27.xyzw = r27.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+            r27.xyzw = (int4)r21.yyyy * (int4)r27.xyzw;
+            r16.xyzw = (int4)r16.xyzw | (int4)r27.xyzw;
+          }
+          r19.zw = cmp(float2(0,0) < r19.zw);
+          if (r19.w != 0) {
+            r19.w = (uint)r21.z >> 8;
+            if (3 == 0) r20.z = 0; else if (3+13 < 32) {             r20.z = (uint)r21.z << (32-(3 + 13)); r20.z = (uint)r20.z >> (32-3);            } else r20.z = (uint)r21.z >> 13;
+            r27.xyzw = cmp((int4)r20.zzzz == int4(0,1,2,3));
+            r28.xyzw = cmp((int4)r20.zzzz == int4(4,5,6,7));
+            r27.xyzw = r27.xyzw ? r15.xyzw : 0;
+            r21.y = (int)r27.x | (int)r27.y;
+            r21.y = (int)r21.y | (int)r27.z;
+            r21.y = (int)r21.y | (int)r27.w;
+            r27.xyzw = r28.xyzw ? r16.xyzw : 0;
+            r21.y = (int)r21.y | (int)r27.x;
+            r21.y = (int)r21.y | (int)r27.y;
+            r21.y = (int)r21.y | (int)r27.z;
+            r21.y = (int)r21.y | (int)r27.w;
+            bitmask.w = ((~(-1 << 1)) << r19.w) & 0xffffffff;  r19.w = (((uint)1 << r19.w) & bitmask.w) | ((uint)r21.y & ~bitmask.w);
+            r20.z = 1 << (int)r20.z;
+            r27.xyzw = (int4)r20.zzzz & int4(1,2,4,8);
+            r27.xyzw = r27.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+            r27.xyzw = (int4)r19.wwww * (int4)r27.xyzw;
+            r15.xyzw = (int4)r15.xyzw | (int4)r27.xyzw;
+            r27.xyzw = (int4)r20.zzzz & int4(16,32,64,128);
+            r27.xyzw = r27.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+            r27.xyzw = (int4)r19.wwww * (int4)r27.xyzw;
+            r16.xyzw = (int4)r16.xyzw | (int4)r27.xyzw;
+          }
+          if (r19.z != 0) {
+            r19.z = (uint)r21.z >> 16;
+            if (3 == 0) r19.w = 0; else if (3+21 < 32) {             r19.w = (uint)r21.z << (32-(3 + 21)); r19.w = (uint)r19.w >> (32-3);            } else r19.w = (uint)r21.z >> 21;
+            r27.xyzw = cmp((int4)r19.wwww == int4(0,1,2,3));
+            r28.xyzw = cmp((int4)r19.wwww == int4(4,5,6,7));
+            r27.xyzw = r27.xyzw ? r15.xyzw : 0;
+            r20.z = (int)r27.x | (int)r27.y;
+            r20.z = (int)r20.z | (int)r27.z;
+            r20.z = (int)r20.z | (int)r27.w;
+            r27.xyzw = r28.xyzw ? r16.xyzw : 0;
+            r20.z = (int)r20.z | (int)r27.x;
+            r20.z = (int)r20.z | (int)r27.y;
+            r20.z = (int)r20.z | (int)r27.z;
+            r20.z = (int)r20.z | (int)r27.w;
+            bitmask.z = ((~(-1 << 1)) << r19.z) & 0xffffffff;  r19.z = (((uint)1 << r19.z) & bitmask.z) | ((uint)r20.z & ~bitmask.z);
+            r19.w = 1 << (int)r19.w;
+            r27.xyzw = (int4)r19.wwww & int4(1,2,4,8);
+            r27.xyzw = r27.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+            r27.xyzw = (int4)r19.zzzz * (int4)r27.xyzw;
+            r15.xyzw = (int4)r15.xyzw | (int4)r27.xyzw;
+            r27.xyzw = (int4)r19.wwww & int4(16,32,64,128);
+            r27.xyzw = r27.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+            r27.xyzw = (int4)r19.zzzz * (int4)r27.xyzw;
+            r16.xyzw = (int4)r16.xyzw | (int4)r27.xyzw;
+          }
+          r19.z = cmp(0 < r20.w);
+          if (r19.z != 0) {
+            r19.z = (uint)r21.z >> 24;
+            r19.w = (uint)r19.z >> 5;
+            r27.xyzw = cmp((int4)r19.wwww == int4(0,1,2,3));
+            r28.xyzw = cmp((int4)r19.wwww == int4(4,5,6,7));
+            r27.xyzw = r27.xyzw ? r15.xyzw : 0;
+            r20.z = (int)r27.x | (int)r27.y;
+            r20.z = (int)r20.z | (int)r27.z;
+            r20.z = (int)r20.z | (int)r27.w;
+            r27.xyzw = r28.xyzw ? r16.xyzw : 0;
+            r20.z = (int)r20.z | (int)r27.x;
+            r20.z = (int)r20.z | (int)r27.y;
+            r20.z = (int)r20.z | (int)r27.z;
+            r20.z = (int)r20.z | (int)r27.w;
+            bitmask.z = ((~(-1 << 1)) << r19.z) & 0xffffffff;  r19.z = (((uint)1 << r19.z) & bitmask.z) | ((uint)r20.z & ~bitmask.z);
+            r19.w = 1 << (int)r19.w;
+            r27.xyzw = (int4)r19.wwww & int4(1,2,4,8);
+            r27.xyzw = r27.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+            r27.xyzw = (int4)r19.zzzz * (int4)r27.xyzw;
+            r15.xyzw = (int4)r15.xyzw | (int4)r27.xyzw;
+            r27.xyzw = (int4)r19.wwww & int4(16,32,64,128);
+            r27.xyzw = r27.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+            r27.xyzw = (int4)r19.zzzz * (int4)r27.xyzw;
+            r16.xyzw = (int4)r16.xyzw | (int4)r27.xyzw;
+          }
+          r19.z = mad((int)r24.z, asint(cb0[5].x), asint(cb0[6].z));
+        // No code for instruction (needs manual fix):
+                ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r19.w, r19.z, t1.xxxx
+          r20.z = f16tof32(r19.w);
+          r19.w = (uint)r19.w >> 16;
+          r19.w = f16tof32(r19.w);
+          r19.z = (int)r19.z + 4;
+        // No code for instruction (needs manual fix):
+                ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r21.yz, r19.z, t1.xxyx
+          r19.z = f16tof32(r21.y);
+          r20.w = (uint)r21.y >> 16;
+          r20.w = f16tof32(r20.w);
+          r20.z = cmp(0 < r20.z);
+          if (r20.z != 0) {
+            if (3 == 0) r20.z = 0; else if (3+5 < 32) {             r20.z = (uint)r21.z << (32-(3 + 5)); r20.z = (uint)r20.z >> (32-3);            } else r20.z = (uint)r21.z >> 5;
+            r27.xyzw = cmp((int4)r20.zzzz == int4(0,1,2,3));
+            r28.xyzw = cmp((int4)r20.zzzz == int4(4,5,6,7));
+            r27.xyzw = r27.xyzw ? r15.xyzw : 0;
+            r21.y = (int)r27.x | (int)r27.y;
+            r21.y = (int)r21.y | (int)r27.z;
+            r21.y = (int)r21.y | (int)r27.w;
+            r27.xyzw = r28.xyzw ? r16.xyzw : 0;
+            r21.y = (int)r21.y | (int)r27.x;
+            r21.y = (int)r21.y | (int)r27.y;
+            r21.y = (int)r21.y | (int)r27.z;
+            r21.y = (int)r21.y | (int)r27.w;
+            bitmask.y = ((~(-1 << 1)) << r21.z) & 0xffffffff;  r21.y = (((uint)1 << r21.z) & bitmask.y) | ((uint)r21.y & ~bitmask.y);
+            r20.z = 1 << (int)r20.z;
+            r27.xyzw = (int4)r20.zzzz & int4(1,2,4,8);
+            r27.xyzw = r27.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+            r27.xyzw = (int4)r21.yyyy * (int4)r27.xyzw;
+            r15.xyzw = (int4)r15.xyzw | (int4)r27.xyzw;
+            r27.xyzw = (int4)r20.zzzz & int4(16,32,64,128);
+            r27.xyzw = r27.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+            r27.xyzw = (int4)r21.yyyy * (int4)r27.xyzw;
+            r16.xyzw = (int4)r16.xyzw | (int4)r27.xyzw;
+          }
+          r19.zw = cmp(float2(0,0) < r19.zw);
+          if (r19.w != 0) {
+            r19.w = (uint)r21.z >> 8;
+            if (3 == 0) r20.z = 0; else if (3+13 < 32) {             r20.z = (uint)r21.z << (32-(3 + 13)); r20.z = (uint)r20.z >> (32-3);            } else r20.z = (uint)r21.z >> 13;
+            r27.xyzw = cmp((int4)r20.zzzz == int4(0,1,2,3));
+            r28.xyzw = cmp((int4)r20.zzzz == int4(4,5,6,7));
+            r27.xyzw = r27.xyzw ? r15.xyzw : 0;
+            r21.y = (int)r27.x | (int)r27.y;
+            r21.y = (int)r21.y | (int)r27.z;
+            r21.y = (int)r21.y | (int)r27.w;
+            r27.xyzw = r28.xyzw ? r16.xyzw : 0;
+            r21.y = (int)r21.y | (int)r27.x;
+            r21.y = (int)r21.y | (int)r27.y;
+            r21.y = (int)r21.y | (int)r27.z;
+            r21.y = (int)r21.y | (int)r27.w;
+            bitmask.w = ((~(-1 << 1)) << r19.w) & 0xffffffff;  r19.w = (((uint)1 << r19.w) & bitmask.w) | ((uint)r21.y & ~bitmask.w);
+            r20.z = 1 << (int)r20.z;
+            r27.xyzw = (int4)r20.zzzz & int4(1,2,4,8);
+            r27.xyzw = r27.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+            r27.xyzw = (int4)r19.wwww * (int4)r27.xyzw;
+            r15.xyzw = (int4)r15.xyzw | (int4)r27.xyzw;
+            r27.xyzw = (int4)r20.zzzz & int4(16,32,64,128);
+            r27.xyzw = r27.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+            r27.xyzw = (int4)r19.wwww * (int4)r27.xyzw;
+            r16.xyzw = (int4)r16.xyzw | (int4)r27.xyzw;
+          }
+          if (r19.z != 0) {
+            r19.z = (uint)r21.z >> 16;
+            if (3 == 0) r19.w = 0; else if (3+21 < 32) {             r19.w = (uint)r21.z << (32-(3 + 21)); r19.w = (uint)r19.w >> (32-3);            } else r19.w = (uint)r21.z >> 21;
+            r27.xyzw = cmp((int4)r19.wwww == int4(0,1,2,3));
+            r28.xyzw = cmp((int4)r19.wwww == int4(4,5,6,7));
+            r27.xyzw = r27.xyzw ? r15.xyzw : 0;
+            r20.z = (int)r27.x | (int)r27.y;
+            r20.z = (int)r20.z | (int)r27.z;
+            r20.z = (int)r20.z | (int)r27.w;
+            r27.xyzw = r28.xyzw ? r16.xyzw : 0;
+            r20.z = (int)r20.z | (int)r27.x;
+            r20.z = (int)r20.z | (int)r27.y;
+            r20.z = (int)r20.z | (int)r27.z;
+            r20.z = (int)r20.z | (int)r27.w;
+            bitmask.z = ((~(-1 << 1)) << r19.z) & 0xffffffff;  r19.z = (((uint)1 << r19.z) & bitmask.z) | ((uint)r20.z & ~bitmask.z);
+            r19.w = 1 << (int)r19.w;
+            r27.xyzw = (int4)r19.wwww & int4(1,2,4,8);
+            r27.xyzw = r27.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+            r27.xyzw = (int4)r19.zzzz * (int4)r27.xyzw;
+            r15.xyzw = (int4)r15.xyzw | (int4)r27.xyzw;
+            r27.xyzw = (int4)r19.wwww & int4(16,32,64,128);
+            r27.xyzw = r27.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+            r27.xyzw = (int4)r19.zzzz * (int4)r27.xyzw;
+            r16.xyzw = (int4)r16.xyzw | (int4)r27.xyzw;
+          }
+          r19.z = cmp(0 < r20.w);
+          if (r19.z != 0) {
+            r19.z = (uint)r21.z >> 24;
+            r19.w = (uint)r19.z >> 5;
+            r27.xyzw = cmp((int4)r19.wwww == int4(0,1,2,3));
+            r28.xyzw = cmp((int4)r19.wwww == int4(4,5,6,7));
+            r27.xyzw = r27.xyzw ? r15.xyzw : 0;
+            r20.z = (int)r27.x | (int)r27.y;
+            r20.z = (int)r20.z | (int)r27.z;
+            r20.z = (int)r20.z | (int)r27.w;
+            r27.xyzw = r28.xyzw ? r16.xyzw : 0;
+            r20.z = (int)r20.z | (int)r27.x;
+            r20.z = (int)r20.z | (int)r27.y;
+            r20.z = (int)r20.z | (int)r27.z;
+            r20.z = (int)r20.z | (int)r27.w;
+            bitmask.z = ((~(-1 << 1)) << r19.z) & 0xffffffff;  r19.z = (((uint)1 << r19.z) & bitmask.z) | ((uint)r20.z & ~bitmask.z);
+            r19.w = 1 << (int)r19.w;
+            r27.xyzw = (int4)r19.wwww & int4(1,2,4,8);
+            r27.xyzw = r27.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+            r27.xyzw = (int4)r19.zzzz * (int4)r27.xyzw;
+            r15.xyzw = (int4)r15.xyzw | (int4)r27.xyzw;
+            r27.xyzw = (int4)r19.wwww & int4(16,32,64,128);
+            r27.xyzw = r27.xyzw ? float4(1,1,1,1) : float4(0,0,0,0);
+            r27.xyzw = (int4)r19.zzzz * (int4)r27.xyzw;
+            r16.xyzw = (int4)r16.xyzw | (int4)r27.xyzw;
+          }
+        // No code for instruction (needs manual fix):
+                ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r19.z, r23.x, u2.xxxx
+          r19.zw = (int2)r19.zz & int2(0xffff,0xffff0000);
+          r19.w = (int)r23.w * (int)r19.w;
+          r19.z = mad((int)r19.z, (int)r22.w, (int)r19.w);
+        // No code for instruction (needs manual fix):
+                store_raw u2.x, r23.x, r19.z
+        // No code for instruction (needs manual fix):
+                ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r19.z, r22.y, u2.xxxx
+          r19.zw = (int2)r19.zz & int2(0xffff,0xffff0000);
+          r19.w = (int)r25.x * (int)r19.w;
+          r19.z = mad((int)r19.z, (int)r24.x, (int)r19.w);
+        // No code for instruction (needs manual fix):
+                store_raw u2.x, r22.y, r19.z
+        // No code for instruction (needs manual fix):
+                ld_raw_indexable(raw_buffer)(mixed,mixed,mixed,mixed) r19.z, r22.z, u2.xxxx
+          r19.zw = (int2)r19.zz & int2(0xffff,0xffff0000);
+          r19.w = (int)r25.y * (int)r19.w;
+          r19.z = mad((int)r19.z, (int)r24.y, (int)r19.w);
+        // No code for instruction (needs manual fix):
+                store_raw u2.x, r22.z, r19.z
+        }
+        r21.w = (int)r21.w | (int)r26.w;
+      }
+      r10.xyzw = r15.xyzw;
+      r11.xyzw = r16.xyzw;
+      r6.xyz = r17.xyz;
+      r7.xyz = r18.xyz;
+      r8.yw = r19.xy;
+      r9.xy = r20.xy;
+      r8.x = r13.z;
+      r8.z = r21.x;
+      r9.w = r17.w;
+      r6.w = r18.w;
+      r13.x = r21.w ? 0 : 1;
+      r13.x = (uint)r13.x << (int)r12.w;
+      r9.z = (int)r9.z | (int)r13.x;
+      r12.w = (int)r12.w + 1;
+    }
+    u0[vThreadID.x].val[0/4] = r6.x;
+    u0[vThreadID.x].val[0/4+1] = r6.y;
+    u0[vThreadID.x].val[0/4+2] = r6.z;
+    u0[vThreadID.x].val[16/4] = r7.x;
+    u0[vThreadID.x].val[16/4+1] = r7.y;
+    u0[vThreadID.x].val[16/4+2] = r7.z;
+    u0[vThreadID.x].val[32/4] = r8.x;
+    u0[vThreadID.x].val[32/4+1] = r8.y;
+    u0[vThreadID.x].val[32/4+2] = r8.z;
+    u0[vThreadID.x].val[32/4+3] = r8.w;
+    u0[vThreadID.x].val[48/4] = r9.x;
+    u0[vThreadID.x].val[48/4+1] = r9.y;
+    u0[vThreadID.x].val[48/4+2] = r9.z;
+    u0[vThreadID.x].val[48/4+3] = r9.w;
+    u0[vThreadID.x].val[64/4] = r10.x;
+    u0[vThreadID.x].val[64/4+1] = r10.y;
+    u0[vThreadID.x].val[64/4+2] = r10.z;
+    u0[vThreadID.x].val[64/4+3] = r10.w;
+    u0[vThreadID.x].val[80/4] = r11.x;
+    u0[vThreadID.x].val[80/4+1] = r11.y;
+    u0[vThreadID.x].val[80/4+2] = r11.z;
+    u0[vThreadID.x].val[80/4+3] = r11.w;
+    u0[vThreadID.x].val[96/4] = r6.w;
+  }
+  return;
+}


### PR DESCRIPTION
### Enhancements:

- **HDR Support:** Implemented HDR support including the ACES and RenoDRT tonemappers. The RenoDRT tonemapper has been specifically tuned to closely match the visual aesthetics of SDR.


### Known Issues:

- **Sign-in Crashes:** There are occasional crashes during the sign-in process. This issue is under active investigation, and updates will be provided as progress is made.
- **Missing UI Elements:** Currently, UI elements for controlling Depth of Field (DOF), autoexposure, and bloom effects are not implemented. These controls are crucial for full graphical fidelity and are targeted for inclusion in future updates.