### PR TITLE
Many usability features

### DIFF
--- a/src/devkit/addon.cpp
+++ b/src/devkit/addon.cpp
@@ -274,7 +274,7 @@ void DestroyPipelineSubojects(reshade::api::pipeline_subobject* subojects, uint3
 void ClearCustomShader(uint32_t shader_hash) {
   const std::lock_guard<std::recursive_mutex> lock(s_mutex_loading);
   auto custom_shader = custom_shaders_cache.find(shader_hash);
-  if (custom_shader != custom_shaders_cache.end()) {
+  if (custom_shader != custom_shaders_cache.end() && custom_shader->second != nullptr) {
     custom_shader->second->code.clear();
     custom_shader->second->is_hlsl = false;
     custom_shader->second->file_path.clear();
@@ -472,7 +472,7 @@ void LoadCustomShaders(const std::unordered_set<uint64_t>& pipelines_filter = st
     auto custom_shader = custom_shaders_cache[shader_hash];
 
     // Skip shaders that don't have code binaries at the moment
-    if (custom_shader->code.empty()) continue;
+    if (custom_shader == nullptr || custom_shader->code.empty()) continue;
 
     auto pipelines_pair = pipeline_caches_by_shader_hash.find(shader_hash);
     if (pipelines_pair == pipeline_caches_by_shader_hash.end()) {

--- a/src/devkit/addon.cpp
+++ b/src/devkit/addon.cpp
@@ -2131,7 +2131,6 @@ void OnRegisterOverlay(reshade::api::effect_runtime* runtime) {
               auto pipeline_handle = trace_pipeline_handles.at(index);
               const bool is_selected = (selected_index == index);
               const auto pipeline_pair = pipeline_cache_by_pipeline_handle.find(pipeline_handle);
-              // Just pick the first pipeline associated to the shader here, they should all be the same as far as we are concerned
               const bool is_valid = pipeline_pair != pipeline_cache_by_pipeline_handle.end() && pipeline_pair->second != nullptr;
               std::stringstream name;
               auto text_color = IM_COL32(255, 255, 255, 255);
@@ -2184,6 +2183,8 @@ void OnRegisterOverlay(reshade::api::effect_runtime* runtime) {
                 ImGui::SetItemDefaultFocus();
               }
             }
+          } else {
+            selected_index = max(selected_index, trace_count - 1);
           }
           ImGui::EndListBox();
         }

--- a/src/devkit/addon.cpp
+++ b/src/devkit/addon.cpp
@@ -2166,9 +2166,11 @@ void OnRegisterOverlay(reshade::api::effect_runtime* runtime) {
       if (ImGui::BeginChild("##ShaderDetails", ImVec2(0, 0))) {
         ImGui::BeginDisabled(selected_index == -1);
         if (ImGui::BeginTabBar("##ShadersCodeTab", ImGuiTabBarFlags_None)) {
-          if (ImGui::BeginTabItem("Disassembly")) {
+          const bool open_disassembly_tab_item = ImGui::BeginTabItem("Disassembly");
+          static bool opened_disassembly_tab_item = false;
+          if (open_disassembly_tab_item) {
             static std::string disasm_string;
-            if (changed_selected) {
+            if (changed_selected || opened_disassembly_tab_item != open_disassembly_tab_item) {
               auto hash = trace_hashes.at(selected_index);
               auto* cache = shader_cache.find(hash)->second;
               if (cache->disasm.empty()) {
@@ -2193,6 +2195,7 @@ void OnRegisterOverlay(reshade::api::effect_runtime* runtime) {
             }
             ImGui::EndTabItem();  // Disassembly
           }
+          opened_disassembly_tab_item = open_disassembly_tab_item;
 
           ImGui::PushID("##LiveTabItem");
           const bool open_live_tab_item = ImGui::BeginTabItem("Live");

--- a/src/devkit/addon.cpp
+++ b/src/devkit/addon.cpp
@@ -443,8 +443,12 @@ void LoadCustomShaders(const std::unordered_set<uint64_t>& pipelines_filter = st
       continue;
     }
 
-    // Re-clone all the pipelines that used this shader hash
+    // Re-clone all the pipelines that used this shader hash (except the ones that are filtered out)
     for (CachedPipeline* cached_pipeline : pipelines_pair->second) {
+      if (!pipelines_filter.empty() && !pipelines_filter.contains(cached_pipeline->pipeline.handle)) continue;
+      // Force destroy this pipeline in case it was already cloned
+      UnloadCustomShaders({cached_pipeline->pipeline.handle});
+
       if (is_hlsl) {
         cached_pipeline->hlsl_path = entry_path;
       } else {

--- a/src/devkit/addon.cpp
+++ b/src/devkit/addon.cpp
@@ -1938,14 +1938,15 @@ void OnRegisterOverlay(reshade::api::effect_runtime* runtime) {
           ImGui::PushID("##LiveTabItem");
           const bool open_live_tab_item = ImGui::BeginTabItem("Live");
           ImGui::PopID();
+          static bool opened_live_tab_item = false;
           if (open_live_tab_item) {
             static std::string hlsl_string;
-            if (changed_selected) {
+            if (changed_selected || opened_live_tab_item != open_live_tab_item) {
               auto hash = trace_hashes.at(selected_index);
 
               if (
                   auto pair = pipeline_cache_by_shader_hash.find(hash);
-                  pair != pipeline_cache_by_shader_hash.end() && !pair->second->hlsl_path.empty()) {
+                  pair != pipeline_cache_by_shader_hash.end() && pair->second != nullptr && !pair->second->hlsl_path.empty()) {
                 auto result = ReadTextFile(pair->second->hlsl_path);
                 if (result.has_value()) {
                   hlsl_string.assign(result.value());
@@ -1956,6 +1957,7 @@ void OnRegisterOverlay(reshade::api::effect_runtime* runtime) {
                 hlsl_string.assign("");
               }
             }
+            opened_live_tab_item = open_live_tab_item;
 
             // Attemping this breaks ImGui
             // if (ImGui::BeginChild("##LiveCodeToolbar", ImVec2(-FLT_MIN, 0))) {

--- a/src/devkit/addon.cpp
+++ b/src/devkit/addon.cpp
@@ -433,7 +433,7 @@ std::optional<std::string> ReadTextFile(const std::filesystem::path& path) {
 }
 
 OVERLAPPED overlapped;
-HANDLE m_target_dir_handle;
+HANDLE m_target_dir_handle = INVALID_HANDLE_VALUE;
 
 bool needs_watcher_init = true;
 
@@ -467,6 +467,12 @@ void ToggleLiveWatching() {
     }
 
     reshade::log_message(reshade::log_level::info, "Watching live.");
+
+    // Clean up any previous handle for safety
+    if (m_target_dir_handle != INVALID_HANDLE_VALUE) {
+      CancelIoEx(m_target_dir_handle, &overlapped);
+    }
+
     m_target_dir_handle = CreateFileW(
         directory.c_str(),
         FILE_LIST_DIRECTORY,

--- a/src/devkit/addon.cpp
+++ b/src/devkit/addon.cpp
@@ -1892,7 +1892,18 @@ void OnRegisterOverlay(reshade::api::effect_runtime* runtime) {
               name << std::setfill('0') << std::setw(3) << index << std::setw(0);
               name << " - " << PRINT_CRC32(hash);
               if (is_cloned) {
-                name << "*";
+                if (!pair->second->hlsl_path.empty()) {
+                  name << " * ";
+                  // TODO: add support for more name variations
+                  static const std::string full_template_name = "0x12345678.xx_x_x.hlsl";
+                  static const auto characters_to_remove_from_end = full_template_name.length();
+                  auto filename_string = pair->second->hlsl_path.filename().string();
+                  filename_string.erase(filename_string.length() - min(characters_to_remove_from_end, filename_string.length()));
+                  name << filename_string;
+                }
+                else {
+                  name << " *";
+                }
               }
               if (ImGui::Selectable(name.str().c_str(), is_selected)) {
                 selected_index = index;

--- a/src/devkit/addon.cpp
+++ b/src/devkit/addon.cpp
@@ -970,7 +970,7 @@ void OnInitPipeline(
 
           // Make sure we didn't already have a valid pipeline in there (this should never happen)
           auto pipelines_pair = pipeline_caches_by_shader_hash.find(shader_hash);
-          if (pipelines_pair == pipeline_caches_by_shader_hash.end()) {
+          if (pipelines_pair != pipeline_caches_by_shader_hash.end()) {
             pipelines_pair->second.emplace(cached_pipeline);
           } else {
             pipeline_caches_by_shader_hash[shader_hash] = { cached_pipeline };

--- a/src/devkit/addon.cpp
+++ b/src/devkit/addon.cpp
@@ -327,7 +327,7 @@ void LoadCustomShaders(const std::unordered_set<uint64_t>& pipelines_filter = st
       if (!pipelines_filter.empty()) {
         bool pipeline_found = false;
         for (const auto& pipeline_pair : pipeline_cache_by_pipeline_handle) {
-          if (std::find(pipeline_pair.second->shader_hashes.begin(), pipeline_pair.second->shader_hashes.end(), shader_hash) != pipeline_pair.second->shader_hashes.end()) continue;
+          if (std::find(pipeline_pair.second->shader_hashes.begin(), pipeline_pair.second->shader_hashes.end(), shader_hash) == pipeline_pair.second->shader_hashes.end()) continue;
           if (pipelines_filter.contains(pipeline_pair.first)) {
             pipeline_found = true;
           }
@@ -395,7 +395,7 @@ void LoadCustomShaders(const std::unordered_set<uint64_t>& pipelines_filter = st
       if (!pipelines_filter.empty()) {
         bool pipeline_found = false;
         for (const auto& pipeline_pair : pipeline_cache_by_pipeline_handle) {
-          if (std::find(pipeline_pair.second->shader_hashes.begin(), pipeline_pair.second->shader_hashes.end(), shader_hash) != pipeline_pair.second->shader_hashes.end()) continue;
+          if (std::find(pipeline_pair.second->shader_hashes.begin(), pipeline_pair.second->shader_hashes.end(), shader_hash) == pipeline_pair.second->shader_hashes.end()) continue;
           if (pipelines_filter.contains(pipeline_pair.first)) {
             pipeline_found = true;
           }

--- a/src/devkit/addon.cpp
+++ b/src/devkit/addon.cpp
@@ -123,7 +123,7 @@ std::vector<uint32_t> trace_shader_hashes;
 std::vector<uint64_t> trace_pipeline_handles;
 std::vector<InstructionState> instructions;
 
-constexpr uint32_t MAX_SHADER_DEFINES = 3;
+constexpr uint32_t MAX_SHADER_DEFINES = 4;
 
 // Settings
 bool auto_dump = false;

--- a/src/devkit/addon.cpp
+++ b/src/devkit/addon.cpp
@@ -1978,16 +1978,20 @@ void OnRegisterOverlay(reshade::api::effect_runtime* runtime) {
               name << " - " << PRINT_CRC32(hash);
               if (is_cloned) {
                 if (!pair->second->hlsl_path.empty()) {
-                  name << " * ";
+                  name << "* - ";
                   // TODO: add support for more name variations
                   static const std::string full_template_name = "0x12345678.xx_x_x.hlsl";
                   static const auto characters_to_remove_from_end = full_template_name.length();
                   auto filename_string = pair->second->hlsl_path.filename().string();
                   filename_string.erase(filename_string.length() - min(characters_to_remove_from_end, filename_string.length()));
+                  if (filename_string.ends_with("_"))
+                  {
+                    filename_string.erase(1);
+                  }
                   name << filename_string;
                 }
                 else {
-                  name << " *";
+                  name << "*";
                 }
               }
               if (ImGui::Selectable(name.str().c_str(), is_selected)) {

--- a/src/devkit/addon.cpp
+++ b/src/devkit/addon.cpp
@@ -973,9 +973,10 @@ void OnInitPipeline(
           auto shader_hash = compute_crc32(static_cast<const uint8_t*>(new_desc->code), new_desc->code_size);
 
           // Delete any previous shader with the same hash (unlikely to happen, but safer nonetheless)
-          if (auto previous_shader_pair = shader_cache.find(shader_hash); previous_shader_pair != shader_cache.end() && previous_shader_pair->second != nullptr)
-          {
+          if (auto previous_shader_pair = shader_cache.find(shader_hash); previous_shader_pair != shader_cache.end() && previous_shader_pair->second != nullptr) {
             auto& previous_shader = previous_shader_pair->second;
+            // Make sure that two shaders have the same hash, their code size also matches (theoretically we could check even more, but the chances hashes overlapping is extremely small)
+            assert(previous_shader->size == new_desc->code_size);
             shader_cache_count--;
             shader_cache_size -= previous_shader->size;
             delete previous_shader->data;

--- a/src/devkit/addon.cpp
+++ b/src/devkit/addon.cpp
@@ -1093,6 +1093,8 @@ void OnDestroyPipeline(
   uint32_t changed = 0;
   changed |= compute_shader_layouts.erase(pipeline.handle);
 
+  pipelines_to_reload.erase(pipeline.handle);
+
   if (
       auto pipeline_cache_pair = pipeline_cache_by_pipeline_handle.find(pipeline.handle);
       pipeline_cache_pair != pipeline_cache_by_pipeline_handle.end()) {
@@ -2167,6 +2169,7 @@ void OnRegisterOverlay(reshade::api::effect_runtime* runtime) {
 
   if (ImGui::Button(std::format("Unload Shaders ({})", cloned_pipeline_count).c_str())) {
     needs_unload_shaders = true;
+    pipelines_to_reload.clear();
     // For consistency, disable live reload, it makes no sense for it to be on if we have unloaded shaders
     if (auto_live_reload) {
       auto_live_reload = false;

--- a/src/devkit/addon.cpp
+++ b/src/devkit/addon.cpp
@@ -231,9 +231,9 @@ void UnloadCustomShaders(const std::unordered_set<uint64_t>& pipelines_filter = 
     auto& cached_pipeline = pair.second;
     if (cached_pipeline == nullptr || (!pipelines_filter.empty() && !pipelines_filter.contains(cached_pipeline->pipeline.handle))) continue;
 
+    cached_pipeline->test = false;  // Disable testing here, otherwise we might not always have a way to do it
     if (!cached_pipeline->cloned) continue;
     cached_pipeline->cloned = false;  // This stops the cloned pipeline from being used in the next frame, allowing us to destroy it
-    cached_pipeline->test = false;  // Disable testing here, otherwise we might not always have a way to do it
     cached_pipeline->compilation_error.clear();
     cloned_pipeline_count--;
     cloned_pipelines_changed = true;
@@ -1130,7 +1130,7 @@ void OnBindPipeline(
   auto* cached_pipeline = pair->second;
 
   if (cached_pipeline->test) {
-    // This will make the shader output black, or skip drawing, so we can easily detect it. This might not be very safe but seems to work.
+    // This will make the shader output black, or skip drawing, so we can easily detect it. This might not be very safe but seems to work in DX11.
     // TODO: replace the pipeline with a shader that outputs all "SV_Target" as purple for more visiblity
     cmd_list->bind_pipeline(stages, reshade::api::pipeline{0});
   }

--- a/src/devkit/addon.cpp
+++ b/src/devkit/addon.cpp
@@ -227,6 +227,7 @@ void UnloadCustomShaders(const std::unordered_set<uint64_t>& pipelines_filter = 
 
     if (!cached_pipeline->cloned) continue;
     cached_pipeline->cloned = false;  // This stops the cloned pipeline from being used in the next frame, allowing us to destroy it
+    cached_pipeline->compilation_error.clear();
     cloned_pipeline_count--;
     cloned_pipelines_changed = true;
 
@@ -1072,6 +1073,7 @@ void OnDestroyPipeline(
       if (cached_pipeline->cloned) {
         cached_pipeline->cloned = false;
         cached_pipeline->device->destroy_pipeline(cached_pipeline->pipeline_clone);
+        cached_pipeline->compilation_error.clear();
         cloned_pipeline_count--;
         cloned_pipelines_changed = true;
       }

--- a/src/devkit/addon.cpp
+++ b/src/devkit/addon.cpp
@@ -2171,7 +2171,7 @@ void OnRegisterOverlay(reshade::api::effect_runtime* runtime) {
           static bool opened_disassembly_tab_item = false;
           if (open_disassembly_tab_item) {
             static std::string disasm_string;
-            if (changed_selected || opened_disassembly_tab_item != open_disassembly_tab_item) {
+            if (!trace_hashes.empty() && (changed_selected || opened_disassembly_tab_item != open_disassembly_tab_item)) {
               auto hash = trace_hashes.at(selected_index);
               auto* cache = shader_cache.find(hash)->second;
               if (cache->disasm.empty()) {
@@ -2205,7 +2205,7 @@ void OnRegisterOverlay(reshade::api::effect_runtime* runtime) {
           if (open_live_tab_item) {
             static std::string hlsl_string;
             static bool hlsl_error = false;
-            if (changed_selected || opened_live_tab_item != open_live_tab_item || cloned_pipelines_changed) {
+            if (!trace_hashes.empty() && (changed_selected || opened_live_tab_item != open_live_tab_item || cloned_pipelines_changed)) {
               auto hash = trace_hashes.at(selected_index);
               
               if (

--- a/src/utils/shader_compiler.hpp
+++ b/src/utils/shader_compiler.hpp
@@ -97,7 +97,7 @@ inline std::optional<std::string> DisassembleShader(void* code, size_t size) {
   return result;
 }
 
-inline std::vector<uint8_t> CompileShaderFromFileFXC(LPCWSTR file_path, LPCSTR shader_target, LPCWSTR library = L"D3DCompiler_47.dll") {
+inline std::vector<uint8_t> CompileShaderFromFileFXC(LPCWSTR file_path, LPCSTR shader_target, std::string* out_error = nullptr, LPCWSTR library = L"D3DCompiler_47.dll") {
   std::vector<uint8_t> result;
   CComPtr<ID3DBlob> out_blob;
 
@@ -131,6 +131,9 @@ inline std::vector<uint8_t> CompileShaderFromFileFXC(LPCWSTR file_path, LPCSTR s
           // auto error_size = error_blob->GetBufferSize();
           auto* error = reinterpret_cast<uint8_t*>(error_blob->GetBufferPointer());
           s << ": " << error;
+          if (out_error != nullptr) {
+            out_error->assign((char*)error);
+          }
         } else {
           s << ".";
         }
@@ -307,7 +310,7 @@ inline HRESULT WINAPI BridgeD3DCompileFromFile(
   return CompileFromBlob(source, file_name, defines, include_handler, entrypoint, target, flags1, flags2, code, error_messages);
 }
 
-inline std::vector<uint8_t> CompileShaderFromFileDXC(LPCWSTR file_path, LPCSTR shader_target) {
+inline std::vector<uint8_t> CompileShaderFromFileDXC(LPCWSTR file_path, LPCSTR shader_target, std::string* out_error = nullptr) {
   std::vector<uint8_t> result;
 
   CComPtr<ID3DBlob> out_blob;
@@ -332,6 +335,9 @@ inline std::vector<uint8_t> CompileShaderFromFileDXC(LPCWSTR file_path, LPCSTR s
       // auto error_size = error_blob->GetBufferSize();
       auto* error = reinterpret_cast<uint8_t*>(error_blob->GetBufferPointer());
       s << ": " << error;
+      if (out_error != nullptr) {
+        out_error->assign((char*)error);
+      }
     } else {
       s << ".";
     }
@@ -343,11 +349,11 @@ inline std::vector<uint8_t> CompileShaderFromFileDXC(LPCWSTR file_path, LPCSTR s
   return result;
 }
 
-inline std::vector<uint8_t> CompileShaderFromFile(LPCWSTR file_path, LPCSTR shader_target, LPCWSTR library = L"D3DCompiler_47.dll") {
+inline std::vector<uint8_t> CompileShaderFromFile(LPCWSTR file_path, LPCSTR shader_target, std::string* out_error = nullptr, LPCWSTR library = L"D3DCompiler_47.dll") {
   if (shader_target[3] < '6') {
-    return CompileShaderFromFileFXC(file_path, shader_target, library);
+    return CompileShaderFromFileFXC(file_path, shader_target, out_error, library);
   }
-  return CompileShaderFromFileDXC(file_path, shader_target);
+  return CompileShaderFromFileDXC(file_path, shader_target, out_error);
 }
 
 }  // namespace renodx::utils::shader::compiler


### PR DESCRIPTION
- Fix live code tab not showing the shader code until you clicked on another shader and back on the one you wanted to see.
- Added shader live replacement (as in, any time a new shader is created by the game, if we already have a custom file matching its hash, we immediately replace it without needing to click the "Load Shaders" button again).
- Added shader auto dumping (as in, any time a new shader is created by the game, it's immediately dumped).
- Show the name the user gave to a shader next to a shader hash when tracing.
- Show shader compile error in the trace live view. Also paint the text red if they failed to compile, and paint them green in their list if they were correctly replaced.
- Automatically append the shader type name to the dumped cso files (e.g. 0x04718E31_ps_5_0.cso).
- Fixed many memory leaks.
- Fixed all thread safety problems I could find.
- Added support for multiple shaders with the same hashes (shaders can be loaded multiple times).
- Added support for multiple pipelines using the same shader (this happened a lot in DX11, at least in Prey). The code did not acknowledge it and just overrid the shader pointer with the last pipeline that used it.
- Added shader defines tab so you can change shader global defines without having to go back to your editor.
- Added a setting (in Trace)to disable shaders from being draw, so we can tell what they do.
- Add vertex shader trace and dump and load support.
- Made shader compilation (and auto loading and auto dumping) async, so they never stutter.

![image](https://github.com/user-attachments/assets/02286f74-5b1f-4679-ac29-b58690362a3d)
![image](https://github.com/user-attachments/assets/caa58505-27aa-447f-8915-c0a02f7f9b2c)
![image](https://github.com/user-attachments/assets/a3632b00-4965-462b-8b43-15c0d388753f)
https://github.com/user-attachments/assets/9162bd8a-14d0-4380-8e8d-d4f9e58b68f5


