### PR TITLE
Add Support for Dark Souls: Remastered

### DIFF
--- a/src/games/darksouls/addon.cpp
+++ b/src/games/darksouls/addon.cpp
@@ -1,0 +1,286 @@
+/*
+ * Copyright (C) 2024 Carlos Lopez
+ * Copyright (C) 2024 Musa Haji
+ * SPDX-License-Identifier: MIT
+ */
+
+#define ImTextureID ImU64
+
+#define DEBUG_LEVEL_0
+
+#include <embed/0xDFCB6E8B.h>    // Far DoF
+// #include <embed/0xE638B2D7.h> // Near DoF
+// #include <embed/0x65E2CEE4.h> // Fog Color
+#include <embed/0x6FDD08FC.h>    // Bloom
+#include <embed/0xF87B3349.h>    // Tonemap
+#include <embed/0x64F62639.h>    // UI - some minor elements
+#include <embed/0x809881A3.h>    // UI - most elements
+#include <embed/0x6024AB96.h>    // UI - Text
+#include <embed/0xB0850BF3.h>    // UI? - need to figure out what this does
+#include <embed/0xAB7CF260.h>    // Gamma
+
+
+#include <chrono>
+
+#include <deps/imgui/imgui.h>
+#include <include/reshade.hpp>
+#include "../../mods/shaderReplaceMod.hpp"
+#include "../../mods/swapChainUpgradeMod.hpp"
+#include "../../utils/userSettingUtil.hpp"
+#include "./shared.h"
+
+extern "C" __declspec(dllexport) const char* NAME = "RenoDX - Dark Souls: Remastered";
+extern "C" __declspec(dllexport) const char* DESCRIPTION = "RenoDX for Dark Souls: Remastered";
+
+ShaderReplaceMod::CustomShaders customShaders = {
+  CustomShaderEntry(0xDFCB6E8B),              // Far DoF
+  // CustomShaderEntry(0xE638B2D7),           // Near DoF
+  // CustomShaderEntry(0x65E2CEE4),           // Fog Color
+  CustomShaderEntry(0x6FDD08FC),              // Bloom  
+  CustomShaderEntry(0xF87B3349),              // Tonemap  
+  CustomShaderEntry(0x64F62639),              // UI - some elements (found in character creator)
+  CustomShaderEntry(0x809881A3),              // UI - most elements
+  CustomShaderEntry(0x6024AB96),              // UI - Text
+  CustomShaderEntry(0xB0850BF3),              // UI? - not sure what this does
+  CustomSwapchainShader(0xAB7CF260),          // Gamma  
+};
+
+ShaderInjectData shaderInjection;
+
+// clang-format off
+UserSettingUtil::UserSettings userSettings = {
+  new UserSettingUtil::UserSetting {
+    .key = "toneMapType",
+    .binding = &shaderInjection.toneMapType,
+    .valueType = UserSettingUtil::UserSettingValueType::integer,
+    .defaultValue = 3.f,
+    .canReset = false,
+    .label = "Tone Mapper",
+    .section = "Tone Mapping",
+    .tooltip = "Sets the tone mapper type",
+    .labels = {"Vanilla", "None", "ACES", "RenoDRT"}
+  },
+  new UserSettingUtil::UserSetting {
+    .key = "toneMapPeakNits",
+    .binding = &shaderInjection.toneMapPeakNits,
+    .defaultValue = 1000.f,
+    .canReset = false,
+    .label = "Peak Brightness",
+    .section = "Tone Mapping",
+    .tooltip = "Sets the value of peak white in nits",
+    .min = 48.f,
+    .max = 4000.f
+  },
+  new UserSettingUtil::UserSetting {
+    .key = "toneMapGameNits",
+    .binding = &shaderInjection.toneMapGameNits,
+    .defaultValue = 203.f,
+    .canReset = false,
+    .label = "Game Brightness",
+    .section = "Tone Mapping",
+    .tooltip = "Sets the value of 100%% white in nits",
+    .min = 48.f,
+    .max = 500.f
+  },
+  new UserSettingUtil::UserSetting {
+    .key = "toneMapUINits",
+    .binding = &shaderInjection.toneMapUINits,
+    .defaultValue = 203.f,
+    .canReset = false,
+    .label = "UI Brightness",
+    .section = "Tone Mapping",
+    .tooltip = "Sets the brightness of UI and HUD elements in nits",
+    .min = 48.f,
+    .max = 500.f
+  },
+  new UserSettingUtil::UserSetting {
+    .key = "toneMapGammaCorrection",
+    .binding = &shaderInjection.toneMapGammaCorrection,
+    .valueType = UserSettingUtil::UserSettingValueType::boolean,
+    .defaultValue = 1,
+    .canReset = false,
+    .label = "Gamma Correction",
+    .section = "Tone Mapping",
+    .tooltip = "Emulates a 2.2 EOTF (use with HDR or sRGB)",
+  },
+  new UserSettingUtil::UserSetting {
+    .key = "toneMapHueCorrection",
+    .binding = &shaderInjection.toneMapHueCorrection,
+    .valueType = UserSettingUtil::UserSettingValueType::boolean,
+    .defaultValue = 1,
+    .canReset = false,
+    .label = "Hue Correction",
+    .section = "Tone Mapping",
+    .tooltip = "Emulates hue shifting from the vanilla tonemapper",
+  },
+  new UserSettingUtil::UserSetting {
+    .key = "colorGradeExposure",
+    .binding = &shaderInjection.colorGradeExposure,
+    .defaultValue = 1.f,
+    .label = "Exposure",
+    .section = "Color Grading",
+    .max = 20.f,
+    .format = "%.2f"
+  },
+  new UserSettingUtil::UserSetting {
+    .key = "colorGradeHighlights",
+    .binding = &shaderInjection.colorGradeHighlights,
+    .defaultValue = 50.f,
+    .label = "Highlights",
+    .section = "Color Grading",
+    .max = 100.f,
+    .parse = [](float value) { return value * 0.02f; }
+  },
+  new UserSettingUtil::UserSetting {
+    .key = "colorGradeShadows",
+    .binding = &shaderInjection.colorGradeShadows,
+    .defaultValue = 50.f,
+    .label = "Shadows",
+    .section = "Color Grading",
+    .max = 100.f,
+    .parse = [](float value) { return value * 0.02f; }
+  },
+  new UserSettingUtil::UserSetting {
+    .key = "colorGradeContrast",
+    .binding = &shaderInjection.colorGradeContrast,
+    .defaultValue = 50.f,
+    .label = "Contrast",
+    .section = "Color Grading",
+    .max = 100.f,
+    .parse = [](float value) { return value * 0.02f; }
+  },
+  new UserSettingUtil::UserSetting {
+    .key = "colorGradeSaturation",
+    .binding = &shaderInjection.colorGradeSaturation,
+    .defaultValue = 50.f,
+    .label = "Saturation",
+    .section = "Color Grading",
+    .max = 100.f,
+    .parse = [](float value) { return value * 0.02f; }
+  },
+  new UserSettingUtil::UserSetting {
+    .key = "colorGradeBlowout",
+    .binding = &shaderInjection.colorGradeBlowout,
+    .defaultValue = 70.f,
+    .label = "Blowout",
+    .section = "Color Grading",
+    .tooltip = "Controls highlight desaturation due to overexposure.",
+    .max = 100.f,
+    .parse = [](float value) { return value * 0.01f; }
+  },
+  new UserSettingUtil::UserSetting {
+    .key = "colorGradeLUTStrength",
+    .binding = &shaderInjection.colorGradeLUTStrength,
+    .defaultValue = 100.f,
+    .label = "Color Filter Strength",
+    .section = "Color Grading",
+    .max = 100.f,
+    .parse = [](float value) { return value * 0.01f; }
+  },
+  new UserSettingUtil::UserSetting {
+    .key = "fxBloom",
+    .binding = &shaderInjection.fxBloom,
+    .defaultValue = 50.f,
+    .label = "Bloom",
+    .section = "Effects",
+    .max = 100.f,
+    .parse = [](float value) { return value * 0.02f; }
+  },
+  new UserSettingUtil::UserSetting {
+    .key = "fxDoF",
+    .binding = &shaderInjection.fxDoF,
+    .defaultValue = 50.f,
+    .label = "Depth of Field",
+    .section = "Effects",
+    .max = 100.f,
+    .parse = [](float value) { return value * 0.02f; }
+  },
+  new UserSettingUtil::UserSetting {
+    .key = "fxFilmGrain",
+    .binding = &shaderInjection.fxFilmGrain,
+    .defaultValue = 0.f,
+    .label = "Film Grain",
+    .section = "Effects",
+    .max = 100.f,
+    .parse = [](float value) { return value * 0.02f; }
+  },
+};
+
+// clang-format on
+
+static void onPresetOff() {
+  UserSettingUtil::updateUserSetting("toneMapType", 0.f);
+  UserSettingUtil::updateUserSetting("toneMapPeakNits", 203.f);
+  UserSettingUtil::updateUserSetting("toneMapGameNits", 203.f);
+  UserSettingUtil::updateUserSetting("toneMapUINits", 203.f);
+  UserSettingUtil::updateUserSetting("toneMapGammaCorrection", 0);
+  UserSettingUtil::updateUserSetting("toneMapHueCorrection", 0);
+  UserSettingUtil::updateUserSetting("colorGradeExposure", 1.f);
+  UserSettingUtil::updateUserSetting("colorGradeHighlights", 50.f);
+  UserSettingUtil::updateUserSetting("colorGradeShadows", 50.f);
+  UserSettingUtil::updateUserSetting("colorGradeContrast", 50.f);
+  UserSettingUtil::updateUserSetting("colorGradeSaturation", 50.f);
+  UserSettingUtil::updateUserSetting("colorGradeBlowout", 70.f);
+  UserSettingUtil::updateUserSetting("colorGradeLUTStrength", 100.f);
+  UserSettingUtil::updateUserSetting("fxBloom", 50.f);
+  UserSettingUtil::updateUserSetting("fxDoF", 50.f);
+  UserSettingUtil::updateUserSetting("fxFilmGrain", 0.f);
+}
+
+static auto start = std::chrono::steady_clock::now();
+
+static void on_present(
+  reshade::api::command_queue* queue,
+  reshade::api::swapchain* swapchain,
+  const reshade::api::rect* source_rect,
+  const reshade::api::rect* dest_rect,
+  uint32_t dirty_rect_count,
+  const reshade::api::rect* dirty_rects
+) {
+  auto end = std::chrono::steady_clock::now();
+  shaderInjection.elapsedTime = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+}
+
+BOOL APIENTRY DllMain(HMODULE hModule, DWORD fdwReason, LPVOID) {
+  switch (fdwReason) {
+    case DLL_PROCESS_ATTACH:
+
+      // ShaderReplaceMod::forcePipelineCloning = true;    
+      ShaderReplaceMod::expectedConstantBufferIndex = 11;
+      ShaderReplaceMod::traceUnmodifiedShaders = true;
+      // SwapChainUpgradeMod::swapChainUpgradeTargets.push_back(
+      //   {reshade::api::format::r8g8b8a8_unorm, reshade::api::format::r16g16b16a16_float} 
+      // );
+      // SwapChainUpgradeMod::swapChainUpgradeTargets.push_back(
+      //   {reshade::api::format::r8g8b8a8_typeless, reshade::api::format::r16g16b16a16_float} 
+      // );
+      // SwapChainUpgradeMod::swapChainUpgradeTargets.push_back(
+      //   {reshade::api::format::r8g8b8a8_unorm_srgb, reshade::api::format::r16g16b16a16_float}
+      // );
+      SwapChainUpgradeMod::swapChainUpgradeTargets.push_back(
+        {reshade::api::format::b8g8r8a8_unorm, reshade::api::format::r16g16b16a16_float, 0}
+      );
+      // SwapChainUpgradeMod::swapChainUpgradeTargets.push_back(
+      //   {reshade::api::format::r10g10b10a2_unorm, reshade::api::format::r16g16b16a16_float}
+      // );
+      // SwapChainUpgradeMod::swapChainUpgradeTargets.push_back(
+      //   {reshade::api::format::r11g11b10_float, reshade::api::format::r16g16b16a16_float}
+      // );
+      
+      if (!reshade::register_addon(hModule)) return FALSE;
+
+      reshade::register_event<reshade::addon_event::present>(on_present);
+
+      break;
+    case DLL_PROCESS_DETACH:
+      reshade::unregister_addon(hModule);
+      reshade::unregister_event<reshade::addon_event::present>(on_present);
+      break;
+  }
+
+  UserSettingUtil::use(fdwReason, &userSettings, &onPresetOff);
+  SwapChainUpgradeMod::use(fdwReason);
+  ShaderReplaceMod::use(fdwReason, customShaders, &shaderInjection);
+
+  return TRUE;
+}

--- a/src/games/darksouls/bloom_0x6FDD08FC.ps_5_0.hlsl
+++ b/src/games/darksouls/bloom_0x6FDD08FC.ps_5_0.hlsl
@@ -1,0 +1,117 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Tue Jun 04 23:18:22 2024
+
+cbuffer _Globals : register(b0) {
+  float4 DL_FREG_007 : packoffset(c7);
+  float4 DL_FREG_008 : packoffset(c8);
+  float4 DL_FREG_009 : packoffset(c9);
+  float4 DL_FREG_010 : packoffset(c10);
+  float4 DL_FREG_011 : packoffset(c11);
+  float4 DL_FREG_012 : packoffset(c12);
+  float4 DL_FREG_013 : packoffset(c13);
+  float4 DL_FREG_014 : packoffset(c14);
+  float4 DL_FREG_015 : packoffset(c15);
+  float4 DL_FREG_016 : packoffset(c16);
+  float4 DL_FREG_017 : packoffset(c17);
+  float4 DL_FREG_018 : packoffset(c18);
+  float4 DL_FREG_019 : packoffset(c19);
+  float4 DL_FREG_020 : packoffset(c20);
+  float4 DL_FREG_021 : packoffset(c21);
+  float4 DL_FREG_022 : packoffset(c22);
+  float4 DL_FREG_023 : packoffset(c23);
+  float4 DL_FREG_024 : packoffset(c24);
+  float4 DL_FREG_025 : packoffset(c25);
+  float4 DL_FREG_026 : packoffset(c26);
+  float4 DL_FREG_027 : packoffset(c27);
+  float4 DL_FREG_028 : packoffset(c28);
+  float4 DL_FREG_029 : packoffset(c29);
+  float4 DL_FREG_030 : packoffset(c30);
+  float4 DL_FREG_031 : packoffset(c31);
+  float4 DL_FREG_032 : packoffset(c32);
+  float4 DL_FREG_033 : packoffset(c33);
+  float4 DL_FREG_034 : packoffset(c34);
+  float4 DL_FREG_035 : packoffset(c35);
+  float4 DL_FREG_036 : packoffset(c36);
+  float4 DL_FREG_037 : packoffset(c37);
+  float4 DL_FREG_038 : packoffset(c38);
+  float4 DL_FREG_039 : packoffset(c39);
+  float4 DL_FREG_040 : packoffset(c40);
+  float4 DL_FREG_041 : packoffset(c41);
+  float4 DL_FREG_042 : packoffset(c42);
+  float4 DL_FREG_043 : packoffset(c43);
+  float4 DL_FREG_044 : packoffset(c44);
+  float4 DL_FREG_045 : packoffset(c45);
+  float4 DL_FREG_046 : packoffset(c46);
+  float4 DL_FREG_047 : packoffset(c47);
+  float4 DL_FREG_048 : packoffset(c48);
+  float4 DL_FREG_049 : packoffset(c49);
+  float4 DL_FREG_050 : packoffset(c50);
+  float4 DL_FREG_051 : packoffset(c51);
+  float4 DL_FREG_052 : packoffset(c52);
+  float4 DL_FREG_053 : packoffset(c53);
+  float4 DL_FREG_054 : packoffset(c54);
+  float4 DL_FREG_055 : packoffset(c55);
+  float4 DL_FREG_056 : packoffset(c56);
+  float4 DL_FREG_057 : packoffset(c57);
+  float4x4 DL_FREG_058 : packoffset(c58);
+  float4x4 DL_FREG_062 : packoffset(c62);
+  float4 DL_FREG_066 : packoffset(c66);
+  float4 DL_FREG_067 : packoffset(c67);
+  float4 DL_FREG_068 : packoffset(c68);
+  float4 DL_FREG_069 : packoffset(c69);
+  float4 DL_FREG_070 : packoffset(c70);
+  float4 DL_FREG_071 : packoffset(c71);
+  float4 DL_FREG_072 : packoffset(c72);
+  float4 DL_FREG_073 : packoffset(c73);
+  float4x4 DL_FREG_074 : packoffset(c74);
+  float4 DL_FREG_078 : packoffset(c78);
+  uint4 gFC_FrameIndex : packoffset(c81);
+  float4x4 gVC_WorldViewClipMtx : packoffset(c82);
+  float4 gVC_ScreenSize : packoffset(c86);
+  float4 gVC_NoiseParam : packoffset(c87);
+}
+
+SamplerState gSMP_0Sampler_s : register(s0);
+SamplerState gSMP_2Sampler_s : register(s2);
+Texture2D<float4> gSMP_0 : register(t0);
+Texture2D<float4> gSMP_2 : register(t2);
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(float4 v0
+          : SV_Position0, float2 v1
+          : TEXCOORD0, out float4 o0
+          : SV_Target0) {
+  float4 r0;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.x = gSMP_2.Sample(gSMP_2Sampler_s, v1.xy).x;
+  r0.y = DL_FREG_008.x + -DL_FREG_008.y;
+  r0.x = r0.x * r0.y + DL_FREG_008.y;
+  r0.x = DL_FREG_008.x / r0.x;
+  r0.yz = DL_FREG_071.zw / DL_FREG_008.yy;
+  r0.x = r0.x + -r0.y;
+  r0.y = r0.z + -r0.y;
+  r0.x = saturate(r0.x / r0.y);
+  r0.y = DL_FREG_071.x + -DL_FREG_011.x;
+  r0.y = r0.x * r0.y + DL_FREG_011.x;
+  o0.w = r0.x;
+  r0.xzw = gSMP_0.Sample(gSMP_0Sampler_s, v1.xy).xyz;
+  r0.xzw = r0.xzw + -r0.yyy;
+  r0.y = 1 + -r0.y;
+  r0.xzw = max(float3(0, 0, 0), r0.xzw);
+
+  // o0.xyz = saturate(r0.xzw / r0.yyy);
+
+  if (injectedData.fxBloom <= 1) { // Vanilla bloom
+    o0.xyz = saturate(r0.xzw / r0.yyy) * injectedData.fxBloom;
+  } else { // Increases bloom strength based on distance
+    o0.xyz = clamp(r0.xzw / r0.yyy, 0, 1.f / injectedData.fxBloom) *
+             pow(injectedData.fxBloom, injectedData.fxBloom);
+  }
+
+  return;
+}

--- a/src/games/darksouls/dof_far_0xDFCB6E8B.ps_5_0.hlsl
+++ b/src/games/darksouls/dof_far_0xDFCB6E8B.ps_5_0.hlsl
@@ -1,0 +1,135 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Tue Jun 04 23:18:33 2024
+
+cbuffer _Globals : register(b0) {
+  float4 DL_FREG_007 : packoffset(c7);
+  float4 DL_FREG_008 : packoffset(c8);
+  float4 DL_FREG_009 : packoffset(c9);
+  float4 DL_FREG_010 : packoffset(c10);
+  float4 DL_FREG_011 : packoffset(c11);
+  float4 DL_FREG_012 : packoffset(c12);
+  float4 DL_FREG_013 : packoffset(c13);
+  float4 DL_FREG_014 : packoffset(c14);
+  float4 DL_FREG_015 : packoffset(c15);
+  float4 DL_FREG_016 : packoffset(c16);
+  float4 DL_FREG_017 : packoffset(c17);
+  float4 DL_FREG_018 : packoffset(c18);
+  float4 DL_FREG_019 : packoffset(c19);
+  float4 DL_FREG_020 : packoffset(c20);
+  float4 DL_FREG_021 : packoffset(c21);
+  float4 DL_FREG_022 : packoffset(c22);
+  float4 DL_FREG_023 : packoffset(c23);
+  float4 DL_FREG_024 : packoffset(c24);
+  float4 DL_FREG_025 : packoffset(c25);
+  float4 DL_FREG_026 : packoffset(c26);
+  float4 DL_FREG_027 : packoffset(c27);
+  float4 DL_FREG_028 : packoffset(c28);
+  float4 DL_FREG_029 : packoffset(c29);
+  float4 DL_FREG_030 : packoffset(c30);
+  float4 DL_FREG_031 : packoffset(c31);
+  float4 DL_FREG_032 : packoffset(c32);
+  float4 DL_FREG_033 : packoffset(c33);
+  float4 DL_FREG_034 : packoffset(c34);
+  float4 DL_FREG_035 : packoffset(c35);
+  float4 DL_FREG_036 : packoffset(c36);
+  float4 DL_FREG_037 : packoffset(c37);
+  float4 DL_FREG_038 : packoffset(c38);
+  float4 DL_FREG_039 : packoffset(c39);
+  float4 DL_FREG_040 : packoffset(c40);
+  float4 DL_FREG_041 : packoffset(c41);
+  float4 DL_FREG_042 : packoffset(c42);
+  float4 DL_FREG_043 : packoffset(c43);
+  float4 DL_FREG_044 : packoffset(c44);
+  float4 DL_FREG_045 : packoffset(c45);
+  float4 DL_FREG_046 : packoffset(c46);
+  float4 DL_FREG_047 : packoffset(c47);
+  float4 DL_FREG_048 : packoffset(c48);
+  float4 DL_FREG_049 : packoffset(c49);
+  float4 DL_FREG_050 : packoffset(c50);
+  float4 DL_FREG_051 : packoffset(c51);
+  float4 DL_FREG_052 : packoffset(c52);
+  float4 DL_FREG_053 : packoffset(c53);
+  float4 DL_FREG_054 : packoffset(c54);
+  float4 DL_FREG_055 : packoffset(c55);
+  float4 DL_FREG_056 : packoffset(c56);
+  float4 DL_FREG_057 : packoffset(c57);
+  float4x4 DL_FREG_058 : packoffset(c58);
+  float4x4 DL_FREG_062 : packoffset(c62);
+  float4 DL_FREG_066 : packoffset(c66);
+  float4 DL_FREG_067 : packoffset(c67);
+  float4 DL_FREG_068 : packoffset(c68);
+  float4 DL_FREG_069 : packoffset(c69);
+  float4 DL_FREG_070 : packoffset(c70);
+  float4 DL_FREG_071 : packoffset(c71);
+  float4 DL_FREG_072 : packoffset(c72);
+  float4 DL_FREG_073 : packoffset(c73);
+  float4x4 DL_FREG_074 : packoffset(c74);
+  float4 DL_FREG_078 : packoffset(c78);
+  uint4 gFC_FrameIndex : packoffset(c81);
+  float4x4 gVC_WorldViewClipMtx : packoffset(c82);
+  float4 gVC_ScreenSize : packoffset(c86);
+  float4 gVC_NoiseParam : packoffset(c87);
+}
+
+SamplerState gSMP_0Sampler_s : register(s0);
+SamplerState gSMP_1Sampler_s : register(s1);
+SamplerState gSMP_2Sampler_s : register(s2);
+SamplerState gSMP_3Sampler_s : register(s3);
+SamplerState gSMP_4Sampler_s : register(s4);
+SamplerState gSMP_5Sampler_s : register(s5);
+Texture2D<float4> gSMP_0 : register(t0);
+Texture2D<float4> gSMP_1 : register(t1);
+Texture2D<float4> gSMP_2 : register(t2);
+Texture2D<float4> gSMP_3 : register(t3);
+Texture2D<float4> gSMP_4 : register(t4);
+Texture2D<float4> gSMP_5 : register(t5);
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(float4 v0
+          : SV_Position0, float4 v1
+          : TEXCOORD0, float4 v2
+          : TEXCOORD1, out float4 o0
+          : SV_Target0) {
+  float4 r0, r1, r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.x = gSMP_5.Sample(gSMP_5Sampler_s, v1.xy).x;
+  r0.y = DL_FREG_008.x + -DL_FREG_008.y;
+  r0.x = r0.x * r0.y + DL_FREG_008.y;
+  r0.x = DL_FREG_008.x / r0.x;
+  r0.yz = DL_FREG_009.xy / DL_FREG_008.yy;
+  r0.x = r0.x + -r0.y;
+  r0.y = r0.z + -r0.y;
+
+  // r0.x = saturate(r0.x / r0.y);
+  // r0.x = saturate(DL_FREG_009.z * r0.x) * injectedData.fxDoF;
+
+  // Increases DoF strength based on distance
+  r0.x = clamp(r0.x / r0.y, 0, injectedData.fxDoF);
+  r0.x = clamp(DL_FREG_009.z * r0.x, 0, injectedData.fxDoF);
+
+  r0.yz = float2(-0.5, -0.5) + v1.xy;
+  r0.yz = DL_FREG_012.xy * r0.yz;
+  r0.y = dot(r0.yz, r0.yz);
+  r0.y = sqrt(r0.y);
+  r0.y = -DL_FREG_007.x + r0.y;
+  r0.y = saturate(DL_FREG_007.y * r0.y);
+  r0.x = r0.y * DL_FREG_007.z + r0.x;
+  r0.y = gSMP_4.Sample(gSMP_4Sampler_s, v1.xy).w;
+  r0.x = max(r0.x, r0.y);
+  r0.xyzw = saturate(r0.xxxx * DL_FREG_066.xyzw + DL_FREG_067.xyzw);
+  r0.yzw = r0.yzw + -r0.xyz;
+  r1.xyzw = gSMP_1.Sample(gSMP_1Sampler_s, v1.xy).xyzw;
+  r1.xyzw = r1.xyzw * r0.yyyy;
+  r2.xyzw = gSMP_0.Sample(gSMP_0Sampler_s, v1.xy).xyzw;
+  r1.xyzw = r2.xyzw * r0.xxxx + r1.xyzw;
+  r2.xyzw = gSMP_2.Sample(gSMP_2Sampler_s, v1.xy).xyzw;
+  r1.xyzw = r2.xyzw * r0.zzzz + r1.xyzw;
+  r2.xyzw = gSMP_3.Sample(gSMP_3Sampler_s, v1.xy).xyzw;
+  o0.xyzw = r2.xyzw * r0.wwww + r1.xyzw;
+  return;
+}

--- a/src/games/darksouls/gamma_0xAB7CF260.ps_5_0.hlsl
+++ b/src/games/darksouls/gamma_0xAB7CF260.ps_5_0.hlsl
@@ -1,0 +1,31 @@
+#include "../../shaders/color.hlsl"
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Tue Jun 04 23:18:27 2024
+
+SamplerState g_TextureSampler_s : register(s0);
+SamplerState g_GammaTextureSampler_s : register(s1);
+Texture2D<float4> g_Texture : register(t0);
+Texture1D<float4> g_GammaTexture : register(t1);
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(float4 v0
+          : SV_Position0, float2 v1
+          : TEXCOORD0, out float4 o0
+          : SV_Target0) {
+  // Needs manual fix for instruction:
+  // unknown dcl_: dcl_resource_texture1d (float,float,float,float) t1
+  float4 r0;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  o0.w = 1;
+  o0.xyz = g_Texture.Sample(g_TextureSampler_s, v1.xy).xyz;
+
+  // Removed gamma slider as it capped brightness
+  // Image is unchanged when set to default 5
+
+  return;
+}

--- a/src/games/darksouls/shared.h
+++ b/src/games/darksouls/shared.h
@@ -1,0 +1,32 @@
+#ifndef SRC_DARKSOULS_SHARED_H_
+#define SRC_DARKSOULS_SHARED_H_
+
+// Must be 32bit aligned
+// Should be 4x32
+struct ShaderInjectData {
+  float toneMapType;
+  float toneMapPeakNits;
+  float toneMapGameNits;
+  float toneMapUINits;
+  float toneMapGammaCorrection;
+  float toneMapHueCorrection;
+  float colorGradeExposure;
+  float colorGradeHighlights;
+  float colorGradeShadows;
+  float colorGradeContrast;
+  float colorGradeSaturation;
+  float colorGradeBlowout;
+  float colorGradeLUTStrength;
+  float fxBloom;
+  float fxDoF;
+  float fxFilmGrain;
+  float elapsedTime;
+};
+
+#ifndef __cplusplus
+cbuffer cb11 : register(b11) {
+  ShaderInjectData injectedData : packoffset(c0);
+}
+#endif
+
+#endif  // SRC_DARKSOULS_SHARED_H_

--- a/src/games/darksouls/tonemap_0xF87B3349.ps_5_0.hlsl
+++ b/src/games/darksouls/tonemap_0xF87B3349.ps_5_0.hlsl
@@ -1,0 +1,295 @@
+#include "../../shaders/filmgrain.hlsl"
+#include "../../shaders/tonemap.hlsl"
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Tue Jun 04 23:18:36 2024
+
+cbuffer _Globals : register(b0) {
+  float4 DL_FREG_007 : packoffset(c7);
+  float4 DL_FREG_008 : packoffset(c8);
+  float4 DL_FREG_009 : packoffset(c9);
+  float4 DL_FREG_010 : packoffset(c10);
+  float4 DL_FREG_011 : packoffset(c11);
+  float4 DL_FREG_012 : packoffset(c12);
+  float4 DL_FREG_013 : packoffset(c13);
+  float4 DL_FREG_014 : packoffset(c14);
+  float4 DL_FREG_015 : packoffset(c15);
+  float4 DL_FREG_016 : packoffset(c16);
+  float4 DL_FREG_017 : packoffset(c17);
+  float4 DL_FREG_018 : packoffset(c18);
+  float4 DL_FREG_019 : packoffset(c19);
+  float4 DL_FREG_020 : packoffset(c20);
+  float4 DL_FREG_021 : packoffset(c21);
+  float4 DL_FREG_022 : packoffset(c22);
+  float4 DL_FREG_023 : packoffset(c23);
+  float4 DL_FREG_024 : packoffset(c24);
+  float4 DL_FREG_025 : packoffset(c25);
+  float4 DL_FREG_026 : packoffset(c26);
+  float4 DL_FREG_027 : packoffset(c27);
+  float4 DL_FREG_028 : packoffset(c28);
+  float4 DL_FREG_029 : packoffset(c29);
+  float4 DL_FREG_030 : packoffset(c30);
+  float4 DL_FREG_031 : packoffset(c31);
+  float4 DL_FREG_032 : packoffset(c32);
+  float4 DL_FREG_033 : packoffset(c33);
+  float4 DL_FREG_034 : packoffset(c34);
+  float4 DL_FREG_035 : packoffset(c35);
+  float4 DL_FREG_036 : packoffset(c36);
+  float4 DL_FREG_037 : packoffset(c37);
+  float4 DL_FREG_038 : packoffset(c38);
+  float4 DL_FREG_039 : packoffset(c39);
+  float4 DL_FREG_040 : packoffset(c40);
+  float4 DL_FREG_041 : packoffset(c41);
+  float4 DL_FREG_042 : packoffset(c42);
+  float4 DL_FREG_043 : packoffset(c43);
+  float4 DL_FREG_044 : packoffset(c44);
+  float4 DL_FREG_045 : packoffset(c45);
+  float4 DL_FREG_046 : packoffset(c46);
+  float4 DL_FREG_047 : packoffset(c47);
+  float4 DL_FREG_048 : packoffset(c48);
+  float4 DL_FREG_049 : packoffset(c49);
+  float4 DL_FREG_050 : packoffset(c50);
+  float4 DL_FREG_051 : packoffset(c51);
+  float4 DL_FREG_052 : packoffset(c52);
+  float4 DL_FREG_053 : packoffset(c53);
+  float4 DL_FREG_054 : packoffset(c54);
+  float4 DL_FREG_055 : packoffset(c55);
+  float4 DL_FREG_056 : packoffset(c56);
+  float4 DL_FREG_057 : packoffset(c57);
+  float4x4 DL_FREG_058 : packoffset(c58);
+  float4x4 DL_FREG_062 : packoffset(c62);
+  float4 DL_FREG_066 : packoffset(c66);
+  float4 DL_FREG_067 : packoffset(c67);
+  float4 DL_FREG_068 : packoffset(c68);
+  float4 DL_FREG_069 : packoffset(c69);
+  float4 DL_FREG_070 : packoffset(c70);
+  float4 DL_FREG_071 : packoffset(c71);
+  float4 DL_FREG_072 : packoffset(c72);
+  float4 DL_FREG_073 : packoffset(c73);
+  float4x4 DL_FREG_074 : packoffset(c74);
+  float4 DL_FREG_078 : packoffset(c78);
+  uint4 gFC_FrameIndex : packoffset(c81);
+  float4x4 gVC_WorldViewClipMtx : packoffset(c82);
+  float4 gVC_ScreenSize : packoffset(c86);
+  float4 gVC_NoiseParam : packoffset(c87);
+}
+
+SamplerState gSMP_0Sampler_s : register(s0);
+SamplerState gSMP_1Sampler_s : register(s1);
+SamplerState gSMP_2Sampler_s : register(s2);
+SamplerState gSMP_3Sampler_s : register(s3);
+SamplerState gSMP_5Sampler_s : register(s5);
+Texture2D<float4> gSMP_0 : register(t0);
+Texture2D<float4> gSMP_1 : register(t1);
+Texture2D<float4> gSMP_2 : register(t2);
+Texture2D<float4> gSMP_3 : register(t3);
+Texture2D<float4> gSMP_5 : register(t5);
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(float4 v0
+          : SV_Position0, float4 v1
+          : TEXCOORD1, out float4 o0
+          : SV_Target0) {
+  float4 r0, r1, r2, r3, r4, r5;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  // Initial tonemapper settings, used in case 0
+  float vanillaMidGray = DL_FREG_054.z / DL_FREG_054.w;
+  float renoDRTContrast = 1.16f;
+  float renoDRTFlare = 0.f;
+  float renoDRTShadows = 1.f;
+  float renoDRTDechroma = injectedData.colorGradeBlowout;
+  float renoDRTSaturation = 1.3f;
+  float renoDRTHighlights = 1.04f;
+
+  r0.xyz = gSMP_0.Sample(gSMP_0Sampler_s, v1.xy).xyz;
+  r1.xyzw = gSMP_1.Sample(gSMP_1Sampler_s, v1.xy).wxyz;
+  if (injectedData.toneMapType == 0) { // Clamp vanilla tonemapper to BT709
+    r0.xyz = max(0, r0.xyz);
+    r1.yzw = max(0, r1.yzw);
+  }
+  r1.x = saturate(r1.x);
+  r2.xyz = gSMP_3.Sample(gSMP_3Sampler_s, v1.xy).xyz;
+  r0.w = DL_FREG_071.y + -DL_FREG_056.x;
+  r0.w = r1.x * r0.w + DL_FREG_056.x;
+  r0.xyz = r0.www * r1.yzw + r0.xyz;
+  r0.xyz = DL_FREG_056.yyy * r2.xyz + r0.xyz;
+  r0.w = (uint)DL_FREG_057.x;
+
+  float3 untonemapped = r0.xyz;
+
+  switch (r0.w) {
+  case 0: // Vanilla tonemapper 0
+    r0.w = gSMP_5.Sample(gSMP_5Sampler_s, float2(0.5, 0.5)).x;
+    r0.w = max(DL_FREG_056.z, r0.w);
+    r0.w = min(DL_FREG_056.w, r0.w);
+    r0.w = 9.99999975e-005 + r0.w;
+    r0.w = DL_FREG_054.x / r0.w;
+    r2.xyz = r0.xyz * r0.www;
+    if (injectedData.toneMapType != 0) { // Custom tonemappers
+      untonemapped = r2.xyz;
+    }
+    r0.w = DL_FREG_055.z * DL_FREG_055.y; // Start of tonemap 0
+    r3.xyz = DL_FREG_055.xxx * r2.xyz + r0.www;
+    r4.xy = DL_FREG_055.ww * DL_FREG_054.zw;
+    r3.xyz = r2.xyz * r3.xyz + r4.xxx;
+    r5.xyz = DL_FREG_055.xxx * r2.xyz + DL_FREG_055.yyy;
+    r2.xyz = r2.xyz * r5.xyz + r4.yyy;
+    r2.xyz = r3.xyz / r2.xyz;
+    r1.w = DL_FREG_054.z / DL_FREG_054.w;
+    r2.xyz = r2.xyz + -r1.www;
+    r0.w = DL_FREG_055.x * DL_FREG_054.y + r0.w;
+    r0.w = DL_FREG_054.y * r0.w + r4.x;
+    r2.w = DL_FREG_055.x * DL_FREG_054.y + DL_FREG_055.y;
+    r2.w = DL_FREG_054.y * r2.w + r4.y;
+    r0.w = r0.w / r2.w;
+    r0.w = r0.w + -r1.w;
+    r1.xyz = r2.xyz / r0.www;
+    break;
+
+  case 1: // Vanilla tonemapper 1
+    r0.w = gSMP_5.Sample(gSMP_5Sampler_s, float2(0.5, 0.5)).x;
+    r0.w = max(DL_FREG_056.z, r0.w);
+    r0.w = min(DL_FREG_056.w, r0.w);
+    r0.w = 9.99999975e-005 + r0.w;
+    r0.w = DL_FREG_054.x / r0.w;
+    r2.xyz = r0.xyz * r0.www;
+    if (injectedData.toneMapType != 0) { // Custom tonemappers
+      vanillaMidGray = .15f;
+      renoDRTContrast = 0.92f;
+      renoDRTFlare = 0.f;
+      renoDRTShadows = 1.f;
+      // renoDRTDechroma = 0.7f;
+      renoDRTSaturation = 1.3f;
+      renoDRTHighlights = 1.f;
+      untonemapped = r2.xyz;
+    }
+    r0.w = dot(r2.xyz, float3(0.212672904, 0.715152204,
+                              0.0721750036)); // Start of tonemap 1
+    r0.w = max(9.99999975e-005, r0.w);
+    r1.w = 1 + r0.w;
+    r1.w = r0.w / r1.w;
+    r2.xyz = r1.www * r2.xyz;
+    r1.xyz = r2.xyz / r0.www;
+    break;
+
+  case 2: // Vanilla tonemapper 2
+    r0.w = gSMP_5.Sample(gSMP_5Sampler_s, float2(0.5, 0.5)).x;
+    r0.w = max(DL_FREG_056.z, r0.w);
+    r0.w = min(DL_FREG_056.w, r0.w);
+    r0.w = 9.99999975e-005 + r0.w;
+    r0.w = DL_FREG_054.x / r0.w;
+    r0.xyz = r0.xyz * r0.www;
+    if (injectedData.toneMapType != 0) { // Custom tonemappers
+      vanillaMidGray = .151f;
+      renoDRTContrast = 0.94f;
+      renoDRTFlare = 0.f;
+      renoDRTShadows = 1.f;
+      // renoDRTDechroma = 0.7f;
+      renoDRTSaturation = 1.3f;
+      renoDRTHighlights = 1.f;
+      untonemapped = r0.xyz;
+    }
+    r0.w = dot(r0.xyz, float3(0.212672904, 0.715152204,
+                              0.0721750036)); // Start of tonemap 2
+    r0.w = max(9.99999975e-005, r0.w);
+    r1.w = DL_FREG_054.y * DL_FREG_054.y;
+    r1.w = r0.w / r1.w;
+    r1.w = 1 + r1.w;
+    r1.w = r1.w * r0.w;
+    r2.x = 1 + r0.w;
+    r1.w = r1.w / r2.x;
+    r0.xyz = r1.www * r0.xyz;
+    r1.xyz = r0.xyz / r0.www;
+    break;
+
+  default: // Debug?
+    r1.xyz = float3(1, 0, 1);
+    break;
+  }
+
+  if (injectedData.toneMapType != 0) {
+
+    ToneMapParams tmParams = {injectedData.toneMapType,
+                              injectedData.toneMapPeakNits,
+                              injectedData.toneMapGameNits,
+                              injectedData.toneMapGammaCorrection,
+                              injectedData.colorGradeExposure,
+                              injectedData.colorGradeHighlights,
+                              injectedData.colorGradeShadows,
+                              injectedData.colorGradeContrast,
+                              injectedData.colorGradeSaturation,
+                              vanillaMidGray,
+                              vanillaMidGray * 100.f,
+                              renoDRTHighlights,
+                              renoDRTShadows,
+                              renoDRTContrast,
+                              renoDRTSaturation,
+                              renoDRTDechroma,
+                              renoDRTFlare};
+
+    if (injectedData.toneMapHueCorrection) {
+      r1.xyz = hueCorrection(toneMap(untonemapped, tmParams), r1.xyz);
+    } else {
+      r1.xyz = toneMap(untonemapped, tmParams);
+    }
+  } else { // Clamp vanilla tonemapper to BT709
+    r0.xyz = max(0, r1.xyz);
+  }
+
+  r0.xyz = sign(r1.xyz) *
+           pow(abs(r1.xyz), 1.f / 2.2f); // Linearize before color grade
+
+  const float3 preLUT = r0.xyz;
+
+  r0.w = 1;
+  r1.x = dot(r0.xyzw, DL_FREG_062._m00_m10_m20_m30);
+  r1.y = dot(r0.xyzw, DL_FREG_062._m01_m11_m21_m31);
+  r1.z = dot(r0.xyzw, DL_FREG_062._m02_m12_m22_m32);
+  r0.xyz = gSMP_2.Sample(gSMP_2Sampler_s, v1.zw).xyz;
+  r2.xyz = r1.xyz * r0.xyz;
+  r2.xyz = r2.xyz + r2.xyz;
+  r3.xyz = float3(1, 1, 1) + -r0.xyz;
+  r3.xyz = r3.xyz + r3.xyz;
+  r4.xyz = float3(1, 1, 1) + -r1.xyz;
+  r3.xyz = -r3.xyz * r4.xyz + float3(1, 1, 1);
+  r0.xyz = cmp(float3(0.5, 0.5, 0.5) >= r0.xyz);
+  r4.xyz = r0.xyz ? float3(1, 1, 1) : 0;
+  r0.xyz = r0.xyz ? float3(0, 0, 0) : float3(1, 1, 1);
+  r0.xyz = r2.xyz * r0.xyz;
+  r0.xyz = r3.xyz * r4.xyz + r0.xyz;
+  r0.xyz = r0.xyz + -r1.xyz;
+  //  r0.xyz = DL_FREG_068.xxx * r0.xyz + r1.xyz;
+  //  DL_FREG_068.xxx = noise
+  r0.xyz =
+      lerp(preLUT + DL_FREG_068.xxx * r0.xyz, DL_FREG_068.xxx * r0.xyz + r1.xyz,
+           injectedData.colorGradeLUTStrength);
+
+  if (injectedData.fxFilmGrain) {
+    float3 grainedColor =
+        computeFilmGrain(r0.rgb, v1.xy, frac(injectedData.elapsedTime / 1000.f),
+                         injectedData.fxFilmGrain * 0.03f, 1.f);
+    r0.xyz = grainedColor;
+  }
+
+  if (injectedData.toneMapType == 0) { // Cap vanilla tonemapper
+    r0.xyz = clamp(r0.xyz, 0, injectedData.toneMapPeakNits / injectedData.toneMapGameNits);
+  }
+
+  r0.rgb = injectedData.toneMapGammaCorrection
+               ? sign(r0.rgb) * pow(abs(r0.rgb), 2.2f)
+               : linearFromSRGB(r0.rgb);
+
+  r0.rgb *= injectedData.toneMapGameNits / 80.f;
+
+  r0.rgb = mul(BT709_2_BT2020_MAT, r0.rgb); // Convert to BT2020
+  r0.rgb = max(0, r0.rgb);               // Clamp to BT2020
+  r0.rgb = mul(BT2020_2_BT709_MAT, r0.rgb); // Convert BT709
+
+  o0.w = dot(r0.xyz, float3(0.298999995, 0.587000012, 0.114));
+  o0.xyz = r0.xyz;
+  return;
+}

--- a/src/games/darksouls/ui_0x64F62639.ps_5_0.hlsl
+++ b/src/games/darksouls/ui_0x64F62639.ps_5_0.hlsl
@@ -1,0 +1,21 @@
+#include "../../shaders/color.hlsl"
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Tue Jun 04 23:18:21 2024
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(float4 v0
+          : SV_Position0, float4 v1
+          : COLOR0, float2 v2
+          : TEXCOORD0, out float4 o0
+          : SV_Target0) {
+  o0.xyzw = v1.xyzw;
+
+  o0.rgb = injectedData.toneMapGammaCorrection ? pow(o0.rgb, 2.2f)
+                                               : linearFromSRGB(o0.rgb);
+  o0.rgb *= injectedData.toneMapUINits / 80.f;
+
+  return;
+}

--- a/src/games/darksouls/ui_0x809881A3.ps_5_0.hlsl
+++ b/src/games/darksouls/ui_0x809881A3.ps_5_0.hlsl
@@ -1,0 +1,29 @@
+#include "../../shaders/color.hlsl"
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Tue Jun 04 23:18:24 2024
+
+SamplerState g_TextureSampler_s : register(s0);
+Texture2D<float4> g_Texture : register(t0);
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(float4 v0
+          : SV_Position0, float4 v1
+          : COLOR0, float2 v2
+          : TEXCOORD0, out float4 o0
+          : SV_Target0) {
+  float4 r0;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = g_Texture.Sample(g_TextureSampler_s, v2.xy).xyzw;
+  o0.xyzw = v1.xyzw * r0.xyzw;
+
+  o0.rgb = injectedData.toneMapGammaCorrection ? pow(o0.rgb, 2.2f)
+                                               : linearFromSRGB(o0.rgb);
+  o0.rgb *= injectedData.toneMapUINits / 80.f;
+
+  return;
+}

--- a/src/games/darksouls/ui_0xB0850BF3.ps_5_0.hlsl
+++ b/src/games/darksouls/ui_0xB0850BF3.ps_5_0.hlsl
@@ -1,0 +1,24 @@
+#include "../../shaders/color.hlsl"
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Tue Jun 04 23:18:28 2024
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(float4 v0
+          : SV_Position0, float4 v1
+          : COLOR0, float3 v2
+          : TEXCOORD0, out float4 o0
+          : SV_Target0) {
+  o0.xyzw = v1.xyzw;
+
+  o0.rgb = injectedData.toneMapGammaCorrection ? pow(o0.rgb, 2.2f)
+                                               : linearFromSRGB(o0.rgb);
+  o0.rgb *= injectedData.toneMapUINits / 80.f;
+
+  // TODO: figure out what this shader does
+  // o0.rgb = (1, 0, 1);
+
+  return;
+}

--- a/src/games/darksouls/ui_text_0x6024AB96.ps_5_0.hlsl
+++ b/src/games/darksouls/ui_text_0x6024AB96.ps_5_0.hlsl
@@ -1,0 +1,48 @@
+#include "../../shaders/color.hlsl"
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Tue Jun 04 23:18:20 2024
+
+cbuffer _Globals : register(b0) {
+  float4 gFC_FontSharpParam : packoffset(c0);
+  float4x4 gVC_WorldViewClipMtx : packoffset(c1);
+  float4 gVC_FontSharpParam : packoffset(c5);
+}
+
+SamplerState g_TextureSampler_s : register(s0);
+Texture2D<float4> g_Texture : register(t0);
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(float4 v0
+          : SV_Position0, float4 v1
+          : COLOR0, float4 v2
+          : TEXCOORD0, float4 v3
+          : TEXCOORD1, float4 v4
+          : TEXCOORD2, out float4 o0
+          : SV_Target0) {
+  float4 r0, r1, r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = g_Texture.Sample(g_TextureSampler_s, v3.xy).xyzw;
+  r1.xyzw = g_Texture.Sample(g_TextureSampler_s, v2.xy).xyzw;
+  r0.xyzw = r1.xyzw * float4(5, 5, 5, 5) + -r0.xyzw;
+  r1.xyzw = gFC_FontSharpParam.yyyy * r1.xyzw;
+  r2.xyzw = g_Texture.Sample(g_TextureSampler_s, v3.zw).xyzw;
+  r0.xyzw = -r2.xyzw + r0.xyzw;
+  r2.xyzw = g_Texture.Sample(g_TextureSampler_s, v4.xy).xyzw;
+  r0.xyzw = -r2.xyzw + r0.xyzw;
+  r2.xyzw = g_Texture.Sample(g_TextureSampler_s, v4.zw).xyzw;
+  r0.xyzw = -r2.xyzw + r0.xyzw;
+  r0.xyzw = r0.xyzw * gFC_FontSharpParam.xxxx + r1.xyzw;
+  o0.xyzw =
+      saturate(v1.xyzw * r0.xyzw); // Added saturate() to cap text brightness
+
+  o0.rgb = injectedData.toneMapGammaCorrection ? pow(o0.rgb, 2.2f)
+                                               : linearFromSRGB(o0.rgb);
+  o0.rgb *= injectedData.toneMapUINits / 80.f;
+
+  return;
+}


### PR DESCRIPTION
### This pull request adds several new graphical features to Dark Souls Remastered, including:
- HDR scRGB support
- Sliders for depth of field and bloom adjustment
- 2.2 gamma correction
- New tonemappers: ACES, RenoDRT, and untonemapped output
- Adjustments for the strength of the game's color filters
- A hue correction toggle that allows other tonemappers to emulate the hue shifting from the vanilla tonemapper
- Full BT.2020 output
- Various color grading options, including sliders for exposure, highlights, contrast, saturation, and shadows
