### PR TITLE
Add renodx::math::SafePow and renodx::math::Pow

### DIFF
--- a/src/shaders/math.hlsl
+++ b/src/shaders/math.hlsl
@@ -10,15 +10,15 @@ static const float FLT10_MAX = 64512.f;
 static const float FLT11_MAX = 65024.f;
 static const float FLT16_MAX = 65504.f;
 
- float3 SafePow(float3 color, float exponent = 2.2f){
+ float3 SafePow(float3 color, float exponent){
   return sign(color) * pow(abs(color), exponent);
  }
 
- float1 SafePow(float1 color, float exponent = 2.2f){
+ float SafePow(float color, float exponent){
   return sign(color) * pow(abs(color), exponent);
  }
         
-float3 Pow(float3 color, float exponent = 2.2f){
+float3 Pow(float3 color, float exponent){
   return pow(color, exponent);
  }
         

--- a/src/shaders/math.hlsl
+++ b/src/shaders/math.hlsl
@@ -18,7 +18,7 @@ static const float FLT16_MAX = 65504.f;
   return sign(color) * pow(abs(color), exponent);
  }
         
-float3 pow(float3 color, float exponent = 2.2f){
+float3 Pow(float3 color, float exponent = 2.2f){
   return pow(color, exponent);
  }
         

--- a/src/shaders/math.hlsl
+++ b/src/shaders/math.hlsl
@@ -10,10 +10,14 @@ static const float FLT10_MAX = 64512.f;
 static const float FLT11_MAX = 65024.f;
 static const float FLT16_MAX = 65504.f;
 
- float3 safePow(float3 color, float exponent = 2.2f){
+ float3 SafePow(float3 color, float exponent = 2.2f){
   return sign(color) * pow(abs(color), exponent);
  }
 
+ float1 SafePow(float1 color, float exponent = 2.2f){
+  return sign(color) * pow(abs(color), exponent);
+ }
+        
 float3 pow(float3 color, float exponent = 2.2f){
   return pow(color, exponent);
  }

--- a/src/shaders/math.hlsl
+++ b/src/shaders/math.hlsl
@@ -10,6 +10,14 @@ static const float FLT10_MAX = 64512.f;
 static const float FLT11_MAX = 65024.f;
 static const float FLT16_MAX = 65504.f;
 
+ float3 safePow(float3 color, float exponent = 2.2f){
+  return sign(color) * pow(abs(color), exponent);
+ }
+
+float3 pow(float3 color, float exponent = 2.2f){
+  return pow(color, exponent);
+ }
+        
 float Average(float3 color) {
   return (color.x + color.y + color.z) / 3.f;
 }


### PR DESCRIPTION
The days of writing out the same formula for gamma encoding is over!

`color = renodx::math::safePow(color)` is the same as `color = sign(color) * pow(abs(color), 2.2f)` -- and you can set a custom exponent as the second argument; so 2.4 gamma would be `color = renodx::math::safePow(color, 2.4f)`

`color= renodx::math::pow(color)` = `color = pow(color, 2.2f)` -- custom gamma supported, same system as safePow