### PR TITLE
Update Fallout 76 Support: Fix UI Blending, Fix Rendering Issues, Add New Features

### DIFF
--- a/src/games/darksouls/gamma_0xAB7CF260.ps_5_0.hlsl
+++ b/src/games/darksouls/gamma_0xAB7CF260.ps_5_0.hlsl
@@ -23,6 +23,17 @@ void main(float4 v0
   o0.w = 1;
   o0.xyz = g_Texture.Sample(g_TextureSampler_s, v1.xy).xyz;
 
+  // linearize and scale paper white
+  float3 signs = sign(o0.rgb);
+  o0.rgb = abs(o0.rgb);
+  o0.rgb = (injectedData.toneMapGammaCorrection
+                ? pow(o0.rgb, 2.2f)
+                : renodx::color::bt709::from::SRGB(o0.rgb));
+  o0.rgb *= signs;
+  o0.rgb *= injectedData.toneMapGameNits / 80.f;
+
+
+
   // Removed gamma slider as it capped brightness
   // Image is unchanged when set to default 5
 

--- a/src/games/darksouls/shared.h
+++ b/src/games/darksouls/shared.h
@@ -14,6 +14,7 @@ struct ShaderInjectData {
   float toneMapUINits;
   float toneMapGammaCorrection;
   float toneMapHueCorrection;
+  float toneMapBlend;
   float colorGradeExposure;
   float colorGradeHighlights;
   float colorGradeShadows;
@@ -23,8 +24,6 @@ struct ShaderInjectData {
   float colorGradeLUTStrength;
   float fxBloom;
   float fxDoF;
-  float fxFilmGrain;
-  float elapsedTime;
 };
 
 #ifndef __cplusplus

--- a/src/games/darksouls/ui_0x64F62639.ps_5_0.hlsl
+++ b/src/games/darksouls/ui_0x64F62639.ps_5_0.hlsl
@@ -12,9 +12,15 @@ void main(float4 v0
           : SV_Target0) {
   o0.xyzw = v1.xyzw;
 
-  o0.rgb = injectedData.toneMapGammaCorrection ? pow(o0.rgb, 2.2f)
-                                               : renodx::color::bt709::from::SRGB(o0.rgb);
-  o0.rgb *= injectedData.toneMapUINits / 80.f;
+  o0.xyz = saturate(o0.xyz);
+  // allow for brightness adjustment while preserving UI blending in gamma space
+  if (injectedData.toneMapUINits != injectedData.toneMapGameNits) {
+    o0.rgb = injectedData.toneMapGammaCorrection ? pow(o0.rgb, 2.2f)
+                                                : renodx::color::bt709::from::SRGB(o0.rgb);
+    o0.rgb *= injectedData.toneMapUINits / injectedData.toneMapGameNits;
+    o0.rgb = injectedData.toneMapGammaCorrection ? pow(o0.rgb, 1.f / 2.2f)
+                                                : renodx::color::srgb::from::BT709(o0.rgb);
+  }
 
   return;
 }

--- a/src/games/darksouls/ui_0x809881A3.ps_5_0.hlsl
+++ b/src/games/darksouls/ui_0x809881A3.ps_5_0.hlsl
@@ -20,9 +20,15 @@ void main(float4 v0
   r0.xyzw = g_Texture.Sample(g_TextureSampler_s, v2.xy).xyzw;
   o0.xyzw = v1.xyzw * r0.xyzw;
 
-  o0.rgb = injectedData.toneMapGammaCorrection ? pow(o0.rgb, 2.2f)
-                                               : renodx::color::bt709::from::SRGB(o0.rgb);
-  o0.rgb *= injectedData.toneMapUINits / 80.f;
+  o0.xyz = saturate(o0.xyz);
+  // allow for brightness adjustment while preserving UI blending in gamma space
+  if (injectedData.toneMapUINits != injectedData.toneMapGameNits) {
+    o0.rgb = injectedData.toneMapGammaCorrection ? pow(o0.rgb, 2.2f)
+                                                : renodx::color::bt709::from::SRGB(o0.rgb);
+    o0.rgb *= injectedData.toneMapUINits / injectedData.toneMapGameNits;
+    o0.rgb = injectedData.toneMapGammaCorrection ? pow(o0.rgb, 1.f / 2.2f)
+                                                : renodx::color::srgb::from::BT709(o0.rgb);
+  }
 
   return;
 }

--- a/src/games/darksouls/ui_0xB0850BF3.ps_5_0.hlsl
+++ b/src/games/darksouls/ui_0xB0850BF3.ps_5_0.hlsl
@@ -12,9 +12,15 @@ void main(float4 v0
           : SV_Target0) {
   o0.xyzw = v1.xyzw;
 
-  o0.rgb = injectedData.toneMapGammaCorrection ? pow(o0.rgb, 2.2f)
-                                               : renodx::color::bt709::from::SRGB(o0.rgb);
-  o0.rgb *= injectedData.toneMapUINits / 80.f;
+  o0.xyz = saturate(o0.xyz);
+  // allow for brightness adjustment while preserving UI blending in gamma space
+  if (injectedData.toneMapUINits != injectedData.toneMapGameNits) {
+    o0.rgb = injectedData.toneMapGammaCorrection ? pow(o0.rgb, 2.2f)
+                                                : renodx::color::bt709::from::SRGB(o0.rgb);
+    o0.rgb *= injectedData.toneMapUINits / injectedData.toneMapGameNits;
+    o0.rgb = injectedData.toneMapGammaCorrection ? pow(o0.rgb, 1.f / 2.2f)
+                                                : renodx::color::srgb::from::BT709(o0.rgb);
+  }
 
   // TODO: figure out what this shader does
   // o0.rgb = (1, 0, 1);


### PR DESCRIPTION
### This pull request introduces several improvements and new features to the Dark Souls Remastered mod, including:

- **Tonemap Blending:** Added tonemap blending to allow custom tonemappers to blend with vanilla.
- **Color Grading Fix:** Resolved an issue where color grading applied post-tonemap did not respect peak luminance by utilizing the new `UpgradeToneMap()` function.
- **UI Blending Fix:** Corrected blending issues within the UI, ensuring a more consistent and visually appealing user interface.
- **Film Grain Slider Removal:** Removed the film grain slider, as the game already incorporates noise, reducing redundancy in graphical settings.
- **Hue Correction Update:** Implemented the new hue correction code, improving accuracy and consistency when emulating the hue shifting from the vanilla tonemapper.