### PR TITLE
Add Support for Ori and the Will of the Wisps

### DIFF
--- a/src/games/ori2/addon.cpp
+++ b/src/games/ori2/addon.cpp
@@ -1,0 +1,231 @@
+/*
+ * Copyright (C) 2024 Musa Haji
+ * Copyright (C) 2024 Carlos Lopez
+ * SPDX-License-Identifier: MIT
+ */
+
+#define ImTextureID ImU64
+
+#define DEBUG_LEVEL_0
+#define DEBUG_SLIDERS_OFF
+
+#include <deps/imgui/imgui.h>
+
+#include <embed/0x24182048.h>   // Color Grading - main menu & prologue
+#include <embed/0x73E7A34D.h>   // Color Grading - main menu & prologue - sharpening low
+#include <embed/0xD7BC63A1.h>   // Color Grading - level 1: Inkwater Marsh
+
+// additional color grading shaders done in batch
+#include <embed/0x063548F6.h>
+#include <embed/0x0BE6093C.h>
+#include <embed/0x0E0EE842.h>
+#include <embed/0x1A46FADC.h>
+#include <embed/0x1E8FDB7D.h>
+#include <embed/0x211F3245.h>
+#include <embed/0x28B10677.h>
+#include <embed/0x2CEC407A.h>
+#include <embed/0x34F7E01C.h>
+#include <embed/0x350163E1.h>
+#include <embed/0x37E6CB72.h>
+#include <embed/0x3F118009.h>
+#include <embed/0x3FDCF7AA.h>
+#include <embed/0x48CDE62E.h>
+#include <embed/0x4A3D4181.h>
+#include <embed/0x596B9BD3.h>
+#include <embed/0x5B0965E4.h>
+#include <embed/0x5CDE4A30.h>
+#include <embed/0x613B5403.h>
+#include <embed/0x62C79AA3.h>
+#include <embed/0x649A0B90.h>
+#include <embed/0x7C14BB2C.h>
+#include <embed/0x841FAF0A.h>
+#include <embed/0x84C7D93E.h>
+#include <embed/0x8A303253.h>
+#include <embed/0x8B1DE268.h>
+#include <embed/0x8D6097D1.h>
+#include <embed/0x8D6C34A5.h>
+#include <embed/0x8EC5798A.h>
+#include <embed/0x9AC0DEEF.h>
+#include <embed/0x9B5CC768.h>
+#include <embed/0x9DA86DCE.h>
+#include <embed/0xA6488EB2.h>
+#include <embed/0xABD8D6B7.h>
+#include <embed/0xB24C1A54.h>
+#include <embed/0xB270CA5B.h>
+#include <embed/0xC4128983.h>
+#include <embed/0xD9B57ECB.h>
+#include <embed/0xDB90C883.h>
+#include <embed/0xDE975B11.h>
+#include <embed/0xE3F6E54F.h>
+#include <embed/0xF017475F.h>
+#include <embed/0xF3917C63.h>
+#include <embed/0xF7933F3F.h>
+#include <embed/0xFCF0717A.h>
+
+#include <embed/0x9D323EA3.h>   // Inverse tonemap, garbage default hdr implementation
+#include <embed/0xF9C2BDE1.h>   // DICE, final bt2020 conversion, paper white, and pq encode
+
+#include <include/reshade.hpp>
+#include "../../mods/shader.hpp"
+#include "../../utils/settings.hpp"
+#include "./shared.h"
+
+namespace {
+
+renodx::mods::shader::CustomShaders custom_shaders = {
+    CustomShaderEntry(0x24182048),   // Color Grading - main menu & prologue
+    CustomShaderEntry(0x73E7A34D),   // Color Grading - main menu & prologue - sharpening low
+    CustomShaderEntry(0xD7BC63A1),   // Color Grading - level 1
+
+    // additional color grading shaders done in batch
+    CustomShaderEntry(0x063548F6),
+    CustomShaderEntry(0x0BE6093C),
+    CustomShaderEntry(0x0E0EE842),
+    CustomShaderEntry(0x1A46FADC),
+    CustomShaderEntry(0x1E8FDB7D),
+    CustomShaderEntry(0x211F3245),
+    CustomShaderEntry(0x28B10677),
+    CustomShaderEntry(0x2CEC407A),
+    CustomShaderEntry(0x34F7E01C),
+    CustomShaderEntry(0x350163E1),
+    CustomShaderEntry(0x37E6CB72),
+    CustomShaderEntry(0x3F118009),
+    CustomShaderEntry(0x3FDCF7AA),
+    CustomShaderEntry(0x48CDE62E),
+    CustomShaderEntry(0x4A3D4181),
+    CustomShaderEntry(0x596B9BD3),
+    CustomShaderEntry(0x5B0965E4),
+    CustomShaderEntry(0x5CDE4A30),
+    CustomShaderEntry(0x613B5403),
+    CustomShaderEntry(0x62C79AA3),
+    CustomShaderEntry(0x649A0B90),
+    CustomShaderEntry(0x7C14BB2C),
+    CustomShaderEntry(0x841FAF0A),
+    CustomShaderEntry(0x84C7D93E),
+    CustomShaderEntry(0x8A303253),
+    CustomShaderEntry(0x8B1DE268),
+    CustomShaderEntry(0x8D6097D1),
+    CustomShaderEntry(0x8D6C34A5),
+    CustomShaderEntry(0x8EC5798A),
+    CustomShaderEntry(0x9AC0DEEF),
+    CustomShaderEntry(0x9B5CC768),
+    CustomShaderEntry(0x9DA86DCE),
+    CustomShaderEntry(0xA6488EB2),
+    CustomShaderEntry(0xABD8D6B7),
+    CustomShaderEntry(0xB24C1A54),
+    CustomShaderEntry(0xB270CA5B),
+    CustomShaderEntry(0xC4128983),
+    CustomShaderEntry(0xD9B57ECB),
+    CustomShaderEntry(0xDB90C883),
+    CustomShaderEntry(0xDE975B11),
+    CustomShaderEntry(0xE3F6E54F),
+    CustomShaderEntry(0xF017475F),
+    CustomShaderEntry(0xF3917C63),
+    CustomShaderEntry(0xF7933F3F),
+    CustomShaderEntry(0xFCF0717A),
+
+    CustomShaderEntry(0x9D323EA3),  // Inverse tonemap, garbage default hdr implementation
+    CustomShaderEntry(0xF9C2BDE1),  // DICE, final bt2020 conversion, paper white, and pq encode
+};
+
+ShaderInjectData shader_injection;
+
+renodx::utils::settings::Settings settings = {
+    new renodx::utils::settings::Setting{
+        .key = "toneMapType",
+        .binding = &shader_injection.toneMapType,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 2.f,
+        .can_reset = false,
+        .label = "Tone Mapper",
+        .section = "Tone Mapping",
+        .tooltip = "Sets the tone mapper type",
+        .labels = {"Vanilla (Fake HDR)", "None", "DICE"},
+    },
+    new renodx::utils::settings::Setting{
+        .key = "toneMapPeakNits",
+        .binding = &shader_injection.toneMapPeakNits,
+        .default_value = 1000.f,
+        .can_reset = false,
+        .label = "Peak Brightness",
+        .section = "Tone Mapping",
+        .tooltip = "Sets the value of peak white in nits",
+        .min = 48.f,
+        .max = 4000.f,
+    },
+    new renodx::utils::settings::Setting{
+        .key = "toneMapGameNits",
+        .binding = &shader_injection.toneMapGameNits,
+        .default_value = 203.f,
+        .can_reset = false,
+        .label = "Game Brightness",
+        .section = "Tone Mapping",
+        .tooltip = "Sets the value of 100%% white in nits",
+        .min = 48.f,
+        .max = 500.f,
+    },
+    new renodx::utils::settings::Setting{
+        .key = "toneMapHueCorrection",
+        .binding = &shader_injection.toneMapHueCorrection,
+        .default_value = 50.f,
+        .can_reset = false,
+        .label = "Hue Correction",
+        .section = "Tone Mapping",
+        .tooltip = "Emulates hue shifting from the vanilla tonemapper",
+        .max = 100.f,
+        .is_enabled = []() { return shader_injection.toneMapType != 0; },
+        .parse = [](float value) { return value * 0.01f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "colorGradeStrength",
+        .binding = &shader_injection.colorGradeStrength,
+        .default_value = 100.f,
+        .label = "Color Grade Strength",
+        .section = "Color Grading",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.01f; },
+    },
+};
+
+void OnPresetOff() {
+  renodx::utils::settings::UpdateSetting("toneMapType", 0);
+  renodx::utils::settings::UpdateSetting("toneMapPeakNits", 1000.f);
+  renodx::utils::settings::UpdateSetting("toneMapGameNits", 203.f);
+  renodx::utils::settings::UpdateSetting("toneMapGammaCorrection", 1.f);
+  renodx::utils::settings::UpdateSetting("colorGradeExposure", 1.f);
+  renodx::utils::settings::UpdateSetting("colorGradeHighlights", 50.f);
+  renodx::utils::settings::UpdateSetting("colorGradeShadows", 50.f);
+  renodx::utils::settings::UpdateSetting("colorGradeContrast", 50.f);
+  renodx::utils::settings::UpdateSetting("colorGradeSaturation", 50.f);
+  renodx::utils::settings::UpdateSetting("colorGradeStrength", 100.f);
+}
+
+}  // namespace
+
+// NOLINTBEGIN(readability-identifier-naming)
+
+extern "C" __declspec(dllexport) const char* NAME = "RenoDX";
+extern "C" __declspec(dllexport) const char* DESCRIPTION = "RenoDX for Ori and the Will of the Wisps";
+
+// NOLINTEND(readability-identifier-naming)
+
+BOOL APIENTRY DllMain(HMODULE h_module, DWORD fdw_reason, LPVOID lpv_reserved) {
+  switch (fdw_reason) {
+    case DLL_PROCESS_ATTACH:
+      renodx::mods::shader::force_pipeline_cloning = true;
+      renodx::mods::shader::expected_constant_buffer_index = 11;
+
+      if (!reshade::register_addon(h_module)) return FALSE;
+
+      break;
+    case DLL_PROCESS_DETACH:
+      reshade::unregister_addon(h_module);
+      break;
+  }
+
+  renodx::utils::settings::Use(fdw_reason, &settings, &OnPresetOff);
+
+  renodx::mods::shader::Use(fdw_reason, custom_shaders, &shader_injection);
+
+  return TRUE;
+}

--- a/src/games/ori2/colorgrade00_0x24182048.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade00_0x24182048.ps_5_0.hlsl
@@ -1,0 +1,141 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:12:45 2024
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[22];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = t0.Sample(s2_s, v2.xy).xy;
+  r0.xy = float2(-0.498039216,-0.498039216) + r0.xy;
+  r0.xy = float2(0.100000001,0.100000001) * r0.xy;
+  r0.zw = r0.xy * cb0[5].xy + v1.xy;
+  r0.xy = r0.xy * cb0[5].xy + v2.xy;
+  r0.xy = min(cb0[6].zw, r0.xy);
+  r1.xyzw = t2.Sample(s1_s, r0.xy).xyzw;  // blur?
+  r1.xyzw = saturate(-r1.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r2.xyzw = min(cb0[6].xyxy, r0.zwzw);
+  r0.xy = r0.zw / cb0[5].xy;
+  r3.xyzw = cb0[3].xyxy * float4(-1.5,-1.5,1.5,-1.5) + r2.zwzw;
+  r4.xyz = t1.Sample(s0_s, r3.xy).xyz;
+  r3.xyz = t1.Sample(s0_s, r3.zw).xyz;
+  r3.xyz = r4.xyz + r3.xyz;
+  r4.xyzw = cb0[3].xyxy * float4(-1.5,1.5,1.5,1.5) + r2.xyzw;
+  r2.xyzw = t1.Sample(s0_s, r2.zw).xyzw;  // render
+ 
+  r5.xyz = t1.Sample(s0_s, r4.xy).xyz;
+  r4.xyz = t1.Sample(s0_s, r4.zw).xyz;
+  r3.xyz = r5.xyz + r3.xyz;
+  r3.xyz = r3.xyz + r4.xyz;
+  r3.xyz = -r3.xyz * float3(0.25,0.25,0.25) + r2.xyz;
+  r3.xyz = r3.xyz * cb0[8].yyy + r2.xyz;
+  r0.zw = min(cb0[13].zw, r0.xy);
+  r4.xyz = t4.Sample(s3_s, r0.xy).xyz;  // ori glow
+  r0.xyz = t3.Sample(s3_s, r0.zw).xyz;  // sun glow
+  r5.xyz = cb0[13].xxx * r0.xyz;
+  r0.xyz = cb0[13].yyy + r0.xyz;
+  r0.xyz = r5.xyz / r0.xyz;
+  r0.xyz = r3.xyz + r0.xyz;
+  r0.w = max(r4.y, r4.z);
+  r0.w = max(r4.x, r0.w);
+  r3.x = cmp(cb0[12].z < r0.w);
+  r0.w = cb0[12].z / r0.w;
+  r0.w = r3.x ? r0.w : 1;
+  r2.xyz = r4.xyz * r0.www + r0.xyz;
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.xyzw = r2.xyzw * r0.xxxx;
+
+  r2.xyz = cb0[17].xyz * r0.xyz;  //  r2.xyz = saturate(cb0[17].xyz * r0.xyz);
+  float3 hdrColor = r2.xyz;
+  r2.xyz = saturate(r2.xyz);
+
+  r3.xyz = r2.xyz * r2.xyz;
+  r4.xyz = r3.xyz * r2.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r2.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r2.xyz = r7.xzy * r2.xzy;
+  r5.x = r8.y;
+  r5.y = r2.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r2.x = r8.z;
+  r8.y = r2.z;
+  r8.z = r3.y;
+  r2.z = r3.z;
+  r8.w = r4.y;
+  r2.w = r4.z;
+  r5.z = dot(r2.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r2.x = saturate(dot(r0.xyz, float3(0.219999999,0.707000017,0.0710000023))); // BOURGIN D65 Y
+  r2.xyzw = r2.xxxx + -r0.xyzw;
+  r0.xyzw = cb0[10].xxxx * r2.xyzw + r0.xyzw;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r2.xyzw = -r1.xyzw * r0.xyzw + float4(1,1,1,1);
+  r0.xyz = -r1.xyz * r0.xyz + float3(0.5,0.5,0.5);
+  r1.xy = float2(-0.5,-0.5) + w1.xy;
+  r0.w = dot(r1.xy, r1.xy);
+  r0.w = sqrt(r0.w);
+  r0.w = r0.w * 0.720000029 + -0.800000012;
+  r0.w = saturate(-1.83715463 * r0.w);
+  r1.x = r0.w * -2 + 3;
+  r0.w = r0.w * r0.w;
+  r1.y = r1.x * r0.w + -1;
+  r0.w = r1.x * r0.w;
+  r1.x = -r1.y * 0.200000003 + 1;
+  r1.x = max(1, r1.x);
+  r0.xyz = r0.xyz * r1.xxx + float3(0.5,0.5,0.5);
+  r0.xyz = r0.xyz * r0.www + -r2.xyz;
+  r0.w = 0;
+
+
+  o0.xyzw = cb0[12].yyyy * r0.xyzw + r2.xyzw; // vignette + render
+  if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+  }
+  return;
+}

--- a/src/games/ori2/colorgrade01_0xD7BC63A1.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade01_0xD7BC63A1.ps_5_0.hlsl
@@ -1,0 +1,132 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:15:32 2024
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[22];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = t0.Sample(s2_s, v2.xy).xy;
+  r0.xy = float2(-0.498039216,-0.498039216) + r0.xy;
+  r0.xy = float2(0.100000001,0.100000001) * r0.xy;
+  r0.zw = r0.xy * cb0[5].xy + v1.xy;
+  r0.xy = r0.xy * cb0[5].xy + v2.xy;
+  r0.xy = min(cb0[6].zw, r0.xy);
+  r1.xyzw = t2.Sample(s1_s, r0.xy).xyzw;
+  r1.xyzw = saturate(-r1.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r2.xyzw = min(cb0[6].xyxy, r0.zwzw);
+  r0.xy = r0.zw / cb0[5].xy;
+  r0.xyz = t3.Sample(s3_s, r0.xy).xyz;
+  r3.xyzw = cb0[3].xyxy * float4(-1.5,-1.5,1.5,-1.5) + r2.zwzw;
+  r4.xyz = t1.Sample(s0_s, r3.xy).xyz;
+  r3.xyz = t1.Sample(s0_s, r3.zw).xyz;
+  r3.xyz = r4.xyz + r3.xyz;
+  r4.xyzw = cb0[3].xyxy * float4(-1.5,1.5,1.5,1.5) + r2.xyzw;
+  r2.xyzw = t1.Sample(s0_s, r2.zw).xyzw;
+  r5.xyz = t1.Sample(s0_s, r4.xy).xyz;
+  r4.xyz = t1.Sample(s0_s, r4.zw).xyz;
+  r3.xyz = r5.xyz + r3.xyz;
+  r3.xyz = r3.xyz + r4.xyz;
+  r3.xyz = -r3.xyz * float3(0.25,0.25,0.25) + r2.xyz;
+  r3.xyz = r3.xyz * cb0[8].yyy + r2.xyz;
+  r0.w = max(r0.y, r0.z);
+  r0.w = max(r0.x, r0.w);
+  r3.w = cmp(cb0[12].z < r0.w);
+  r0.w = cb0[12].z / r0.w;
+  r0.w = r3.w ? r0.w : 1;
+  r2.xyz = r0.xyz * r0.www + r3.xyz;
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.xyzw = r2.xyzw * r0.xxxx;
+
+  r2.xyz = cb0[17].xyz * r0.xyz;  //  r2.xyz = saturate(cb0[17].xyz * r0.xyz);
+  float3 hdrColor = r2.xyz;
+  r2.xyz = saturate(r2.xyz);
+
+  r3.xyz = r2.xyz * r2.xyz;
+  r4.xyz = r3.xyz * r2.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r2.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r2.xyz = r7.xzy * r2.xzy;
+  r5.x = r8.y;
+  r5.y = r2.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r2.x = r8.z;
+  r8.y = r2.z;
+  r8.z = r3.y;
+  r2.z = r3.z;
+  r8.w = r4.y;
+  r2.w = r4.z;
+  r5.z = dot(r2.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r2.x = saturate(dot(r0.xyz, float3(0.219999999,0.707000017,0.0710000023)));
+  r2.xyzw = r2.xxxx + -r0.xyzw;
+  r0.xyzw = cb0[10].xxxx * r2.xyzw + r0.xyzw;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r2.xyzw = -r1.xyzw * r0.xyzw + float4(1,1,1,1);
+  r0.xyz = -r1.xyz * r0.xyz + float3(0.5,0.5,0.5);
+  r1.xy = float2(-0.5,-0.5) + w1.xy;
+  r0.w = dot(r1.xy, r1.xy);
+  r0.w = sqrt(r0.w);
+  r0.w = r0.w * 0.720000029 + -0.800000012;
+  r0.w = saturate(-1.83715463 * r0.w);
+  r1.x = r0.w * -2 + 3;
+  r0.w = r0.w * r0.w;
+  r1.y = r1.x * r0.w + -1;
+  r0.w = r1.x * r0.w;
+  r1.x = -r1.y * 0.200000003 + 1;
+  r1.x = max(1, r1.x);
+  r0.xyz = r0.xyz * r1.xxx + float3(0.5,0.5,0.5);
+  r0.xyz = r0.xyz * r0.www + -r2.xyz;
+  r0.w = 0;
+
+
+  o0.xyzw = cb0[12].yyyy * r0.xyzw + r2.xyzw;
+  if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+  }
+  return;
+}

--- a/src/games/ori2/colorgrade02_0x73E7A34D.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade02_0x73E7A34D.ps_5_0.hlsl
@@ -1,0 +1,129 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:13:58 2024
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[22];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = t0.Sample(s2_s, v2.xy).xy;
+  r0.xy = float2(-0.498039216,-0.498039216) + r0.xy;
+  r0.xy = float2(0.100000001,0.100000001) * r0.xy;
+  r0.zw = r0.xy * cb0[5].xy + v1.xy;
+  r0.xy = r0.xy * cb0[5].xy + v2.xy;
+  r0.xy = min(cb0[6].zw, r0.xy);
+  r1.xyzw = t2.Sample(s1_s, r0.xy).xyzw;
+  r1.xyzw = saturate(-r1.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r0.xy = r0.zw / cb0[5].xy;
+  r0.zw = min(cb0[6].xy, r0.zw);
+  r2.xyzw = t1.Sample(s0_s, r0.zw).xyzw;
+  r0.zw = min(cb0[13].zw, r0.xy);
+  r3.xyz = t4.Sample(s3_s, r0.xy).xyz;
+  r0.xyz = t3.Sample(s3_s, r0.zw).xyz;
+  r4.xyz = cb0[13].xxx * r0.xyz;
+  r0.xyz = cb0[13].yyy + r0.xyz;
+  r0.xyz = r4.xyz / r0.xyz;
+  r0.xyz = r2.xyz + r0.xyz;
+  r0.w = max(r3.y, r3.z);
+  r0.w = max(r3.x, r0.w);
+  r3.w = cmp(cb0[12].z < r0.w);
+  r0.w = cb0[12].z / r0.w;
+  r0.w = r3.w ? r0.w : 1;
+  r2.xyz = r3.xyz * r0.www + r0.xyz;
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.xyzw = r2.xyzw * r0.xxxx;
+
+  r2.xyz = cb0[17].xyz * r0.xyz;  //  r2.xyz = saturate(cb0[17].xyz * r0.xyz);
+  float3 hdrColor = r2.xyz;
+  r2.xyz = saturate(r2.xyz);
+
+  r3.xyz = r2.xyz * r2.xyz;
+  r4.xyz = r3.xyz * r2.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r2.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r2.xyz = r7.xzy * r2.xzy;
+  r5.x = r8.y;
+  r5.y = r2.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r2.x = r8.z;
+  r8.y = r2.z;
+  r8.z = r3.y;
+  r2.z = r3.z;
+  r8.w = r4.y;
+  r2.w = r4.z;
+  r5.z = dot(r2.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r2.x = saturate(dot(r0.xyz, float3(0.219999999,0.707000017,0.0710000023)));
+  r2.xyzw = r2.xxxx + -r0.xyzw;
+  r0.xyzw = cb0[10].xxxx * r2.xyzw + r0.xyzw;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r2.xyzw = -r1.xyzw * r0.xyzw + float4(1,1,1,1);
+  r0.xyz = -r1.xyz * r0.xyz + float3(0.5,0.5,0.5);
+  r1.xy = float2(-0.5,-0.5) + w1.xy;
+  r0.w = dot(r1.xy, r1.xy);
+  r0.w = sqrt(r0.w);
+  r0.w = r0.w * 0.720000029 + -0.800000012;
+  r0.w = saturate(-1.83715463 * r0.w);
+  r1.x = r0.w * -2 + 3;
+  r0.w = r0.w * r0.w;
+  r1.y = r1.x * r0.w + -1;
+  r0.w = r1.x * r0.w;
+  r1.x = -r1.y * 0.200000003 + 1;
+  r1.x = max(1, r1.x);
+  r0.xyz = r0.xyz * r1.xxx + float3(0.5,0.5,0.5);
+  r0.xyz = r0.xyz * r0.www + -r2.xyz;
+  r0.w = 0;
+
+
+  o0.xyzw = cb0[12].yyyy * r0.xyzw + r2.xyzw;
+  if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+  }
+  return;
+}

--- a/src/games/ori2/colorgrade_0x063548F6.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0x063548F6.ps_5_0.hlsl
@@ -1,0 +1,125 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:12:19 2024
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[22];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = t0.Sample(s2_s, v2.xy).xy;
+  r0.xy = float2(-0.498039216,-0.498039216) + r0.xy;
+  r0.xy = float2(0.100000001,0.100000001) * r0.xy;
+  r0.zw = r0.xy * cb0[5].xy + v1.xy;
+  r0.xy = r0.xy * cb0[5].xy + v2.xy;
+  r0.xy = min(cb0[6].zw, r0.xy);
+  r1.xyzw = t2.Sample(s1_s, r0.xy).xyzw;
+  r1.xyzw = saturate(-r1.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r2.xyzw = min(cb0[6].xyxy, r0.zwzw);
+  r0.xy = r0.zw / cb0[5].xy;
+  r0.xy = min(cb0[13].zw, r0.xy);
+  r0.xyz = t3.Sample(s3_s, r0.xy).xyz;
+  r3.xyzw = cb0[3].xyxy * float4(-1.5,-1.5,1.5,-1.5) + r2.zwzw;
+  r4.xyz = t1.Sample(s0_s, r3.xy).xyz;
+  r3.xyz = t1.Sample(s0_s, r3.zw).xyz;
+  r3.xyz = r4.xyz + r3.xyz;
+  r4.xyzw = cb0[3].xyxy * float4(-1.5,1.5,1.5,1.5) + r2.xyzw;
+  r2.xyzw = t1.Sample(s0_s, r2.zw).xyzw;
+  r5.xyz = t1.Sample(s0_s, r4.xy).xyz;
+  r4.xyz = t1.Sample(s0_s, r4.zw).xyz;
+  r3.xyz = r5.xyz + r3.xyz;
+  r3.xyz = r3.xyz + r4.xyz;
+  r3.xyz = -r3.xyz * float3(0.25,0.25,0.25) + r2.xyz;
+  r3.xyz = r3.xyz * cb0[8].yyy + r2.xyz;
+  r4.xyz = cb0[13].xxx * r0.xyz;
+  r0.xyz = cb0[13].yyy + r0.xyz;
+  r0.xyz = r4.xyz / r0.xyz;
+  r2.xyz = r3.xyz + r0.xyz;
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.xyzw = r2.xyzw * r0.xxxx;
+r2.xyz = cb0[17].xyz * r0.xyz;  //    r2.xyz = saturate(cb0[17].xyz * r0.xyz);
+float3 hdrColor = r2.xyz;
+r2.xyz = saturate(r2.xyz);
+
+  r3.xyz = r2.xyz * r2.xyz;
+  r4.xyz = r3.xyz * r2.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r2.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r2.xyz = r7.xzy * r2.xzy;
+  r5.x = r8.y;
+  r5.y = r2.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r2.x = r8.z;
+  r8.y = r2.z;
+  r8.z = r3.y;
+  r2.z = r3.z;
+  r8.w = r4.y;
+  r2.w = r4.z;
+  r5.z = dot(r2.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r2.xyzw = -r1.xyzw * r0.xyzw + float4(1,1,1,1);
+  r0.xyz = -r1.xyz * r0.xyz + float3(0.5,0.5,0.5);
+  r1.xy = float2(-0.5,-0.5) + w1.xy;
+  r0.w = dot(r1.xy, r1.xy);
+  r0.w = sqrt(r0.w);
+  r0.w = r0.w * 0.720000029 + -0.800000012;
+  r0.w = saturate(-1.83715463 * r0.w);
+  r1.x = r0.w * -2 + 3;
+  r0.w = r0.w * r0.w;
+  r1.y = r1.x * r0.w + -1;
+  r0.w = r1.x * r0.w;
+  r1.x = -r1.y * 0.200000003 + 1;
+  r1.x = max(1, r1.x);
+  r0.xyz = r0.xyz * r1.xxx + float3(0.5,0.5,0.5);
+  r0.xyz = r0.xyz * r0.www + -r2.xyz;
+  r0.w = 0;
+  o0.xyzw = cb0[12].yyyy * r0.xyzw + r2.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/colorgrade_0x0BE6093C.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0x0BE6093C.ps_5_0.hlsl
@@ -1,0 +1,149 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:12:24 2024
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[28];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = t0.Sample(s2_s, v2.xy).xy;
+  r0.xy = float2(-0.498039216,-0.498039216) + r0.xy;
+  r0.xy = float2(0.100000001,0.100000001) * r0.xy;
+  r0.zw = r0.xy * cb0[5].xy + v1.xy;
+  r0.xy = r0.xy * cb0[5].xy + v2.xy;
+  r0.xy = min(cb0[6].zw, r0.xy);
+  r1.xyzw = t2.Sample(s1_s, r0.xy).xyzw;
+  r1.xyzw = saturate(-r1.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r0.xy = r0.zw / cb0[5].xy;
+  r0.zw = min(cb0[6].xy, r0.zw);
+  r2.xyzw = t1.Sample(s0_s, r0.zw).xyzw;
+  r0.zw = min(cb0[13].zw, r0.xy);
+  r3.xyz = t4.Sample(s3_s, r0.xy).xyz;
+  r0.xyz = t3.Sample(s3_s, r0.zw).xyz;
+  r0.xyz = saturate(r0.xyz);
+  r0.xyz = float3(1,1,1) + -r0.xyz;
+  r4.xyz = float3(1,1,1) + -r2.xyz;
+  r0.xyz = -r4.xyz * r0.xyz + float3(1,1,1);
+  r0.w = max(r3.y, r3.z);
+  r0.w = max(r3.x, r0.w);
+  r3.w = cmp(cb0[12].z < r0.w);
+  r0.w = cb0[12].z / r0.w;
+  r0.w = r3.w ? r0.w : 1;
+  r2.xyz = r3.xyz * r0.www + r0.xyz;
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.xyzw = r2.xyzw * r0.xxxx;
+r2.xyz = cb0[17].xyz * r0.xyz;  //    r2.xyz = saturate(cb0[17].xyz * r0.xyz);
+float3 hdrColor = r2.xyz;
+r2.xyz = saturate(r2.xyz);
+
+  r3.xyz = r2.xyz * r2.xyz;
+  r4.xyz = r3.xyz * r2.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r2.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r2.xyz = r7.xzy * r2.xzy;
+  r5.x = r8.y;
+  r5.y = r2.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r2.x = r8.z;
+  r8.y = r2.z;
+  r8.z = r3.y;
+  r2.z = r3.z;
+  r8.w = r4.y;
+  r2.w = r4.z;
+  r5.z = dot(r2.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r0.xyzw = -r1.xyzw * r0.xyzw + float4(1,1,1,1);
+  r1.xyz = saturate(r0.xyz);
+  r1.w = dot(r1.xyz, float3(0.212670997,0.715160012,0.0721689984));
+  r2.x = cb0[27].z / cb0[27].x;
+  r2.xy = float2(9.99999975e-005,-0.999899983) + r2.xx;
+  r2.x = r2.x / r2.y;
+  r3.xyzw = r2.xxxx * r1.xyzw;
+  r4.xyzw = r2.xxxx + -r1.xyzw;
+  r3.xyzw = r3.xyzw / r4.xyzw;
+  r2.y = 0.5 * r2.x;
+  r2.x = -0.5 + r2.x;
+  r2.x = r2.y / r2.x;
+  r2.x = 1 + -r2.x;
+  r2.xyzw = r2.xxxx + r3.xyzw;
+  r3.xyzw = float4(1.00010002,1.00010002,1.00010002,1.00010002) + -r1.xyzw;
+  r3.xyzw = r1.xyzw / r3.xyzw;
+  r4.xyzw = cmp(float4(0.5,0.5,0.5,0.5) < r1.xyzw);
+  r1.w = 9.99999975e-005 + r1.w;
+  r1.xyz = r1.xyz / r1.www;
+  r2.xyzw = r4.xyzw ? r2.xyzw : r3.xyzw;
+  r1.xyz = r2.www * r1.xyz;
+  r2.xyz = cb0[27].yyy * r2.xyz;
+  r1.w = 1 + -cb0[27].y;
+  r0.xyz = r1.www * r1.xyz + r2.xyz;
+  r1.x = saturate(dot(r0.xyz, float3(0.219999999,0.707000017,0.0710000023)));
+  r1.xyzw = r1.xxxx + -r0.xyzw;
+  r0.xyzw = cb0[10].xxxx * r1.xyzw + r0.xyzw;
+  r1.xyz = float3(-0.5,-0.5,-0.5) + r0.xyz;
+  r2.xy = float2(-0.5,-0.5) + w1.xy;
+  r1.w = dot(r2.xy, r2.xy);
+  r1.w = sqrt(r1.w);
+  r1.w = r1.w * 0.720000029 + -0.800000012;
+  r1.w = saturate(-1.83715463 * r1.w);
+  r2.x = r1.w * -2 + 3;
+  r1.w = r1.w * r1.w;
+  r2.y = r2.x * r1.w + -1;
+  r1.w = r2.x * r1.w;
+  r2.x = -r2.y * 0.200000003 + 1;
+  r2.x = max(1, r2.x);
+  r1.xyz = r1.xyz * r2.xxx + float3(0.5,0.5,0.5);
+  r1.xyz = r1.xyz * r1.www + -r0.xyz;
+  r1.w = 0;
+  o0.xyzw = cb0[12].yyyy * r1.xyzw + r0.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/colorgrade_0x0E0EE842.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0x0E0EE842.ps_5_0.hlsl
@@ -1,0 +1,107 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:12:26 2024
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[22];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.yz = t0.Sample(s2_s, v2.xy).xy;
+  r0.yz = float2(-0.498039216,-0.498039216) + r0.yz;
+  r0.yz = float2(0.100000001,0.100000001) * r0.yz;
+  r1.xy = r0.yz * cb0[5].xy + v1.xy;
+  r0.yz = r0.yz * cb0[5].xy + v2.xy;
+  r0.yz = min(cb0[6].zw, r0.yz);
+  r2.xyzw = t2.Sample(s1_s, r0.yz).xyzw;
+  r2.xyzw = saturate(-r2.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r0.yz = min(cb0[6].xy, r1.xy);
+  r1.xyzw = t1.Sample(s0_s, r0.yz).xyzw;
+  r0.xyzw = r1.xyzw * r0.xxxx;
+  r1.xyz = cb0[17].xyz * r0.xyz;  //  r1.xyz = saturate(cb0[17].xyz * r0.xyz);
+  float3 hdrColor = r1.xyz;
+  r1.xyz = saturate(r1.xyz);
+
+
+
+  r3.xyz = r1.xyz * r1.xyz;
+  r4.xyz = r3.xyz * r1.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r1.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r1.xyz = r7.xzy * r1.xzy;
+  r5.x = r8.y;
+  r5.y = r1.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r1.x = r8.z;
+  r8.y = r1.z;
+  r8.z = r3.y;
+  r1.z = r3.z;
+  r8.w = r4.y;
+  r1.w = r4.z;
+  r5.z = dot(r1.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r1.xyzw = -r2.xyzw * r0.xyzw + float4(1,1,1,1);
+  r0.xyz = -r2.xyz * r0.xyz + float3(0.5,0.5,0.5);
+  r2.xy = float2(-0.5,-0.5) + w1.xy;
+  r0.w = dot(r2.xy, r2.xy);
+  r0.w = sqrt(r0.w);
+  r0.w = r0.w * 0.720000029 + -0.800000012;
+  r0.w = saturate(-1.83715463 * r0.w);
+  r2.x = r0.w * -2 + 3;
+  r0.w = r0.w * r0.w;
+  r2.y = r2.x * r0.w + -1;
+  r0.w = r2.x * r0.w;
+  r2.x = -r2.y * 0.200000003 + 1;
+  r2.x = max(1, r2.x);
+  r0.xyz = r0.xyz * r2.xxx + float3(0.5,0.5,0.5);
+  r0.xyz = r0.xyz * r0.www + -r1.xyz;
+  r0.w = 0;
+
+
+  o0.xyzw = cb0[12].yyyy * r0.xyzw + r1.xyzw;
+  if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+  }
+  return;
+}

--- a/src/games/ori2/colorgrade_0x1A46FADC.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0x1A46FADC.ps_5_0.hlsl
@@ -1,0 +1,152 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:12:36 2024
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[28];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = t0.Sample(s2_s, v2.xy).xy;
+  r0.xy = float2(-0.498039216,-0.498039216) + r0.xy;
+  r0.xy = float2(0.100000001,0.100000001) * r0.xy;
+  r0.zw = r0.xy * cb0[5].xy + v1.xy;
+  r0.xy = r0.xy * cb0[5].xy + v2.xy;
+  r0.xy = min(cb0[6].zw, r0.xy);
+  r1.xyzw = t2.Sample(s1_s, r0.xy).xyzw;
+  r1.xyzw = saturate(-r1.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r2.xyzw = min(cb0[6].xyxy, r0.zwzw);
+  r0.xy = r0.zw / cb0[5].xy;
+  r0.xyz = t3.Sample(s3_s, r0.xy).xyz;
+  r3.xyzw = cb0[3].xyxy * float4(-1.5,-1.5,1.5,-1.5) + r2.zwzw;
+  r4.xyz = t1.Sample(s0_s, r3.xy).xyz;
+  r3.xyz = t1.Sample(s0_s, r3.zw).xyz;
+  r3.xyz = r4.xyz + r3.xyz;
+  r4.xyzw = cb0[3].xyxy * float4(-1.5,1.5,1.5,1.5) + r2.xyzw;
+  r2.xyzw = t1.Sample(s0_s, r2.zw).xyzw;
+  r5.xyz = t1.Sample(s0_s, r4.xy).xyz;
+  r4.xyz = t1.Sample(s0_s, r4.zw).xyz;
+  r3.xyz = r5.xyz + r3.xyz;
+  r3.xyz = r3.xyz + r4.xyz;
+  r3.xyz = -r3.xyz * float3(0.25,0.25,0.25) + r2.xyz;
+  r3.xyz = r3.xyz * cb0[8].yyy + r2.xyz;
+  r0.w = max(r0.y, r0.z);
+  r0.w = max(r0.x, r0.w);
+  r3.w = cmp(cb0[12].z < r0.w);
+  r0.w = cb0[12].z / r0.w;
+  r0.w = r3.w ? r0.w : 1;
+  r2.xyz = r0.xyz * r0.www + r3.xyz;
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.xyzw = r2.xyzw * r0.xxxx;
+r2.xyz = cb0[17].xyz * r0.xyz;  //    r2.xyz = saturate(cb0[17].xyz * r0.xyz);
+float3 hdrColor = r2.xyz;
+r2.xyz = saturate(r2.xyz);
+
+  r3.xyz = r2.xyz * r2.xyz;
+  r4.xyz = r3.xyz * r2.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r2.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r2.xyz = r7.xzy * r2.xzy;
+  r5.x = r8.y;
+  r5.y = r2.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r2.x = r8.z;
+  r8.y = r2.z;
+  r8.z = r3.y;
+  r2.z = r3.z;
+  r8.w = r4.y;
+  r2.w = r4.z;
+  r5.z = dot(r2.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r0.xyzw = -r1.xyzw * r0.xyzw + float4(1,1,1,1);
+  r1.xyz = saturate(r0.xyz);
+  r1.w = dot(r1.xyz, float3(0.212670997,0.715160012,0.0721689984));
+  r2.x = cb0[27].z / cb0[27].x;
+  r2.xy = float2(9.99999975e-005,-0.999899983) + r2.xx;
+  r2.x = r2.x / r2.y;
+  r3.xyzw = r2.xxxx * r1.xyzw;
+  r4.xyzw = r2.xxxx + -r1.xyzw;
+  r3.xyzw = r3.xyzw / r4.xyzw;
+  r2.y = 0.5 * r2.x;
+  r2.x = -0.5 + r2.x;
+  r2.x = r2.y / r2.x;
+  r2.x = 1 + -r2.x;
+  r2.xyzw = r2.xxxx + r3.xyzw;
+  r3.xyzw = float4(1.00010002,1.00010002,1.00010002,1.00010002) + -r1.xyzw;
+  r3.xyzw = r1.xyzw / r3.xyzw;
+  r4.xyzw = cmp(float4(0.5,0.5,0.5,0.5) < r1.xyzw);
+  r1.w = 9.99999975e-005 + r1.w;
+  r1.xyz = r1.xyz / r1.www;
+  r2.xyzw = r4.xyzw ? r2.xyzw : r3.xyzw;
+  r1.xyz = r2.www * r1.xyz;
+  r2.xyz = cb0[27].yyy * r2.xyz;
+  r1.w = 1 + -cb0[27].y;
+  r0.xyz = r1.www * r1.xyz + r2.xyz;
+  r1.x = saturate(dot(r0.xyz, float3(0.219999999,0.707000017,0.0710000023)));
+  r1.xyzw = r1.xxxx + -r0.xyzw;
+  r0.xyzw = cb0[10].xxxx * r1.xyzw + r0.xyzw;
+  r1.xyz = float3(-0.5,-0.5,-0.5) + r0.xyz;
+  r2.xy = float2(-0.5,-0.5) + w1.xy;
+  r1.w = dot(r2.xy, r2.xy);
+  r1.w = sqrt(r1.w);
+  r1.w = r1.w * 0.720000029 + -0.800000012;
+  r1.w = saturate(-1.83715463 * r1.w);
+  r2.x = r1.w * -2 + 3;
+  r1.w = r1.w * r1.w;
+  r2.y = r2.x * r1.w + -1;
+  r1.w = r2.x * r1.w;
+  r2.x = -r2.y * 0.200000003 + 1;
+  r2.x = max(1, r2.x);
+  r1.xyz = r1.xyz * r2.xxx + float3(0.5,0.5,0.5);
+  r1.xyz = r1.xyz * r1.www + -r0.xyz;
+  r1.w = 0;
+  o0.xyzw = cb0[12].yyyy * r1.xyzw + r0.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/colorgrade_0x1E8FDB7D.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0x1E8FDB7D.ps_5_0.hlsl
@@ -1,0 +1,137 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:12:40 2024
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[28];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.yz = t0.Sample(s2_s, v2.xy).xy;
+  r0.yz = float2(-0.498039216,-0.498039216) + r0.yz;
+  r0.yz = float2(0.100000001,0.100000001) * r0.yz;
+  r1.xy = r0.yz * cb0[5].xy + v1.xy;
+  r0.yz = r0.yz * cb0[5].xy + v2.xy;
+  r0.yz = min(cb0[6].zw, r0.yz);
+  r2.xyzw = t2.Sample(s1_s, r0.yz).xyzw;
+  r2.xyzw = saturate(-r2.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r0.yz = r1.xy / cb0[5].xy;
+  r1.xy = min(cb0[6].xy, r1.xy);
+  r1.xyzw = t1.Sample(s0_s, r1.xy).xyzw;
+  r0.yz = min(cb0[13].zw, r0.yz);
+  r0.yzw = t3.Sample(s3_s, r0.yz).xyz;
+  r3.xyz = cb0[13].xxx * r0.yzw;
+  r0.yzw = cb0[13].yyy + r0.yzw;
+  r0.yzw = r3.xyz / r0.yzw;
+  r1.xyz = r1.xyz + r0.yzw;
+  r0.xyzw = r1.xyzw * r0.xxxx;
+r1.xyz = cb0[17].xyz * r0.xyz;  //    r1.xyz = saturate(cb0[17].xyz * r0.xyz);
+float3 hdrColor = r1.xyz;
+r1.xyz = saturate(r1.xyz);
+
+  r3.xyz = r1.xyz * r1.xyz;
+  r4.xyz = r3.xyz * r1.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r1.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r1.xyz = r7.xzy * r1.xzy;
+  r5.x = r8.y;
+  r5.y = r1.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r1.x = r8.z;
+  r8.y = r1.z;
+  r8.z = r3.y;
+  r1.z = r3.z;
+  r8.w = r4.y;
+  r1.w = r4.z;
+  r5.z = dot(r1.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r0.xyzw = -r2.xyzw * r0.xyzw + float4(1,1,1,1);
+  r1.xyz = saturate(r0.xyz);
+  r1.w = dot(r1.xyz, float3(0.212670997,0.715160012,0.0721689984));
+  r2.x = cb0[27].z / cb0[27].x;
+  r2.xy = float2(9.99999975e-005,-0.999899983) + r2.xx;
+  r2.x = r2.x / r2.y;
+  r3.xyzw = r2.xxxx * r1.xyzw;
+  r4.xyzw = r2.xxxx + -r1.xyzw;
+  r3.xyzw = r3.xyzw / r4.xyzw;
+  r2.y = 0.5 * r2.x;
+  r2.x = -0.5 + r2.x;
+  r2.x = r2.y / r2.x;
+  r2.x = 1 + -r2.x;
+  r2.xyzw = r2.xxxx + r3.xyzw;
+  r3.xyzw = float4(1.00010002,1.00010002,1.00010002,1.00010002) + -r1.xyzw;
+  r3.xyzw = r1.xyzw / r3.xyzw;
+  r4.xyzw = cmp(float4(0.5,0.5,0.5,0.5) < r1.xyzw);
+  r1.w = 9.99999975e-005 + r1.w;
+  r1.xyz = r1.xyz / r1.www;
+  r2.xyzw = r4.xyzw ? r2.xyzw : r3.xyzw;
+  r1.xyz = r2.www * r1.xyz;
+  r2.xyz = cb0[27].yyy * r2.xyz;
+  r1.w = 1 + -cb0[27].y;
+  r0.xyz = r1.www * r1.xyz + r2.xyz;
+  r1.xyz = float3(-0.5,-0.5,-0.5) + r0.xyz;
+  r2.xy = float2(-0.5,-0.5) + w1.xy;
+  r1.w = dot(r2.xy, r2.xy);
+  r1.w = sqrt(r1.w);
+  r1.w = r1.w * 0.720000029 + -0.800000012;
+  r1.w = saturate(-1.83715463 * r1.w);
+  r2.x = r1.w * -2 + 3;
+  r1.w = r1.w * r1.w;
+  r2.y = r2.x * r1.w + -1;
+  r1.w = r2.x * r1.w;
+  r2.x = -r2.y * 0.200000003 + 1;
+  r2.x = max(1, r2.x);
+  r1.xyz = r1.xyz * r2.xxx + float3(0.5,0.5,0.5);
+  r1.xyz = r1.xyz * r1.www + -r0.xyz;
+  r1.w = 0;
+  o0.xyzw = cb0[12].yyyy * r1.xyzw + r0.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/colorgrade_0x211F3245.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0x211F3245.ps_5_0.hlsl
@@ -1,0 +1,151 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:12:42 2024
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[28];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = t0.Sample(s2_s, v2.xy).xy;
+  r0.xy = float2(-0.498039216,-0.498039216) + r0.xy;
+  r0.xy = float2(0.100000001,0.100000001) * r0.xy;
+  r0.zw = r0.xy * cb0[5].xy + v1.xy;
+  r0.xy = r0.xy * cb0[5].xy + v2.xy;
+  r0.xy = min(cb0[6].zw, r0.xy);
+  r1.xyzw = t2.Sample(s1_s, r0.xy).xyzw;
+  r1.xyzw = saturate(-r1.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r2.xyzw = min(cb0[6].xyxy, r0.zwzw);
+  r0.xy = r0.zw / cb0[5].xy;
+  r0.xy = min(cb0[13].zw, r0.xy);
+  r0.xyz = t3.Sample(s3_s, r0.xy).xyz;
+  r0.xyz = saturate(r0.xyz);
+  r0.xyz = float3(1,1,1) + -r0.xyz;
+  r3.xyzw = cb0[3].xyxy * float4(-1.5,-1.5,1.5,-1.5) + r2.zwzw;
+  r4.xyz = t1.Sample(s0_s, r3.xy).xyz;
+  r3.xyz = t1.Sample(s0_s, r3.zw).xyz;
+  r3.xyz = r4.xyz + r3.xyz;
+  r4.xyzw = cb0[3].xyxy * float4(-1.5,1.5,1.5,1.5) + r2.xyzw;
+  r2.xyzw = t1.Sample(s0_s, r2.zw).xyzw;
+  r5.xyz = t1.Sample(s0_s, r4.xy).xyz;
+  r4.xyz = t1.Sample(s0_s, r4.zw).xyz;
+  r3.xyz = r5.xyz + r3.xyz;
+  r3.xyz = r3.xyz + r4.xyz;
+  r3.xyz = -r3.xyz * float3(0.25,0.25,0.25) + r2.xyz;
+  r3.xyz = r3.xyz * cb0[8].yyy + r2.xyz;
+  r3.xyz = float3(1,1,1) + -r3.xyz;
+  r2.xyz = -r3.xyz * r0.xyz + float3(1,1,1);
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.xyzw = r2.xyzw * r0.xxxx;
+r2.xyz = cb0[17].xyz * r0.xyz;  //    r2.xyz = saturate(cb0[17].xyz * r0.xyz);
+float3 hdrColor = r2.xyz;
+r2.xyz = saturate(r2.xyz);
+
+  r3.xyz = r2.xyz * r2.xyz;
+  r4.xyz = r3.xyz * r2.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r2.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r2.xyz = r7.xzy * r2.xzy;
+  r5.x = r8.y;
+  r5.y = r2.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r2.x = r8.z;
+  r8.y = r2.z;
+  r8.z = r3.y;
+  r2.z = r3.z;
+  r8.w = r4.y;
+  r2.w = r4.z;
+  r5.z = dot(r2.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r0.xyzw = -r1.xyzw * r0.xyzw + float4(1,1,1,1);
+  r1.xyz = saturate(r0.xyz);
+  r1.w = dot(r1.xyz, float3(0.212670997,0.715160012,0.0721689984));
+  r2.x = cb0[27].z / cb0[27].x;
+  r2.xy = float2(9.99999975e-005,-0.999899983) + r2.xx;
+  r2.x = r2.x / r2.y;
+  r3.xyzw = r2.xxxx * r1.xyzw;
+  r4.xyzw = r2.xxxx + -r1.xyzw;
+  r3.xyzw = r3.xyzw / r4.xyzw;
+  r2.y = 0.5 * r2.x;
+  r2.x = -0.5 + r2.x;
+  r2.x = r2.y / r2.x;
+  r2.x = 1 + -r2.x;
+  r2.xyzw = r2.xxxx + r3.xyzw;
+  r3.xyzw = float4(1.00010002,1.00010002,1.00010002,1.00010002) + -r1.xyzw;
+  r3.xyzw = r1.xyzw / r3.xyzw;
+  r4.xyzw = cmp(float4(0.5,0.5,0.5,0.5) < r1.xyzw);
+  r1.w = 9.99999975e-005 + r1.w;
+  r1.xyz = r1.xyz / r1.www;
+  r2.xyzw = r4.xyzw ? r2.xyzw : r3.xyzw;
+  r1.xyz = r2.www * r1.xyz;
+  r2.xyz = cb0[27].yyy * r2.xyz;
+  r1.w = 1 + -cb0[27].y;
+  r0.xyz = r1.www * r1.xyz + r2.xyz;
+  r1.x = saturate(dot(r0.xyz, float3(0.219999999,0.707000017,0.0710000023)));
+  r1.xyzw = r1.xxxx + -r0.xyzw;
+  r0.xyzw = cb0[10].xxxx * r1.xyzw + r0.xyzw;
+  r1.xyz = float3(-0.5,-0.5,-0.5) + r0.xyz;
+  r2.xy = float2(-0.5,-0.5) + w1.xy;
+  r1.w = dot(r2.xy, r2.xy);
+  r1.w = sqrt(r1.w);
+  r1.w = r1.w * 0.720000029 + -0.800000012;
+  r1.w = saturate(-1.83715463 * r1.w);
+  r2.x = r1.w * -2 + 3;
+  r1.w = r1.w * r1.w;
+  r2.y = r2.x * r1.w + -1;
+  r1.w = r2.x * r1.w;
+  r2.x = -r2.y * 0.200000003 + 1;
+  r2.x = max(1, r2.x);
+  r1.xyz = r1.xyz * r2.xxx + float3(0.5,0.5,0.5);
+  r1.xyz = r1.xyz * r1.www + -r0.xyz;
+  r1.w = 0;
+  o0.xyzw = cb0[12].yyyy * r1.xyzw + r0.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/colorgrade_0x28B10677.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0x28B10677.ps_5_0.hlsl
@@ -1,0 +1,114 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:12:49 2024
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[22];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.yz = t0.Sample(s2_s, v2.xy).xy;
+  r0.yz = float2(-0.498039216,-0.498039216) + r0.yz;
+  r0.yz = float2(0.100000001,0.100000001) * r0.yz;
+  r1.xy = r0.yz * cb0[5].xy + v1.xy;
+  r0.yz = r0.yz * cb0[5].xy + v2.xy;
+  r0.yz = min(cb0[6].zw, r0.yz);
+  r2.xyzw = t2.Sample(s1_s, r0.yz).xyzw;
+  r2.xyzw = saturate(-r2.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r0.yz = r1.xy / cb0[5].xy;
+  r1.xy = min(cb0[6].xy, r1.xy);
+  r1.xyzw = t1.Sample(s0_s, r1.xy).xyzw;
+  r0.yz = min(cb0[13].zw, r0.yz);
+  r0.yzw = t3.Sample(s3_s, r0.yz).xyz;
+  r0.yzw = saturate(r0.yzw);
+  r0.yzw = float3(1,1,1) + -r0.yzw;
+  r3.xyz = float3(1,1,1) + -r1.xyz;
+  r1.xyz = -r3.xyz * r0.yzw + float3(1,1,1);
+  r0.xyzw = r1.xyzw * r0.xxxx;
+r1.xyz = cb0[17].xyz * r0.xyz;  //    r1.xyz = saturate(cb0[17].xyz * r0.xyz);
+float3 hdrColor = r1.xyz;
+r1.xyz = saturate(r1.xyz);
+
+  r3.xyz = r1.xyz * r1.xyz;
+  r4.xyz = r3.xyz * r1.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r1.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r1.xyz = r7.xzy * r1.xzy;
+  r5.x = r8.y;
+  r5.y = r1.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r1.x = r8.z;
+  r8.y = r1.z;
+  r8.z = r3.y;
+  r1.z = r3.z;
+  r8.w = r4.y;
+  r1.w = r4.z;
+  r5.z = dot(r1.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r1.xyzw = -r2.xyzw * r0.xyzw + float4(1,1,1,1);
+  r0.xyz = -r2.xyz * r0.xyz + float3(0.5,0.5,0.5);
+  r2.xy = float2(-0.5,-0.5) + w1.xy;
+  r0.w = dot(r2.xy, r2.xy);
+  r0.w = sqrt(r0.w);
+  r0.w = r0.w * 0.720000029 + -0.800000012;
+  r0.w = saturate(-1.83715463 * r0.w);
+  r2.x = r0.w * -2 + 3;
+  r0.w = r0.w * r0.w;
+  r2.y = r2.x * r0.w + -1;
+  r0.w = r2.x * r0.w;
+  r2.x = -r2.y * 0.200000003 + 1;
+  r2.x = max(1, r2.x);
+  r0.xyz = r0.xyz * r2.xxx + float3(0.5,0.5,0.5);
+  r0.xyz = r0.xyz * r0.www + -r1.xyz;
+  r0.w = 0;
+  o0.xyzw = cb0[12].yyyy * r0.xyzw + r1.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/colorgrade_0x2CEC407A.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0x2CEC407A.ps_5_0.hlsl
@@ -1,0 +1,146 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:12:53 2024
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[28];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = t0.Sample(s2_s, v2.xy).xy;
+  r0.xy = float2(-0.498039216,-0.498039216) + r0.xy;
+  r0.xy = float2(0.100000001,0.100000001) * r0.xy;
+  r0.zw = r0.xy * cb0[5].xy + v1.xy;
+  r0.xy = r0.xy * cb0[5].xy + v2.xy;
+  r0.xy = min(cb0[6].zw, r0.xy);
+  r1.xyzw = t2.Sample(s1_s, r0.xy).xyzw;
+  r1.xyzw = saturate(-r1.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r0.xy = r0.zw / cb0[5].xy;
+  r0.zw = min(cb0[6].xy, r0.zw);
+  r2.xyzw = t1.Sample(s0_s, r0.zw).xyzw;
+  r0.zw = min(cb0[13].zw, r0.xy);
+  r3.xyz = t4.Sample(s3_s, r0.xy).xyz;
+  r0.xyz = t3.Sample(s3_s, r0.zw).xyz;
+  r4.xyz = cb0[13].xxx * r0.xyz;
+  r0.xyz = cb0[13].yyy + r0.xyz;
+  r0.xyz = r4.xyz / r0.xyz;
+  r0.xyz = r2.xyz + r0.xyz;
+  r0.w = max(r3.y, r3.z);
+  r0.w = max(r3.x, r0.w);
+  r3.w = cmp(cb0[12].z < r0.w);
+  r0.w = cb0[12].z / r0.w;
+  r0.w = r3.w ? r0.w : 1;
+  r2.xyz = r3.xyz * r0.www + r0.xyz;
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.xyzw = r2.xyzw * r0.xxxx;
+r2.xyz = cb0[17].xyz * r0.xyz;  //    r2.xyz = saturate(cb0[17].xyz * r0.xyz);
+float3 hdrColor = r2.xyz;
+r2.xyz = saturate(r2.xyz);
+
+  r3.xyz = r2.xyz * r2.xyz;
+  r4.xyz = r3.xyz * r2.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r2.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r2.xyz = r7.xzy * r2.xzy;
+  r5.x = r8.y;
+  r5.y = r2.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r2.x = r8.z;
+  r8.y = r2.z;
+  r8.z = r3.y;
+  r2.z = r3.z;
+  r8.w = r4.y;
+  r2.w = r4.z;
+  r5.z = dot(r2.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r0.xyzw = -r1.xyzw * r0.xyzw + float4(1,1,1,1);
+  r1.xyz = saturate(r0.xyz);
+  r1.w = dot(r1.xyz, float3(0.212670997,0.715160012,0.0721689984));
+  r2.x = cb0[27].z / cb0[27].x;
+  r2.xy = float2(9.99999975e-005,-0.999899983) + r2.xx;
+  r2.x = r2.x / r2.y;
+  r3.xyzw = r2.xxxx * r1.xyzw;
+  r4.xyzw = r2.xxxx + -r1.xyzw;
+  r3.xyzw = r3.xyzw / r4.xyzw;
+  r2.y = 0.5 * r2.x;
+  r2.x = -0.5 + r2.x;
+  r2.x = r2.y / r2.x;
+  r2.x = 1 + -r2.x;
+  r2.xyzw = r2.xxxx + r3.xyzw;
+  r3.xyzw = float4(1.00010002,1.00010002,1.00010002,1.00010002) + -r1.xyzw;
+  r3.xyzw = r1.xyzw / r3.xyzw;
+  r4.xyzw = cmp(float4(0.5,0.5,0.5,0.5) < r1.xyzw);
+  r1.w = 9.99999975e-005 + r1.w;
+  r1.xyz = r1.xyz / r1.www;
+  r2.xyzw = r4.xyzw ? r2.xyzw : r3.xyzw;
+  r1.xyz = r2.www * r1.xyz;
+  r2.xyz = cb0[27].yyy * r2.xyz;
+  r1.w = 1 + -cb0[27].y;
+  r0.xyz = r1.www * r1.xyz + r2.xyz;
+  r1.xyz = float3(-0.5,-0.5,-0.5) + r0.xyz;
+  r2.xy = float2(-0.5,-0.5) + w1.xy;
+  r1.w = dot(r2.xy, r2.xy);
+  r1.w = sqrt(r1.w);
+  r1.w = r1.w * 0.720000029 + -0.800000012;
+  r1.w = saturate(-1.83715463 * r1.w);
+  r2.x = r1.w * -2 + 3;
+  r1.w = r1.w * r1.w;
+  r2.y = r2.x * r1.w + -1;
+  r1.w = r2.x * r1.w;
+  r2.x = -r2.y * 0.200000003 + 1;
+  r2.x = max(1, r2.x);
+  r1.xyz = r1.xyz * r2.xxx + float3(0.5,0.5,0.5);
+  r1.xyz = r1.xyz * r1.www + -r0.xyz;
+  r1.w = 0;
+  o0.xyzw = cb0[12].yyyy * r1.xyzw + r0.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/colorgrade_0x34F7E01C.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0x34F7E01C.ps_5_0.hlsl
@@ -1,0 +1,126 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:13:00 2024
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[22];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = t0.Sample(s2_s, v2.xy).xy;
+  r0.xy = float2(-0.498039216,-0.498039216) + r0.xy;
+  r0.xy = float2(0.100000001,0.100000001) * r0.xy;
+  r0.zw = r0.xy * cb0[5].xy + v1.xy;
+  r0.xy = r0.xy * cb0[5].xy + v2.xy;
+  r0.xy = min(cb0[6].zw, r0.xy);
+  r1.xyzw = t2.Sample(s1_s, r0.xy).xyzw;
+  r1.xyzw = saturate(-r1.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r0.xy = r0.zw / cb0[5].xy;
+  r0.zw = min(cb0[6].xy, r0.zw);
+  r2.xyzw = t1.Sample(s0_s, r0.zw).xyzw;
+  r0.zw = min(cb0[13].zw, r0.xy);
+  r3.xyz = t4.Sample(s3_s, r0.xy).xyz;
+  r0.xyz = t3.Sample(s3_s, r0.zw).xyz;
+  r0.xyz = saturate(r0.xyz);
+  r0.xyz = float3(1,1,1) + -r0.xyz;
+  r4.xyz = float3(1,1,1) + -r2.xyz;
+  r0.xyz = -r4.xyz * r0.xyz + float3(1,1,1);
+  r0.w = max(r3.y, r3.z);
+  r0.w = max(r3.x, r0.w);
+  r3.w = cmp(cb0[12].z < r0.w);
+  r0.w = cb0[12].z / r0.w;
+  r0.w = r3.w ? r0.w : 1;
+  r2.xyz = r3.xyz * r0.www + r0.xyz;
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.xyzw = r2.xyzw * r0.xxxx;
+r2.xyz = cb0[17].xyz * r0.xyz;  //    r2.xyz = saturate(cb0[17].xyz * r0.xyz);
+float3 hdrColor = r2.xyz;
+r2.xyz = saturate(r2.xyz);
+
+  r3.xyz = r2.xyz * r2.xyz;
+  r4.xyz = r3.xyz * r2.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r2.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r2.xyz = r7.xzy * r2.xzy;
+  r5.x = r8.y;
+  r5.y = r2.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r2.x = r8.z;
+  r8.y = r2.z;
+  r8.z = r3.y;
+  r2.z = r3.z;
+  r8.w = r4.y;
+  r2.w = r4.z;
+  r5.z = dot(r2.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r2.x = saturate(dot(r0.xyz, float3(0.219999999,0.707000017,0.0710000023)));
+  r2.xyzw = r2.xxxx + -r0.xyzw;
+  r0.xyzw = cb0[10].xxxx * r2.xyzw + r0.xyzw;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r2.xyzw = -r1.xyzw * r0.xyzw + float4(1,1,1,1);
+  r0.xyz = -r1.xyz * r0.xyz + float3(0.5,0.5,0.5);
+  r1.xy = float2(-0.5,-0.5) + w1.xy;
+  r0.w = dot(r1.xy, r1.xy);
+  r0.w = sqrt(r0.w);
+  r0.w = r0.w * 0.720000029 + -0.800000012;
+  r0.w = saturate(-1.83715463 * r0.w);
+  r1.x = r0.w * -2 + 3;
+  r0.w = r0.w * r0.w;
+  r1.y = r1.x * r0.w + -1;
+  r0.w = r1.x * r0.w;
+  r1.x = -r1.y * 0.200000003 + 1;
+  r1.x = max(1, r1.x);
+  r0.xyz = r0.xyz * r1.xxx + float3(0.5,0.5,0.5);
+  r0.xyz = r0.xyz * r0.www + -r2.xyz;
+  r0.w = 0;
+  o0.xyzw = cb0[12].yyyy * r0.xyzw + r2.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/colorgrade_0x350163E1.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0x350163E1.ps_5_0.hlsl
@@ -1,0 +1,117 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:13:00 2024
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[22];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = t0.Sample(s2_s, v2.xy).xy;
+  r0.xy = float2(-0.498039216,-0.498039216) + r0.xy;
+  r0.xy = float2(0.100000001,0.100000001) * r0.xy;
+  r1.xyzw = r0.xyxy * cb0[5].xyxy + v1.xyxy;
+  r0.xy = r0.xy * cb0[5].xy + v2.xy;
+  r0.xy = min(cb0[6].zw, r0.xy);
+  r0.xyzw = t2.Sample(s1_s, r0.xy).xyzw;
+  r0.xyzw = saturate(-r0.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r1.xyzw = min(cb0[6].xyxy, r1.xyzw);
+  r2.xyzw = cb0[3].xyxy * float4(-1.5,-1.5,1.5,-1.5) + r1.zwzw;
+  r3.xyz = t1.Sample(s0_s, r2.xy).xyz;
+  r2.xyz = t1.Sample(s0_s, r2.zw).xyz;
+  r2.xyz = r3.xyz + r2.xyz;
+  r3.xyzw = cb0[3].xyxy * float4(-1.5,1.5,1.5,1.5) + r1.xyzw;
+  r1.xyzw = t1.Sample(s0_s, r1.zw).xyzw;
+  r4.xyz = t1.Sample(s0_s, r3.xy).xyz;
+  r3.xyz = t1.Sample(s0_s, r3.zw).xyz;
+  r2.xyz = r4.xyz + r2.xyz;
+  r2.xyz = r2.xyz + r3.xyz;
+  r2.xyz = -r2.xyz * float3(0.25,0.25,0.25) + r1.xyz;
+  r1.xyz = r2.xyz * cb0[8].yyy + r1.xyz;
+  r2.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r2.x = dot(r2.xy, r2.xy);
+  r2.x = min(1, r2.x);
+  r2.x = cb0[8].x * r2.x;
+  r2.x = r2.x * 7 + 1;
+  r1.xyzw = r2.xxxx * r1.xyzw;
+r2.xyz = cb0[17].xyz * r1.xyz;  //    r2.xyz = saturate(cb0[17].xyz * r1.xyz);
+float3 hdrColor = r2.xyz;
+r2.xyz = saturate(r2.xyz);
+
+  r3.xyz = r2.xyz * r2.xyz;
+  r4.xyz = r3.xyz * r2.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r2.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r2.xyz = r7.xzy * r2.xzy;
+  r5.x = r8.y;
+  r5.y = r2.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r2.x = r8.z;
+  r8.y = r2.z;
+  r8.z = r3.y;
+  r2.z = r3.z;
+  r8.w = r4.y;
+  r2.w = r4.z;
+  r5.z = dot(r2.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r1.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r2.x = saturate(dot(r1.xyz, float3(0.219999999,0.707000017,0.0710000023)));
+  r2.xyzw = r2.xxxx + -r1.xyzw;
+  r1.xyzw = cb0[10].xxxx * r2.xyzw + r1.xyzw;
+  r1.xyzw = float4(1,1,1,1) + -r1.xyzw;
+  r2.xyzw = -r0.xyzw * r1.xyzw + float4(1,1,1,1);
+  r0.xyz = -r0.xyz * r1.xyz + float3(0.5,0.5,0.5);
+  r1.xy = float2(-0.5,-0.5) + w1.xy;
+  r0.w = dot(r1.xy, r1.xy);
+  r0.w = sqrt(r0.w);
+  r0.w = r0.w * 0.720000029 + -0.800000012;
+  r0.w = saturate(-1.83715463 * r0.w);
+  r1.x = r0.w * -2 + 3;
+  r0.w = r0.w * r0.w;
+  r1.y = r1.x * r0.w + -1;
+  r0.w = r1.x * r0.w;
+  r1.x = -r1.y * 0.200000003 + 1;
+  r1.x = max(1, r1.x);
+  r0.xyz = r0.xyz * r1.xxx + float3(0.5,0.5,0.5);
+  r0.xyz = r0.xyz * r0.www + -r2.xyz;
+  r0.w = 0;
+  o0.xyzw = cb0[12].yyyy * r0.xyzw + r2.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/colorgrade_0x37E6CB72.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0x37E6CB72.ps_5_0.hlsl
@@ -1,0 +1,149 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:13:02 2024
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[28];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = t0.Sample(s2_s, v2.xy).xy;
+  r0.xy = float2(-0.498039216,-0.498039216) + r0.xy;
+  r0.xy = float2(0.100000001,0.100000001) * r0.xy;
+  r0.zw = r0.xy * cb0[5].xy + v1.xy;
+  r0.xy = r0.xy * cb0[5].xy + v2.xy;
+  r0.xy = min(cb0[6].zw, r0.xy);
+  r1.xyzw = t2.Sample(s1_s, r0.xy).xyzw;
+  r1.xyzw = saturate(-r1.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r2.xyzw = min(cb0[6].xyxy, r0.zwzw);
+  r0.xy = r0.zw / cb0[5].xy;
+  r0.xyz = t3.Sample(s3_s, r0.xy).xyz;
+  r3.xyzw = cb0[3].xyxy * float4(-1.5,-1.5,1.5,-1.5) + r2.zwzw;
+  r4.xyz = t1.Sample(s0_s, r3.xy).xyz;
+  r3.xyz = t1.Sample(s0_s, r3.zw).xyz;
+  r3.xyz = r4.xyz + r3.xyz;
+  r4.xyzw = cb0[3].xyxy * float4(-1.5,1.5,1.5,1.5) + r2.xyzw;
+  r2.xyzw = t1.Sample(s0_s, r2.zw).xyzw;
+  r5.xyz = t1.Sample(s0_s, r4.xy).xyz;
+  r4.xyz = t1.Sample(s0_s, r4.zw).xyz;
+  r3.xyz = r5.xyz + r3.xyz;
+  r3.xyz = r3.xyz + r4.xyz;
+  r3.xyz = -r3.xyz * float3(0.25,0.25,0.25) + r2.xyz;
+  r3.xyz = r3.xyz * cb0[8].yyy + r2.xyz;
+  r0.w = max(r0.y, r0.z);
+  r0.w = max(r0.x, r0.w);
+  r3.w = cmp(cb0[12].z < r0.w);
+  r0.w = cb0[12].z / r0.w;
+  r0.w = r3.w ? r0.w : 1;
+  r2.xyz = r0.xyz * r0.www + r3.xyz;
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.xyzw = r2.xyzw * r0.xxxx;
+r2.xyz = cb0[17].xyz * r0.xyz;  //    r2.xyz = saturate(cb0[17].xyz * r0.xyz);
+float3 hdrColor = r2.xyz;
+r2.xyz = saturate(r2.xyz);
+
+  r3.xyz = r2.xyz * r2.xyz;
+  r4.xyz = r3.xyz * r2.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r2.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r2.xyz = r7.xzy * r2.xzy;
+  r5.x = r8.y;
+  r5.y = r2.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r2.x = r8.z;
+  r8.y = r2.z;
+  r8.z = r3.y;
+  r2.z = r3.z;
+  r8.w = r4.y;
+  r2.w = r4.z;
+  r5.z = dot(r2.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r0.xyzw = -r1.xyzw * r0.xyzw + float4(1,1,1,1);
+  r1.xyz = saturate(r0.xyz);
+  r1.w = dot(r1.xyz, float3(0.212670997,0.715160012,0.0721689984));
+  r2.x = cb0[27].z / cb0[27].x;
+  r2.xy = float2(9.99999975e-005,-0.999899983) + r2.xx;
+  r2.x = r2.x / r2.y;
+  r3.xyzw = r2.xxxx * r1.xyzw;
+  r4.xyzw = r2.xxxx + -r1.xyzw;
+  r3.xyzw = r3.xyzw / r4.xyzw;
+  r2.y = 0.5 * r2.x;
+  r2.x = -0.5 + r2.x;
+  r2.x = r2.y / r2.x;
+  r2.x = 1 + -r2.x;
+  r2.xyzw = r2.xxxx + r3.xyzw;
+  r3.xyzw = float4(1.00010002,1.00010002,1.00010002,1.00010002) + -r1.xyzw;
+  r3.xyzw = r1.xyzw / r3.xyzw;
+  r4.xyzw = cmp(float4(0.5,0.5,0.5,0.5) < r1.xyzw);
+  r1.w = 9.99999975e-005 + r1.w;
+  r1.xyz = r1.xyz / r1.www;
+  r2.xyzw = r4.xyzw ? r2.xyzw : r3.xyzw;
+  r1.xyz = r2.www * r1.xyz;
+  r2.xyz = cb0[27].yyy * r2.xyz;
+  r1.w = 1 + -cb0[27].y;
+  r0.xyz = r1.www * r1.xyz + r2.xyz;
+  r1.xyz = float3(-0.5,-0.5,-0.5) + r0.xyz;
+  r2.xy = float2(-0.5,-0.5) + w1.xy;
+  r1.w = dot(r2.xy, r2.xy);
+  r1.w = sqrt(r1.w);
+  r1.w = r1.w * 0.720000029 + -0.800000012;
+  r1.w = saturate(-1.83715463 * r1.w);
+  r2.x = r1.w * -2 + 3;
+  r1.w = r1.w * r1.w;
+  r2.y = r2.x * r1.w + -1;
+  r1.w = r2.x * r1.w;
+  r2.x = -r2.y * 0.200000003 + 1;
+  r2.x = max(1, r2.x);
+  r1.xyz = r1.xyz * r2.xxx + float3(0.5,0.5,0.5);
+  r1.xyz = r1.xyz * r1.www + -r0.xyz;
+  r1.w = 0;
+  o0.xyzw = cb0[12].yyyy * r1.xyzw + r0.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/colorgrade_0x3F118009.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0x3F118009.ps_5_0.hlsl
@@ -1,0 +1,106 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:13:08 2024
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[22];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.yz = t0.Sample(s2_s, v2.xy).xy;
+  r0.yz = float2(-0.498039216,-0.498039216) + r0.yz;
+  r0.yz = float2(0.100000001,0.100000001) * r0.yz;
+  r1.xy = r0.yz * cb0[5].xy + v1.xy;
+  r0.yz = r0.yz * cb0[5].xy + v2.xy;
+  r0.yz = min(cb0[6].zw, r0.yz);
+  r2.xyzw = t2.Sample(s1_s, r0.yz).xyzw;
+  r2.xyzw = saturate(-r2.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r0.yz = min(cb0[6].xy, r1.xy);
+  r1.xyzw = t1.Sample(s0_s, r0.yz).xyzw;
+  r0.xyzw = r1.xyzw * r0.xxxx;
+r1.xyz = cb0[17].xyz * r0.xyz;  //    r1.xyz = saturate(cb0[17].xyz * r0.xyz);
+float3 hdrColor = r1.xyz;
+r1.xyz = saturate(r1.xyz);
+
+  r3.xyz = r1.xyz * r1.xyz;
+  r4.xyz = r3.xyz * r1.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r1.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r1.xyz = r7.xzy * r1.xzy;
+  r5.x = r8.y;
+  r5.y = r1.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r1.x = r8.z;
+  r8.y = r1.z;
+  r8.z = r3.y;
+  r1.z = r3.z;
+  r8.w = r4.y;
+  r1.w = r4.z;
+  r5.z = dot(r1.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r1.x = saturate(dot(r0.xyz, float3(0.219999999,0.707000017,0.0710000023)));
+  r1.xyzw = r1.xxxx + -r0.xyzw;
+  r0.xyzw = cb0[10].xxxx * r1.xyzw + r0.xyzw;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r1.xyzw = -r2.xyzw * r0.xyzw + float4(1,1,1,1);
+  r0.xyz = -r2.xyz * r0.xyz + float3(0.5,0.5,0.5);
+  r2.xy = float2(-0.5,-0.5) + w1.xy;
+  r0.w = dot(r2.xy, r2.xy);
+  r0.w = sqrt(r0.w);
+  r0.w = r0.w * 0.720000029 + -0.800000012;
+  r0.w = saturate(-1.83715463 * r0.w);
+  r2.x = r0.w * -2 + 3;
+  r0.w = r0.w * r0.w;
+  r2.y = r2.x * r0.w + -1;
+  r0.w = r2.x * r0.w;
+  r2.x = -r2.y * 0.200000003 + 1;
+  r2.x = max(1, r2.x);
+  r0.xyz = r0.xyz * r2.xxx + float3(0.5,0.5,0.5);
+  r0.xyz = r0.xyz * r0.www + -r1.xyz;
+  r0.w = 0;
+  o0.xyzw = cb0[12].yyyy * r0.xyzw + r1.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/colorgrade_0x3FDCF7AA.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0x3FDCF7AA.ps_5_0.hlsl
@@ -1,0 +1,148 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:13:09 2024
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[28];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = t0.Sample(s2_s, v2.xy).xy;
+  r0.xy = float2(-0.498039216,-0.498039216) + r0.xy;
+  r0.xy = float2(0.100000001,0.100000001) * r0.xy;
+  r0.zw = r0.xy * cb0[5].xy + v1.xy;
+  r0.xy = r0.xy * cb0[5].xy + v2.xy;
+  r0.xy = min(cb0[6].zw, r0.xy);
+  r1.xyzw = t2.Sample(s1_s, r0.xy).xyzw;
+  r1.xyzw = saturate(-r1.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r2.xyzw = min(cb0[6].xyxy, r0.zwzw);
+  r0.xy = r0.zw / cb0[5].xy;
+  r0.xy = min(cb0[13].zw, r0.xy);
+  r0.xyz = t3.Sample(s3_s, r0.xy).xyz;
+  r0.xyz = saturate(r0.xyz);
+  r0.xyz = float3(1,1,1) + -r0.xyz;
+  r3.xyzw = cb0[3].xyxy * float4(-1.5,-1.5,1.5,-1.5) + r2.zwzw;
+  r4.xyz = t1.Sample(s0_s, r3.xy).xyz;
+  r3.xyz = t1.Sample(s0_s, r3.zw).xyz;
+  r3.xyz = r4.xyz + r3.xyz;
+  r4.xyzw = cb0[3].xyxy * float4(-1.5,1.5,1.5,1.5) + r2.xyzw;
+  r2.xyzw = t1.Sample(s0_s, r2.zw).xyzw;
+  r5.xyz = t1.Sample(s0_s, r4.xy).xyz;
+  r4.xyz = t1.Sample(s0_s, r4.zw).xyz;
+  r3.xyz = r5.xyz + r3.xyz;
+  r3.xyz = r3.xyz + r4.xyz;
+  r3.xyz = -r3.xyz * float3(0.25,0.25,0.25) + r2.xyz;
+  r3.xyz = r3.xyz * cb0[8].yyy + r2.xyz;
+  r3.xyz = float3(1,1,1) + -r3.xyz;
+  r2.xyz = -r3.xyz * r0.xyz + float3(1,1,1);
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.xyzw = r2.xyzw * r0.xxxx;
+r2.xyz = cb0[17].xyz * r0.xyz;  //    r2.xyz = saturate(cb0[17].xyz * r0.xyz);
+float3 hdrColor = r2.xyz;
+r2.xyz = saturate(r2.xyz);
+
+  r3.xyz = r2.xyz * r2.xyz;
+  r4.xyz = r3.xyz * r2.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r2.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r2.xyz = r7.xzy * r2.xzy;
+  r5.x = r8.y;
+  r5.y = r2.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r2.x = r8.z;
+  r8.y = r2.z;
+  r8.z = r3.y;
+  r2.z = r3.z;
+  r8.w = r4.y;
+  r2.w = r4.z;
+  r5.z = dot(r2.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r0.xyzw = -r1.xyzw * r0.xyzw + float4(1,1,1,1);
+  r1.xyz = saturate(r0.xyz);
+  r1.w = dot(r1.xyz, float3(0.212670997,0.715160012,0.0721689984));
+  r2.x = cb0[27].z / cb0[27].x;
+  r2.xy = float2(9.99999975e-005,-0.999899983) + r2.xx;
+  r2.x = r2.x / r2.y;
+  r3.xyzw = r2.xxxx * r1.xyzw;
+  r4.xyzw = r2.xxxx + -r1.xyzw;
+  r3.xyzw = r3.xyzw / r4.xyzw;
+  r2.y = 0.5 * r2.x;
+  r2.x = -0.5 + r2.x;
+  r2.x = r2.y / r2.x;
+  r2.x = 1 + -r2.x;
+  r2.xyzw = r2.xxxx + r3.xyzw;
+  r3.xyzw = float4(1.00010002,1.00010002,1.00010002,1.00010002) + -r1.xyzw;
+  r3.xyzw = r1.xyzw / r3.xyzw;
+  r4.xyzw = cmp(float4(0.5,0.5,0.5,0.5) < r1.xyzw);
+  r1.w = 9.99999975e-005 + r1.w;
+  r1.xyz = r1.xyz / r1.www;
+  r2.xyzw = r4.xyzw ? r2.xyzw : r3.xyzw;
+  r1.xyz = r2.www * r1.xyz;
+  r2.xyz = cb0[27].yyy * r2.xyz;
+  r1.w = 1 + -cb0[27].y;
+  r0.xyz = r1.www * r1.xyz + r2.xyz;
+  r1.xyz = float3(-0.5,-0.5,-0.5) + r0.xyz;
+  r2.xy = float2(-0.5,-0.5) + w1.xy;
+  r1.w = dot(r2.xy, r2.xy);
+  r1.w = sqrt(r1.w);
+  r1.w = r1.w * 0.720000029 + -0.800000012;
+  r1.w = saturate(-1.83715463 * r1.w);
+  r2.x = r1.w * -2 + 3;
+  r1.w = r1.w * r1.w;
+  r2.y = r2.x * r1.w + -1;
+  r1.w = r2.x * r1.w;
+  r2.x = -r2.y * 0.200000003 + 1;
+  r2.x = max(1, r2.x);
+  r1.xyz = r1.xyz * r2.xxx + float3(0.5,0.5,0.5);
+  r1.xyz = r1.xyz * r1.www + -r0.xyz;
+  r1.w = 0;
+  o0.xyzw = cb0[12].yyyy * r1.xyzw + r0.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/colorgrade_0x48CDE62E.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0x48CDE62E.ps_5_0.hlsl
@@ -1,0 +1,114 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:13:18 2024
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[22];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.yz = t0.Sample(s2_s, v2.xy).xy;
+  r0.yz = float2(-0.498039216,-0.498039216) + r0.yz;
+  r0.yz = float2(0.100000001,0.100000001) * r0.yz;
+  r1.xy = r0.yz * cb0[5].xy + v1.xy;
+  r0.yz = r0.yz * cb0[5].xy + v2.xy;
+  r0.yz = min(cb0[6].zw, r0.yz);
+  r2.xyzw = t2.Sample(s1_s, r0.yz).xyzw;
+  r2.xyzw = saturate(-r2.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r0.yz = r1.xy / cb0[5].xy;
+  r1.xy = min(cb0[6].xy, r1.xy);
+  r1.xyzw = t1.Sample(s0_s, r1.xy).xyzw;
+  r0.yz = min(cb0[13].zw, r0.yz);
+  r0.yzw = t3.Sample(s3_s, r0.yz).xyz;
+  r3.xyz = cb0[13].xxx * r0.yzw;
+  r0.yzw = cb0[13].yyy + r0.yzw;
+  r0.yzw = r3.xyz / r0.yzw;
+  r1.xyz = r1.xyz + r0.yzw;
+  r0.xyzw = r1.xyzw * r0.xxxx;
+r1.xyz = cb0[17].xyz * r0.xyz;  //    r1.xyz = saturate(cb0[17].xyz * r0.xyz);
+float3 hdrColor = r1.xyz;
+r1.xyz = saturate(r1.xyz);
+
+  r3.xyz = r1.xyz * r1.xyz;
+  r4.xyz = r3.xyz * r1.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r1.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r1.xyz = r7.xzy * r1.xzy;
+  r5.x = r8.y;
+  r5.y = r1.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r1.x = r8.z;
+  r8.y = r1.z;
+  r8.z = r3.y;
+  r1.z = r3.z;
+  r8.w = r4.y;
+  r1.w = r4.z;
+  r5.z = dot(r1.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r1.xyzw = -r2.xyzw * r0.xyzw + float4(1,1,1,1);
+  r0.xyz = -r2.xyz * r0.xyz + float3(0.5,0.5,0.5);
+  r2.xy = float2(-0.5,-0.5) + w1.xy;
+  r0.w = dot(r2.xy, r2.xy);
+  r0.w = sqrt(r0.w);
+  r0.w = r0.w * 0.720000029 + -0.800000012;
+  r0.w = saturate(-1.83715463 * r0.w);
+  r2.x = r0.w * -2 + 3;
+  r0.w = r0.w * r0.w;
+  r2.y = r2.x * r0.w + -1;
+  r0.w = r2.x * r0.w;
+  r2.x = -r2.y * 0.200000003 + 1;
+  r2.x = max(1, r2.x);
+  r0.xyz = r0.xyz * r2.xxx + float3(0.5,0.5,0.5);
+  r0.xyz = r0.xyz * r0.www + -r1.xyz;
+  r0.w = 0;
+  o0.xyzw = cb0[12].yyyy * r0.xyzw + r1.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/colorgrade_0x4A3D4181.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0x4A3D4181.ps_5_0.hlsl
@@ -1,0 +1,157 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:13:19 2024
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[28];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = t0.Sample(s2_s, v2.xy).xy;
+  r0.xy = float2(-0.498039216,-0.498039216) + r0.xy;
+  r0.xy = float2(0.100000001,0.100000001) * r0.xy;
+  r0.zw = r0.xy * cb0[5].xy + v1.xy;
+  r0.xy = r0.xy * cb0[5].xy + v2.xy;
+  r0.xy = min(cb0[6].zw, r0.xy);
+  r1.xyzw = t2.Sample(s1_s, r0.xy).xyzw;
+  r1.xyzw = saturate(-r1.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r2.xyzw = min(cb0[6].xyxy, r0.zwzw);
+  r0.xy = r0.zw / cb0[5].xy;
+  r3.xyzw = cb0[3].xyxy * float4(-1.5,-1.5,1.5,-1.5) + r2.zwzw;
+  r4.xyz = t1.Sample(s0_s, r3.xy).xyz;
+  r3.xyz = t1.Sample(s0_s, r3.zw).xyz;
+  r3.xyz = r4.xyz + r3.xyz;
+  r4.xyzw = cb0[3].xyxy * float4(-1.5,1.5,1.5,1.5) + r2.xyzw;
+  r2.xyzw = t1.Sample(s0_s, r2.zw).xyzw;
+  r5.xyz = t1.Sample(s0_s, r4.xy).xyz;
+  r4.xyz = t1.Sample(s0_s, r4.zw).xyz;
+  r3.xyz = r5.xyz + r3.xyz;
+  r3.xyz = r3.xyz + r4.xyz;
+  r3.xyz = -r3.xyz * float3(0.25,0.25,0.25) + r2.xyz;
+  r3.xyz = r3.xyz * cb0[8].yyy + r2.xyz;
+  r0.zw = min(cb0[13].zw, r0.xy);
+  r4.xyz = t4.Sample(s3_s, r0.xy).xyz;
+  r0.xyz = t3.Sample(s3_s, r0.zw).xyz;
+  r5.xyz = cb0[13].xxx * r0.xyz;
+  r0.xyz = cb0[13].yyy + r0.xyz;
+  r0.xyz = r5.xyz / r0.xyz;
+  r0.xyz = r3.xyz + r0.xyz;
+  r0.w = max(r4.y, r4.z);
+  r0.w = max(r4.x, r0.w);
+  r3.x = cmp(cb0[12].z < r0.w);
+  r0.w = cb0[12].z / r0.w;
+  r0.w = r3.x ? r0.w : 1;
+  r2.xyz = r4.xyz * r0.www + r0.xyz;
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.xyzw = r2.xyzw * r0.xxxx;
+r2.xyz = cb0[17].xyz * r0.xyz;  //    r2.xyz = saturate(cb0[17].xyz * r0.xyz);
+float3 hdrColor = r2.xyz;
+r2.xyz = saturate(r2.xyz);
+
+  r3.xyz = r2.xyz * r2.xyz;
+  r4.xyz = r3.xyz * r2.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r2.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r2.xyz = r7.xzy * r2.xzy;
+  r5.x = r8.y;
+  r5.y = r2.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r2.x = r8.z;
+  r8.y = r2.z;
+  r8.z = r3.y;
+  r2.z = r3.z;
+  r8.w = r4.y;
+  r2.w = r4.z;
+  r5.z = dot(r2.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r0.xyzw = -r1.xyzw * r0.xyzw + float4(1,1,1,1);
+  r1.xyz = saturate(r0.xyz);
+  r1.w = dot(r1.xyz, float3(0.212670997,0.715160012,0.0721689984));
+  r2.x = cb0[27].z / cb0[27].x;
+  r2.xy = float2(9.99999975e-005,-0.999899983) + r2.xx;
+  r2.x = r2.x / r2.y;
+  r3.xyzw = r2.xxxx * r1.xyzw;
+  r4.xyzw = r2.xxxx + -r1.xyzw;
+  r3.xyzw = r3.xyzw / r4.xyzw;
+  r2.y = 0.5 * r2.x;
+  r2.x = -0.5 + r2.x;
+  r2.x = r2.y / r2.x;
+  r2.x = 1 + -r2.x;
+  r2.xyzw = r2.xxxx + r3.xyzw;
+  r3.xyzw = float4(1.00010002,1.00010002,1.00010002,1.00010002) + -r1.xyzw;
+  r3.xyzw = r1.xyzw / r3.xyzw;
+  r4.xyzw = cmp(float4(0.5,0.5,0.5,0.5) < r1.xyzw);
+  r1.w = 9.99999975e-005 + r1.w;
+  r1.xyz = r1.xyz / r1.www;
+  r2.xyzw = r4.xyzw ? r2.xyzw : r3.xyzw;
+  r1.xyz = r2.www * r1.xyz;
+  r2.xyz = cb0[27].yyy * r2.xyz;
+  r1.w = 1 + -cb0[27].y;
+  r0.xyz = r1.www * r1.xyz + r2.xyz;
+  r1.xyz = float3(-0.5,-0.5,-0.5) + r0.xyz;
+  r2.xy = float2(-0.5,-0.5) + w1.xy;
+  r1.w = dot(r2.xy, r2.xy);
+  r1.w = sqrt(r1.w);
+  r1.w = r1.w * 0.720000029 + -0.800000012;
+  r1.w = saturate(-1.83715463 * r1.w);
+  r2.x = r1.w * -2 + 3;
+  r1.w = r1.w * r1.w;
+  r2.y = r2.x * r1.w + -1;
+  r1.w = r2.x * r1.w;
+  r2.x = -r2.y * 0.200000003 + 1;
+  r2.x = max(1, r2.x);
+  r1.xyz = r1.xyz * r2.xxx + float3(0.5,0.5,0.5);
+  r1.xyz = r1.xyz * r1.www + -r0.xyz;
+  r1.w = 0;
+  o0.xyzw = cb0[12].yyyy * r1.xyzw + r0.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/colorgrade_0x596B9BD3.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0x596B9BD3.ps_5_0.hlsl
@@ -1,0 +1,138 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:13:33 2024
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[28];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.yz = t0.Sample(s2_s, v2.xy).xy;
+  r0.yz = float2(-0.498039216,-0.498039216) + r0.yz;
+  r0.yz = float2(0.100000001,0.100000001) * r0.yz;
+  r1.xy = r0.yz * cb0[5].xy + v1.xy;
+  r0.yz = r0.yz * cb0[5].xy + v2.xy;
+  r0.yz = min(cb0[6].zw, r0.yz);
+  r2.xyzw = t2.Sample(s1_s, r0.yz).xyzw;
+  r2.xyzw = saturate(-r2.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r0.yz = r1.xy / cb0[5].xy;
+  r1.xy = min(cb0[6].xy, r1.xy);
+  r1.xyzw = t1.Sample(s0_s, r1.xy).xyzw;
+  r0.yzw = t3.Sample(s3_s, r0.yz).xyz;
+  r3.x = max(r0.z, r0.w);
+  r3.x = max(r3.x, r0.y);
+  r3.y = cmp(cb0[12].z < r3.x);
+  r3.x = cb0[12].z / r3.x;
+  r3.x = r3.y ? r3.x : 1;
+  r1.xyz = r0.yzw * r3.xxx + r1.xyz;
+  r0.xyzw = r1.xyzw * r0.xxxx;
+r1.xyz = cb0[17].xyz * r0.xyz;  //    r1.xyz = saturate(cb0[17].xyz * r0.xyz);
+float3 hdrColor = r1.xyz;
+r1.xyz = saturate(r1.xyz);
+
+  r3.xyz = r1.xyz * r1.xyz;
+  r4.xyz = r3.xyz * r1.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r1.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r1.xyz = r7.xzy * r1.xzy;
+  r5.x = r8.y;
+  r5.y = r1.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r1.x = r8.z;
+  r8.y = r1.z;
+  r8.z = r3.y;
+  r1.z = r3.z;
+  r8.w = r4.y;
+  r1.w = r4.z;
+  r5.z = dot(r1.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r0.xyzw = -r2.xyzw * r0.xyzw + float4(1,1,1,1);
+  r1.xyz = saturate(r0.xyz);
+  r1.w = dot(r1.xyz, float3(0.212670997,0.715160012,0.0721689984));
+  r2.x = cb0[27].z / cb0[27].x;
+  r2.xy = float2(9.99999975e-005,-0.999899983) + r2.xx;
+  r2.x = r2.x / r2.y;
+  r3.xyzw = r2.xxxx * r1.xyzw;
+  r4.xyzw = r2.xxxx + -r1.xyzw;
+  r3.xyzw = r3.xyzw / r4.xyzw;
+  r2.y = 0.5 * r2.x;
+  r2.x = -0.5 + r2.x;
+  r2.x = r2.y / r2.x;
+  r2.x = 1 + -r2.x;
+  r2.xyzw = r2.xxxx + r3.xyzw;
+  r3.xyzw = float4(1.00010002,1.00010002,1.00010002,1.00010002) + -r1.xyzw;
+  r3.xyzw = r1.xyzw / r3.xyzw;
+  r4.xyzw = cmp(float4(0.5,0.5,0.5,0.5) < r1.xyzw);
+  r1.w = 9.99999975e-005 + r1.w;
+  r1.xyz = r1.xyz / r1.www;
+  r2.xyzw = r4.xyzw ? r2.xyzw : r3.xyzw;
+  r1.xyz = r2.www * r1.xyz;
+  r2.xyz = cb0[27].yyy * r2.xyz;
+  r1.w = 1 + -cb0[27].y;
+  r0.xyz = r1.www * r1.xyz + r2.xyz;
+  r1.xyz = float3(-0.5,-0.5,-0.5) + r0.xyz;
+  r2.xy = float2(-0.5,-0.5) + w1.xy;
+  r1.w = dot(r2.xy, r2.xy);
+  r1.w = sqrt(r1.w);
+  r1.w = r1.w * 0.720000029 + -0.800000012;
+  r1.w = saturate(-1.83715463 * r1.w);
+  r2.x = r1.w * -2 + 3;
+  r1.w = r1.w * r1.w;
+  r2.y = r2.x * r1.w + -1;
+  r1.w = r2.x * r1.w;
+  r2.x = -r2.y * 0.200000003 + 1;
+  r2.x = max(1, r2.x);
+  r1.xyz = r1.xyz * r2.xxx + float3(0.5,0.5,0.5);
+  r1.xyz = r1.xyz * r1.www + -r0.xyz;
+  r1.w = 0;
+  o0.xyzw = cb0[12].yyyy * r1.xyzw + r0.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/colorgrade_0x5B0965E4.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0x5B0965E4.ps_5_0.hlsl
@@ -1,0 +1,115 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:13:35 2024
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[22];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.yz = t0.Sample(s2_s, v2.xy).xy;
+  r0.yz = float2(-0.498039216,-0.498039216) + r0.yz;
+  r0.yz = float2(0.100000001,0.100000001) * r0.yz;
+  r1.xy = r0.yz * cb0[5].xy + v1.xy;
+  r0.yz = r0.yz * cb0[5].xy + v2.xy;
+  r0.yz = min(cb0[6].zw, r0.yz);
+  r2.xyzw = t2.Sample(s1_s, r0.yz).xyzw;
+  r2.xyzw = saturate(-r2.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r0.yz = r1.xy / cb0[5].xy;
+  r1.xy = min(cb0[6].xy, r1.xy);
+  r1.xyzw = t1.Sample(s0_s, r1.xy).xyzw;
+  r0.yzw = t3.Sample(s3_s, r0.yz).xyz;
+  r3.x = max(r0.z, r0.w);
+  r3.x = max(r3.x, r0.y);
+  r3.y = cmp(cb0[12].z < r3.x);
+  r3.x = cb0[12].z / r3.x;
+  r3.x = r3.y ? r3.x : 1;
+  r1.xyz = r0.yzw * r3.xxx + r1.xyz;
+  r0.xyzw = r1.xyzw * r0.xxxx;
+r1.xyz = cb0[17].xyz * r0.xyz;  //    r1.xyz = saturate(cb0[17].xyz * r0.xyz);
+float3 hdrColor = r1.xyz;
+r1.xyz = saturate(r1.xyz);
+
+  r3.xyz = r1.xyz * r1.xyz;
+  r4.xyz = r3.xyz * r1.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r1.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r1.xyz = r7.xzy * r1.xzy;
+  r5.x = r8.y;
+  r5.y = r1.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r1.x = r8.z;
+  r8.y = r1.z;
+  r8.z = r3.y;
+  r1.z = r3.z;
+  r8.w = r4.y;
+  r1.w = r4.z;
+  r5.z = dot(r1.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r1.xyzw = -r2.xyzw * r0.xyzw + float4(1,1,1,1);
+  r0.xyz = -r2.xyz * r0.xyz + float3(0.5,0.5,0.5);
+  r2.xy = float2(-0.5,-0.5) + w1.xy;
+  r0.w = dot(r2.xy, r2.xy);
+  r0.w = sqrt(r0.w);
+  r0.w = r0.w * 0.720000029 + -0.800000012;
+  r0.w = saturate(-1.83715463 * r0.w);
+  r2.x = r0.w * -2 + 3;
+  r0.w = r0.w * r0.w;
+  r2.y = r2.x * r0.w + -1;
+  r0.w = r2.x * r0.w;
+  r2.x = -r2.y * 0.200000003 + 1;
+  r2.x = max(1, r2.x);
+  r0.xyz = r0.xyz * r2.xxx + float3(0.5,0.5,0.5);
+  r0.xyz = r0.xyz * r0.www + -r1.xyz;
+  r0.w = 0;
+  o0.xyzw = cb0[12].yyyy * r0.xyzw + r1.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/colorgrade_0x5CDE4A30.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0x5CDE4A30.ps_5_0.hlsl
@@ -1,0 +1,151 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:13:37 2024
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[28];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = t0.Sample(s2_s, v2.xy).xy;
+  r0.xy = float2(-0.498039216,-0.498039216) + r0.xy;
+  r0.xy = float2(0.100000001,0.100000001) * r0.xy;
+  r0.zw = r0.xy * cb0[5].xy + v1.xy;
+  r0.xy = r0.xy * cb0[5].xy + v2.xy;
+  r0.xy = min(cb0[6].zw, r0.xy);
+  r1.xyzw = t2.Sample(s1_s, r0.xy).xyzw;
+  r1.xyzw = saturate(-r1.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r2.xyzw = min(cb0[6].xyxy, r0.zwzw);
+  r0.xy = r0.zw / cb0[5].xy;
+  r0.xy = min(cb0[13].zw, r0.xy);
+  r0.xyz = t3.Sample(s3_s, r0.xy).xyz;
+  r3.xyzw = cb0[3].xyxy * float4(-1.5,-1.5,1.5,-1.5) + r2.zwzw;
+  r4.xyz = t1.Sample(s0_s, r3.xy).xyz;
+  r3.xyz = t1.Sample(s0_s, r3.zw).xyz;
+  r3.xyz = r4.xyz + r3.xyz;
+  r4.xyzw = cb0[3].xyxy * float4(-1.5,1.5,1.5,1.5) + r2.xyzw;
+  r2.xyzw = t1.Sample(s0_s, r2.zw).xyzw;
+  r5.xyz = t1.Sample(s0_s, r4.xy).xyz;
+  r4.xyz = t1.Sample(s0_s, r4.zw).xyz;
+  r3.xyz = r5.xyz + r3.xyz;
+  r3.xyz = r3.xyz + r4.xyz;
+  r3.xyz = -r3.xyz * float3(0.25,0.25,0.25) + r2.xyz;
+  r3.xyz = r3.xyz * cb0[8].yyy + r2.xyz;
+  r4.xyz = cb0[13].xxx * r0.xyz;
+  r0.xyz = cb0[13].yyy + r0.xyz;
+  r0.xyz = r4.xyz / r0.xyz;
+  r2.xyz = r3.xyz + r0.xyz;
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.xyzw = r2.xyzw * r0.xxxx;
+r2.xyz = cb0[17].xyz * r0.xyz;  //    r2.xyz = saturate(cb0[17].xyz * r0.xyz);
+float3 hdrColor = r2.xyz;
+r2.xyz = saturate(r2.xyz);
+
+  r3.xyz = r2.xyz * r2.xyz;
+  r4.xyz = r3.xyz * r2.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r2.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r2.xyz = r7.xzy * r2.xzy;
+  r5.x = r8.y;
+  r5.y = r2.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r2.x = r8.z;
+  r8.y = r2.z;
+  r8.z = r3.y;
+  r2.z = r3.z;
+  r8.w = r4.y;
+  r2.w = r4.z;
+  r5.z = dot(r2.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r0.xyzw = -r1.xyzw * r0.xyzw + float4(1,1,1,1);
+  r1.xyz = saturate(r0.xyz);
+  r1.w = dot(r1.xyz, float3(0.212670997,0.715160012,0.0721689984));
+  r2.x = cb0[27].z / cb0[27].x;
+  r2.xy = float2(9.99999975e-005,-0.999899983) + r2.xx;
+  r2.x = r2.x / r2.y;
+  r3.xyzw = r2.xxxx * r1.xyzw;
+  r4.xyzw = r2.xxxx + -r1.xyzw;
+  r3.xyzw = r3.xyzw / r4.xyzw;
+  r2.y = 0.5 * r2.x;
+  r2.x = -0.5 + r2.x;
+  r2.x = r2.y / r2.x;
+  r2.x = 1 + -r2.x;
+  r2.xyzw = r2.xxxx + r3.xyzw;
+  r3.xyzw = float4(1.00010002,1.00010002,1.00010002,1.00010002) + -r1.xyzw;
+  r3.xyzw = r1.xyzw / r3.xyzw;
+  r4.xyzw = cmp(float4(0.5,0.5,0.5,0.5) < r1.xyzw);
+  r1.w = 9.99999975e-005 + r1.w;
+  r1.xyz = r1.xyz / r1.www;
+  r2.xyzw = r4.xyzw ? r2.xyzw : r3.xyzw;
+  r1.xyz = r2.www * r1.xyz;
+  r2.xyz = cb0[27].yyy * r2.xyz;
+  r1.w = 1 + -cb0[27].y;
+  r0.xyz = r1.www * r1.xyz + r2.xyz;
+  r1.x = saturate(dot(r0.xyz, float3(0.219999999,0.707000017,0.0710000023)));
+  r1.xyzw = r1.xxxx + -r0.xyzw;
+  r0.xyzw = cb0[10].xxxx * r1.xyzw + r0.xyzw;
+  r1.xyz = float3(-0.5,-0.5,-0.5) + r0.xyz;
+  r2.xy = float2(-0.5,-0.5) + w1.xy;
+  r1.w = dot(r2.xy, r2.xy);
+  r1.w = sqrt(r1.w);
+  r1.w = r1.w * 0.720000029 + -0.800000012;
+  r1.w = saturate(-1.83715463 * r1.w);
+  r2.x = r1.w * -2 + 3;
+  r1.w = r1.w * r1.w;
+  r2.y = r2.x * r1.w + -1;
+  r1.w = r2.x * r1.w;
+  r2.x = -r2.y * 0.200000003 + 1;
+  r2.x = max(1, r2.x);
+  r1.xyz = r1.xyz * r2.xxx + float3(0.5,0.5,0.5);
+  r1.xyz = r1.xyz * r1.www + -r0.xyz;
+  r1.w = 0;
+  o0.xyzw = cb0[12].yyyy * r1.xyzw + r0.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/colorgrade_0x613B5403.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0x613B5403.ps_5_0.hlsl
@@ -1,0 +1,128 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:13:41 2024
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[22];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = t0.Sample(s2_s, v2.xy).xy;
+  r0.xy = float2(-0.498039216,-0.498039216) + r0.xy;
+  r0.xy = float2(0.100000001,0.100000001) * r0.xy;
+  r0.zw = r0.xy * cb0[5].xy + v1.xy;
+  r0.xy = r0.xy * cb0[5].xy + v2.xy;
+  r0.xy = min(cb0[6].zw, r0.xy);
+  r1.xyzw = t2.Sample(s1_s, r0.xy).xyzw;
+  r1.xyzw = saturate(-r1.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r2.xyzw = min(cb0[6].xyxy, r0.zwzw);
+  r0.xy = r0.zw / cb0[5].xy;
+  r0.xy = min(cb0[13].zw, r0.xy);
+  r0.xyz = t3.Sample(s3_s, r0.xy).xyz;
+  r3.xyzw = cb0[3].xyxy * float4(-1.5,-1.5,1.5,-1.5) + r2.zwzw;
+  r4.xyz = t1.Sample(s0_s, r3.xy).xyz;
+  r3.xyz = t1.Sample(s0_s, r3.zw).xyz;
+  r3.xyz = r4.xyz + r3.xyz;
+  r4.xyzw = cb0[3].xyxy * float4(-1.5,1.5,1.5,1.5) + r2.xyzw;
+  r2.xyzw = t1.Sample(s0_s, r2.zw).xyzw;
+  r5.xyz = t1.Sample(s0_s, r4.xy).xyz;
+  r4.xyz = t1.Sample(s0_s, r4.zw).xyz;
+  r3.xyz = r5.xyz + r3.xyz;
+  r3.xyz = r3.xyz + r4.xyz;
+  r3.xyz = -r3.xyz * float3(0.25,0.25,0.25) + r2.xyz;
+  r3.xyz = r3.xyz * cb0[8].yyy + r2.xyz;
+  r4.xyz = cb0[13].xxx * r0.xyz;
+  r0.xyz = cb0[13].yyy + r0.xyz;
+  r0.xyz = r4.xyz / r0.xyz;
+  r2.xyz = r3.xyz + r0.xyz;
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.xyzw = r2.xyzw * r0.xxxx;
+r2.xyz = cb0[17].xyz * r0.xyz;  //    r2.xyz = saturate(cb0[17].xyz * r0.xyz);
+float3 hdrColor = r2.xyz;
+r2.xyz = saturate(r2.xyz);
+
+  r3.xyz = r2.xyz * r2.xyz;
+  r4.xyz = r3.xyz * r2.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r2.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r2.xyz = r7.xzy * r2.xzy;
+  r5.x = r8.y;
+  r5.y = r2.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r2.x = r8.z;
+  r8.y = r2.z;
+  r8.z = r3.y;
+  r2.z = r3.z;
+  r8.w = r4.y;
+  r2.w = r4.z;
+  r5.z = dot(r2.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r2.x = saturate(dot(r0.xyz, float3(0.219999999,0.707000017,0.0710000023)));
+  r2.xyzw = r2.xxxx + -r0.xyzw;
+  r0.xyzw = cb0[10].xxxx * r2.xyzw + r0.xyzw;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r2.xyzw = -r1.xyzw * r0.xyzw + float4(1,1,1,1);
+  r0.xyz = -r1.xyz * r0.xyz + float3(0.5,0.5,0.5);
+  r1.xy = float2(-0.5,-0.5) + w1.xy;
+  r0.w = dot(r1.xy, r1.xy);
+  r0.w = sqrt(r0.w);
+  r0.w = r0.w * 0.720000029 + -0.800000012;
+  r0.w = saturate(-1.83715463 * r0.w);
+  r1.x = r0.w * -2 + 3;
+  r0.w = r0.w * r0.w;
+  r1.y = r1.x * r0.w + -1;
+  r0.w = r1.x * r0.w;
+  r1.x = -r1.y * 0.200000003 + 1;
+  r1.x = max(1, r1.x);
+  r0.xyz = r0.xyz * r1.xxx + float3(0.5,0.5,0.5);
+  r0.xyz = r0.xyz * r0.www + -r2.xyz;
+  r0.w = 0;
+  o0.xyzw = cb0[12].yyyy * r0.xyzw + r2.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/colorgrade_0x62C79AA3.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0x62C79AA3.ps_5_0.hlsl
@@ -1,0 +1,149 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:13:42 2024
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[28];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = t0.Sample(s2_s, v2.xy).xy;
+  r0.xy = float2(-0.498039216,-0.498039216) + r0.xy;
+  r0.xy = float2(0.100000001,0.100000001) * r0.xy;
+  r0.zw = r0.xy * cb0[5].xy + v1.xy;
+  r0.xy = r0.xy * cb0[5].xy + v2.xy;
+  r0.xy = min(cb0[6].zw, r0.xy);
+  r1.xyzw = t2.Sample(s1_s, r0.xy).xyzw;
+  r1.xyzw = saturate(-r1.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r0.xy = r0.zw / cb0[5].xy;
+  r0.zw = min(cb0[6].xy, r0.zw);
+  r2.xyzw = t1.Sample(s0_s, r0.zw).xyzw;
+  r0.zw = min(cb0[13].zw, r0.xy);
+  r3.xyz = t4.Sample(s3_s, r0.xy).xyz;
+  r0.xyz = t3.Sample(s3_s, r0.zw).xyz;
+  r4.xyz = cb0[13].xxx * r0.xyz;
+  r0.xyz = cb0[13].yyy + r0.xyz;
+  r0.xyz = r4.xyz / r0.xyz;
+  r0.xyz = r2.xyz + r0.xyz;
+  r0.w = max(r3.y, r3.z);
+  r0.w = max(r3.x, r0.w);
+  r3.w = cmp(cb0[12].z < r0.w);
+  r0.w = cb0[12].z / r0.w;
+  r0.w = r3.w ? r0.w : 1;
+  r2.xyz = r3.xyz * r0.www + r0.xyz;
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.xyzw = r2.xyzw * r0.xxxx;
+r2.xyz = cb0[17].xyz * r0.xyz;  //    r2.xyz = saturate(cb0[17].xyz * r0.xyz);
+float3 hdrColor = r2.xyz;
+r2.xyz = saturate(r2.xyz);
+
+  r3.xyz = r2.xyz * r2.xyz;
+  r4.xyz = r3.xyz * r2.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r2.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r2.xyz = r7.xzy * r2.xzy;
+  r5.x = r8.y;
+  r5.y = r2.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r2.x = r8.z;
+  r8.y = r2.z;
+  r8.z = r3.y;
+  r2.z = r3.z;
+  r8.w = r4.y;
+  r2.w = r4.z;
+  r5.z = dot(r2.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r0.xyzw = -r1.xyzw * r0.xyzw + float4(1,1,1,1);
+  r1.xyz = saturate(r0.xyz);
+  r1.w = dot(r1.xyz, float3(0.212670997,0.715160012,0.0721689984));
+  r2.x = cb0[27].z / cb0[27].x;
+  r2.xy = float2(9.99999975e-005,-0.999899983) + r2.xx;
+  r2.x = r2.x / r2.y;
+  r3.xyzw = r2.xxxx * r1.xyzw;
+  r4.xyzw = r2.xxxx + -r1.xyzw;
+  r3.xyzw = r3.xyzw / r4.xyzw;
+  r2.y = 0.5 * r2.x;
+  r2.x = -0.5 + r2.x;
+  r2.x = r2.y / r2.x;
+  r2.x = 1 + -r2.x;
+  r2.xyzw = r2.xxxx + r3.xyzw;
+  r3.xyzw = float4(1.00010002,1.00010002,1.00010002,1.00010002) + -r1.xyzw;
+  r3.xyzw = r1.xyzw / r3.xyzw;
+  r4.xyzw = cmp(float4(0.5,0.5,0.5,0.5) < r1.xyzw);
+  r1.w = 9.99999975e-005 + r1.w;
+  r1.xyz = r1.xyz / r1.www;
+  r2.xyzw = r4.xyzw ? r2.xyzw : r3.xyzw;
+  r1.xyz = r2.www * r1.xyz;
+  r2.xyz = cb0[27].yyy * r2.xyz;
+  r1.w = 1 + -cb0[27].y;
+  r0.xyz = r1.www * r1.xyz + r2.xyz;
+  r1.x = saturate(dot(r0.xyz, float3(0.219999999,0.707000017,0.0710000023)));
+  r1.xyzw = r1.xxxx + -r0.xyzw;
+  r0.xyzw = cb0[10].xxxx * r1.xyzw + r0.xyzw;
+  r1.xyz = float3(-0.5,-0.5,-0.5) + r0.xyz;
+  r2.xy = float2(-0.5,-0.5) + w1.xy;
+  r1.w = dot(r2.xy, r2.xy);
+  r1.w = sqrt(r1.w);
+  r1.w = r1.w * 0.720000029 + -0.800000012;
+  r1.w = saturate(-1.83715463 * r1.w);
+  r2.x = r1.w * -2 + 3;
+  r1.w = r1.w * r1.w;
+  r2.y = r2.x * r1.w + -1;
+  r1.w = r2.x * r1.w;
+  r2.x = -r2.y * 0.200000003 + 1;
+  r2.x = max(1, r2.x);
+  r1.xyz = r1.xyz * r2.xxx + float3(0.5,0.5,0.5);
+  r1.xyz = r1.xyz * r1.www + -r0.xyz;
+  r1.w = 0;
+  o0.xyzw = cb0[12].yyyy * r1.xyzw + r0.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/colorgrade_0x649A0B90.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0x649A0B90.ps_5_0.hlsl
@@ -1,0 +1,137 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:13:44 2024
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[22];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = t0.Sample(s2_s, v2.xy).xy;
+  r0.xy = float2(-0.498039216,-0.498039216) + r0.xy;
+  r0.xy = float2(0.100000001,0.100000001) * r0.xy;
+  r0.zw = r0.xy * cb0[5].xy + v1.xy;
+  r0.xy = r0.xy * cb0[5].xy + v2.xy;
+  r0.xy = min(cb0[6].zw, r0.xy);
+  r1.xyzw = t2.Sample(s1_s, r0.xy).xyzw;
+  r1.xyzw = saturate(-r1.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r2.xyzw = min(cb0[6].xyxy, r0.zwzw);
+  r0.xy = r0.zw / cb0[5].xy;
+  r3.xyzw = cb0[3].xyxy * float4(-1.5,-1.5,1.5,-1.5) + r2.zwzw;
+  r4.xyz = t1.Sample(s0_s, r3.xy).xyz;
+  r3.xyz = t1.Sample(s0_s, r3.zw).xyz;
+  r3.xyz = r4.xyz + r3.xyz;
+  r4.xyzw = cb0[3].xyxy * float4(-1.5,1.5,1.5,1.5) + r2.xyzw;
+  r2.xyzw = t1.Sample(s0_s, r2.zw).xyzw;
+  r5.xyz = t1.Sample(s0_s, r4.xy).xyz;
+  r4.xyz = t1.Sample(s0_s, r4.zw).xyz;
+  r3.xyz = r5.xyz + r3.xyz;
+  r3.xyz = r3.xyz + r4.xyz;
+  r3.xyz = -r3.xyz * float3(0.25,0.25,0.25) + r2.xyz;
+  r3.xyz = r3.xyz * cb0[8].yyy + r2.xyz;
+  r3.xyz = float3(1,1,1) + -r3.xyz;
+  r0.zw = min(cb0[13].zw, r0.xy);
+  r4.xyz = t4.Sample(s3_s, r0.xy).xyz;
+  r0.xyz = t3.Sample(s3_s, r0.zw).xyz;
+  r0.xyz = saturate(r0.xyz);
+  r0.xyz = float3(1,1,1) + -r0.xyz;
+  r0.xyz = -r3.xyz * r0.xyz + float3(1,1,1);
+  r0.w = max(r4.y, r4.z);
+  r0.w = max(r4.x, r0.w);
+  r3.x = cmp(cb0[12].z < r0.w);
+  r0.w = cb0[12].z / r0.w;
+  r0.w = r3.x ? r0.w : 1;
+  r2.xyz = r4.xyz * r0.www + r0.xyz;
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.xyzw = r2.xyzw * r0.xxxx;
+r2.xyz = cb0[17].xyz * r0.xyz;  //    r2.xyz = saturate(cb0[17].xyz * r0.xyz);
+float3 hdrColor = r2.xyz;
+r2.xyz = saturate(r2.xyz);
+
+  r3.xyz = r2.xyz * r2.xyz;
+  r4.xyz = r3.xyz * r2.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r2.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r2.xyz = r7.xzy * r2.xzy;
+  r5.x = r8.y;
+  r5.y = r2.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r2.x = r8.z;
+  r8.y = r2.z;
+  r8.z = r3.y;
+  r2.z = r3.z;
+  r8.w = r4.y;
+  r2.w = r4.z;
+  r5.z = dot(r2.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r2.x = saturate(dot(r0.xyz, float3(0.219999999,0.707000017,0.0710000023)));
+  r2.xyzw = r2.xxxx + -r0.xyzw;
+  r0.xyzw = cb0[10].xxxx * r2.xyzw + r0.xyzw;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r2.xyzw = -r1.xyzw * r0.xyzw + float4(1,1,1,1);
+  r0.xyz = -r1.xyz * r0.xyz + float3(0.5,0.5,0.5);
+  r1.xy = float2(-0.5,-0.5) + w1.xy;
+  r0.w = dot(r1.xy, r1.xy);
+  r0.w = sqrt(r0.w);
+  r0.w = r0.w * 0.720000029 + -0.800000012;
+  r0.w = saturate(-1.83715463 * r0.w);
+  r1.x = r0.w * -2 + 3;
+  r0.w = r0.w * r0.w;
+  r1.y = r1.x * r0.w + -1;
+  r0.w = r1.x * r0.w;
+  r1.x = -r1.y * 0.200000003 + 1;
+  r1.x = max(1, r1.x);
+  r0.xyz = r0.xyz * r1.xxx + float3(0.5,0.5,0.5);
+  r0.xyz = r0.xyz * r0.www + -r2.xyz;
+  r0.w = 0;
+  o0.xyzw = cb0[12].yyyy * r0.xyzw + r2.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/colorgrade_0x7C14BB2C.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0x7C14BB2C.ps_5_0.hlsl
@@ -1,0 +1,118 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:14:06 2024
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[22];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.yz = t0.Sample(s2_s, v2.xy).xy;
+  r0.yz = float2(-0.498039216,-0.498039216) + r0.yz;
+  r0.yz = float2(0.100000001,0.100000001) * r0.yz;
+  r1.xy = r0.yz * cb0[5].xy + v1.xy;
+  r0.yz = r0.yz * cb0[5].xy + v2.xy;
+  r0.yz = min(cb0[6].zw, r0.yz);
+  r2.xyzw = t2.Sample(s1_s, r0.yz).xyzw;
+  r2.xyzw = saturate(-r2.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r0.yz = r1.xy / cb0[5].xy;
+  r1.xy = min(cb0[6].xy, r1.xy);
+  r1.xyzw = t1.Sample(s0_s, r1.xy).xyzw;
+  r0.yzw = t3.Sample(s3_s, r0.yz).xyz;
+  r3.x = max(r0.z, r0.w);
+  r3.x = max(r3.x, r0.y);
+  r3.y = cmp(cb0[12].z < r3.x);
+  r3.x = cb0[12].z / r3.x;
+  r3.x = r3.y ? r3.x : 1;
+  r1.xyz = r0.yzw * r3.xxx + r1.xyz;
+  r0.xyzw = r1.xyzw * r0.xxxx;
+r1.xyz = cb0[17].xyz * r0.xyz;  //    r1.xyz = saturate(cb0[17].xyz * r0.xyz);
+float3 hdrColor = r1.xyz;
+r1.xyz = saturate(r1.xyz);
+
+  r3.xyz = r1.xyz * r1.xyz;
+  r4.xyz = r3.xyz * r1.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r1.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r1.xyz = r7.xzy * r1.xzy;
+  r5.x = r8.y;
+  r5.y = r1.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r1.x = r8.z;
+  r8.y = r1.z;
+  r8.z = r3.y;
+  r1.z = r3.z;
+  r8.w = r4.y;
+  r1.w = r4.z;
+  r5.z = dot(r1.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r1.x = saturate(dot(r0.xyz, float3(0.219999999,0.707000017,0.0710000023)));
+  r1.xyzw = r1.xxxx + -r0.xyzw;
+  r0.xyzw = cb0[10].xxxx * r1.xyzw + r0.xyzw;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r1.xyzw = -r2.xyzw * r0.xyzw + float4(1,1,1,1);
+  r0.xyz = -r2.xyz * r0.xyz + float3(0.5,0.5,0.5);
+  r2.xy = float2(-0.5,-0.5) + w1.xy;
+  r0.w = dot(r2.xy, r2.xy);
+  r0.w = sqrt(r0.w);
+  r0.w = r0.w * 0.720000029 + -0.800000012;
+  r0.w = saturate(-1.83715463 * r0.w);
+  r2.x = r0.w * -2 + 3;
+  r0.w = r0.w * r0.w;
+  r2.y = r2.x * r0.w + -1;
+  r0.w = r2.x * r0.w;
+  r2.x = -r2.y * 0.200000003 + 1;
+  r2.x = max(1, r2.x);
+  r0.xyz = r0.xyz * r2.xxx + float3(0.5,0.5,0.5);
+  r0.xyz = r0.xyz * r0.www + -r1.xyz;
+  r0.w = 0;
+  o0.xyzw = cb0[12].yyyy * r0.xyzw + r1.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/colorgrade_0x841FAF0A.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0x841FAF0A.ps_5_0.hlsl
@@ -1,0 +1,134 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:14:13 2024
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[22];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = t0.Sample(s2_s, v2.xy).xy;
+  r0.xy = float2(-0.498039216,-0.498039216) + r0.xy;
+  r0.xy = float2(0.100000001,0.100000001) * r0.xy;
+  r0.zw = r0.xy * cb0[5].xy + v1.xy;
+  r0.xy = r0.xy * cb0[5].xy + v2.xy;
+  r0.xy = min(cb0[6].zw, r0.xy);
+  r1.xyzw = t2.Sample(s1_s, r0.xy).xyzw;
+  r1.xyzw = saturate(-r1.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r2.xyzw = min(cb0[6].xyxy, r0.zwzw);
+  r0.xy = r0.zw / cb0[5].xy;
+  r3.xyzw = cb0[3].xyxy * float4(-1.5,-1.5,1.5,-1.5) + r2.zwzw;
+  r4.xyz = t1.Sample(s0_s, r3.xy).xyz;
+  r3.xyz = t1.Sample(s0_s, r3.zw).xyz;
+  r3.xyz = r4.xyz + r3.xyz;
+  r4.xyzw = cb0[3].xyxy * float4(-1.5,1.5,1.5,1.5) + r2.xyzw;
+  r2.xyzw = t1.Sample(s0_s, r2.zw).xyzw;
+  r5.xyz = t1.Sample(s0_s, r4.xy).xyz;
+  r4.xyz = t1.Sample(s0_s, r4.zw).xyz;
+  r3.xyz = r5.xyz + r3.xyz;
+  r3.xyz = r3.xyz + r4.xyz;
+  r3.xyz = -r3.xyz * float3(0.25,0.25,0.25) + r2.xyz;
+  r3.xyz = r3.xyz * cb0[8].yyy + r2.xyz;
+  r0.zw = min(cb0[13].zw, r0.xy);
+  r4.xyz = t4.Sample(s3_s, r0.xy).xyz;
+  r0.xyz = t3.Sample(s3_s, r0.zw).xyz;
+  r5.xyz = cb0[13].xxx * r0.xyz;
+  r0.xyz = cb0[13].yyy + r0.xyz;
+  r0.xyz = r5.xyz / r0.xyz;
+  r0.xyz = r3.xyz + r0.xyz;
+  r0.w = max(r4.y, r4.z);
+  r0.w = max(r4.x, r0.w);
+  r3.x = cmp(cb0[12].z < r0.w);
+  r0.w = cb0[12].z / r0.w;
+  r0.w = r3.x ? r0.w : 1;
+  r2.xyz = r4.xyz * r0.www + r0.xyz;
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.xyzw = r2.xyzw * r0.xxxx;
+r2.xyz = cb0[17].xyz * r0.xyz;  //    r2.xyz = saturate(cb0[17].xyz * r0.xyz);
+float3 hdrColor = r2.xyz;
+r2.xyz = saturate(r2.xyz);
+
+  r3.xyz = r2.xyz * r2.xyz;
+  r4.xyz = r3.xyz * r2.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r2.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r2.xyz = r7.xzy * r2.xzy;
+  r5.x = r8.y;
+  r5.y = r2.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r2.x = r8.z;
+  r8.y = r2.z;
+  r8.z = r3.y;
+  r2.z = r3.z;
+  r8.w = r4.y;
+  r2.w = r4.z;
+  r5.z = dot(r2.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r2.xyzw = -r1.xyzw * r0.xyzw + float4(1,1,1,1);
+  r0.xyz = -r1.xyz * r0.xyz + float3(0.5,0.5,0.5);
+  r1.xy = float2(-0.5,-0.5) + w1.xy;
+  r0.w = dot(r1.xy, r1.xy);
+  r0.w = sqrt(r0.w);
+  r0.w = r0.w * 0.720000029 + -0.800000012;
+  r0.w = saturate(-1.83715463 * r0.w);
+  r1.x = r0.w * -2 + 3;
+  r0.w = r0.w * r0.w;
+  r1.y = r1.x * r0.w + -1;
+  r0.w = r1.x * r0.w;
+  r1.x = -r1.y * 0.200000003 + 1;
+  r1.x = max(1, r1.x);
+  r0.xyz = r0.xyz * r1.xxx + float3(0.5,0.5,0.5);
+  r0.xyz = r0.xyz * r0.www + -r2.xyz;
+  r0.w = 0;
+  o0.xyzw = cb0[12].yyyy * r0.xyzw + r2.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/colorgrade_0x84C7D93E.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0x84C7D93E.ps_5_0.hlsl
@@ -1,0 +1,140 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:14:13 2024
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[28];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = t0.Sample(s2_s, v2.xy).xy;
+  r0.xy = float2(-0.498039216,-0.498039216) + r0.xy;
+  r0.xy = float2(0.100000001,0.100000001) * r0.xy;
+  r1.xyzw = r0.xyxy * cb0[5].xyxy + v1.xyxy;
+  r0.xy = r0.xy * cb0[5].xy + v2.xy;
+  r0.xy = min(cb0[6].zw, r0.xy);
+  r0.xyzw = t2.Sample(s1_s, r0.xy).xyzw;
+  r0.xyzw = saturate(-r0.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r1.xyzw = min(cb0[6].xyxy, r1.xyzw);
+  r2.xyzw = cb0[3].xyxy * float4(-1.5,-1.5,1.5,-1.5) + r1.zwzw;
+  r3.xyz = t1.Sample(s0_s, r2.xy).xyz;
+  r2.xyz = t1.Sample(s0_s, r2.zw).xyz;
+  r2.xyz = r3.xyz + r2.xyz;
+  r3.xyzw = cb0[3].xyxy * float4(-1.5,1.5,1.5,1.5) + r1.xyzw;
+  r1.xyzw = t1.Sample(s0_s, r1.zw).xyzw;
+  r4.xyz = t1.Sample(s0_s, r3.xy).xyz;
+  r3.xyz = t1.Sample(s0_s, r3.zw).xyz;
+  r2.xyz = r4.xyz + r2.xyz;
+  r2.xyz = r2.xyz + r3.xyz;
+  r2.xyz = -r2.xyz * float3(0.25,0.25,0.25) + r1.xyz;
+  r1.xyz = r2.xyz * cb0[8].yyy + r1.xyz;
+  r2.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r2.x = dot(r2.xy, r2.xy);
+  r2.x = min(1, r2.x);
+  r2.x = cb0[8].x * r2.x;
+  r2.x = r2.x * 7 + 1;
+  r1.xyzw = r2.xxxx * r1.xyzw;
+r2.xyz = cb0[17].xyz * r1.xyz;  //    r2.xyz = saturate(cb0[17].xyz * r1.xyz);
+float3 hdrColor = r2.xyz;
+r2.xyz = saturate(r2.xyz);
+
+  r3.xyz = r2.xyz * r2.xyz;
+  r4.xyz = r3.xyz * r2.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r2.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r2.xyz = r7.xzy * r2.xzy;
+  r5.x = r8.y;
+  r5.y = r2.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r2.x = r8.z;
+  r8.y = r2.z;
+  r8.z = r3.y;
+  r2.z = r3.z;
+  r8.w = r4.y;
+  r2.w = r4.z;
+  r5.z = dot(r2.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r1.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r1.xyzw = float4(1,1,1,1) + -r1.xyzw;
+  r0.xyzw = -r0.xyzw * r1.xyzw + float4(1,1,1,1);
+  r1.xyz = saturate(r0.xyz);
+  r1.w = dot(r1.xyz, float3(0.212670997,0.715160012,0.0721689984));
+  r2.x = cb0[27].z / cb0[27].x;
+  r2.xy = float2(9.99999975e-005,-0.999899983) + r2.xx;
+  r2.x = r2.x / r2.y;
+  r3.xyzw = r2.xxxx * r1.xyzw;
+  r4.xyzw = r2.xxxx + -r1.xyzw;
+  r3.xyzw = r3.xyzw / r4.xyzw;
+  r2.y = 0.5 * r2.x;
+  r2.x = -0.5 + r2.x;
+  r2.x = r2.y / r2.x;
+  r2.x = 1 + -r2.x;
+  r2.xyzw = r2.xxxx + r3.xyzw;
+  r3.xyzw = float4(1.00010002,1.00010002,1.00010002,1.00010002) + -r1.xyzw;
+  r3.xyzw = r1.xyzw / r3.xyzw;
+  r4.xyzw = cmp(float4(0.5,0.5,0.5,0.5) < r1.xyzw);
+  r1.w = 9.99999975e-005 + r1.w;
+  r1.xyz = r1.xyz / r1.www;
+  r2.xyzw = r4.xyzw ? r2.xyzw : r3.xyzw;
+  r1.xyz = r2.www * r1.xyz;
+  r2.xyz = cb0[27].yyy * r2.xyz;
+  r1.w = 1 + -cb0[27].y;
+  r0.xyz = r1.www * r1.xyz + r2.xyz;
+  r1.x = saturate(dot(r0.xyz, float3(0.219999999,0.707000017,0.0710000023)));
+  r1.xyzw = r1.xxxx + -r0.xyzw;
+  r0.xyzw = cb0[10].xxxx * r1.xyzw + r0.xyzw;
+  r1.xyz = float3(-0.5,-0.5,-0.5) + r0.xyz;
+  r2.xy = float2(-0.5,-0.5) + w1.xy;
+  r1.w = dot(r2.xy, r2.xy);
+  r1.w = sqrt(r1.w);
+  r1.w = r1.w * 0.720000029 + -0.800000012;
+  r1.w = saturate(-1.83715463 * r1.w);
+  r2.x = r1.w * -2 + 3;
+  r1.w = r1.w * r1.w;
+  r2.y = r2.x * r1.w + -1;
+  r1.w = r2.x * r1.w;
+  r2.x = -r2.y * 0.200000003 + 1;
+  r2.x = max(1, r2.x);
+  r1.xyz = r1.xyz * r2.xxx + float3(0.5,0.5,0.5);
+  r1.xyz = r1.xyz * r1.www + -r0.xyz;
+  r1.w = 0;
+  o0.xyzw = cb0[12].yyyy * r1.xyzw + r0.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/colorgrade_0x8A303253.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0x8A303253.ps_5_0.hlsl
@@ -1,0 +1,157 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:14:19 2024
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[28];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = t0.Sample(s2_s, v2.xy).xy;
+  r0.xy = float2(-0.498039216,-0.498039216) + r0.xy;
+  r0.xy = float2(0.100000001,0.100000001) * r0.xy;
+  r0.zw = r0.xy * cb0[5].xy + v1.xy;
+  r0.xy = r0.xy * cb0[5].xy + v2.xy;
+  r0.xy = min(cb0[6].zw, r0.xy);
+  r1.xyzw = t2.Sample(s1_s, r0.xy).xyzw;
+  r1.xyzw = saturate(-r1.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r2.xyzw = min(cb0[6].xyxy, r0.zwzw);
+  r0.xy = r0.zw / cb0[5].xy;
+  r3.xyzw = cb0[3].xyxy * float4(-1.5,-1.5,1.5,-1.5) + r2.zwzw;
+  r4.xyz = t1.Sample(s0_s, r3.xy).xyz;
+  r3.xyz = t1.Sample(s0_s, r3.zw).xyz;
+  r3.xyz = r4.xyz + r3.xyz;
+  r4.xyzw = cb0[3].xyxy * float4(-1.5,1.5,1.5,1.5) + r2.xyzw;
+  r2.xyzw = t1.Sample(s0_s, r2.zw).xyzw;
+  r5.xyz = t1.Sample(s0_s, r4.xy).xyz;
+  r4.xyz = t1.Sample(s0_s, r4.zw).xyz;
+  r3.xyz = r5.xyz + r3.xyz;
+  r3.xyz = r3.xyz + r4.xyz;
+  r3.xyz = -r3.xyz * float3(0.25,0.25,0.25) + r2.xyz;
+  r3.xyz = r3.xyz * cb0[8].yyy + r2.xyz;
+  r3.xyz = float3(1,1,1) + -r3.xyz;
+  r0.zw = min(cb0[13].zw, r0.xy);
+  r4.xyz = t4.Sample(s3_s, r0.xy).xyz;
+  r0.xyz = t3.Sample(s3_s, r0.zw).xyz;
+  r0.xyz = saturate(r0.xyz);
+  r0.xyz = float3(1,1,1) + -r0.xyz;
+  r0.xyz = -r3.xyz * r0.xyz + float3(1,1,1);
+  r0.w = max(r4.y, r4.z);
+  r0.w = max(r4.x, r0.w);
+  r3.x = cmp(cb0[12].z < r0.w);
+  r0.w = cb0[12].z / r0.w;
+  r0.w = r3.x ? r0.w : 1;
+  r2.xyz = r4.xyz * r0.www + r0.xyz;
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.xyzw = r2.xyzw * r0.xxxx;
+r2.xyz = cb0[17].xyz * r0.xyz;  //    r2.xyz = saturate(cb0[17].xyz * r0.xyz);
+float3 hdrColor = r2.xyz;
+r2.xyz = saturate(r2.xyz);
+
+  r3.xyz = r2.xyz * r2.xyz;
+  r4.xyz = r3.xyz * r2.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r2.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r2.xyz = r7.xzy * r2.xzy;
+  r5.x = r8.y;
+  r5.y = r2.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r2.x = r8.z;
+  r8.y = r2.z;
+  r8.z = r3.y;
+  r2.z = r3.z;
+  r8.w = r4.y;
+  r2.w = r4.z;
+  r5.z = dot(r2.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r0.xyzw = -r1.xyzw * r0.xyzw + float4(1,1,1,1);
+  r1.xyz = saturate(r0.xyz);
+  r1.w = dot(r1.xyz, float3(0.212670997,0.715160012,0.0721689984));
+  r2.x = cb0[27].z / cb0[27].x;
+  r2.xy = float2(9.99999975e-005,-0.999899983) + r2.xx;
+  r2.x = r2.x / r2.y;
+  r3.xyzw = r2.xxxx * r1.xyzw;
+  r4.xyzw = r2.xxxx + -r1.xyzw;
+  r3.xyzw = r3.xyzw / r4.xyzw;
+  r2.y = 0.5 * r2.x;
+  r2.x = -0.5 + r2.x;
+  r2.x = r2.y / r2.x;
+  r2.x = 1 + -r2.x;
+  r2.xyzw = r2.xxxx + r3.xyzw;
+  r3.xyzw = float4(1.00010002,1.00010002,1.00010002,1.00010002) + -r1.xyzw;
+  r3.xyzw = r1.xyzw / r3.xyzw;
+  r4.xyzw = cmp(float4(0.5,0.5,0.5,0.5) < r1.xyzw);
+  r1.w = 9.99999975e-005 + r1.w;
+  r1.xyz = r1.xyz / r1.www;
+  r2.xyzw = r4.xyzw ? r2.xyzw : r3.xyzw;
+  r1.xyz = r2.www * r1.xyz;
+  r2.xyz = cb0[27].yyy * r2.xyz;
+  r1.w = 1 + -cb0[27].y;
+  r0.xyz = r1.www * r1.xyz + r2.xyz;
+  r1.xyz = float3(-0.5,-0.5,-0.5) + r0.xyz;
+  r2.xy = float2(-0.5,-0.5) + w1.xy;
+  r1.w = dot(r2.xy, r2.xy);
+  r1.w = sqrt(r1.w);
+  r1.w = r1.w * 0.720000029 + -0.800000012;
+  r1.w = saturate(-1.83715463 * r1.w);
+  r2.x = r1.w * -2 + 3;
+  r1.w = r1.w * r1.w;
+  r2.y = r2.x * r1.w + -1;
+  r1.w = r2.x * r1.w;
+  r2.x = -r2.y * 0.200000003 + 1;
+  r2.x = max(1, r2.x);
+  r1.xyz = r1.xyz * r2.xxx + float3(0.5,0.5,0.5);
+  r1.xyz = r1.xyz * r1.www + -r0.xyz;
+  r1.w = 0;
+  o0.xyzw = cb0[12].yyyy * r1.xyzw + r0.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/colorgrade_0x8B1DE268.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0x8B1DE268.ps_5_0.hlsl
@@ -1,0 +1,137 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:14:19 2024
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[28];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = t0.Sample(s2_s, v2.xy).xy;
+  r0.xy = float2(-0.498039216,-0.498039216) + r0.xy;
+  r0.xy = float2(0.100000001,0.100000001) * r0.xy;
+  r1.xyzw = r0.xyxy * cb0[5].xyxy + v1.xyxy;
+  r0.xy = r0.xy * cb0[5].xy + v2.xy;
+  r0.xy = min(cb0[6].zw, r0.xy);
+  r0.xyzw = t2.Sample(s1_s, r0.xy).xyzw;
+  r0.xyzw = saturate(-r0.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r1.xyzw = min(cb0[6].xyxy, r1.xyzw);
+  r2.xyzw = cb0[3].xyxy * float4(-1.5,-1.5,1.5,-1.5) + r1.zwzw;
+  r3.xyz = t1.Sample(s0_s, r2.xy).xyz;
+  r2.xyz = t1.Sample(s0_s, r2.zw).xyz;
+  r2.xyz = r3.xyz + r2.xyz;
+  r3.xyzw = cb0[3].xyxy * float4(-1.5,1.5,1.5,1.5) + r1.xyzw;
+  r1.xyzw = t1.Sample(s0_s, r1.zw).xyzw;
+  r4.xyz = t1.Sample(s0_s, r3.xy).xyz;
+  r3.xyz = t1.Sample(s0_s, r3.zw).xyz;
+  r2.xyz = r4.xyz + r2.xyz;
+  r2.xyz = r2.xyz + r3.xyz;
+  r2.xyz = -r2.xyz * float3(0.25,0.25,0.25) + r1.xyz;
+  r1.xyz = r2.xyz * cb0[8].yyy + r1.xyz;
+  r2.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r2.x = dot(r2.xy, r2.xy);
+  r2.x = min(1, r2.x);
+  r2.x = cb0[8].x * r2.x;
+  r2.x = r2.x * 7 + 1;
+  r1.xyzw = r2.xxxx * r1.xyzw;
+r2.xyz = cb0[17].xyz * r1.xyz;  //    r2.xyz = saturate(cb0[17].xyz * r1.xyz);
+float3 hdrColor = r2.xyz;
+r2.xyz = saturate(r2.xyz);
+
+  r3.xyz = r2.xyz * r2.xyz;
+  r4.xyz = r3.xyz * r2.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r2.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r2.xyz = r7.xzy * r2.xzy;
+  r5.x = r8.y;
+  r5.y = r2.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r2.x = r8.z;
+  r8.y = r2.z;
+  r8.z = r3.y;
+  r2.z = r3.z;
+  r8.w = r4.y;
+  r2.w = r4.z;
+  r5.z = dot(r2.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r1.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r1.xyzw = float4(1,1,1,1) + -r1.xyzw;
+  r0.xyzw = -r0.xyzw * r1.xyzw + float4(1,1,1,1);
+  r1.xyz = saturate(r0.xyz);
+  r1.w = dot(r1.xyz, float3(0.212670997,0.715160012,0.0721689984));
+  r2.x = cb0[27].z / cb0[27].x;
+  r2.xy = float2(9.99999975e-005,-0.999899983) + r2.xx;
+  r2.x = r2.x / r2.y;
+  r3.xyzw = r2.xxxx * r1.xyzw;
+  r4.xyzw = r2.xxxx + -r1.xyzw;
+  r3.xyzw = r3.xyzw / r4.xyzw;
+  r2.y = 0.5 * r2.x;
+  r2.x = -0.5 + r2.x;
+  r2.x = r2.y / r2.x;
+  r2.x = 1 + -r2.x;
+  r2.xyzw = r2.xxxx + r3.xyzw;
+  r3.xyzw = float4(1.00010002,1.00010002,1.00010002,1.00010002) + -r1.xyzw;
+  r3.xyzw = r1.xyzw / r3.xyzw;
+  r4.xyzw = cmp(float4(0.5,0.5,0.5,0.5) < r1.xyzw);
+  r1.w = 9.99999975e-005 + r1.w;
+  r1.xyz = r1.xyz / r1.www;
+  r2.xyzw = r4.xyzw ? r2.xyzw : r3.xyzw;
+  r1.xyz = r2.www * r1.xyz;
+  r2.xyz = cb0[27].yyy * r2.xyz;
+  r1.w = 1 + -cb0[27].y;
+  r0.xyz = r1.www * r1.xyz + r2.xyz;
+  r1.xyz = float3(-0.5,-0.5,-0.5) + r0.xyz;
+  r2.xy = float2(-0.5,-0.5) + w1.xy;
+  r1.w = dot(r2.xy, r2.xy);
+  r1.w = sqrt(r1.w);
+  r1.w = r1.w * 0.720000029 + -0.800000012;
+  r1.w = saturate(-1.83715463 * r1.w);
+  r2.x = r1.w * -2 + 3;
+  r1.w = r1.w * r1.w;
+  r2.y = r2.x * r1.w + -1;
+  r1.w = r2.x * r1.w;
+  r2.x = -r2.y * 0.200000003 + 1;
+  r2.x = max(1, r2.x);
+  r1.xyz = r1.xyz * r2.xxx + float3(0.5,0.5,0.5);
+  r1.xyz = r1.xyz * r1.www + -r0.xyz;
+  r1.w = 0;
+  o0.xyzw = cb0[12].yyyy * r1.xyzw + r0.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/colorgrade_0x8D6097D1.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0x8D6097D1.ps_5_0.hlsl
@@ -1,0 +1,141 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:14:21 2024
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[28];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.yz = t0.Sample(s2_s, v2.xy).xy;
+  r0.yz = float2(-0.498039216,-0.498039216) + r0.yz;
+  r0.yz = float2(0.100000001,0.100000001) * r0.yz;
+  r1.xy = r0.yz * cb0[5].xy + v1.xy;
+  r0.yz = r0.yz * cb0[5].xy + v2.xy;
+  r0.yz = min(cb0[6].zw, r0.yz);
+  r2.xyzw = t2.Sample(s1_s, r0.yz).xyzw;
+  r2.xyzw = saturate(-r2.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r0.yz = r1.xy / cb0[5].xy;
+  r1.xy = min(cb0[6].xy, r1.xy);
+  r1.xyzw = t1.Sample(s0_s, r1.xy).xyzw;
+  r0.yzw = t3.Sample(s3_s, r0.yz).xyz;
+  r3.x = max(r0.z, r0.w);
+  r3.x = max(r3.x, r0.y);
+  r3.y = cmp(cb0[12].z < r3.x);
+  r3.x = cb0[12].z / r3.x;
+  r3.x = r3.y ? r3.x : 1;
+  r1.xyz = r0.yzw * r3.xxx + r1.xyz;
+  r0.xyzw = r1.xyzw * r0.xxxx;
+r1.xyz = cb0[17].xyz * r0.xyz;  //    r1.xyz = saturate(cb0[17].xyz * r0.xyz);
+float3 hdrColor = r1.xyz;
+r1.xyz = saturate(r1.xyz);
+
+  r3.xyz = r1.xyz * r1.xyz;
+  r4.xyz = r3.xyz * r1.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r1.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r1.xyz = r7.xzy * r1.xzy;
+  r5.x = r8.y;
+  r5.y = r1.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r1.x = r8.z;
+  r8.y = r1.z;
+  r8.z = r3.y;
+  r1.z = r3.z;
+  r8.w = r4.y;
+  r1.w = r4.z;
+  r5.z = dot(r1.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r0.xyzw = -r2.xyzw * r0.xyzw + float4(1,1,1,1);
+  r1.xyz = saturate(r0.xyz);
+  r1.w = dot(r1.xyz, float3(0.212670997,0.715160012,0.0721689984));
+  r2.x = cb0[27].z / cb0[27].x;
+  r2.xy = float2(9.99999975e-005,-0.999899983) + r2.xx;
+  r2.x = r2.x / r2.y;
+  r3.xyzw = r2.xxxx * r1.xyzw;
+  r4.xyzw = r2.xxxx + -r1.xyzw;
+  r3.xyzw = r3.xyzw / r4.xyzw;
+  r2.y = 0.5 * r2.x;
+  r2.x = -0.5 + r2.x;
+  r2.x = r2.y / r2.x;
+  r2.x = 1 + -r2.x;
+  r2.xyzw = r2.xxxx + r3.xyzw;
+  r3.xyzw = float4(1.00010002,1.00010002,1.00010002,1.00010002) + -r1.xyzw;
+  r3.xyzw = r1.xyzw / r3.xyzw;
+  r4.xyzw = cmp(float4(0.5,0.5,0.5,0.5) < r1.xyzw);
+  r1.w = 9.99999975e-005 + r1.w;
+  r1.xyz = r1.xyz / r1.www;
+  r2.xyzw = r4.xyzw ? r2.xyzw : r3.xyzw;
+  r1.xyz = r2.www * r1.xyz;
+  r2.xyz = cb0[27].yyy * r2.xyz;
+  r1.w = 1 + -cb0[27].y;
+  r0.xyz = r1.www * r1.xyz + r2.xyz;
+  r1.x = saturate(dot(r0.xyz, float3(0.219999999,0.707000017,0.0710000023)));
+  r1.xyzw = r1.xxxx + -r0.xyzw;
+  r0.xyzw = cb0[10].xxxx * r1.xyzw + r0.xyzw;
+  r1.xyz = float3(-0.5,-0.5,-0.5) + r0.xyz;
+  r2.xy = float2(-0.5,-0.5) + w1.xy;
+  r1.w = dot(r2.xy, r2.xy);
+  r1.w = sqrt(r1.w);
+  r1.w = r1.w * 0.720000029 + -0.800000012;
+  r1.w = saturate(-1.83715463 * r1.w);
+  r2.x = r1.w * -2 + 3;
+  r1.w = r1.w * r1.w;
+  r2.y = r2.x * r1.w + -1;
+  r1.w = r2.x * r1.w;
+  r2.x = -r2.y * 0.200000003 + 1;
+  r2.x = max(1, r2.x);
+  r1.xyz = r1.xyz * r2.xxx + float3(0.5,0.5,0.5);
+  r1.xyz = r1.xyz * r1.www + -r0.xyz;
+  r1.w = 0;
+  o0.xyzw = cb0[12].yyyy * r1.xyzw + r0.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/colorgrade_0x8D6C34A5.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0x8D6C34A5.ps_5_0.hlsl
@@ -1,0 +1,117 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:14:21 2024
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[22];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.yz = t0.Sample(s2_s, v2.xy).xy;
+  r0.yz = float2(-0.498039216,-0.498039216) + r0.yz;
+  r0.yz = float2(0.100000001,0.100000001) * r0.yz;
+  r1.xy = r0.yz * cb0[5].xy + v1.xy;
+  r0.yz = r0.yz * cb0[5].xy + v2.xy;
+  r0.yz = min(cb0[6].zw, r0.yz);
+  r2.xyzw = t2.Sample(s1_s, r0.yz).xyzw;
+  r2.xyzw = saturate(-r2.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r0.yz = r1.xy / cb0[5].xy;
+  r1.xy = min(cb0[6].xy, r1.xy);
+  r1.xyzw = t1.Sample(s0_s, r1.xy).xyzw;
+  r0.yz = min(cb0[13].zw, r0.yz);
+  r0.yzw = t3.Sample(s3_s, r0.yz).xyz;
+  r0.yzw = saturate(r0.yzw);
+  r0.yzw = float3(1,1,1) + -r0.yzw;
+  r3.xyz = float3(1,1,1) + -r1.xyz;
+  r1.xyz = -r3.xyz * r0.yzw + float3(1,1,1);
+  r0.xyzw = r1.xyzw * r0.xxxx;
+r1.xyz = cb0[17].xyz * r0.xyz;  //    r1.xyz = saturate(cb0[17].xyz * r0.xyz);
+float3 hdrColor = r1.xyz;
+r1.xyz = saturate(r1.xyz);
+
+  r3.xyz = r1.xyz * r1.xyz;
+  r4.xyz = r3.xyz * r1.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r1.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r1.xyz = r7.xzy * r1.xzy;
+  r5.x = r8.y;
+  r5.y = r1.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r1.x = r8.z;
+  r8.y = r1.z;
+  r8.z = r3.y;
+  r1.z = r3.z;
+  r8.w = r4.y;
+  r1.w = r4.z;
+  r5.z = dot(r1.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r1.x = saturate(dot(r0.xyz, float3(0.219999999,0.707000017,0.0710000023)));
+  r1.xyzw = r1.xxxx + -r0.xyzw;
+  r0.xyzw = cb0[10].xxxx * r1.xyzw + r0.xyzw;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r1.xyzw = -r2.xyzw * r0.xyzw + float4(1,1,1,1);
+  r0.xyz = -r2.xyz * r0.xyz + float3(0.5,0.5,0.5);
+  r2.xy = float2(-0.5,-0.5) + w1.xy;
+  r0.w = dot(r2.xy, r2.xy);
+  r0.w = sqrt(r0.w);
+  r0.w = r0.w * 0.720000029 + -0.800000012;
+  r0.w = saturate(-1.83715463 * r0.w);
+  r2.x = r0.w * -2 + 3;
+  r0.w = r0.w * r0.w;
+  r2.y = r2.x * r0.w + -1;
+  r0.w = r2.x * r0.w;
+  r2.x = -r2.y * 0.200000003 + 1;
+  r2.x = max(1, r2.x);
+  r0.xyz = r0.xyz * r2.xxx + float3(0.5,0.5,0.5);
+  r0.xyz = r0.xyz * r0.www + -r1.xyz;
+  r0.w = 0;
+  o0.xyzw = cb0[12].yyyy * r0.xyzw + r1.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/colorgrade_0x8EC5798A.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0x8EC5798A.ps_5_0.hlsl
@@ -1,0 +1,134 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:14:23 2024
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[22];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = t0.Sample(s2_s, v2.xy).xy;
+  r0.xy = float2(-0.498039216,-0.498039216) + r0.xy;
+  r0.xy = float2(0.100000001,0.100000001) * r0.xy;
+  r0.zw = r0.xy * cb0[5].xy + v1.xy;
+  r0.xy = r0.xy * cb0[5].xy + v2.xy;
+  r0.xy = min(cb0[6].zw, r0.xy);
+  r1.xyzw = t2.Sample(s1_s, r0.xy).xyzw;
+  r1.xyzw = saturate(-r1.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r2.xyzw = min(cb0[6].xyxy, r0.zwzw);
+  r0.xy = r0.zw / cb0[5].xy;
+  r3.xyzw = cb0[3].xyxy * float4(-1.5,-1.5,1.5,-1.5) + r2.zwzw;
+  r4.xyz = t1.Sample(s0_s, r3.xy).xyz;
+  r3.xyz = t1.Sample(s0_s, r3.zw).xyz;
+  r3.xyz = r4.xyz + r3.xyz;
+  r4.xyzw = cb0[3].xyxy * float4(-1.5,1.5,1.5,1.5) + r2.xyzw;
+  r2.xyzw = t1.Sample(s0_s, r2.zw).xyzw;
+  r5.xyz = t1.Sample(s0_s, r4.xy).xyz;
+  r4.xyz = t1.Sample(s0_s, r4.zw).xyz;
+  r3.xyz = r5.xyz + r3.xyz;
+  r3.xyz = r3.xyz + r4.xyz;
+  r3.xyz = -r3.xyz * float3(0.25,0.25,0.25) + r2.xyz;
+  r3.xyz = r3.xyz * cb0[8].yyy + r2.xyz;
+  r3.xyz = float3(1,1,1) + -r3.xyz;
+  r0.zw = min(cb0[13].zw, r0.xy);
+  r4.xyz = t4.Sample(s3_s, r0.xy).xyz;
+  r0.xyz = t3.Sample(s3_s, r0.zw).xyz;
+  r0.xyz = saturate(r0.xyz);
+  r0.xyz = float3(1,1,1) + -r0.xyz;
+  r0.xyz = -r3.xyz * r0.xyz + float3(1,1,1);
+  r0.w = max(r4.y, r4.z);
+  r0.w = max(r4.x, r0.w);
+  r3.x = cmp(cb0[12].z < r0.w);
+  r0.w = cb0[12].z / r0.w;
+  r0.w = r3.x ? r0.w : 1;
+  r2.xyz = r4.xyz * r0.www + r0.xyz;
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.xyzw = r2.xyzw * r0.xxxx;
+r2.xyz = cb0[17].xyz * r0.xyz;  //    r2.xyz = saturate(cb0[17].xyz * r0.xyz);
+float3 hdrColor = r2.xyz;
+r2.xyz = saturate(r2.xyz);
+
+  r3.xyz = r2.xyz * r2.xyz;
+  r4.xyz = r3.xyz * r2.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r2.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r2.xyz = r7.xzy * r2.xzy;
+  r5.x = r8.y;
+  r5.y = r2.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r2.x = r8.z;
+  r8.y = r2.z;
+  r8.z = r3.y;
+  r2.z = r3.z;
+  r8.w = r4.y;
+  r2.w = r4.z;
+  r5.z = dot(r2.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r2.xyzw = -r1.xyzw * r0.xyzw + float4(1,1,1,1);
+  r0.xyz = -r1.xyz * r0.xyz + float3(0.5,0.5,0.5);
+  r1.xy = float2(-0.5,-0.5) + w1.xy;
+  r0.w = dot(r1.xy, r1.xy);
+  r0.w = sqrt(r0.w);
+  r0.w = r0.w * 0.720000029 + -0.800000012;
+  r0.w = saturate(-1.83715463 * r0.w);
+  r1.x = r0.w * -2 + 3;
+  r0.w = r0.w * r0.w;
+  r1.y = r1.x * r0.w + -1;
+  r0.w = r1.x * r0.w;
+  r1.x = -r1.y * 0.200000003 + 1;
+  r1.x = max(1, r1.x);
+  r0.xyz = r0.xyz * r1.xxx + float3(0.5,0.5,0.5);
+  r0.xyz = r0.xyz * r0.www + -r2.xyz;
+  r0.w = 0;
+  o0.xyzw = cb0[12].yyyy * r0.xyzw + r2.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/colorgrade_0x9AC0DEEF.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0x9AC0DEEF.ps_5_0.hlsl
@@ -1,0 +1,137 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:14:34 2024
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[28];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.yz = t0.Sample(s2_s, v2.xy).xy;
+  r0.yz = float2(-0.498039216,-0.498039216) + r0.yz;
+  r0.yz = float2(0.100000001,0.100000001) * r0.yz;
+  r1.xy = r0.yz * cb0[5].xy + v1.xy;
+  r0.yz = r0.yz * cb0[5].xy + v2.xy;
+  r0.yz = min(cb0[6].zw, r0.yz);
+  r2.xyzw = t2.Sample(s1_s, r0.yz).xyzw;
+  r2.xyzw = saturate(-r2.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r0.yz = r1.xy / cb0[5].xy;
+  r1.xy = min(cb0[6].xy, r1.xy);
+  r1.xyzw = t1.Sample(s0_s, r1.xy).xyzw;
+  r0.yz = min(cb0[13].zw, r0.yz);
+  r0.yzw = t3.Sample(s3_s, r0.yz).xyz;
+  r0.yzw = saturate(r0.yzw);
+  r0.yzw = float3(1,1,1) + -r0.yzw;
+  r3.xyz = float3(1,1,1) + -r1.xyz;
+  r1.xyz = -r3.xyz * r0.yzw + float3(1,1,1);
+  r0.xyzw = r1.xyzw * r0.xxxx;
+r1.xyz = cb0[17].xyz * r0.xyz;  //    r1.xyz = saturate(cb0[17].xyz * r0.xyz);
+float3 hdrColor = r1.xyz;
+r1.xyz = saturate(r1.xyz);
+
+  r3.xyz = r1.xyz * r1.xyz;
+  r4.xyz = r3.xyz * r1.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r1.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r1.xyz = r7.xzy * r1.xzy;
+  r5.x = r8.y;
+  r5.y = r1.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r1.x = r8.z;
+  r8.y = r1.z;
+  r8.z = r3.y;
+  r1.z = r3.z;
+  r8.w = r4.y;
+  r1.w = r4.z;
+  r5.z = dot(r1.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r0.xyzw = -r2.xyzw * r0.xyzw + float4(1,1,1,1);
+  r1.xyz = saturate(r0.xyz);
+  r1.w = dot(r1.xyz, float3(0.212670997,0.715160012,0.0721689984));
+  r2.x = cb0[27].z / cb0[27].x;
+  r2.xy = float2(9.99999975e-005,-0.999899983) + r2.xx;
+  r2.x = r2.x / r2.y;
+  r3.xyzw = r2.xxxx * r1.xyzw;
+  r4.xyzw = r2.xxxx + -r1.xyzw;
+  r3.xyzw = r3.xyzw / r4.xyzw;
+  r2.y = 0.5 * r2.x;
+  r2.x = -0.5 + r2.x;
+  r2.x = r2.y / r2.x;
+  r2.x = 1 + -r2.x;
+  r2.xyzw = r2.xxxx + r3.xyzw;
+  r3.xyzw = float4(1.00010002,1.00010002,1.00010002,1.00010002) + -r1.xyzw;
+  r3.xyzw = r1.xyzw / r3.xyzw;
+  r4.xyzw = cmp(float4(0.5,0.5,0.5,0.5) < r1.xyzw);
+  r1.w = 9.99999975e-005 + r1.w;
+  r1.xyz = r1.xyz / r1.www;
+  r2.xyzw = r4.xyzw ? r2.xyzw : r3.xyzw;
+  r1.xyz = r2.www * r1.xyz;
+  r2.xyz = cb0[27].yyy * r2.xyz;
+  r1.w = 1 + -cb0[27].y;
+  r0.xyz = r1.www * r1.xyz + r2.xyz;
+  r1.xyz = float3(-0.5,-0.5,-0.5) + r0.xyz;
+  r2.xy = float2(-0.5,-0.5) + w1.xy;
+  r1.w = dot(r2.xy, r2.xy);
+  r1.w = sqrt(r1.w);
+  r1.w = r1.w * 0.720000029 + -0.800000012;
+  r1.w = saturate(-1.83715463 * r1.w);
+  r2.x = r1.w * -2 + 3;
+  r1.w = r1.w * r1.w;
+  r2.y = r2.x * r1.w + -1;
+  r1.w = r2.x * r1.w;
+  r2.x = -r2.y * 0.200000003 + 1;
+  r2.x = max(1, r2.x);
+  r1.xyz = r1.xyz * r2.xxx + float3(0.5,0.5,0.5);
+  r1.xyz = r1.xyz * r1.www + -r0.xyz;
+  r1.w = 0;
+  o0.xyzw = cb0[12].yyyy * r1.xyzw + r0.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/colorgrade_0x9B5CC768.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0x9B5CC768.ps_5_0.hlsl
@@ -1,0 +1,146 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:14:35 2024
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[28];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = t0.Sample(s2_s, v2.xy).xy;
+  r0.xy = float2(-0.498039216,-0.498039216) + r0.xy;
+  r0.xy = float2(0.100000001,0.100000001) * r0.xy;
+  r0.zw = r0.xy * cb0[5].xy + v1.xy;
+  r0.xy = r0.xy * cb0[5].xy + v2.xy;
+  r0.xy = min(cb0[6].zw, r0.xy);
+  r1.xyzw = t2.Sample(s1_s, r0.xy).xyzw;
+  r1.xyzw = saturate(-r1.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r0.xy = r0.zw / cb0[5].xy;
+  r0.zw = min(cb0[6].xy, r0.zw);
+  r2.xyzw = t1.Sample(s0_s, r0.zw).xyzw;
+  r0.zw = min(cb0[13].zw, r0.xy);
+  r3.xyz = t4.Sample(s3_s, r0.xy).xyz;
+  r0.xyz = t3.Sample(s3_s, r0.zw).xyz;
+  r0.xyz = saturate(r0.xyz);
+  r0.xyz = float3(1,1,1) + -r0.xyz;
+  r4.xyz = float3(1,1,1) + -r2.xyz;
+  r0.xyz = -r4.xyz * r0.xyz + float3(1,1,1);
+  r0.w = max(r3.y, r3.z);
+  r0.w = max(r3.x, r0.w);
+  r3.w = cmp(cb0[12].z < r0.w);
+  r0.w = cb0[12].z / r0.w;
+  r0.w = r3.w ? r0.w : 1;
+  r2.xyz = r3.xyz * r0.www + r0.xyz;
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.xyzw = r2.xyzw * r0.xxxx;
+r2.xyz = cb0[17].xyz * r0.xyz;  //    r2.xyz = saturate(cb0[17].xyz * r0.xyz);
+float3 hdrColor = r2.xyz;
+r2.xyz = saturate(r2.xyz);
+
+  r3.xyz = r2.xyz * r2.xyz;
+  r4.xyz = r3.xyz * r2.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r2.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r2.xyz = r7.xzy * r2.xzy;
+  r5.x = r8.y;
+  r5.y = r2.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r2.x = r8.z;
+  r8.y = r2.z;
+  r8.z = r3.y;
+  r2.z = r3.z;
+  r8.w = r4.y;
+  r2.w = r4.z;
+  r5.z = dot(r2.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r0.xyzw = -r1.xyzw * r0.xyzw + float4(1,1,1,1);
+  r1.xyz = saturate(r0.xyz);
+  r1.w = dot(r1.xyz, float3(0.212670997,0.715160012,0.0721689984));
+  r2.x = cb0[27].z / cb0[27].x;
+  r2.xy = float2(9.99999975e-005,-0.999899983) + r2.xx;
+  r2.x = r2.x / r2.y;
+  r3.xyzw = r2.xxxx * r1.xyzw;
+  r4.xyzw = r2.xxxx + -r1.xyzw;
+  r3.xyzw = r3.xyzw / r4.xyzw;
+  r2.y = 0.5 * r2.x;
+  r2.x = -0.5 + r2.x;
+  r2.x = r2.y / r2.x;
+  r2.x = 1 + -r2.x;
+  r2.xyzw = r2.xxxx + r3.xyzw;
+  r3.xyzw = float4(1.00010002,1.00010002,1.00010002,1.00010002) + -r1.xyzw;
+  r3.xyzw = r1.xyzw / r3.xyzw;
+  r4.xyzw = cmp(float4(0.5,0.5,0.5,0.5) < r1.xyzw);
+  r1.w = 9.99999975e-005 + r1.w;
+  r1.xyz = r1.xyz / r1.www;
+  r2.xyzw = r4.xyzw ? r2.xyzw : r3.xyzw;
+  r1.xyz = r2.www * r1.xyz;
+  r2.xyz = cb0[27].yyy * r2.xyz;
+  r1.w = 1 + -cb0[27].y;
+  r0.xyz = r1.www * r1.xyz + r2.xyz;
+  r1.xyz = float3(-0.5,-0.5,-0.5) + r0.xyz;
+  r2.xy = float2(-0.5,-0.5) + w1.xy;
+  r1.w = dot(r2.xy, r2.xy);
+  r1.w = sqrt(r1.w);
+  r1.w = r1.w * 0.720000029 + -0.800000012;
+  r1.w = saturate(-1.83715463 * r1.w);
+  r2.x = r1.w * -2 + 3;
+  r1.w = r1.w * r1.w;
+  r2.y = r2.x * r1.w + -1;
+  r1.w = r2.x * r1.w;
+  r2.x = -r2.y * 0.200000003 + 1;
+  r2.x = max(1, r2.x);
+  r1.xyz = r1.xyz * r2.xxx + float3(0.5,0.5,0.5);
+  r1.xyz = r1.xyz * r1.www + -r0.xyz;
+  r1.w = 0;
+  o0.xyzw = cb0[12].yyyy * r1.xyzw + r0.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/colorgrade_0x9DA86DCE.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0x9DA86DCE.ps_5_0.hlsl
@@ -1,0 +1,125 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:14:37 2024
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[22];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = t0.Sample(s2_s, v2.xy).xy;
+  r0.xy = float2(-0.498039216,-0.498039216) + r0.xy;
+  r0.xy = float2(0.100000001,0.100000001) * r0.xy;
+  r0.zw = r0.xy * cb0[5].xy + v1.xy;
+  r0.xy = r0.xy * cb0[5].xy + v2.xy;
+  r0.xy = min(cb0[6].zw, r0.xy);
+  r1.xyzw = t2.Sample(s1_s, r0.xy).xyzw;
+  r1.xyzw = saturate(-r1.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r2.xyzw = min(cb0[6].xyxy, r0.zwzw);
+  r0.xy = r0.zw / cb0[5].xy;
+  r0.xy = min(cb0[13].zw, r0.xy);
+  r0.xyz = t3.Sample(s3_s, r0.xy).xyz;
+  r0.xyz = saturate(r0.xyz);
+  r0.xyz = float3(1,1,1) + -r0.xyz;
+  r3.xyzw = cb0[3].xyxy * float4(-1.5,-1.5,1.5,-1.5) + r2.zwzw;
+  r4.xyz = t1.Sample(s0_s, r3.xy).xyz;
+  r3.xyz = t1.Sample(s0_s, r3.zw).xyz;
+  r3.xyz = r4.xyz + r3.xyz;
+  r4.xyzw = cb0[3].xyxy * float4(-1.5,1.5,1.5,1.5) + r2.xyzw;
+  r2.xyzw = t1.Sample(s0_s, r2.zw).xyzw;
+  r5.xyz = t1.Sample(s0_s, r4.xy).xyz;
+  r4.xyz = t1.Sample(s0_s, r4.zw).xyz;
+  r3.xyz = r5.xyz + r3.xyz;
+  r3.xyz = r3.xyz + r4.xyz;
+  r3.xyz = -r3.xyz * float3(0.25,0.25,0.25) + r2.xyz;
+  r3.xyz = r3.xyz * cb0[8].yyy + r2.xyz;
+  r3.xyz = float3(1,1,1) + -r3.xyz;
+  r2.xyz = -r3.xyz * r0.xyz + float3(1,1,1);
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.xyzw = r2.xyzw * r0.xxxx;
+r2.xyz = cb0[17].xyz * r0.xyz;  //    r2.xyz = saturate(cb0[17].xyz * r0.xyz);
+float3 hdrColor = r2.xyz;
+r2.xyz = saturate(r2.xyz);
+
+  r3.xyz = r2.xyz * r2.xyz;
+  r4.xyz = r3.xyz * r2.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r2.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r2.xyz = r7.xzy * r2.xzy;
+  r5.x = r8.y;
+  r5.y = r2.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r2.x = r8.z;
+  r8.y = r2.z;
+  r8.z = r3.y;
+  r2.z = r3.z;
+  r8.w = r4.y;
+  r2.w = r4.z;
+  r5.z = dot(r2.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r2.xyzw = -r1.xyzw * r0.xyzw + float4(1,1,1,1);
+  r0.xyz = -r1.xyz * r0.xyz + float3(0.5,0.5,0.5);
+  r1.xy = float2(-0.5,-0.5) + w1.xy;
+  r0.w = dot(r1.xy, r1.xy);
+  r0.w = sqrt(r0.w);
+  r0.w = r0.w * 0.720000029 + -0.800000012;
+  r0.w = saturate(-1.83715463 * r0.w);
+  r1.x = r0.w * -2 + 3;
+  r0.w = r0.w * r0.w;
+  r1.y = r1.x * r0.w + -1;
+  r0.w = r1.x * r0.w;
+  r1.x = -r1.y * 0.200000003 + 1;
+  r1.x = max(1, r1.x);
+  r0.xyz = r0.xyz * r1.xxx + float3(0.5,0.5,0.5);
+  r0.xyz = r0.xyz * r0.www + -r2.xyz;
+  r0.w = 0;
+  o0.xyzw = cb0[12].yyyy * r0.xyzw + r2.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/colorgrade_0xA6488EB2.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0xA6488EB2.ps_5_0.hlsl
@@ -1,0 +1,129 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:14:45 2024
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[28];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.yz = t0.Sample(s2_s, v2.xy).xy;
+  r0.yz = float2(-0.498039216,-0.498039216) + r0.yz;
+  r0.yz = float2(0.100000001,0.100000001) * r0.yz;
+  r1.xy = r0.yz * cb0[5].xy + v1.xy;
+  r0.yz = r0.yz * cb0[5].xy + v2.xy;
+  r0.yz = min(cb0[6].zw, r0.yz);
+  r2.xyzw = t2.Sample(s1_s, r0.yz).xyzw;
+  r2.xyzw = saturate(-r2.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r0.yz = min(cb0[6].xy, r1.xy);
+  r1.xyzw = t1.Sample(s0_s, r0.yz).xyzw;
+  r0.xyzw = r1.xyzw * r0.xxxx;
+r1.xyz = cb0[17].xyz * r0.xyz;  //    r1.xyz = saturate(cb0[17].xyz * r0.xyz);
+float3 hdrColor = r1.xyz;
+r1.xyz = saturate(r1.xyz);
+
+  r3.xyz = r1.xyz * r1.xyz;
+  r4.xyz = r3.xyz * r1.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r1.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r1.xyz = r7.xzy * r1.xzy;
+  r5.x = r8.y;
+  r5.y = r1.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r1.x = r8.z;
+  r8.y = r1.z;
+  r8.z = r3.y;
+  r1.z = r3.z;
+  r8.w = r4.y;
+  r1.w = r4.z;
+  r5.z = dot(r1.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r0.xyzw = -r2.xyzw * r0.xyzw + float4(1,1,1,1);
+  r1.xyz = saturate(r0.xyz);
+  r1.w = dot(r1.xyz, float3(0.212670997,0.715160012,0.0721689984));
+  r2.x = cb0[27].z / cb0[27].x;
+  r2.xy = float2(9.99999975e-005,-0.999899983) + r2.xx;
+  r2.x = r2.x / r2.y;
+  r3.xyzw = r2.xxxx * r1.xyzw;
+  r4.xyzw = r2.xxxx + -r1.xyzw;
+  r3.xyzw = r3.xyzw / r4.xyzw;
+  r2.y = 0.5 * r2.x;
+  r2.x = -0.5 + r2.x;
+  r2.x = r2.y / r2.x;
+  r2.x = 1 + -r2.x;
+  r2.xyzw = r2.xxxx + r3.xyzw;
+  r3.xyzw = float4(1.00010002,1.00010002,1.00010002,1.00010002) + -r1.xyzw;
+  r3.xyzw = r1.xyzw / r3.xyzw;
+  r4.xyzw = cmp(float4(0.5,0.5,0.5,0.5) < r1.xyzw);
+  r1.w = 9.99999975e-005 + r1.w;
+  r1.xyz = r1.xyz / r1.www;
+  r2.xyzw = r4.xyzw ? r2.xyzw : r3.xyzw;
+  r1.xyz = r2.www * r1.xyz;
+  r2.xyz = cb0[27].yyy * r2.xyz;
+  r1.w = 1 + -cb0[27].y;
+  r0.xyz = r1.www * r1.xyz + r2.xyz;
+  r1.x = saturate(dot(r0.xyz, float3(0.219999999,0.707000017,0.0710000023)));
+  r1.xyzw = r1.xxxx + -r0.xyzw;
+  r0.xyzw = cb0[10].xxxx * r1.xyzw + r0.xyzw;
+  r1.xyz = float3(-0.5,-0.5,-0.5) + r0.xyz;
+  r2.xy = float2(-0.5,-0.5) + w1.xy;
+  r1.w = dot(r2.xy, r2.xy);
+  r1.w = sqrt(r1.w);
+  r1.w = r1.w * 0.720000029 + -0.800000012;
+  r1.w = saturate(-1.83715463 * r1.w);
+  r2.x = r1.w * -2 + 3;
+  r1.w = r1.w * r1.w;
+  r2.y = r2.x * r1.w + -1;
+  r1.w = r2.x * r1.w;
+  r2.x = -r2.y * 0.200000003 + 1;
+  r2.x = max(1, r2.x);
+  r1.xyz = r1.xyz * r2.xxx + float3(0.5,0.5,0.5);
+  r1.xyz = r1.xyz * r1.www + -r0.xyz;
+  r1.w = 0;
+  o0.xyzw = cb0[12].yyyy * r1.xyzw + r0.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/colorgrade_0xABD8D6B7.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0xABD8D6B7.ps_5_0.hlsl
@@ -1,0 +1,128 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:14:51 2024
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[22];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = t0.Sample(s2_s, v2.xy).xy;
+  r0.xy = float2(-0.498039216,-0.498039216) + r0.xy;
+  r0.xy = float2(0.100000001,0.100000001) * r0.xy;
+  r0.zw = r0.xy * cb0[5].xy + v1.xy;
+  r0.xy = r0.xy * cb0[5].xy + v2.xy;
+  r0.xy = min(cb0[6].zw, r0.xy);
+  r1.xyzw = t2.Sample(s1_s, r0.xy).xyzw;
+  r1.xyzw = saturate(-r1.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r2.xyzw = min(cb0[6].xyxy, r0.zwzw);
+  r0.xy = r0.zw / cb0[5].xy;
+  r0.xy = min(cb0[13].zw, r0.xy);
+  r0.xyz = t3.Sample(s3_s, r0.xy).xyz;
+  r0.xyz = saturate(r0.xyz);
+  r0.xyz = float3(1,1,1) + -r0.xyz;
+  r3.xyzw = cb0[3].xyxy * float4(-1.5,-1.5,1.5,-1.5) + r2.zwzw;
+  r4.xyz = t1.Sample(s0_s, r3.xy).xyz;
+  r3.xyz = t1.Sample(s0_s, r3.zw).xyz;
+  r3.xyz = r4.xyz + r3.xyz;
+  r4.xyzw = cb0[3].xyxy * float4(-1.5,1.5,1.5,1.5) + r2.xyzw;
+  r2.xyzw = t1.Sample(s0_s, r2.zw).xyzw;
+  r5.xyz = t1.Sample(s0_s, r4.xy).xyz;
+  r4.xyz = t1.Sample(s0_s, r4.zw).xyz;
+  r3.xyz = r5.xyz + r3.xyz;
+  r3.xyz = r3.xyz + r4.xyz;
+  r3.xyz = -r3.xyz * float3(0.25,0.25,0.25) + r2.xyz;
+  r3.xyz = r3.xyz * cb0[8].yyy + r2.xyz;
+  r3.xyz = float3(1,1,1) + -r3.xyz;
+  r2.xyz = -r3.xyz * r0.xyz + float3(1,1,1);
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.xyzw = r2.xyzw * r0.xxxx;
+r2.xyz = cb0[17].xyz * r0.xyz;  //    r2.xyz = saturate(cb0[17].xyz * r0.xyz);
+float3 hdrColor = r2.xyz;
+r2.xyz = saturate(r2.xyz);
+
+  r3.xyz = r2.xyz * r2.xyz;
+  r4.xyz = r3.xyz * r2.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r2.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r2.xyz = r7.xzy * r2.xzy;
+  r5.x = r8.y;
+  r5.y = r2.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r2.x = r8.z;
+  r8.y = r2.z;
+  r8.z = r3.y;
+  r2.z = r3.z;
+  r8.w = r4.y;
+  r2.w = r4.z;
+  r5.z = dot(r2.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r2.x = saturate(dot(r0.xyz, float3(0.219999999,0.707000017,0.0710000023)));
+  r2.xyzw = r2.xxxx + -r0.xyzw;
+  r0.xyzw = cb0[10].xxxx * r2.xyzw + r0.xyzw;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r2.xyzw = -r1.xyzw * r0.xyzw + float4(1,1,1,1);
+  r0.xyz = -r1.xyz * r0.xyz + float3(0.5,0.5,0.5);
+  r1.xy = float2(-0.5,-0.5) + w1.xy;
+  r0.w = dot(r1.xy, r1.xy);
+  r0.w = sqrt(r0.w);
+  r0.w = r0.w * 0.720000029 + -0.800000012;
+  r0.w = saturate(-1.83715463 * r0.w);
+  r1.x = r0.w * -2 + 3;
+  r0.w = r0.w * r0.w;
+  r1.y = r1.x * r0.w + -1;
+  r0.w = r1.x * r0.w;
+  r1.x = -r1.y * 0.200000003 + 1;
+  r1.x = max(1, r1.x);
+  r0.xyz = r0.xyz * r1.xxx + float3(0.5,0.5,0.5);
+  r0.xyz = r0.xyz * r0.www + -r2.xyz;
+  r0.w = 0;
+  o0.xyzw = cb0[12].yyyy * r0.xyzw + r2.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/colorgrade_0xB24C1A54.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0xB24C1A54.ps_5_0.hlsl
@@ -1,0 +1,114 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:14:57 2024
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[22];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = t0.Sample(s2_s, v2.xy).xy;
+  r0.xy = float2(-0.498039216,-0.498039216) + r0.xy;
+  r0.xy = float2(0.100000001,0.100000001) * r0.xy;
+  r1.xyzw = r0.xyxy * cb0[5].xyxy + v1.xyxy;
+  r0.xy = r0.xy * cb0[5].xy + v2.xy;
+  r0.xy = min(cb0[6].zw, r0.xy);
+  r0.xyzw = t2.Sample(s1_s, r0.xy).xyzw;
+  r0.xyzw = saturate(-r0.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r1.xyzw = min(cb0[6].xyxy, r1.xyzw);
+  r2.xyzw = cb0[3].xyxy * float4(-1.5,-1.5,1.5,-1.5) + r1.zwzw;
+  r3.xyz = t1.Sample(s0_s, r2.xy).xyz;
+  r2.xyz = t1.Sample(s0_s, r2.zw).xyz;
+  r2.xyz = r3.xyz + r2.xyz;
+  r3.xyzw = cb0[3].xyxy * float4(-1.5,1.5,1.5,1.5) + r1.xyzw;
+  r1.xyzw = t1.Sample(s0_s, r1.zw).xyzw;
+  r4.xyz = t1.Sample(s0_s, r3.xy).xyz;
+  r3.xyz = t1.Sample(s0_s, r3.zw).xyz;
+  r2.xyz = r4.xyz + r2.xyz;
+  r2.xyz = r2.xyz + r3.xyz;
+  r2.xyz = -r2.xyz * float3(0.25,0.25,0.25) + r1.xyz;
+  r1.xyz = r2.xyz * cb0[8].yyy + r1.xyz;
+  r2.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r2.x = dot(r2.xy, r2.xy);
+  r2.x = min(1, r2.x);
+  r2.x = cb0[8].x * r2.x;
+  r2.x = r2.x * 7 + 1;
+  r1.xyzw = r2.xxxx * r1.xyzw;
+r2.xyz = cb0[17].xyz * r1.xyz;  //    r2.xyz = saturate(cb0[17].xyz * r1.xyz);
+float3 hdrColor = r2.xyz;
+r2.xyz = saturate(r2.xyz);
+
+  r3.xyz = r2.xyz * r2.xyz;
+  r4.xyz = r3.xyz * r2.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r2.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r2.xyz = r7.xzy * r2.xzy;
+  r5.x = r8.y;
+  r5.y = r2.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r2.x = r8.z;
+  r8.y = r2.z;
+  r8.z = r3.y;
+  r2.z = r3.z;
+  r8.w = r4.y;
+  r2.w = r4.z;
+  r5.z = dot(r2.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r1.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r1.xyzw = float4(1,1,1,1) + -r1.xyzw;
+  r2.xyzw = -r0.xyzw * r1.xyzw + float4(1,1,1,1);
+  r0.xyz = -r0.xyz * r1.xyz + float3(0.5,0.5,0.5);
+  r1.xy = float2(-0.5,-0.5) + w1.xy;
+  r0.w = dot(r1.xy, r1.xy);
+  r0.w = sqrt(r0.w);
+  r0.w = r0.w * 0.720000029 + -0.800000012;
+  r0.w = saturate(-1.83715463 * r0.w);
+  r1.x = r0.w * -2 + 3;
+  r0.w = r0.w * r0.w;
+  r1.y = r1.x * r0.w + -1;
+  r0.w = r1.x * r0.w;
+  r1.x = -r1.y * 0.200000003 + 1;
+  r1.x = max(1, r1.x);
+  r0.xyz = r0.xyz * r1.xxx + float3(0.5,0.5,0.5);
+  r0.xyz = r0.xyz * r0.www + -r2.xyz;
+  r0.w = 0;
+  o0.xyzw = cb0[12].yyyy * r0.xyzw + r2.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/colorgrade_0xB270CA5B.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0xB270CA5B.ps_5_0.hlsl
@@ -1,0 +1,117 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:14:57 2024
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[22];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.yz = t0.Sample(s2_s, v2.xy).xy;
+  r0.yz = float2(-0.498039216,-0.498039216) + r0.yz;
+  r0.yz = float2(0.100000001,0.100000001) * r0.yz;
+  r1.xy = r0.yz * cb0[5].xy + v1.xy;
+  r0.yz = r0.yz * cb0[5].xy + v2.xy;
+  r0.yz = min(cb0[6].zw, r0.yz);
+  r2.xyzw = t2.Sample(s1_s, r0.yz).xyzw;
+  r2.xyzw = saturate(-r2.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r0.yz = r1.xy / cb0[5].xy;
+  r1.xy = min(cb0[6].xy, r1.xy);
+  r1.xyzw = t1.Sample(s0_s, r1.xy).xyzw;
+  r0.yz = min(cb0[13].zw, r0.yz);
+  r0.yzw = t3.Sample(s3_s, r0.yz).xyz;
+  r3.xyz = cb0[13].xxx * r0.yzw;
+  r0.yzw = cb0[13].yyy + r0.yzw;
+  r0.yzw = r3.xyz / r0.yzw;
+  r1.xyz = r1.xyz + r0.yzw;
+  r0.xyzw = r1.xyzw * r0.xxxx;
+r1.xyz = cb0[17].xyz * r0.xyz;  //    r1.xyz = saturate(cb0[17].xyz * r0.xyz);
+float3 hdrColor = r1.xyz;
+r1.xyz = saturate(r1.xyz);
+
+  r3.xyz = r1.xyz * r1.xyz;
+  r4.xyz = r3.xyz * r1.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r1.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r1.xyz = r7.xzy * r1.xzy;
+  r5.x = r8.y;
+  r5.y = r1.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r1.x = r8.z;
+  r8.y = r1.z;
+  r8.z = r3.y;
+  r1.z = r3.z;
+  r8.w = r4.y;
+  r1.w = r4.z;
+  r5.z = dot(r1.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r1.x = saturate(dot(r0.xyz, float3(0.219999999,0.707000017,0.0710000023)));
+  r1.xyzw = r1.xxxx + -r0.xyzw;
+  r0.xyzw = cb0[10].xxxx * r1.xyzw + r0.xyzw;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r1.xyzw = -r2.xyzw * r0.xyzw + float4(1,1,1,1);
+  r0.xyz = -r2.xyz * r0.xyz + float3(0.5,0.5,0.5);
+  r2.xy = float2(-0.5,-0.5) + w1.xy;
+  r0.w = dot(r2.xy, r2.xy);
+  r0.w = sqrt(r0.w);
+  r0.w = r0.w * 0.720000029 + -0.800000012;
+  r0.w = saturate(-1.83715463 * r0.w);
+  r2.x = r0.w * -2 + 3;
+  r0.w = r0.w * r0.w;
+  r2.y = r2.x * r0.w + -1;
+  r0.w = r2.x * r0.w;
+  r2.x = -r2.y * 0.200000003 + 1;
+  r2.x = max(1, r2.x);
+  r0.xyz = r0.xyz * r2.xxx + float3(0.5,0.5,0.5);
+  r0.xyz = r0.xyz * r0.www + -r1.xyz;
+  r0.w = 0;
+  o0.xyzw = cb0[12].yyyy * r0.xyzw + r1.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/colorgrade_0xC4128983.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0xC4128983.ps_5_0.hlsl
@@ -1,0 +1,140 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:15:13 2024
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[28];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.yz = t0.Sample(s2_s, v2.xy).xy;
+  r0.yz = float2(-0.498039216,-0.498039216) + r0.yz;
+  r0.yz = float2(0.100000001,0.100000001) * r0.yz;
+  r1.xy = r0.yz * cb0[5].xy + v1.xy;
+  r0.yz = r0.yz * cb0[5].xy + v2.xy;
+  r0.yz = min(cb0[6].zw, r0.yz);
+  r2.xyzw = t2.Sample(s1_s, r0.yz).xyzw;
+  r2.xyzw = saturate(-r2.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r0.yz = r1.xy / cb0[5].xy;
+  r1.xy = min(cb0[6].xy, r1.xy);
+  r1.xyzw = t1.Sample(s0_s, r1.xy).xyzw;
+  r0.yz = min(cb0[13].zw, r0.yz);
+  r0.yzw = t3.Sample(s3_s, r0.yz).xyz;
+  r0.yzw = saturate(r0.yzw);
+  r0.yzw = float3(1,1,1) + -r0.yzw;
+  r3.xyz = float3(1,1,1) + -r1.xyz;
+  r1.xyz = -r3.xyz * r0.yzw + float3(1,1,1);
+  r0.xyzw = r1.xyzw * r0.xxxx;
+r1.xyz = cb0[17].xyz * r0.xyz;  //    r1.xyz = saturate(cb0[17].xyz * r0.xyz);
+float3 hdrColor = r1.xyz;
+r1.xyz = saturate(r1.xyz);
+
+  r3.xyz = r1.xyz * r1.xyz;
+  r4.xyz = r3.xyz * r1.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r1.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r1.xyz = r7.xzy * r1.xzy;
+  r5.x = r8.y;
+  r5.y = r1.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r1.x = r8.z;
+  r8.y = r1.z;
+  r8.z = r3.y;
+  r1.z = r3.z;
+  r8.w = r4.y;
+  r1.w = r4.z;
+  r5.z = dot(r1.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r0.xyzw = -r2.xyzw * r0.xyzw + float4(1,1,1,1);
+  r1.xyz = saturate(r0.xyz);
+  r1.w = dot(r1.xyz, float3(0.212670997,0.715160012,0.0721689984));
+  r2.x = cb0[27].z / cb0[27].x;
+  r2.xy = float2(9.99999975e-005,-0.999899983) + r2.xx;
+  r2.x = r2.x / r2.y;
+  r3.xyzw = r2.xxxx * r1.xyzw;
+  r4.xyzw = r2.xxxx + -r1.xyzw;
+  r3.xyzw = r3.xyzw / r4.xyzw;
+  r2.y = 0.5 * r2.x;
+  r2.x = -0.5 + r2.x;
+  r2.x = r2.y / r2.x;
+  r2.x = 1 + -r2.x;
+  r2.xyzw = r2.xxxx + r3.xyzw;
+  r3.xyzw = float4(1.00010002,1.00010002,1.00010002,1.00010002) + -r1.xyzw;
+  r3.xyzw = r1.xyzw / r3.xyzw;
+  r4.xyzw = cmp(float4(0.5,0.5,0.5,0.5) < r1.xyzw);
+  r1.w = 9.99999975e-005 + r1.w;
+  r1.xyz = r1.xyz / r1.www;
+  r2.xyzw = r4.xyzw ? r2.xyzw : r3.xyzw;
+  r1.xyz = r2.www * r1.xyz;
+  r2.xyz = cb0[27].yyy * r2.xyz;
+  r1.w = 1 + -cb0[27].y;
+  r0.xyz = r1.www * r1.xyz + r2.xyz;
+  r1.x = saturate(dot(r0.xyz, float3(0.219999999,0.707000017,0.0710000023)));
+  r1.xyzw = r1.xxxx + -r0.xyzw;
+  r0.xyzw = cb0[10].xxxx * r1.xyzw + r0.xyzw;
+  r1.xyz = float3(-0.5,-0.5,-0.5) + r0.xyz;
+  r2.xy = float2(-0.5,-0.5) + w1.xy;
+  r1.w = dot(r2.xy, r2.xy);
+  r1.w = sqrt(r1.w);
+  r1.w = r1.w * 0.720000029 + -0.800000012;
+  r1.w = saturate(-1.83715463 * r1.w);
+  r2.x = r1.w * -2 + 3;
+  r1.w = r1.w * r1.w;
+  r2.y = r2.x * r1.w + -1;
+  r1.w = r2.x * r1.w;
+  r2.x = -r2.y * 0.200000003 + 1;
+  r2.x = max(1, r2.x);
+  r1.xyz = r1.xyz * r2.xxx + float3(0.5,0.5,0.5);
+  r1.xyz = r1.xyz * r1.www + -r0.xyz;
+  r1.w = 0;
+  o0.xyzw = cb0[12].yyyy * r1.xyzw + r0.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/colorgrade_0xD9B57ECB.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0xD9B57ECB.ps_5_0.hlsl
@@ -1,0 +1,161 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:15:33 2024
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[28];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = t0.Sample(s2_s, v2.xy).xy;
+  r0.xy = float2(-0.498039216,-0.498039216) + r0.xy;
+  r0.xy = float2(0.100000001,0.100000001) * r0.xy;
+  r0.zw = r0.xy * cb0[5].xy + v1.xy;
+  r0.xy = r0.xy * cb0[5].xy + v2.xy;
+  r0.xy = min(cb0[6].zw, r0.xy);
+  r1.xyzw = t2.Sample(s1_s, r0.xy).xyzw;
+  r1.xyzw = saturate(-r1.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r2.xyzw = min(cb0[6].xyxy, r0.zwzw);
+  r0.xy = r0.zw / cb0[5].xy;
+  r3.xyzw = cb0[3].xyxy * float4(-1.5,-1.5,1.5,-1.5) + r2.zwzw;
+  r4.xyz = t1.Sample(s0_s, r3.xy).xyz;
+  r3.xyz = t1.Sample(s0_s, r3.zw).xyz;
+  r3.xyz = r4.xyz + r3.xyz;
+  r4.xyzw = cb0[3].xyxy * float4(-1.5,1.5,1.5,1.5) + r2.xyzw;
+  r2.xyzw = t1.Sample(s0_s, r2.zw).xyzw;
+  r5.xyz = t1.Sample(s0_s, r4.xy).xyz;
+  r4.xyz = t1.Sample(s0_s, r4.zw).xyz;
+  r3.xyz = r5.xyz + r3.xyz;
+  r3.xyz = r3.xyz + r4.xyz;
+  r3.xyz = -r3.xyz * float3(0.25,0.25,0.25) + r2.xyz;
+  r3.xyz = r3.xyz * cb0[8].yyy + r2.xyz;
+  r3.xyz = float3(1,1,1) + -r3.xyz;
+  r0.zw = min(cb0[13].zw, r0.xy);
+  r4.xyz = t4.Sample(s3_s, r0.xy).xyz;
+  r0.xyz = t3.Sample(s3_s, r0.zw).xyz;
+  r0.xyz = saturate(r0.xyz);
+  r0.xyz = float3(1,1,1) + -r0.xyz;
+  r0.xyz = -r3.xyz * r0.xyz + float3(1,1,1);
+  r0.w = max(r4.y, r4.z);
+  r0.w = max(r4.x, r0.w);
+  r3.x = cmp(cb0[12].z < r0.w);
+  r0.w = cb0[12].z / r0.w;
+  r0.w = r3.x ? r0.w : 1;
+  r2.xyz = r4.xyz * r0.www + r0.xyz;
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.xyzw = r2.xyzw * r0.xxxx;
+r2.xyz = cb0[17].xyz * r0.xyz;  //    r2.xyz = saturate(cb0[17].xyz * r0.xyz);
+float3 hdrColor = r2.xyz;
+r2.xyz = saturate(r2.xyz);
+
+  r3.xyz = r2.xyz * r2.xyz;
+  r4.xyz = r3.xyz * r2.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r2.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r2.xyz = r7.xzy * r2.xzy;
+  r5.x = r8.y;
+  r5.y = r2.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r2.x = r8.z;
+  r8.y = r2.z;
+  r8.z = r3.y;
+  r2.z = r3.z;
+  r8.w = r4.y;
+  r2.w = r4.z;
+  r5.z = dot(r2.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r0.xyzw = -r1.xyzw * r0.xyzw + float4(1,1,1,1);
+  r1.w = r0.w;
+  r0.xyz = saturate(r0.xyz);
+  r0.w = dot(r0.xyz, float3(0.212670997,0.715160012,0.0721689984));
+  r2.x = cb0[27].z / cb0[27].x;
+  r2.xy = float2(9.99999975e-005,-0.999899983) + r2.xx;
+  r2.x = r2.x / r2.y;
+  r3.xyzw = r2.xxxx * r0.xyzw;
+  r4.xyzw = r2.xxxx + -r0.xyzw;
+  r3.xyzw = r3.xyzw / r4.xyzw;
+  r2.y = 0.5 * r2.x;
+  r2.x = -0.5 + r2.x;
+  r2.x = r2.y / r2.x;
+  r2.x = 1 + -r2.x;
+  r2.xyzw = r2.xxxx + r3.xyzw;
+  r3.xyzw = float4(1.00010002,1.00010002,1.00010002,1.00010002) + -r0.xyzw;
+  r3.xyzw = r0.xyzw / r3.xyzw;
+  r4.xyzw = cmp(float4(0.5,0.5,0.5,0.5) < r0.xyzw);
+  r0.w = 9.99999975e-005 + r0.w;
+  r0.xyz = r0.xyz / r0.www;
+  r2.xyzw = r4.xyzw ? r2.xyzw : r3.xyzw;
+  r0.xyz = r2.www * r0.xyz;
+  r2.xyz = cb0[27].yyy * r2.xyz;
+  r0.w = 1 + -cb0[27].y;
+  r1.xyz = r0.www * r0.xyz + r2.xyz;
+  r0.x = saturate(dot(r1.xyz, float3(0.219999999,0.707000017,0.0710000023)));
+  r0.xyzw = r0.xxxx + -r1.xyzw;
+  r0.xyzw = cb0[10].xxxx * r0.xyzw + r1.xyzw;
+  r1.xyz = float3(-0.5,-0.5,-0.5) + r0.xyz;
+  r2.xy = float2(-0.5,-0.5) + w1.xy;
+  r1.w = dot(r2.xy, r2.xy);
+  r1.w = sqrt(r1.w);
+  r1.w = r1.w * 0.720000029 + -0.800000012;
+  r1.w = saturate(-1.83715463 * r1.w);
+  r2.x = r1.w * -2 + 3;
+  r1.w = r1.w * r1.w;
+  r2.y = r2.x * r1.w + -1;
+  r1.w = r2.x * r1.w;
+  r2.x = -r2.y * 0.200000003 + 1;
+  r2.x = max(1, r2.x);
+  r1.xyz = r1.xyz * r2.xxx + float3(0.5,0.5,0.5);
+  r1.xyz = r1.xyz * r1.www + -r0.xyz;
+  r1.w = 0;
+  o0.xyzw = cb0[12].yyyy * r1.xyzw + r0.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/colorgrade_0xDB90C883.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0xDB90C883.ps_5_0.hlsl
@@ -1,0 +1,123 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:15:35 2024
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[22];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = t0.Sample(s2_s, v2.xy).xy;
+  r0.xy = float2(-0.498039216,-0.498039216) + r0.xy;
+  r0.xy = float2(0.100000001,0.100000001) * r0.xy;
+  r0.zw = r0.xy * cb0[5].xy + v1.xy;
+  r0.xy = r0.xy * cb0[5].xy + v2.xy;
+  r0.xy = min(cb0[6].zw, r0.xy);
+  r1.xyzw = t2.Sample(s1_s, r0.xy).xyzw;
+  r1.xyzw = saturate(-r1.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r0.xy = r0.zw / cb0[5].xy;
+  r0.zw = min(cb0[6].xy, r0.zw);
+  r2.xyzw = t1.Sample(s0_s, r0.zw).xyzw;
+  r0.zw = min(cb0[13].zw, r0.xy);
+  r3.xyz = t4.Sample(s3_s, r0.xy).xyz;
+  r0.xyz = t3.Sample(s3_s, r0.zw).xyz;
+  r4.xyz = cb0[13].xxx * r0.xyz;
+  r0.xyz = cb0[13].yyy + r0.xyz;
+  r0.xyz = r4.xyz / r0.xyz;
+  r0.xyz = r2.xyz + r0.xyz;
+  r0.w = max(r3.y, r3.z);
+  r0.w = max(r3.x, r0.w);
+  r3.w = cmp(cb0[12].z < r0.w);
+  r0.w = cb0[12].z / r0.w;
+  r0.w = r3.w ? r0.w : 1;
+  r2.xyz = r3.xyz * r0.www + r0.xyz;
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.xyzw = r2.xyzw * r0.xxxx;
+r2.xyz = cb0[17].xyz * r0.xyz;  //    r2.xyz = saturate(cb0[17].xyz * r0.xyz);
+float3 hdrColor = r2.xyz;
+r2.xyz = saturate(r2.xyz);
+
+  r3.xyz = r2.xyz * r2.xyz;
+  r4.xyz = r3.xyz * r2.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r2.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r2.xyz = r7.xzy * r2.xzy;
+  r5.x = r8.y;
+  r5.y = r2.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r2.x = r8.z;
+  r8.y = r2.z;
+  r8.z = r3.y;
+  r2.z = r3.z;
+  r8.w = r4.y;
+  r2.w = r4.z;
+  r5.z = dot(r2.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r2.xyzw = -r1.xyzw * r0.xyzw + float4(1,1,1,1);
+  r0.xyz = -r1.xyz * r0.xyz + float3(0.5,0.5,0.5);
+  r1.xy = float2(-0.5,-0.5) + w1.xy;
+  r0.w = dot(r1.xy, r1.xy);
+  r0.w = sqrt(r0.w);
+  r0.w = r0.w * 0.720000029 + -0.800000012;
+  r0.w = saturate(-1.83715463 * r0.w);
+  r1.x = r0.w * -2 + 3;
+  r0.w = r0.w * r0.w;
+  r1.y = r1.x * r0.w + -1;
+  r0.w = r1.x * r0.w;
+  r1.x = -r1.y * 0.200000003 + 1;
+  r1.x = max(1, r1.x);
+  r0.xyz = r0.xyz * r1.xxx + float3(0.5,0.5,0.5);
+  r0.xyz = r0.xyz * r0.www + -r2.xyz;
+  r0.w = 0;
+  o0.xyzw = cb0[12].yyyy * r0.xyzw + r2.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/colorgrade_0xDE975B11.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0xDE975B11.ps_5_0.hlsl
@@ -1,0 +1,140 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:15:38 2024
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[28];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.yz = t0.Sample(s2_s, v2.xy).xy;
+  r0.yz = float2(-0.498039216,-0.498039216) + r0.yz;
+  r0.yz = float2(0.100000001,0.100000001) * r0.yz;
+  r1.xy = r0.yz * cb0[5].xy + v1.xy;
+  r0.yz = r0.yz * cb0[5].xy + v2.xy;
+  r0.yz = min(cb0[6].zw, r0.yz);
+  r2.xyzw = t2.Sample(s1_s, r0.yz).xyzw;
+  r2.xyzw = saturate(-r2.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r0.yz = r1.xy / cb0[5].xy;
+  r1.xy = min(cb0[6].xy, r1.xy);
+  r1.xyzw = t1.Sample(s0_s, r1.xy).xyzw;
+  r0.yz = min(cb0[13].zw, r0.yz);
+  r0.yzw = t3.Sample(s3_s, r0.yz).xyz;
+  r3.xyz = cb0[13].xxx * r0.yzw;
+  r0.yzw = cb0[13].yyy + r0.yzw;
+  r0.yzw = r3.xyz / r0.yzw;
+  r1.xyz = r1.xyz + r0.yzw;
+  r0.xyzw = r1.xyzw * r0.xxxx;
+r1.xyz = cb0[17].xyz * r0.xyz;  //    r1.xyz = saturate(cb0[17].xyz * r0.xyz);
+float3 hdrColor = r1.xyz;
+r1.xyz = saturate(r1.xyz);
+
+  r3.xyz = r1.xyz * r1.xyz;
+  r4.xyz = r3.xyz * r1.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r1.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r1.xyz = r7.xzy * r1.xzy;
+  r5.x = r8.y;
+  r5.y = r1.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r1.x = r8.z;
+  r8.y = r1.z;
+  r8.z = r3.y;
+  r1.z = r3.z;
+  r8.w = r4.y;
+  r1.w = r4.z;
+  r5.z = dot(r1.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r0.xyzw = -r2.xyzw * r0.xyzw + float4(1,1,1,1);
+  r1.xyz = saturate(r0.xyz);
+  r1.w = dot(r1.xyz, float3(0.212670997,0.715160012,0.0721689984));
+  r2.x = cb0[27].z / cb0[27].x;
+  r2.xy = float2(9.99999975e-005,-0.999899983) + r2.xx;
+  r2.x = r2.x / r2.y;
+  r3.xyzw = r2.xxxx * r1.xyzw;
+  r4.xyzw = r2.xxxx + -r1.xyzw;
+  r3.xyzw = r3.xyzw / r4.xyzw;
+  r2.y = 0.5 * r2.x;
+  r2.x = -0.5 + r2.x;
+  r2.x = r2.y / r2.x;
+  r2.x = 1 + -r2.x;
+  r2.xyzw = r2.xxxx + r3.xyzw;
+  r3.xyzw = float4(1.00010002,1.00010002,1.00010002,1.00010002) + -r1.xyzw;
+  r3.xyzw = r1.xyzw / r3.xyzw;
+  r4.xyzw = cmp(float4(0.5,0.5,0.5,0.5) < r1.xyzw);
+  r1.w = 9.99999975e-005 + r1.w;
+  r1.xyz = r1.xyz / r1.www;
+  r2.xyzw = r4.xyzw ? r2.xyzw : r3.xyzw;
+  r1.xyz = r2.www * r1.xyz;
+  r2.xyz = cb0[27].yyy * r2.xyz;
+  r1.w = 1 + -cb0[27].y;
+  r0.xyz = r1.www * r1.xyz + r2.xyz;
+  r1.x = saturate(dot(r0.xyz, float3(0.219999999,0.707000017,0.0710000023)));
+  r1.xyzw = r1.xxxx + -r0.xyzw;
+  r0.xyzw = cb0[10].xxxx * r1.xyzw + r0.xyzw;
+  r1.xyz = float3(-0.5,-0.5,-0.5) + r0.xyz;
+  r2.xy = float2(-0.5,-0.5) + w1.xy;
+  r1.w = dot(r2.xy, r2.xy);
+  r1.w = sqrt(r1.w);
+  r1.w = r1.w * 0.720000029 + -0.800000012;
+  r1.w = saturate(-1.83715463 * r1.w);
+  r2.x = r1.w * -2 + 3;
+  r1.w = r1.w * r1.w;
+  r2.y = r2.x * r1.w + -1;
+  r1.w = r2.x * r1.w;
+  r2.x = -r2.y * 0.200000003 + 1;
+  r2.x = max(1, r2.x);
+  r1.xyz = r1.xyz * r2.xxx + float3(0.5,0.5,0.5);
+  r1.xyz = r1.xyz * r1.www + -r0.xyz;
+  r1.w = 0;
+  o0.xyzw = cb0[12].yyyy * r1.xyzw + r0.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/colorgrade_0xE3F6E54F.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0xE3F6E54F.ps_5_0.hlsl
@@ -1,0 +1,161 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:15:43 2024
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[28];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = t0.Sample(s2_s, v2.xy).xy;
+  r0.xy = float2(-0.498039216,-0.498039216) + r0.xy;
+  r0.xy = float2(0.100000001,0.100000001) * r0.xy;
+  r0.zw = r0.xy * cb0[5].xy + v1.xy;
+  r0.xy = r0.xy * cb0[5].xy + v2.xy;
+  r0.xy = min(cb0[6].zw, r0.xy);
+  r1.xyzw = t2.Sample(s1_s, r0.xy).xyzw;
+  r1.xyzw = saturate(-r1.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r2.xyzw = min(cb0[6].xyxy, r0.zwzw);
+  r0.xy = r0.zw / cb0[5].xy;
+  r3.xyzw = cb0[3].xyxy * float4(-1.5,-1.5,1.5,-1.5) + r2.zwzw;
+  r4.xyz = t1.Sample(s0_s, r3.xy).xyz;
+  r3.xyz = t1.Sample(s0_s, r3.zw).xyz;
+  r3.xyz = r4.xyz + r3.xyz;
+  r4.xyzw = cb0[3].xyxy * float4(-1.5,1.5,1.5,1.5) + r2.xyzw;
+  r2.xyzw = t1.Sample(s0_s, r2.zw).xyzw;
+  r5.xyz = t1.Sample(s0_s, r4.xy).xyz;
+  r4.xyz = t1.Sample(s0_s, r4.zw).xyz;
+  r3.xyz = r5.xyz + r3.xyz;
+  r3.xyz = r3.xyz + r4.xyz;
+  r3.xyz = -r3.xyz * float3(0.25,0.25,0.25) + r2.xyz;
+  r3.xyz = r3.xyz * cb0[8].yyy + r2.xyz;
+  r0.zw = min(cb0[13].zw, r0.xy);
+  r4.xyz = t4.Sample(s3_s, r0.xy).xyz;
+  r0.xyz = t3.Sample(s3_s, r0.zw).xyz;
+  r5.xyz = cb0[13].xxx * r0.xyz;
+  r0.xyz = cb0[13].yyy + r0.xyz;
+  r0.xyz = r5.xyz / r0.xyz;
+  r0.xyz = r3.xyz + r0.xyz;
+  r0.w = max(r4.y, r4.z);
+  r0.w = max(r4.x, r0.w);
+  r3.x = cmp(cb0[12].z < r0.w);
+  r0.w = cb0[12].z / r0.w;
+  r0.w = r3.x ? r0.w : 1;
+  r2.xyz = r4.xyz * r0.www + r0.xyz;
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.xyzw = r2.xyzw * r0.xxxx;
+r2.xyz = cb0[17].xyz * r0.xyz;  //    r2.xyz = saturate(cb0[17].xyz * r0.xyz);
+float3 hdrColor = r2.xyz;
+r2.xyz = saturate(r2.xyz);
+
+  r3.xyz = r2.xyz * r2.xyz;
+  r4.xyz = r3.xyz * r2.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r2.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r2.xyz = r7.xzy * r2.xzy;
+  r5.x = r8.y;
+  r5.y = r2.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r2.x = r8.z;
+  r8.y = r2.z;
+  r8.z = r3.y;
+  r2.z = r3.z;
+  r8.w = r4.y;
+  r2.w = r4.z;
+  r5.z = dot(r2.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r0.xyzw = -r1.xyzw * r0.xyzw + float4(1,1,1,1);
+  r1.w = r0.w;
+  r0.xyz = saturate(r0.xyz);
+  r0.w = dot(r0.xyz, float3(0.212670997,0.715160012,0.0721689984));
+  r2.x = cb0[27].z / cb0[27].x;
+  r2.xy = float2(9.99999975e-005,-0.999899983) + r2.xx;
+  r2.x = r2.x / r2.y;
+  r3.xyzw = r2.xxxx * r0.xyzw;
+  r4.xyzw = r2.xxxx + -r0.xyzw;
+  r3.xyzw = r3.xyzw / r4.xyzw;
+  r2.y = 0.5 * r2.x;
+  r2.x = -0.5 + r2.x;
+  r2.x = r2.y / r2.x;
+  r2.x = 1 + -r2.x;
+  r2.xyzw = r2.xxxx + r3.xyzw;
+  r3.xyzw = float4(1.00010002,1.00010002,1.00010002,1.00010002) + -r0.xyzw;
+  r3.xyzw = r0.xyzw / r3.xyzw;
+  r4.xyzw = cmp(float4(0.5,0.5,0.5,0.5) < r0.xyzw);
+  r0.w = 9.99999975e-005 + r0.w;
+  r0.xyz = r0.xyz / r0.www;
+  r2.xyzw = r4.xyzw ? r2.xyzw : r3.xyzw;
+  r0.xyz = r2.www * r0.xyz;
+  r2.xyz = cb0[27].yyy * r2.xyz;
+  r0.w = 1 + -cb0[27].y;
+  r1.xyz = r0.www * r0.xyz + r2.xyz;
+  r0.x = saturate(dot(r1.xyz, float3(0.219999999,0.707000017,0.0710000023)));
+  r0.xyzw = r0.xxxx + -r1.xyzw;
+  r0.xyzw = cb0[10].xxxx * r0.xyzw + r1.xyzw;
+  r1.xyz = float3(-0.5,-0.5,-0.5) + r0.xyz;
+  r2.xy = float2(-0.5,-0.5) + w1.xy;
+  r1.w = dot(r2.xy, r2.xy);
+  r1.w = sqrt(r1.w);
+  r1.w = r1.w * 0.720000029 + -0.800000012;
+  r1.w = saturate(-1.83715463 * r1.w);
+  r2.x = r1.w * -2 + 3;
+  r1.w = r1.w * r1.w;
+  r2.y = r2.x * r1.w + -1;
+  r1.w = r2.x * r1.w;
+  r2.x = -r2.y * 0.200000003 + 1;
+  r2.x = max(1, r2.x);
+  r1.xyz = r1.xyz * r2.xxx + float3(0.5,0.5,0.5);
+  r1.xyz = r1.xyz * r1.www + -r0.xyz;
+  r1.w = 0;
+  o0.xyzw = cb0[12].yyyy * r1.xyzw + r0.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/colorgrade_0xF017475F.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0xF017475F.ps_5_0.hlsl
@@ -1,0 +1,126 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:15:54 2024
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[22];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = t0.Sample(s2_s, v2.xy).xy;
+  r0.xy = float2(-0.498039216,-0.498039216) + r0.xy;
+  r0.xy = float2(0.100000001,0.100000001) * r0.xy;
+  r0.zw = r0.xy * cb0[5].xy + v1.xy;
+  r0.xy = r0.xy * cb0[5].xy + v2.xy;
+  r0.xy = min(cb0[6].zw, r0.xy);
+  r1.xyzw = t2.Sample(s1_s, r0.xy).xyzw;
+  r1.xyzw = saturate(-r1.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r2.xyzw = min(cb0[6].xyxy, r0.zwzw);
+  r0.xy = r0.zw / cb0[5].xy;
+  r0.xyz = t3.Sample(s3_s, r0.xy).xyz;
+  r3.xyzw = cb0[3].xyxy * float4(-1.5,-1.5,1.5,-1.5) + r2.zwzw;
+  r4.xyz = t1.Sample(s0_s, r3.xy).xyz;
+  r3.xyz = t1.Sample(s0_s, r3.zw).xyz;
+  r3.xyz = r4.xyz + r3.xyz;
+  r4.xyzw = cb0[3].xyxy * float4(-1.5,1.5,1.5,1.5) + r2.xyzw;
+  r2.xyzw = t1.Sample(s0_s, r2.zw).xyzw;
+  r5.xyz = t1.Sample(s0_s, r4.xy).xyz;
+  r4.xyz = t1.Sample(s0_s, r4.zw).xyz;
+  r3.xyz = r5.xyz + r3.xyz;
+  r3.xyz = r3.xyz + r4.xyz;
+  r3.xyz = -r3.xyz * float3(0.25,0.25,0.25) + r2.xyz;
+  r3.xyz = r3.xyz * cb0[8].yyy + r2.xyz;
+  r0.w = max(r0.y, r0.z);
+  r0.w = max(r0.x, r0.w);
+  r3.w = cmp(cb0[12].z < r0.w);
+  r0.w = cb0[12].z / r0.w;
+  r0.w = r3.w ? r0.w : 1;
+  r2.xyz = r0.xyz * r0.www + r3.xyz;
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.xyzw = r2.xyzw * r0.xxxx;
+r2.xyz = cb0[17].xyz * r0.xyz;  //    r2.xyz = saturate(cb0[17].xyz * r0.xyz);
+float3 hdrColor = r2.xyz;
+r2.xyz = saturate(r2.xyz);
+
+  r3.xyz = r2.xyz * r2.xyz;
+  r4.xyz = r3.xyz * r2.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r2.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r2.xyz = r7.xzy * r2.xzy;
+  r5.x = r8.y;
+  r5.y = r2.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r2.x = r8.z;
+  r8.y = r2.z;
+  r8.z = r3.y;
+  r2.z = r3.z;
+  r8.w = r4.y;
+  r2.w = r4.z;
+  r5.z = dot(r2.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r2.xyzw = -r1.xyzw * r0.xyzw + float4(1,1,1,1);
+  r0.xyz = -r1.xyz * r0.xyz + float3(0.5,0.5,0.5);
+  r1.xy = float2(-0.5,-0.5) + w1.xy;
+  r0.w = dot(r1.xy, r1.xy);
+  r0.w = sqrt(r0.w);
+  r0.w = r0.w * 0.720000029 + -0.800000012;
+  r0.w = saturate(-1.83715463 * r0.w);
+  r1.x = r0.w * -2 + 3;
+  r0.w = r0.w * r0.w;
+  r1.y = r1.x * r0.w + -1;
+  r0.w = r1.x * r0.w;
+  r1.x = -r1.y * 0.200000003 + 1;
+  r1.x = max(1, r1.x);
+  r0.xyz = r0.xyz * r1.xxx + float3(0.5,0.5,0.5);
+  r0.xyz = r0.xyz * r0.www + -r2.xyz;
+  r0.w = 0;
+  o0.xyzw = cb0[12].yyyy * r0.xyzw + r2.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/colorgrade_0xF3917C63.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0xF3917C63.ps_5_0.hlsl
@@ -1,0 +1,126 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:15:57 2024
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[28];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.yz = t0.Sample(s2_s, v2.xy).xy;
+  r0.yz = float2(-0.498039216,-0.498039216) + r0.yz;
+  r0.yz = float2(0.100000001,0.100000001) * r0.yz;
+  r1.xy = r0.yz * cb0[5].xy + v1.xy;
+  r0.yz = r0.yz * cb0[5].xy + v2.xy;
+  r0.yz = min(cb0[6].zw, r0.yz);
+  r2.xyzw = t2.Sample(s1_s, r0.yz).xyzw;
+  r2.xyzw = saturate(-r2.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r0.yz = min(cb0[6].xy, r1.xy);
+  r1.xyzw = t1.Sample(s0_s, r0.yz).xyzw;
+  r0.xyzw = r1.xyzw * r0.xxxx;
+r1.xyz = cb0[17].xyz * r0.xyz;  //    r1.xyz = saturate(cb0[17].xyz * r0.xyz);
+float3 hdrColor = r1.xyz;
+r1.xyz = saturate(r1.xyz);
+
+  r3.xyz = r1.xyz * r1.xyz;
+  r4.xyz = r3.xyz * r1.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r1.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r1.xyz = r7.xzy * r1.xzy;
+  r5.x = r8.y;
+  r5.y = r1.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r1.x = r8.z;
+  r8.y = r1.z;
+  r8.z = r3.y;
+  r1.z = r3.z;
+  r8.w = r4.y;
+  r1.w = r4.z;
+  r5.z = dot(r1.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r0.xyzw = -r2.xyzw * r0.xyzw + float4(1,1,1,1);
+  r1.xyz = saturate(r0.xyz);
+  r1.w = dot(r1.xyz, float3(0.212670997,0.715160012,0.0721689984));
+  r2.x = cb0[27].z / cb0[27].x;
+  r2.xy = float2(9.99999975e-005,-0.999899983) + r2.xx;
+  r2.x = r2.x / r2.y;
+  r3.xyzw = r2.xxxx * r1.xyzw;
+  r4.xyzw = r2.xxxx + -r1.xyzw;
+  r3.xyzw = r3.xyzw / r4.xyzw;
+  r2.y = 0.5 * r2.x;
+  r2.x = -0.5 + r2.x;
+  r2.x = r2.y / r2.x;
+  r2.x = 1 + -r2.x;
+  r2.xyzw = r2.xxxx + r3.xyzw;
+  r3.xyzw = float4(1.00010002,1.00010002,1.00010002,1.00010002) + -r1.xyzw;
+  r3.xyzw = r1.xyzw / r3.xyzw;
+  r4.xyzw = cmp(float4(0.5,0.5,0.5,0.5) < r1.xyzw);
+  r1.w = 9.99999975e-005 + r1.w;
+  r1.xyz = r1.xyz / r1.www;
+  r2.xyzw = r4.xyzw ? r2.xyzw : r3.xyzw;
+  r1.xyz = r2.www * r1.xyz;
+  r2.xyz = cb0[27].yyy * r2.xyz;
+  r1.w = 1 + -cb0[27].y;
+  r0.xyz = r1.www * r1.xyz + r2.xyz;
+  r1.xyz = float3(-0.5,-0.5,-0.5) + r0.xyz;
+  r2.xy = float2(-0.5,-0.5) + w1.xy;
+  r1.w = dot(r2.xy, r2.xy);
+  r1.w = sqrt(r1.w);
+  r1.w = r1.w * 0.720000029 + -0.800000012;
+  r1.w = saturate(-1.83715463 * r1.w);
+  r2.x = r1.w * -2 + 3;
+  r1.w = r1.w * r1.w;
+  r2.y = r2.x * r1.w + -1;
+  r1.w = r2.x * r1.w;
+  r2.x = -r2.y * 0.200000003 + 1;
+  r2.x = max(1, r2.x);
+  r1.xyz = r1.xyz * r2.xxx + float3(0.5,0.5,0.5);
+  r1.xyz = r1.xyz * r1.www + -r0.xyz;
+  r1.w = 0;
+  o0.xyzw = cb0[12].yyyy * r1.xyzw + r0.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/colorgrade_0xF7933F3F.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0xF7933F3F.ps_5_0.hlsl
@@ -1,0 +1,123 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:16:01 2024
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[22];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = t0.Sample(s2_s, v2.xy).xy;
+  r0.xy = float2(-0.498039216,-0.498039216) + r0.xy;
+  r0.xy = float2(0.100000001,0.100000001) * r0.xy;
+  r0.zw = r0.xy * cb0[5].xy + v1.xy;
+  r0.xy = r0.xy * cb0[5].xy + v2.xy;
+  r0.xy = min(cb0[6].zw, r0.xy);
+  r1.xyzw = t2.Sample(s1_s, r0.xy).xyzw;
+  r1.xyzw = saturate(-r1.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r0.xy = r0.zw / cb0[5].xy;
+  r0.zw = min(cb0[6].xy, r0.zw);
+  r2.xyzw = t1.Sample(s0_s, r0.zw).xyzw;
+  r0.zw = min(cb0[13].zw, r0.xy);
+  r3.xyz = t4.Sample(s3_s, r0.xy).xyz;
+  r0.xyz = t3.Sample(s3_s, r0.zw).xyz;
+  r0.xyz = saturate(r0.xyz);
+  r0.xyz = float3(1,1,1) + -r0.xyz;
+  r4.xyz = float3(1,1,1) + -r2.xyz;
+  r0.xyz = -r4.xyz * r0.xyz + float3(1,1,1);
+  r0.w = max(r3.y, r3.z);
+  r0.w = max(r3.x, r0.w);
+  r3.w = cmp(cb0[12].z < r0.w);
+  r0.w = cb0[12].z / r0.w;
+  r0.w = r3.w ? r0.w : 1;
+  r2.xyz = r3.xyz * r0.www + r0.xyz;
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.xyzw = r2.xyzw * r0.xxxx;
+r2.xyz = cb0[17].xyz * r0.xyz;  //    r2.xyz = saturate(cb0[17].xyz * r0.xyz);
+float3 hdrColor = r2.xyz;
+r2.xyz = saturate(r2.xyz);
+
+  r3.xyz = r2.xyz * r2.xyz;
+  r4.xyz = r3.xyz * r2.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r2.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r2.xyz = r7.xzy * r2.xzy;
+  r5.x = r8.y;
+  r5.y = r2.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r2.x = r8.z;
+  r8.y = r2.z;
+  r8.z = r3.y;
+  r2.z = r3.z;
+  r8.w = r4.y;
+  r2.w = r4.z;
+  r5.z = dot(r2.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r2.xyzw = -r1.xyzw * r0.xyzw + float4(1,1,1,1);
+  r0.xyz = -r1.xyz * r0.xyz + float3(0.5,0.5,0.5);
+  r1.xy = float2(-0.5,-0.5) + w1.xy;
+  r0.w = dot(r1.xy, r1.xy);
+  r0.w = sqrt(r0.w);
+  r0.w = r0.w * 0.720000029 + -0.800000012;
+  r0.w = saturate(-1.83715463 * r0.w);
+  r1.x = r0.w * -2 + 3;
+  r0.w = r0.w * r0.w;
+  r1.y = r1.x * r0.w + -1;
+  r0.w = r1.x * r0.w;
+  r1.x = -r1.y * 0.200000003 + 1;
+  r1.x = max(1, r1.x);
+  r0.xyz = r0.xyz * r1.xxx + float3(0.5,0.5,0.5);
+  r0.xyz = r0.xyz * r0.www + -r2.xyz;
+  r0.w = 0;
+  o0.xyzw = cb0[12].yyyy * r0.xyzw + r2.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/colorgrade_0xFCF0717A.ps_5_0.hlsl
+++ b/src/games/ori2/colorgrade_0xFCF0717A.ps_5_0.hlsl
@@ -1,0 +1,148 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:16:06 2024
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[28];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  linear noperspective float2 w1 : TEXCOORD1,
+  linear noperspective float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = t0.Sample(s2_s, v2.xy).xy;
+  r0.xy = float2(-0.498039216,-0.498039216) + r0.xy;
+  r0.xy = float2(0.100000001,0.100000001) * r0.xy;
+  r0.zw = r0.xy * cb0[5].xy + v1.xy;
+  r0.xy = r0.xy * cb0[5].xy + v2.xy;
+  r0.xy = min(cb0[6].zw, r0.xy);
+  r1.xyzw = t2.Sample(s1_s, r0.xy).xyzw;
+  r1.xyzw = saturate(-r1.xyzw * cb0[21].xxxx + float4(1,1,1,1));
+  r2.xyzw = min(cb0[6].xyxy, r0.zwzw);
+  r0.xy = r0.zw / cb0[5].xy;
+  r0.xy = min(cb0[13].zw, r0.xy);
+  r0.xyz = t3.Sample(s3_s, r0.xy).xyz;
+  r3.xyzw = cb0[3].xyxy * float4(-1.5,-1.5,1.5,-1.5) + r2.zwzw;
+  r4.xyz = t1.Sample(s0_s, r3.xy).xyz;
+  r3.xyz = t1.Sample(s0_s, r3.zw).xyz;
+  r3.xyz = r4.xyz + r3.xyz;
+  r4.xyzw = cb0[3].xyxy * float4(-1.5,1.5,1.5,1.5) + r2.xyzw;
+  r2.xyzw = t1.Sample(s0_s, r2.zw).xyzw;
+  r5.xyz = t1.Sample(s0_s, r4.xy).xyz;
+  r4.xyz = t1.Sample(s0_s, r4.zw).xyz;
+  r3.xyz = r5.xyz + r3.xyz;
+  r3.xyz = r3.xyz + r4.xyz;
+  r3.xyz = -r3.xyz * float3(0.25,0.25,0.25) + r2.xyz;
+  r3.xyz = r3.xyz * cb0[8].yyy + r2.xyz;
+  r4.xyz = cb0[13].xxx * r0.xyz;
+  r0.xyz = cb0[13].yyy + r0.xyz;
+  r0.xyz = r4.xyz / r0.xyz;
+  r2.xyz = r3.xyz + r0.xyz;
+  r0.xy = w1.xy * float2(2,2) + float2(-1,-1);
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
+  r0.xyzw = r2.xyzw * r0.xxxx;
+r2.xyz = cb0[17].xyz * r0.xyz;  //    r2.xyz = saturate(cb0[17].xyz * r0.xyz);
+float3 hdrColor = r2.xyz;
+r2.xyz = saturate(r2.xyz);
+
+  r3.xyz = r2.xyz * r2.xyz;
+  r4.xyz = r3.xyz * r2.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1,1,1) + -r2.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r2.xyz = r7.xzy * r2.xzy;
+  r5.x = r8.y;
+  r5.y = r2.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[14].xyzw);
+  r2.x = r8.z;
+  r8.y = r2.z;
+  r8.z = r3.y;
+  r2.z = r3.z;
+  r8.w = r4.y;
+  r2.w = r4.z;
+  r5.z = dot(r2.xyzw, cb0[16].xyzw);
+  r5.y = dot(r8.xyzw, cb0[15].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx + cb0[9].yyy;
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r0.xyzw = -r1.xyzw * r0.xyzw + float4(1,1,1,1);
+  r1.xyz = saturate(r0.xyz);
+  r1.w = dot(r1.xyz, float3(0.212670997,0.715160012,0.0721689984));
+  r2.x = cb0[27].z / cb0[27].x;
+  r2.xy = float2(9.99999975e-005,-0.999899983) + r2.xx;
+  r2.x = r2.x / r2.y;
+  r3.xyzw = r2.xxxx * r1.xyzw;
+  r4.xyzw = r2.xxxx + -r1.xyzw;
+  r3.xyzw = r3.xyzw / r4.xyzw;
+  r2.y = 0.5 * r2.x;
+  r2.x = -0.5 + r2.x;
+  r2.x = r2.y / r2.x;
+  r2.x = 1 + -r2.x;
+  r2.xyzw = r2.xxxx + r3.xyzw;
+  r3.xyzw = float4(1.00010002,1.00010002,1.00010002,1.00010002) + -r1.xyzw;
+  r3.xyzw = r1.xyzw / r3.xyzw;
+  r4.xyzw = cmp(float4(0.5,0.5,0.5,0.5) < r1.xyzw);
+  r1.w = 9.99999975e-005 + r1.w;
+  r1.xyz = r1.xyz / r1.www;
+  r2.xyzw = r4.xyzw ? r2.xyzw : r3.xyzw;
+  r1.xyz = r2.www * r1.xyz;
+  r2.xyz = cb0[27].yyy * r2.xyz;
+  r1.w = 1 + -cb0[27].y;
+  r0.xyz = r1.www * r1.xyz + r2.xyz;
+  r1.xyz = float3(-0.5,-0.5,-0.5) + r0.xyz;
+  r2.xy = float2(-0.5,-0.5) + w1.xy;
+  r1.w = dot(r2.xy, r2.xy);
+  r1.w = sqrt(r1.w);
+  r1.w = r1.w * 0.720000029 + -0.800000012;
+  r1.w = saturate(-1.83715463 * r1.w);
+  r2.x = r1.w * -2 + 3;
+  r1.w = r1.w * r1.w;
+  r2.y = r2.x * r1.w + -1;
+  r1.w = r2.x * r1.w;
+  r2.x = -r2.y * 0.200000003 + 1;
+  r2.x = max(1, r2.x);
+  r1.xyz = r1.xyz * r2.xxx + float3(0.5,0.5,0.5);
+  r1.xyz = r1.xyz * r1.www + -r0.xyz;
+  r1.w = 0;
+  o0.xyzw = cb0[12].yyyy * r1.xyzw + r0.xyzw;
+if (injectedData.toneMapType != 0) {
+    // preserve SDR color grading
+    o0.xyz = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(hdrColor), o0.xyz, injectedData.colorGradeStrength);
+}
+  return;
+}

--- a/src/games/ori2/finalpq_0xF9C2BDE1.ps_4_0.hlsl
+++ b/src/games/ori2/finalpq_0xF9C2BDE1.ps_4_0.hlsl
@@ -1,0 +1,83 @@
+#include "./shared.h"
+#include "./hueHelper.hlsl"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:16:03 2024
+
+cbuffer HDRDisplayMappingCB : register(b0)
+{
+  float _NitsForPaperWhite : packoffset(c0);
+  uint _DisplayCurve : packoffset(c0.y);
+  float _SoftShoulderStart : packoffset(c0.z);
+  float _MaxBrightnessOfTV : packoffset(c0.w);
+  float _MaxBrightnessOfHDRScene : packoffset(c1);
+  float _ColorGamutExpansion : packoffset(c1.y);
+}
+
+SamplerState _Sampler0_s : register(s0);
+Texture2D<float4> _MainTex : register(t0);
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_TARGET0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = _MainTex.Sample(_Sampler0_s, v1.xy).xyzw;
+  o0.w = r0.w;
+
+  r0.xyz = sign(r0.xyz) * pow(abs(r0.xyz), 2.2f);  // linearize
+
+  if (injectedData.toneMapType == 0) {
+    // bt2020 conversion + gamut expansion
+    r0.w = max(r0.x, r0.y);
+    r0.w = max(r0.w, r0.z);
+    r0.w = -2 + r0.w;
+    r0.w = saturate(0.125 * r0.w);
+    r1.x = dot(float3(0.710796118,0.247670293,0.0415336005), r0.xyz);
+    r1.y = dot(float3(0.0434204005,0.943510771,0.0130687999), r0.xyz);
+    r1.z = dot(float3(-0.00108149997,0.0272474997,0.973834097), r0.xyz);
+    r1.xyz = r1.xyz * r0.www;
+    r0.w = 1 + -r0.w;
+    r2.x = dot(float3(0.627403975,0.329281986,0.0433136001), r0.xyz);
+    r2.y = dot(float3(0.0457456,0.941776991,0.0124771995), r0.xyz);
+    r2.z = dot(float3(-0.00121054996,0.0176040996,0.983606994), r0.xyz);
+    r1.xyz = r0.www * r2.xyz + r1.xyz;
+    r1.xyz = _ColorGamutExpansion * r1.xyz;
+    r0.w = 1 + -_ColorGamutExpansion;
+    r2.x = dot(float3(0.627403975,0.329281986,0.0433136001), r0.xyz);
+    r2.y = dot(float3(0.0690969974,0.919539988,0.0113612004), r0.xyz);
+    r2.z = dot(float3(0.0163915996,0.088013202,0.895595014), r0.xyz);
+    r0.xyz = r0.www * r2.xyz + r1.xyz;
+
+    // paper white + pq encoding
+    r0.w = 9.99999975e-005 * _NitsForPaperWhite;
+    r0.xyz = r0.xyz * r0.www;
+    r0.xyz = pow(abs(r0.xyz), 0.1593017578125f);
+    r1.xyz = r0.xyz * float3(18.8515625,18.8515625,18.8515625) + float3(0.8359375,0.8359375,0.8359375);
+    r0.xyz = r0.xyz * float3(18.6875,18.6875,18.6875) + float3(1,1,1);
+    r0.xyz = r1.xyz / r0.xyz;
+    r0.xyz = pow(r0.xyz, 78.84375f);
+  } else {
+    if (injectedData.toneMapType != 1) {
+      const float paperWhite = injectedData.toneMapGameNits / renodx::color::srgb::REFERENCE_WHITE;
+      r0.xyz *= paperWhite;
+      const float peakWhite = injectedData.toneMapPeakNits / renodx::color::srgb::REFERENCE_WHITE;
+      const float highlightsShoulderStart = paperWhite;  // Don't tonemap the "SDR" range (in luminance), we want to keep it looking as it used to look in SDR
+      r0.xyz = renodx::tonemap::dice::BT709(r0.xyz, peakWhite, highlightsShoulderStart);
+      r0.xyz /= paperWhite;
+    }
+    r0.xyz = Hue(r0.xyz, injectedData.toneMapHueCorrection);
+    r0.xyz = renodx::color::bt2020::from::BT709(r0.xyz);
+    r0.xyz = renodx::color::pq::from::BT2020((r0.xyz * injectedData.toneMapGameNits) / 10000.f);
+  }
+  o0.xyz = r0.xyz;
+  return;
+}

--- a/src/games/ori2/hueHelper.hlsl
+++ b/src/games/ori2/hueHelper.hlsl
@@ -1,0 +1,37 @@
+#include "./shared.h"
+
+// Applies the hue shifts from clamping input_color while minimizing broken gradients
+float3 Hue(float3 input_color, float correct_amount = 1.f) {
+    // If no correction is needed, return the original color
+    if (correct_amount == 0) {
+        return input_color;
+    } else {
+        // Calculate average channel values of the original (unclamped) input_color
+        float avg_unclamped = renodx::math::Average(input_color);
+
+        // calculate average channel values for the clamped input_color
+        float3 clamped_color = saturate(input_color);
+        float avg_clamped = renodx::math::Average(clamped_color);
+
+        // Compute the hue clipping percentage based on the difference in averages
+        float hue_clip_percentage = saturate((avg_unclamped - avg_clamped) / max(avg_unclamped, renodx::math::FLT_MIN));  // Prevent division by zero
+
+        // Interpolate hue components (a, b in OkLab) based on correct_amount using clamped_color
+        float3 correct_lab = renodx::color::oklab::from::BT709(clamped_color);
+        float3 incorrect_lab = renodx::color::oklab::from::BT709(input_color);
+        float3 new_lab = incorrect_lab;
+
+        // Apply hue correction based on clipping percentage and interpolate based on correct_amount
+        new_lab.yz = lerp(incorrect_lab.yz, correct_lab.yz, hue_clip_percentage);
+        new_lab.yz = lerp(incorrect_lab.yz, new_lab.yz, abs(correct_amount));
+
+        // Restore original chrominance from input_color in OkLCh space
+        float3 incorrect_lch = renodx::color::oklch::from::OkLab(incorrect_lab);
+        float3 new_lch = renodx::color::oklch::from::OkLab(new_lab);
+        new_lch[1] = incorrect_lch[1];
+
+        // Convert back to linear BT.709 space
+        float3 color = renodx::color::bt709::from::OkLCh(new_lch);
+        return color;
+    }
+}

--- a/src/games/ori2/itm_0x9D323EA3.ps_4_0.hlsl
+++ b/src/games/ori2/itm_0x9D323EA3.ps_4_0.hlsl
@@ -1,0 +1,67 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 15 21:14:36 2024
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[9];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  linear noperspective float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r1.xyzw = t0.Sample(s0_s, v1.xy).xyzw;
+  o0.w = r1.w;
+  if (injectedData.toneMapType != 0) {
+    o0.xyz = r1.xyz * cb0[5].xxx + cb0[5].yyy;  // fade to black
+  } else {  // inverse tonemapping garbage, also applies to UI
+    r0.x = cb0[7].z / cb0[7].x;
+    r0.xy = float2(9.99999975e-005,-0.999899983) + r0.xx;
+    r0.x = r0.x / r0.y;
+    r0.y = 0.5 * r0.x;
+    r0.z = -0.5 + r0.x;
+    r0.y = r0.y / r0.z;
+    r0.y = 1 + -r0.y;
+    r1.xyz = saturate(r1.xyz);  // clamps render
+    r1.w = dot(r1.xyz, float3(0.212670997,0.715160012,0.0721689984));
+    r2.xyzw = r1.xyzw * r0.xxxx;
+    r3.xyzw = -r1.xyzw + r0.xxxx;
+    r2.xyzw = r2.xyzw / r3.xyzw;
+    r0.xyzw = r2.xyzw + r0.yyyy;
+    r2.xyzw = float4(1.00010002,1.00010002,1.00010002,1.00010002) + -r1.xyzw;
+    r2.xyzw = r1.xyzw / r2.xyzw;
+    r3.xyzw = cmp(float4(0.5,0.5,0.5,0.5) < r1.xyzw);
+    r1.w = 9.99999975e-005 + r1.w;
+    r1.xyz = r1.xyz / r1.www;
+    r0.xyzw = r3.xyzw ? r0.xyzw : r2.xyzw;
+    r1.xyz = r1.xyz * r0.www;
+    r0.xyz = cb0[7].yyy * r0.xyz;
+    r0.w = 1 + -cb0[7].y;
+    r0.xyz = r0.www * r1.xyz + r0.xyz;
+    r0.w = dot(r0.xyz, float3(0.212670997,0.715160012,0.0721689984));
+    r1.xy = -cb0[8].xz + r0.ww;
+    r1.xy = saturate(cb0[8].yw * r1.xy);
+    r0.w = 1 + -r1.y;
+    r0.w = min(r1.x, r0.w);
+    r0.xyz = r0.www * cb0[6].www + r0.xyz;
+    r0.xyz = r0.xyz * cb0[5].xxx + cb0[5].yyy;  // fade to black
+    o0.xyz = max(float3(0,0,0), r0.xyz);
+  }
+  return;
+}

--- a/src/games/ori2/shared.h
+++ b/src/games/ori2/shared.h
@@ -1,0 +1,24 @@
+#ifndef SRC_ORI2_SHARED_H_
+#define SRC_ORI2_SHARED_H_
+
+#ifndef __cplusplus
+#include "../../shaders/renodx.hlsl"
+#endif
+
+// Must be 32bit aligned
+// Should be 4x32
+struct ShaderInjectData {
+  float toneMapType;
+  float toneMapPeakNits;
+  float toneMapGameNits;
+  float toneMapHueCorrection;
+  float colorGradeStrength;
+};
+
+#ifndef __cplusplus
+cbuffer cb11 : register(b11) {
+  ShaderInjectData injectedData : packoffset(c0);
+}
+#endif
+
+#endif  // SRC_ORI2_SHARED_H_


### PR DESCRIPTION
### Pull Request: HDR Fixes and Enhancements for Ori and the Will of the Wisps

#### Summary
This pull request addresses significant flaws in the game's original HDR implementation, which did not deliver true HDR. The original use of `saturate()` before an inverse tonemapping process resulted in an SDR image that was unnaturally stretched and "deep-fried" to fake an HDR appearance. This mod introduces key improvements to the HDR output, ensuring a more authentic and visually appealing experience.

#### Key Changes
1. **Enhanced Tonemapping Options**:
   - Replaces the original approach with the ability to select between:
     - **Vanilla** (Original clamping via `saturate()` followed by inverse tonemapping)
     - **No Tonemapping**
     - **DICE Tonemapping**
   - These options prevent the clamping of highlights and remove the ugly, oversaturated, and overly contrasty look of the original inverse tonemap method, providing a more genuine HDR experience.

2. **Hue Correction**:
   - Introduces a hue correction feature using custom OkLab code, which accurately transfers the hue from the clamped SDR color to the unclamped HDR color. This method restores the hues of the clamped image without causing broken gradients or unpleasant color distortions.

#### Notes
This update ensures that the HDR output truly reflects the capabilities of HDR, avoiding artificial clamping and preserving natural color gradients while correcting oversaturation and contrast issues. The mod has been thoroughly tested over multiple hours of gameplay with no issues so far.
