### PR TITLE
Add Support for Dying Light

### DIFF
--- a/src/games/dyinglight/addon.cpp
+++ b/src/games/dyinglight/addon.cpp
@@ -1,0 +1,314 @@
+/*
+ * Copyright (C) 2024 Musa Haji
+ * Copyright (C) 2024 Carlos Lopez
+ * SPDX-License-Identifier: MIT
+ */
+
+#define ImTextureID ImU64
+
+#define DEBUG_LEVEL_0
+
+// #include <embed/0x9165A474.h> // black smoke
+// #include <embed/0xEC3D14D2.h> // distant fog/smoke
+// #include <embed/0x32A56036.h> // distant fog/smoke
+// #include <embed/0x372AEE4E.h> // black smoke
+// #include <embed/0xAB16B3F7.h> // fire
+// #include <embed/0xB561688F.h> // distant smoke?
+// #include <embed/0x1FB36E90.h> // screen blood effect
+#include <embed/0X61D242D6.h>    // bloom
+// #include <embed/0XBA89E3AC.h> // lens flare - sunstar
+#include <embed/0x3F53E66E.h>    // lens flare - circles and color
+// #include <embed/0x95588EA5.h> // radial dirty lens effect
+// #include <embed/0x8135BEA2.h> // radial lens flare
+#include <embed/0xA6EC1DEC.h>    // god rays
+#include <embed/0xA67ABF78.h>    // tonemap
+// #include <embed/0x11737C11.h> // debris and other effects?
+#include <embed/0x372BEBAB.h>    // LUT 1 (only used in title screen?)
+// #include <embed/0xED9872EB.h> // AA?
+#include <embed/0xC20255E1.h>    // LUT 2a - Film Grain
+#include <embed/0xD42BAD58.h>    // LUT 2b - No Film Grain
+#include <embed/0x45D95DCB.h>    // LUT 2c - B&W Film Grain
+#include <embed/0xBA423838.h>    // LUT 2d - B&W No Film Grain
+#include <embed/0x8194877A.h>    // caps brightness
+#include <embed/0x558540C8.h>    // Gamma adjust
+#include <embed/0x548937E1.h>    // UI - loading screen
+#include <embed/0x404A04C7.h>    // UI - highlighted stuff, orange elements
+#include <embed/0xBCBEE1E5.h>    // UI - text
+#include <embed/0xDC15A986.h>    // UI - Alpha, semitransparent UI boxes, quit overlay
+#include <embed/0x6562755C.h>    // UI - Alpha, some text
+#include <embed/0xB917BF4E.h>    // UI - HUD, nav arrows, sliders, some icons, text boxes
+#include <embed/0x7E8358E3.h>    // UI - HUD numbers
+#include <embed/0x929C8CA5.h>    // UI - Minimap
+#include <embed/0x4D09799F.h>    // UI - HUD Floating markers
+#include <embed/0x9F9A6B19.h>    // UI - Menu tab bar
+#include <embed/0xD292312D.h>    // UI - ?
+#include <embed/0x822D56FA.h>    // UI - Menu blur
+#include <embed/0x23EFA382.h>    // UI - Images
+#include <embed/0x7D5191F6.h>    // UI - Loading please wait
+#include <embed/0x637A1F5C.h>    // UI - popup notification
+#include <embed/0x379D46ED.h>    // UI - Death screen images
+
+#include <deps/imgui/imgui.h>
+#include <include/reshade.hpp>
+
+#include "../../mods/shader.hpp"
+#include "../../mods/swapchain.hpp"
+#include "../../utils/settings.hpp"
+#include "./shared.h"
+
+namespace {
+
+renodx::mods::shader::CustomShaders custom_shaders = {
+    // CustomShaderEntry(0x1FB36E90),       // screen blood effect
+    CustomShaderEntry(0x61D242D6),          // bloom
+    CustomShaderEntry(0x3F53E66E),          // lens flare - circles and color
+    // CustomShaderEntry(0x95588EA5),       // radial dirty lens effect
+    // CustomShaderEntry(0x8135BEA2),       // radial lens flare
+    CustomShaderEntry(0xA6EC1DEC),          // god rays
+    CustomShaderEntry(0xA67ABF78),          // tonemap
+    // CustomShaderEntry(0x11737C11),       // debris and other effects?
+    CustomShaderEntry(0x372BEBAB),          // LUT 1
+    // CustomShaderEntry(0xED9872EB),       // AA?
+    CustomShaderEntry(0xC20255E1),          // LUT 2a - Film Grain
+    CustomShaderEntry(0xD42BAD58),          // LUT 2b - No Film Grain
+    CustomShaderEntry(0x45D95DCB),          // LUT 2c - B&W Film Grain
+    CustomShaderEntry(0xBA423838),          // LUT 2d - B&W No Film Grain
+    CustomShaderEntry(0x8194877A),          // caps brightness
+    CustomSwapchainShader(0x558540C8),      // Gamma adjust
+    CustomSwapchainShader(0x548937E1),      // UI - loading screen
+    CustomSwapchainShader(0x404A04C7),      // UI - highlighted stuff, orange elements
+    CustomSwapchainShader(0xBCBEE1E5),      // UI - text
+    CustomSwapchainShader(0xDC15A986),      // UI - Alpha, semitransparent UI boxes, quit overlay
+    CustomSwapchainShader(0x6562755C),      // UI - Alpha, some text
+    CustomSwapchainShader(0xB917BF4E),      // UI - HUD, nav arrows, slider outlines, some icons, some text boxes
+    CustomSwapchainShader(0x7E8358E3),      // UI - HUD numbers
+    CustomSwapchainShader(0x929C8CA5),      // UI - Minimap  
+    CustomShaderEntry(0x4D09799F),      // UI - HUD Floating markers
+    CustomSwapchainShader(0x9F9A6B19),      // UI - Menu tab bar
+    CustomSwapchainShader(0xD292312D),      // UI - ?
+    CustomSwapchainShader(0x822D56FA),      // UI - Menu blur
+    // CustomSwapchainShader(0x03554D47),      // UI - Menu background - breaks alpha
+    CustomSwapchainShader(0x23EFA382),      // UI - Images
+    CustomSwapchainShader(0x7D5191F6),      // UI - Loading please wait
+    CustomSwapchainShader(0x637A1F5C),      // UI - popup notification
+    CustomSwapchainShader(0x379D46ED),      // UI - Death screen images
+};
+
+ShaderInjectData shader_injection;
+
+renodx::utils::settings::Settings settings = {
+    new renodx::utils::settings::Setting{
+        .key = "toneMapType",
+        .binding = &shader_injection.toneMapType,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 4.f,
+        .can_reset = false,
+        .label = "Tone Mapper",
+        .section = "Tone Mapping",
+        .tooltip = "Sets the tone mapper type",
+        .labels = {"Vanilla", "None", "Vanilla+ (DICE)"},
+    },
+    new renodx::utils::settings::Setting{
+        .key = "toneMapPeakNits",
+        .binding = &shader_injection.toneMapPeakNits,
+        .default_value = 1000.f,
+        .can_reset = false,
+        .label = "Peak Brightness",
+        .section = "Tone Mapping",
+        .tooltip = "Sets the value of peak white in nits",
+        .min = 48.f,
+        .max = 4000.f,
+        .is_enabled = []() { return shader_injection.toneMapType == 2; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "toneMapGameNits",
+        .binding = &shader_injection.toneMapGameNits,
+        .default_value = 203.f,
+        .can_reset = false,
+        .label = "Game Brightness",
+        .section = "Tone Mapping",
+        .tooltip = "Sets the value of 100%% white in nits",
+        .min = 48.f,
+        .max = 500.f,
+    },
+    new renodx::utils::settings::Setting{
+        .key = "toneMapUINits",
+        .binding = &shader_injection.toneMapUINits,
+        .default_value = 203.f,
+        .can_reset = false,
+        .label = "UI Brightness",
+        .section = "Tone Mapping",
+        .tooltip = "Sets the brightness of UI and HUD elements in nits",
+        .min = 48.f,
+        .max = 500.f,
+    },
+    new renodx::utils::settings::Setting{
+        .key = "toneMapGammaCorrection",
+        .binding = &shader_injection.toneMapGammaCorrection,
+        .value_type = renodx::utils::settings::SettingValueType::BOOLEAN,
+        .default_value = 1.f,
+        .can_reset = false,
+        .label = "Gamma Correction",
+        .section = "Tone Mapping",
+        .tooltip = "Emulates a 2.2 EOTF (use with HDR or sRGB)",
+    },
+    new renodx::utils::settings::Setting{
+        .key = "toneMapHueCorrection",
+        .binding = &shader_injection.toneMapHueCorrection,
+        .default_value = 50.f,
+        .can_reset = false,
+        .label = "Hue Correction",
+        .section = "Tone Mapping",
+        .tooltip = "Emulates hue shifting from the vanilla tonemapper",
+        .max = 100.f,
+        .is_enabled = []() { return shader_injection.toneMapType == 2; },
+        .parse = [](float value) { return value * 0.01f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "colorGradeExposure",
+        .binding = &shader_injection.colorGradeExposure,
+        .default_value = 1.f,
+        .label = "Exposure",
+        .section = "Color Grading",
+        .max = 10.f,
+        .format = "%.2f",
+        .is_enabled = []() { return shader_injection.toneMapType == 2; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "colorGradeHighlights",
+        .binding = &shader_injection.colorGradeHighlights,
+        .default_value = 50.f,
+        .label = "Highlights",
+        .section = "Color Grading",
+        .max = 100.f,
+        .is_enabled = []() { return shader_injection.toneMapType == 2; },
+        .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "colorGradeShadows",
+        .binding = &shader_injection.colorGradeShadows,
+        .default_value = 50.f,
+        .label = "Shadows",
+        .section = "Color Grading",
+        .max = 100.f,
+        .is_enabled = []() { return shader_injection.toneMapType == 2; },
+        .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "colorGradeContrast",
+        .binding = &shader_injection.colorGradeContrast,
+        .default_value = 50.f,
+        .label = "Contrast",
+        .section = "Color Grading",
+        .max = 100.f,
+        .is_enabled = []() { return shader_injection.toneMapType == 2; },
+        .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "colorGradeSaturation",
+        .binding = &shader_injection.colorGradeSaturation,
+        .default_value = 50.f,
+        .label = "Saturation",
+        .section = "Color Grading",
+        .max = 100.f,
+        .is_enabled = []() { return shader_injection.toneMapType == 2; },
+        .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "colorGradeLUTStrength",
+        .binding = &shader_injection.colorGradeLUTStrength,
+        .default_value = 100.f,
+        .label = "LUT Strength",
+        .section = "Color Grading",
+        .max = 100.f,
+        .is_enabled = []() { return shader_injection.toneMapType != 1; },
+        .parse = [](float value) { return value * 0.01f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "fxBloom",
+        .binding = &shader_injection.fxBloom,
+        .default_value = 50.f,
+        .label = "Bloom",
+        .section = "Effects",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "fxLensFlare",
+        .binding = &shader_injection.fxLensFlare,
+        .default_value = 50.f,
+        .label = "Lens Flare",
+        .section = "Effects",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "fxFilmGrain",
+        .binding = &shader_injection.fxFilmGrain,
+        .default_value = 50.f,
+        .label = "FilmGrain",
+        .section = "Effects",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+    },
+};
+
+void OnPresetOff() {
+  renodx::utils::settings::UpdateSetting("toneMapType", 0.f);
+  renodx::utils::settings::UpdateSetting("toneMapPeakNits", 203.f);
+  renodx::utils::settings::UpdateSetting("toneMapGameNits", 203.f);
+  renodx::utils::settings::UpdateSetting("toneMapUINits", 203.f);
+  renodx::utils::settings::UpdateSetting("toneMapGammaCorrection", 0);
+  renodx::utils::settings::UpdateSetting("toneMapHueCorrection", 100);
+  renodx::utils::settings::UpdateSetting("colorGradeExposure", 1.f);
+  renodx::utils::settings::UpdateSetting("colorGradeHighlights", 50.f);
+  renodx::utils::settings::UpdateSetting("colorGradeShadows", 50.f);
+  renodx::utils::settings::UpdateSetting("colorGradeContrast", 50.f);
+  renodx::utils::settings::UpdateSetting("colorGradeSaturation", 50.f);
+  renodx::utils::settings::UpdateSetting("colorGradeLUTStrength", 100.f);
+  renodx::utils::settings::UpdateSetting("colorGradeBlowout", 0.f);
+  renodx::utils::settings::UpdateSetting("fxBloom", 50.f);
+  renodx::utils::settings::UpdateSetting("fxLensFlare", 50.f);
+  renodx::utils::settings::UpdateSetting("fxFilmGrain", 50.f);
+}
+
+}  // namespace
+
+// NOLINTBEGIN(readability-identifier-naming)
+
+extern "C" __declspec(dllexport) const char* NAME = "RenoDX";
+extern "C" __declspec(dllexport) const char* DESCRIPTION = "RenoDX for Dying Light";
+
+// NOLINTEND(readability-identifier-naming)
+
+BOOL APIENTRY DllMain(HMODULE h_module, DWORD fdw_reason, LPVOID lpv_reserved) {
+  switch (fdw_reason) {
+    case DLL_PROCESS_ATTACH:
+      if (!reshade::register_addon(h_module)) return FALSE;
+
+    //   renodx::mods::shader::force_pipeline_cloning = true;
+    //   renodx::mods::shader::trace_unmodified_shaders = true;
+      renodx::mods::swapchain::force_borderless = false;
+    //   renodx::mods::swapchain::prevent_full_screen = true;
+      for (auto index : {3, 4}) {
+        renodx::mods::swapchain::swap_chain_upgrade_targets.push_back({
+            .old_format = reshade::api::format::r8g8b8a8_typeless,
+            .new_format = reshade::api::format::r16g16b16a16_float,
+            .index = index,
+        });
+      }
+
+      break;
+    case DLL_PROCESS_DETACH:
+      reshade::unregister_addon(h_module);
+      break;
+  }
+
+  renodx::utils::settings::Use(fdw_reason, &settings, &OnPresetOff);
+
+  renodx::mods::swapchain::Use(fdw_reason);
+
+  renodx::mods::shader::Use(fdw_reason, custom_shaders, &shader_injection);
+
+  return TRUE;
+}

--- a/src/games/dyinglight/bloom_0x61D242D6.ps_5_0.hlsl
+++ b/src/games/dyinglight/bloom_0x61D242D6.ps_5_0.hlsl
@@ -1,0 +1,94 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sat May 25 22:39:13 2024
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s0_s : register(s0);
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  float4 v4 : TEXCOORD3,
+  float4 v5 : TEXCOORD4,
+  float4 v6 : TEXCOORD5,
+  float4 v7 : TEXCOORD6,
+  float4 v8 : TEXCOORD7,
+  float4 v9 : TEXCOORD8,
+  float4 v10 : TEXCOORD9,
+  out float4 o0 : SV_TARGET0)
+{
+  float4 r0,r1;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = t0.Sample(s0_s, v7.wy).xyzw;
+  r0.xyzw = float4(0.0840036124,0.0840036124,0.0840036124,0.0840036124) * r0.xyzw;
+  r1.xyzw = t0.Sample(s0_s, v7.wx).xyzw;
+  r0.xyzw = r1.xyzw * float4(0.133958012,0.133958012,0.133958012,0.133958012) + r0.xyzw;
+  r1.xyzw = t0.Sample(s0_s, v7.wz).xyzw;
+  r0.xyzw = r1.xyzw * float4(0.0526777469,0.0526777469,0.0526777469,0.0526777469) + r0.xyzw;
+  r1.xyzw = t0.Sample(s0_s, v6.wx).xyzw;
+  r0.xyzw = r1.xyzw * float4(0.0330336392,0.0330336392,0.0330336392,0.0330336392) + r0.xyzw;
+  r1.xyzw = t0.Sample(s0_s, v6.wy).xyzw;
+  r0.xyzw = r1.xyzw * float4(0.0207150355,0.0207150355,0.0207150355,0.0207150355) + r0.xyzw;
+  r1.xyzw = t0.Sample(s0_s, v6.wz).xyzw;
+  r0.xyzw = r1.xyzw * float4(0.012990172,0.012990172,0.012990172,0.012990172) + r0.xyzw;
+  r1.xyzw = t0.Sample(s0_s, v8.wx).xyzw;
+  r0.xyzw = r1.xyzw * float4(0.00814599544,0.00814599544,0.00814599544,0.00814599544) + r0.xyzw;
+  r1.xyzw = t0.Sample(s0_s, v8.wy).xyzw;
+  r0.xyzw = r1.xyzw * float4(0.00510826474,0.00510826474,0.00510826474,0.00510826474) + r0.xyzw;
+  r1.xyzw = t0.Sample(s0_s, v8.wz).xyzw;
+  r0.xyzw = r1.xyzw * float4(0.00320333708,0.00320333708,0.00320333708,0.00320333708) + r0.xyzw;
+  r1.xyzw = t0.Sample(s0_s, v10.wx).xyzw;
+  r0.xyzw = r1.xyzw * float4(0.00200877781,0.00200877781,0.00200877781,0.00200877781) + r0.xyzw;
+  r1.xyzw = t0.Sample(s0_s, v10.wy).xyzw;
+  r0.xyzw = r1.xyzw * float4(0.00125968258,0.00125968258,0.00125968258,0.00125968258) + r0.xyzw;
+  r1.xyzw = t0.Sample(s0_s, v10.wz).xyzw;
+  r0.xyzw = r1.xyzw * float4(0.000789933198,0.000789933198,0.000789933198,0.000789933198) + r0.xyzw;
+  r1.xyzw = t0.Sample(s0_s, v9.wx).xyzw;
+  r0.xyzw = r1.xyzw * float4(0.000495358487,0.000495358487,0.000495358487,0.000495358487) + r0.xyzw;
+  r1.xyzw = t0.Sample(s0_s, v9.wy).xyzw;
+  r0.xyzw = r1.xyzw * float4(0.000310633885,0.000310633885,0.000310633885,0.000310633885) + r0.xyzw;
+  r1.xyzw = t0.Sample(s0_s, v9.wz).xyzw;
+  r0.xyzw = r1.xyzw * float4(0.000194795124,0.000194795124,0.000194795124,0.000194795124) + r0.xyzw;
+  r1.xyzw = t0.Sample(s0_s, v2.wx).xyzw;
+  r0.xyzw = r1.xyzw * float4(0.133958012,0.133958012,0.133958012,0.133958012) + r0.xyzw;
+  r1.xyzw = t0.Sample(s0_s, v2.wy).xyzw;
+  r0.xyzw = r1.xyzw * float4(0.0840036124,0.0840036124,0.0840036124,0.0840036124) + r0.xyzw;
+  r1.xyzw = t0.Sample(s0_s, v2.wz).xyzw;
+  r0.xyzw = r1.xyzw * float4(0.0526777469,0.0526777469,0.0526777469,0.0526777469) + r0.xyzw;
+  r1.xyzw = t0.Sample(s0_s, v1.wx).xyzw;
+  r0.xyzw = r1.xyzw * float4(0.0330336392,0.0330336392,0.0330336392,0.0330336392) + r0.xyzw;
+  r1.xyzw = t0.Sample(s0_s, v1.wy).xyzw;
+  r0.xyzw = r1.xyzw * float4(0.0207150355,0.0207150355,0.0207150355,0.0207150355) + r0.xyzw;
+  r1.xyzw = t0.Sample(s0_s, v1.wz).xyzw;
+  r0.xyzw = r1.xyzw * float4(0.012990172,0.012990172,0.012990172,0.012990172) + r0.xyzw;
+  r1.xyzw = t0.Sample(s0_s, v3.wx).xyzw;
+  r0.xyzw = r1.xyzw * float4(0.00814599544,0.00814599544,0.00814599544,0.00814599544) + r0.xyzw;
+  r1.xyzw = t0.Sample(s0_s, v3.wy).xyzw;
+  r0.xyzw = r1.xyzw * float4(0.00510826474,0.00510826474,0.00510826474,0.00510826474) + r0.xyzw;
+  r1.xyzw = t0.Sample(s0_s, v3.wz).xyzw;
+  r0.xyzw = r1.xyzw * float4(0.00320333708,0.00320333708,0.00320333708,0.00320333708) + r0.xyzw;
+  r1.xyzw = t0.Sample(s0_s, v5.wx).xyzw;
+  r0.xyzw = r1.xyzw * float4(0.00200877781,0.00200877781,0.00200877781,0.00200877781) + r0.xyzw;
+  r1.xyzw = t0.Sample(s0_s, v5.wy).xyzw;
+  r0.xyzw = r1.xyzw * float4(0.00125968258,0.00125968258,0.00125968258,0.00125968258) + r0.xyzw;
+  r1.xyzw = t0.Sample(s0_s, v5.wz).xyzw;
+  r0.xyzw = r1.xyzw * float4(0.000789933198,0.000789933198,0.000789933198,0.000789933198) + r0.xyzw;
+  r1.xyzw = t0.Sample(s0_s, v4.wx).xyzw;
+  r0.xyzw = r1.xyzw * float4(0.000495358487,0.000495358487,0.000495358487,0.000495358487) + r0.xyzw;
+  r1.xyzw = t0.Sample(s0_s, v4.wy).xyzw;
+  r0.xyzw = r1.xyzw * float4(0.000310633885,0.000310633885,0.000310633885,0.000310633885) + r0.xyzw;
+  r1.xyzw = t0.Sample(s0_s, v4.wz).xyzw;
+  o0.xyzw = r1.xyzw * float4(0.000194795124,0.000194795124,0.000194795124,0.000194795124) + r0.xyzw * injectedData.fxBloom;
+  return;
+}

--- a/src/games/dyinglight/cap_0x8194877A.ps_5_0.hlsl
+++ b/src/games/dyinglight/cap_0x8194877A.ps_5_0.hlsl
@@ -1,0 +1,39 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sat May 25 22:39:21 2024
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[1];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_TARGET0)
+{
+  float4 r0,r1;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = t0.Sample(s0_s, v1.xy).xyzw;
+
+  // no noticeable effect when skipping this code
+  r1.x = r0.x + r0.y;
+  r1.x = r1.x + r0.z;
+  r0.xyzw = -r1.xxxx * float4(0.333333343,0.333333343,0.333333343,0.333333343) + r0.xyzw;
+  r1.x = 0.333333343 * r1.x;
+  o0.xyzw = cb0[0].xxxx * r0.xyzw + r1.xxxx;  //  o0.xyzw = saturate(cb0[0].xxxx * r0.xyzw + r1.xxxx);
+  o0.w = saturate(o0.w);
+  return;
+}

--- a/src/games/dyinglight/gamma_0x558540C8.ps_5_0.hlsl
+++ b/src/games/dyinglight/gamma_0x558540C8.ps_5_0.hlsl
@@ -1,0 +1,46 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sat May 25 22:39:10 2024
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[1];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_TARGET0)
+{
+  float4 r0;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = t0.SampleLevel(s0_s, v1.xy, 0).xyzw;
+  o0.xyzw = r0.xyzw;
+
+  if (injectedData.toneMapType == 0) {  // vanilla tonemap flickers if left unclamped
+    o0.xyz = saturate(o0.xyz);
+  }
+
+  if (injectedData.toneMapGammaCorrection) { // fix srgb 2.2 mismatch
+    o0.xyz = renodx::color::srgb::from::BT709(o0.xyz);
+    o0.xyz = sign(o0.xyz) * pow(abs(o0.xyz), 2.2f);
+  }
+  // apply game gamma adjustment slider
+  o0.xyz = sign(o0.xyz) * pow(abs(o0.xyz), cb0[0].xxx);
+
+  o0.xyz *= injectedData.toneMapGameNits/80.f;
+  o0.w = saturate(o0.w);
+  return;
+}

--- a/src/games/dyinglight/godrays_0xA6EC1DEC.ps_5_0.hlsl
+++ b/src/games/dyinglight/godrays_0xA6EC1DEC.ps_5_0.hlsl
@@ -1,0 +1,48 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sat May 25 22:39:30 2024
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[1];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_TARGET0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyz = t2.SampleLevel(s2_s, v1.xy, 0).xyz;
+  r0.xyz = cb0[0].yyy * r0.xyz;
+  r0.w = t1.SampleLevel(s1_s, float2(0,0), 0).x;
+  r1.xyzw = t0.SampleLevel(s0_s, v1.xy, 0).xyzw;
+  r1.xyz = r1.xyz * r0.www;
+  o0.w = r1.w;
+  r0.w = dot(float3(0.212500006,0.715399981,0.0720999986), r1.xyz);
+  r2.xy = r0.ww * cb0[0].xz + cb0[0].zz;
+  r0.w = r2.x / r2.y;
+  o0.xyz = r1.xyz * r0.www + r0.xyz;  //  o0.xyz = saturate(r1.xyz * r0.www + r0.xyz);
+  return;
+}

--- a/src/games/dyinglight/lensflare_0x3F53E66E.ps_5_0.hlsl
+++ b/src/games/dyinglight/lensflare_0x3F53E66E.ps_5_0.hlsl
@@ -1,0 +1,47 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sat May 25 22:39:05 2024
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[1];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  out float4 o0 : SV_TARGET0)
+{
+  float4 r0,r1;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyz = t0.Sample(s0_s, v2.zw).xyz;
+  r0.xyz = v1.xyz * r0.xyz;
+  r0.w = t1.SampleLevel(s1_s, v2.xy, 0).x;
+  r0.xyz = r0.xyz * r0.www;
+  r1.xy = t2.SampleLevel(s2_s, v2.xy, 0).zw;
+  r1.x = saturate(cb0[0].y * r1.x + r1.y);
+  r0.w = v1.w;
+  o0.xyzw = -r0.xyzw * r1.xxxx + r0.xyzw * injectedData.fxLensFlare;
+  return;
+}

--- a/src/games/dyinglight/load_0x548937E1.ps_5_0.hlsl
+++ b/src/games/dyinglight/load_0x548937E1.ps_5_0.hlsl
@@ -1,0 +1,48 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sat May 25 22:39:10 2024
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float3 v2 : TEXCOORD1,
+  out float4 o0 : SV_TARGET0)
+{
+  float4 r0,r1;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.x = t0.SampleLevel(s0_s, v2.xy, 0).y;
+  r0.y = t0.SampleLevel(s0_s, v1.zw, 0).y;
+  r0.x = r0.x + r0.y;
+  r0.y = v2.z * 2 + -1;
+  r0.x = r0.x * 0.5 + r0.y;
+  r0.x = saturate(20 * r0.x);
+  r1.xyzw = t1.SampleLevel(s1_s, v1.xy, 0).wxyz;
+  r1.x = saturate(r1.x);
+  r0.yzw = r1.xxx * r1.yzw;
+  o0.xyz = r0.yzw * r0.xxx;
+  o0.w = 1;
+
+  o0.xyz = saturate(o0.xyz);
+  if (injectedData.toneMapGammaCorrection) { // fix srgb 2.2 mismatch
+    o0.xyz = renodx::color::srgb::from::BT709(o0.xyz);
+    o0.xyz = pow(o0.xyz, 2.2f);
+  }
+  o0.xyz *= injectedData.toneMapUINits/80.f;
+  return;
+}

--- a/src/games/dyinglight/lut1_0x372BEBAB.ps_5_0.hlsl
+++ b/src/games/dyinglight/lut1_0x372BEBAB.ps_5_0.hlsl
@@ -1,0 +1,92 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sat May 25 22:39:03 2024
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[8];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  float4 v4 : TEXCOORD3,
+  float3 v5 : TEXCOORD4,
+  out float4 o0 : SV_TARGET0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = t0.SampleLevel(s0_s, v3.xz, 0).xyzw;
+
+  float3 inputColor = r0.xyz;
+
+  r0.xyzw = cb0[2].zzzz * r0.xyzw;
+  r1.xyzw = t0.SampleLevel(s0_s, v3.xy, 0).xyzw;
+  r0.xyzw = r1.xyzw * cb0[2].yyyy + r0.xyzw;
+  r1.xyzw = t0.SampleLevel(s0_s, v3.xw, 0).xyzw;
+  r0.xyzw = r1.xyzw * cb0[2].wwww + r0.xyzw;
+  r1.xyzw = t0.SampleLevel(s0_s, v5.xy, 0).xyzw;
+  r0.xyzw = r1.xyzw * cb0[3].xxxx + r0.xyzw;
+  r1.xyzw = t0.SampleLevel(s0_s, v5.xz, 0).xyzw;
+  r0.xyzw = r1.xyzw * cb0[3].yyyy + r0.xyzw;
+  r1.xyz = r0.xyz * float3(0.996093988,0.996093988,0.996093988) + float3(0.00195299997,0.00195299997,0.00195299997);  // 255/256 + 1/512
+  o0.w = r0.w;
+  r0.x = r1.z;
+  r0.y = cb0[1].w;
+  r0.z = t0.SampleLevel(s0_s, r0.xy, 0).z;
+  r2.xz = r1.xy;
+  r2.yw = cb0[1].ww;
+  r0.x = t0.SampleLevel(s0_s, r2.xy, 0).x;
+  r0.y = t0.SampleLevel(s0_s, r2.zw, 0).y;
+  r1.w = cb0[0].w;
+  r2.x = t0.SampleLevel(s0_s, r1.xw, 0).x;
+  r2.y = t0.SampleLevel(s0_s, r1.yw, 0).y;
+  r2.z = t0.SampleLevel(s0_s, r1.zw, 0).z;
+  r0.xyz = -r2.xyz + r0.xyz;
+  r0.xyz = cb0[2].xxx * r0.xyz + r2.xyz;
+  r1.xyz = t0.SampleLevel(s0_s, v4.xy, 0).xyz;
+  r1.xyz = r1.xyz + -r0.xyz;
+  r0.xyz = cb0[3].zzz * r1.xyz + r0.xyz;
+  r1.xyz = t0.SampleLevel(s0_s, v4.xz, 0).xyz;
+  r1.xyz = r1.xyz + -r0.xyz;
+  r0.xyz = cb0[3].www * r1.xyz + r0.xyz;
+  r1.xyz = t0.SampleLevel(s0_s, v4.xw, 0).xyz;
+  r1.xyz = r1.xyz + -r0.xyz;
+  r0.xyz = cb0[4].www * r1.xyz + r0.xyz;
+  r1.xyz = t0.SampleLevel(s0_s, v1.xy, 0).xyz;
+  r1.xyz = r1.xyz + -r0.xyz;
+  r0.xyz = cb0[5].www * r1.xyz + r0.xyz;
+  r1.xyz = t0.SampleLevel(s0_s, v1.xz, 0).xyz;
+  r1.xyz = r1.xyz + -r0.xyz;
+  r0.xyz = cb0[6].www * r1.xyz + r0.xyz;
+  r1.xyz = t0.SampleLevel(s0_s, v1.xw, 0).xyz;
+  r1.xyz = r1.xyz + -r0.xyz;
+  r0.xyz = cb0[7].xxx * r1.xyz + r0.xyz;
+  r1.xyz = t0.SampleLevel(s0_s, v2.xy, 0).xyz;
+  r1.xyz = r1.xyz + -r0.xyz;
+  r0.xyz = cb0[7].yyy * r1.xyz + r0.xyz;
+  r1.xyz = t0.SampleLevel(s0_s, v2.xz, 0).xyz;
+  r1.xyz = r1.xyz + -r0.xyz;
+  r0.xyz = cb0[7].zzz * r1.xyz + r0.xyz;
+  r1.xyz = t0.SampleLevel(s0_s, v2.xw, 0).xyz;
+  r1.xyz = r1.xyz + -r0.xyz;
+  o0.xyz = cb0[7].www * r1.xyz + r0.xyz;
+
+  o0.xyz = lerp(inputColor, o0.xyz, injectedData.colorGradeLUTStrength);
+
+  return;
+}

--- a/src/games/dyinglight/lut2_grain_0xC20255E1.ps_5_0.hlsl
+++ b/src/games/dyinglight/lut2_grain_0xC20255E1.ps_5_0.hlsl
@@ -1,0 +1,119 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sat May 25 22:39:36 2024
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[4];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  out float4 o0 : SV_TARGET0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = t1.Sample(s1_s, v1.xy).xyzw;
+  r0.xyzw = r0.xyzw * float4(2,2,2,2) + float4(-1,-1,-1,-1);
+  r1.xyzw = t2.Sample(s2_s, v1.zw).xyzw;
+  r1.xyzw = r1.xyzw * float4(2,2,2,2) + float4(-1,-1,-1,-1);
+  r0.xyzw = r1.xyzw + r0.xyzw;
+  r0.xyzw = cb0[2].wwww + r0.xyzw;
+  r0.xyzw = frac(r0.xyzw);
+  r0.xyzw = r0.xyzw * float4(2,2,2,2) + float4(-1,-1,-1,-1);
+  r0.xyzw = saturate(abs(r0.xyzw) * float4(5,5,5,5) + float4(-1,-1,-1,-1)); // making this max() increases film grain
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r0.xyzw = r0.xyzw * cb0[2].yyyy + cb0[2].zzzz;
+  r0.xyz = r0.xyz + -r0.www;
+  r0.xyz = cb0[3].xxx * r0.xyz + r0.www;
+  r1.xy = -abs(v3.xy) * abs(v3.xy) + float2(1,1);
+  r0.w = saturate(-r1.x * r1.y + 1);  //  r0.w = saturate(-r1.x * r1.y + 1);
+  r0.w = cb0[2].x * r0.w;
+  r0.w = cb0[0].w * r0.w;
+  r1.x = t0.SampleLevel(s0_s, v2.xy, 0).x;
+  r1.y = t0.SampleLevel(s0_s, v2.zw, 0).z;
+  r2.xyzw = t0.SampleLevel(s0_s, v3.zw, 0).xyzw;  // render
+  r1.xy = -r2.xz + r1.xy;
+  r2.xz = r0.ww * r1.xy + r2.xz;
+  o0.w = r2.w;
+  r0.w = saturate(dot(float3(0.212500006,0.715399981,0.0720999986), r2.xyz)); //    r0.w = saturate(dot(float3(0.212500006,0.715399981,0.0720999986), r2.xyz));
+  r0.w = sign(r0.w) * sqrt(abs(r0.w));
+  r0.w = sign(r0.w) * sqrt(abs(r0.w));
+  r0.xyz = r0.xyz * r0.www;
+  r1.xyz = r0.xyz * r0.xyz;
+  r0.xyz = cmp(r0.xyz >= float3(0,0,0));
+  r0.xyz = r0.xyz ? r1.xyz : -r1.xyz;
+  r0.xyz = r0.xyz * injectedData.fxFilmGrain + r2.xyz;  // film grain
+  r0.w = dot(float3(0.212500006,0.715399981,0.0720999986), r0.xyz);
+  r1.xyz = r0.www + -r0.xyz;
+  r0.w = saturate(r0.w * cb0[0].y + cb0[0].z);  //  r0.w = saturate(r0.w * cb0[0].y + cb0[0].z);
+  r0.w = cb0[0].x * r0.w;
+  r0.xyz = r0.www * r1.xyz + r0.xyz;
+  r0.w = dot(r0.xyz, cb0[1].xyz);
+  r0.xyz = r0.xyz * cb0[1].www + r0.www;
+
+  float3 outputColor = r0.xyz;
+  float3 hdrColor = outputColor;
+  float3 sdrColor = outputColor;
+  const float vanillaMidGray = 0.178f;
+  if (injectedData.toneMapType == 2) {
+    const float paperWhite = injectedData.toneMapGameNits / renodx::color::srgb::REFERENCE_WHITE;
+    hdrColor = outputColor * paperWhite;
+    const float peakWhite = injectedData.toneMapPeakNits / renodx::color::srgb::REFERENCE_WHITE;
+    const float highlightsShoulderStart = vanillaMidGray * paperWhite;  // Don't tonemap the blended part of the tonemapper
+    hdrColor = renodx::tonemap::dice::BT709(hdrColor, peakWhite, highlightsShoulderStart);
+    sdrColor = renodx::tonemap::dice::BT709(hdrColor, paperWhite, highlightsShoulderStart);
+    hdrColor /= paperWhite;
+    sdrColor /= paperWhite;
+  }
+  r0.xyz = sdrColor;
+
+  // LUT
+  r0.xyz = sign(r0.xyz) * pow(abs(r0.xyz), 1.f / 2.2f);
+  r0.xyz = r0.xyz * float3(0.99609375,0.99609375,0.99609375) + float3(0.001953125,0.001953125,0.001953125);
+  r1.x = t4.Sample(s4_s, r0.xx).x;
+  r1.y = t4.Sample(s4_s, r0.yy).y;
+  r1.z = t4.Sample(s4_s, r0.zz).z;
+  r0.xyz = sign(r1.xyz) * pow(abs(r1.xyz), 2.2f);
+
+  if (injectedData.toneMapType > 1) {
+    outputColor = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(sdrColor), r0.xyz, injectedData.colorGradeLUTStrength);
+  } else if (injectedData.toneMapType == 0) {
+    outputColor = lerp(outputColor, r0.xyz, injectedData.colorGradeLUTStrength);
+  }
+
+  r1.xyz = t3.SampleLevel(s3_s, v3.zw, 0).xyz;
+  o0.xyz = r1.xyz * outputColor; //  o0.xyz = r1.xyz * r0.xyz;
+  return;
+}

--- a/src/games/dyinglight/lut2_no_grain_0xD42BAD58.ps_5_0.hlsl
+++ b/src/games/dyinglight/lut2_no_grain_0xD42BAD58.ps_5_0.hlsl
@@ -1,0 +1,86 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sat May 25 22:39:40 2024
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[3];
+}
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(
+    float4 v0 : SV_POSITION0,
+                float4 v1 : TEXCOORD0,
+                            float4 v2 : TEXCOORD1,
+                                        out float4 o0 : SV_TARGET0)
+{
+  float4 r0, r1;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  // not sure what this code does, no observed effect when i skip it
+  r0.xy = -abs(v2.xy) * abs(v2.xy) + float2(1, 1);
+  r0.x = saturate(-r0.x * r0.y + 1); //  r0.x = saturate(-r0.x * r0.y + 1);
+  r0.x = cb0[2].x * r0.x;
+  r0.x = cb0[0].w * r0.x;
+  r0.y = t0.SampleLevel(s0_s, v1.xy, 0).x;
+  r0.z = t0.SampleLevel(s0_s, v1.zw, 0).z;
+  r1.xyzw = t0.SampleLevel(s0_s, v2.zw, 0).xyzw; // render
+  r0.yz = -r1.xz + r0.yz;
+  r1.xz = r0.xx * r0.yz + r1.xz;
+  o0.w = r1.w;
+  r0.x = dot(float3(0.212500006, 0.715399981, 0.0720999986), r1.xyz);
+  r0.yzw = r0.xxx + -r1.xyz;
+  r0.x = saturate(r0.x * cb0[0].y + cb0[0].z);  //  r0.x = saturate(r0.x * cb0[0].y + cb0[0].z);
+  r0.x = cb0[0].x * r0.x;
+  r0.xyz = r0.xxx * r0.yzw + r1.xyz;
+  r0.w = dot(r0.xyz, cb0[1].xyz);
+  r0.xyz = r0.xyz * cb0[1].www + r0.www; //    r0.xyz = saturate(r0.xyz * cb0[1].www + r0.www);
+
+  float3 outputColor = r0.xyz;
+  float3 hdrColor = outputColor;
+  float3 sdrColor = outputColor;
+  const float vanillaMidGray = 0.178f;
+  if (injectedData.toneMapType == 2) {
+    const float paperWhite = injectedData.toneMapGameNits / renodx::color::srgb::REFERENCE_WHITE;
+    hdrColor = outputColor * paperWhite;
+    const float peakWhite = injectedData.toneMapPeakNits / renodx::color::srgb::REFERENCE_WHITE;
+    const float highlightsShoulderStart = vanillaMidGray * paperWhite;  // Don't tonemap the blended part of the tonemapper
+    hdrColor = renodx::tonemap::dice::BT709(hdrColor, peakWhite, highlightsShoulderStart);
+    sdrColor = renodx::tonemap::dice::BT709(hdrColor, paperWhite, highlightsShoulderStart);
+    hdrColor /= paperWhite;
+    sdrColor /= paperWhite;
+  }
+  r0.xyz = sdrColor;
+
+  // LUT
+  r0.xyz = sign(r0.xyz) * pow(abs(r0.xyz), 1.f / 2.2f);
+  r0.xyz = r0.xyz * float3(0.99609375,0.99609375,0.99609375) + float3(0.001953125,0.001953125,0.001953125);
+  r1.x = t2.Sample(s2_s, r0.xx).x;
+  r1.y = t2.Sample(s2_s, r0.yy).y;
+  r1.z = t2.Sample(s2_s, r0.zz).z;
+  r0.xyz = sign(r1.xyz) * pow(abs(r1.xyz), 2.2f);
+  
+  if (injectedData.toneMapType > 1) {
+    outputColor = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(sdrColor), r0.xyz, injectedData.colorGradeLUTStrength);
+  } else if (injectedData.toneMapType == 0) {
+    outputColor = lerp(outputColor, r0.xyz, injectedData.colorGradeLUTStrength);
+  }
+
+  r1.xyz = t1.SampleLevel(s1_s, v2.zw, 0).xyz;
+  o0.xyz = r1.xyz * outputColor; //  o0.xyz = r1.xyz * r0.xyz;
+  return;
+}

--- a/src/games/dyinglight/lut_bw_grain_0x45D95DCB.ps_5_0.hlsl
+++ b/src/games/dyinglight/lut_bw_grain_0x45D95DCB.ps_5_0.hlsl
@@ -1,0 +1,125 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sat May 25 22:39:06 2024
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[8];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  out float4 o0 : SV_TARGET0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = t1.Sample(s1_s, v1.xy).xyzw;
+  r0.xyzw = r0.xyzw * float4(2,2,2,2) + float4(-1,-1,-1,-1);
+  r1.xyzw = t2.Sample(s2_s, v1.zw).xyzw;
+  r1.xyzw = r1.xyzw * float4(2,2,2,2) + float4(-1,-1,-1,-1);
+  r0.xyzw = r1.xyzw + r0.xyzw;
+  r0.xyzw = cb0[2].wwww + r0.xyzw;
+  r0.xyzw = frac(r0.xyzw);
+  r0.xyzw = r0.xyzw * float4(2,2,2,2) + float4(-1,-1,-1,-1);
+  r0.xyzw = saturate(abs(r0.xyzw) * float4(5,5,5,5) + float4(-1,-1,-1,-1));
+  r0.xyzw = float4(1,1,1,1) + -r0.xyzw;
+  r0.xyzw = r0.xyzw * cb0[2].yyyy + cb0[2].zzzz;
+  r0.xyz = r0.xyz + -r0.www;
+  r0.xyz = cb0[3].xxx * r0.xyz + r0.www;
+  r1.xy = -abs(v3.xy) * abs(v3.xy) + float2(1,1);
+  r0.w = saturate(-r1.x * r1.y + 1);
+  r0.w = cb0[2].x * r0.w;
+  r0.w = cb0[0].w * r0.w;
+  r1.x = t0.SampleLevel(s0_s, v2.xy, 0).x;
+  r1.y = t0.SampleLevel(s0_s, v2.zw, 0).z;
+  r2.xyzw = t0.SampleLevel(s0_s, v3.zw, 0).xyzw;
+  r1.xy = -r2.xz + r1.xy;
+  r2.xz = r0.ww * r1.xy + r2.xz;
+  o0.w = r2.w;
+  r0.w = saturate(dot(float3(0.212500006,0.715399981,0.0720999986), r2.xyz));
+  r0.w = sqrt(r0.w);
+  r0.w = sqrt(r0.w);
+  r0.xyz = r0.xyz * r0.www;
+  r1.xyz = r0.xyz * r0.xyz;
+  r0.xyz = cmp(r0.xyz >= float3(0,0,0));
+  r0.xyz = r0.xyz ? r1.xyz : -r1.xyz;
+  r0.xyz = r0.xyz + r2.xyz; //  r0.xyz = saturate(r0.xyz + r2.xyz);
+  r0.w = dot(float3(0.212500006,0.715399981,0.0720999986), r0.xyz);
+  r1.xyz = r0.www + -r0.xyz;
+  r0.w = saturate(r0.w * cb0[0].y + cb0[0].z);
+  r0.w = cb0[0].x * r0.w;
+  r0.xyz = r0.www * r1.xyz + r0.xyz;
+  r0.w = dot(r0.xyz, cb0[1].xyz);
+  r0.xyz = r0.xyz * cb0[1].www + r0.www;  //  r0.xyz = saturate(r0.xyz * cb0[1].www + r0.www);
+  r0.w = saturate(dot(r0.xyz, cb0[4].xyz));
+  r1.xyz = cb0[6].xyz * r0.www;
+  r2.xyz = r0.xyz * cb0[7].xyz + -r1.xyz;
+  r0.w = saturate(dot(r0.xyz, cb0[5].xyz));
+  r1.xyz = r0.www * r2.xyz + r1.xyz;  //  r1.xyz = saturate(r0.www * r2.xyz + r1.xyz);
+  r0.xyz = r0.xyz * cb0[6].www + r1.xyz;  //  r0.xyz = saturate(r0.xyz * cb0[6].www + r1.xyz);
+
+  float3 outputColor = r0.xyz;
+  float3 hdrColor = outputColor;
+  float3 sdrColor = outputColor;
+  const float vanillaMidGray = 0.178f;
+  if (injectedData.toneMapType == 2) {
+    const float paperWhite = injectedData.toneMapGameNits / renodx::color::srgb::REFERENCE_WHITE;
+    hdrColor = outputColor * paperWhite;
+    const float peakWhite = injectedData.toneMapPeakNits / renodx::color::srgb::REFERENCE_WHITE;
+    const float highlightsShoulderStart = vanillaMidGray * paperWhite;  // Don't tonemap the blended part of the tonemapper
+    hdrColor = renodx::tonemap::dice::BT709(hdrColor, peakWhite, highlightsShoulderStart);
+    sdrColor = renodx::tonemap::dice::BT709(hdrColor, paperWhite, highlightsShoulderStart);
+    hdrColor /= paperWhite;
+    sdrColor /= paperWhite;
+  }
+  r0.xyz = sdrColor;
+
+  // LUT
+  r0.xyz = sign(r0.xyz) * pow(abs(r0.xyz), 1.f / 2.2f );
+  r0.xyz = r0.xyz * float3(0.99609375,0.99609375,0.99609375) + float3(0.001953125,0.001953125,0.001953125);
+  r1.x = t4.Sample(s4_s, r0.xx).x;
+  r1.y = t4.Sample(s4_s, r0.yy).y;
+  r1.z = t4.Sample(s4_s, r0.zz).z;
+  r0.xyz = sign(r1.xyz) * pow(abs(r1.xyz), 2.2f );
+
+  if (injectedData.toneMapType > 1) {
+    outputColor = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(sdrColor), r0.xyz, injectedData.colorGradeLUTStrength);
+  } else if (injectedData.toneMapType == 0) {
+    outputColor = lerp(outputColor, r0.xyz, injectedData.colorGradeLUTStrength);
+  }
+
+  r1.xyz = t3.SampleLevel(s3_s, v3.zw, 0).xyz;
+  o0.xyz = r1.xyz * outputColor; //  o0.xyz = r1.xyz * r0.xyz;
+  return;
+}

--- a/src/games/dyinglight/lut_bw_no_grain_0xBA423838.ps_5_0.hlsl
+++ b/src/games/dyinglight/lut_bw_no_grain_0xBA423838.ps_5_0.hlsl
@@ -1,0 +1,95 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sat May 25 22:39:34 2024
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[7];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  out float4 o0 : SV_TARGET0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = -abs(v2.xy) * abs(v2.xy) + float2(1,1);
+  r0.x = saturate(-r0.x * r0.y + 1);
+  r0.x = cb0[2].x * r0.x;
+  r0.x = cb0[0].w * r0.x;
+  r0.y = t0.SampleLevel(s0_s, v1.xy, 0).x;
+  r0.z = t0.SampleLevel(s0_s, v1.zw, 0).z;
+  r1.xyzw = t0.SampleLevel(s0_s, v2.zw, 0).xyzw;
+  r0.yz = -r1.xz + r0.yz;
+  r1.xz = r0.xx * r0.yz + r1.xz;
+  o0.w = r1.w;
+  r0.x = dot(float3(0.212500006,0.715399981,0.0720999986), r1.xyz);
+  r0.yzw = r0.xxx + -r1.xyz;
+  r0.x = saturate(r0.x * cb0[0].y + cb0[0].z);
+  r0.x = cb0[0].x * r0.x;
+  r0.xyz = r0.xxx * r0.yzw + r1.xyz;
+  r0.w = dot(r0.xyz, cb0[1].xyz);
+  r0.xyz = r0.xyz * cb0[1].www + r0.www;  //  r0.xyz = saturate(r0.xyz * cb0[1].www + r0.www);
+  r0.w = saturate(dot(r0.xyz, cb0[3].xyz));
+  r1.xyz = cb0[5].xyz * r0.www;
+  r2.xyz = r0.xyz * cb0[6].xyz + -r1.xyz;
+  r0.w = saturate(dot(r0.xyz, cb0[4].xyz));
+  r1.xyz = r0.www * r2.xyz + r1.xyz;  //  r1.xyz = saturate(r0.www * r2.xyz + r1.xyz);
+  r0.xyz = r0.xyz * cb0[5].www + r1.xyz;  //  r0.xyz = saturate(r0.xyz * cb0[5].www + r1.xyz);
+
+  float3 outputColor = r0.xyz;
+  float3 hdrColor = outputColor;
+  float3 sdrColor = outputColor;
+  const float vanillaMidGray = 0.178f;
+  if (injectedData.toneMapType == 2) {
+    const float paperWhite = injectedData.toneMapGameNits / renodx::color::srgb::REFERENCE_WHITE;
+    hdrColor = outputColor * paperWhite;
+    const float peakWhite = injectedData.toneMapPeakNits / renodx::color::srgb::REFERENCE_WHITE;
+    const float highlightsShoulderStart = vanillaMidGray * paperWhite;  // Don't tonemap the blended part of the tonemapper
+    hdrColor = renodx::tonemap::dice::BT709(hdrColor, peakWhite, highlightsShoulderStart);
+    sdrColor = renodx::tonemap::dice::BT709(hdrColor, paperWhite, highlightsShoulderStart);
+    hdrColor /= paperWhite;
+    sdrColor /= paperWhite;
+  }
+  r0.xyz = sdrColor;
+
+  // LUT
+  r0.xyz = sign(r0.xyz) * pow(abs(r0.xyz), 1.f / 2.2f );
+  r0.xyz = r0.xyz * float3(0.99609375,0.99609375,0.99609375) + float3(0.001953125,0.001953125,0.001953125);
+  r1.x = t2.Sample(s2_s, r0.xx).x;
+  r1.y = t2.Sample(s2_s, r0.yy).y;
+  r1.z = t2.Sample(s2_s, r0.zz).z;
+  r0.xyz = sign(r1.xyz) * pow(abs(r1.xyz), 2.2f );
+
+  if (injectedData.toneMapType > 1) {
+    outputColor = renodx::tonemap::UpgradeToneMap(hdrColor, saturate(sdrColor), r0.xyz, injectedData.colorGradeLUTStrength);
+  } else if (injectedData.toneMapType == 0) {
+    outputColor = lerp(outputColor, r0.xyz, injectedData.colorGradeLUTStrength);
+  }
+
+  r1.xyz = t1.SampleLevel(s1_s, v2.zw, 0).xyz;
+  o0.xyz = r1.xyz * outputColor; //  o0.xyz = r1.xyz * r0.xyz;
+  return;
+}

--- a/src/games/dyinglight/shared.h
+++ b/src/games/dyinglight/shared.h
@@ -1,0 +1,35 @@
+#ifndef SRC_DYING_LIGHT_SHARED_H_
+#define SRC_DYING_LIGHT_SHARED_H_
+
+#ifndef __cplusplus
+#include "../../shaders/renodx.hlsl"
+#endif
+
+// Must be 32bit aligned
+// Should be 4x32
+struct ShaderInjectData {
+  float toneMapType;
+  float toneMapPeakNits;
+  float toneMapGameNits;
+  float toneMapUINits;
+  float toneMapGammaCorrection;
+  float toneMapHueCorrection;
+  float colorGradeExposure;
+  float colorGradeHighlights;
+  float colorGradeShadows;
+  float colorGradeContrast;
+  float colorGradeSaturation;
+  float colorGradeLUTStrength;
+  float colorGradeLUTScaling;
+  float fxBloom;
+  float fxLensFlare;
+  float fxFilmGrain;
+};
+
+#ifndef __cplusplus
+cbuffer cb13 : register(b13) {
+  ShaderInjectData injectedData : packoffset(c0);
+}
+#endif
+
+#endif  // SRC_DYING_LIGHT_SHARED_H_

--- a/src/games/dyinglight/tonemap_0xA67ABF78.ps_5_0.hlsl
+++ b/src/games/dyinglight/tonemap_0xA67ABF78.ps_5_0.hlsl
@@ -1,0 +1,81 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sat May 25 22:39:29 2024
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_TARGET0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = t0.SampleLevel(s0_s, v1.xy, 0).xy;
+  r0.xy = v1.xy + -r0.xy;
+  r0.zw = r0.xy * float2(2,2) + float2(-1,-1);
+  r1.xyzw = t2.SampleLevel(s2_s, r0.xy, 0).xyzw;
+  r0.x = max(abs(r0.z), abs(r0.w));
+  r0.x = cmp(r0.x >= 1);
+  r0.y = r1.w * r1.w;
+  r2.xyzw = t1.SampleLevel(s1_s, v1.xy, 0).xyzw;
+
+  float3 untonemapped = r2.xyz;
+  
+  r0.y = r2.w * r2.w + -r0.y;
+  r0.y = 0.200000003 * abs(r0.y);
+  r0.y = sqrt(r0.y);
+  r0.y = -r0.y * 30 + 1;
+  r0.y = max(0, r0.y);
+  r0.y = 0.5 * r0.y;
+  r0.x = r0.x ? 0 : r0.y;
+  r0.yzw = -r2.xyz + r1.xyz;
+  o0.xyz = r0.xxx * r0.yzw + r2.xyz;
+  o0.w = r2.w;
+  // vanilla tonemapper causes highlights to flicker, clamped in a later shader
+
+  float3 vanillaColor = o0.rgb;
+  float vanillaMidGray = 0.178f;
+  if (injectedData.toneMapType == 2) {
+    untonemapped *= vanillaMidGray / 0.18f;
+    untonemapped = renodx::color::grade::UserColorGrading(
+        untonemapped,
+        1.f,
+        1.04 * injectedData.colorGradeHighlights,
+        1.f,
+        1.f,
+        1.f,
+        injectedData.toneMapHueCorrection,
+        vanillaColor);
+    float vanillaLum = renodx::color::y::from::BT709(vanillaColor.rgb);
+    o0.xyz = lerp(vanillaColor.rgb, untonemapped, saturate(vanillaLum / vanillaMidGray));  // combine tonemappers
+    o0.xyz = renodx::color::grade::UserColorGrading(
+        o0.xyz,
+        injectedData.colorGradeExposure,
+        1.f,
+        injectedData.colorGradeShadows,
+        injectedData.colorGradeContrast,
+        injectedData.colorGradeSaturation);
+  } else if (injectedData.toneMapType == 1) {
+    o0.xyz = untonemapped;
+  }
+  return;
+}

--- a/src/games/dyinglight/ui_0x23EFA382.ps_5_0.hlsl
+++ b/src/games/dyinglight/ui_0x23EFA382.ps_5_0.hlsl
@@ -1,0 +1,48 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sat May 25 22:38:58 2024
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[1];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  out float4 o0 : SV_TARGET0)
+{
+  float4 r0,r1;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = v1.xyxy * float4(1,1,-1,-1) + float4(0,0,1,1);
+  r0.xyzw = cmp(r0.xyzw < float4(0,0,0,0));
+  r0.xy = (int2)r0.zw | (int2)r0.xy;
+  r0.x = (int)r0.y | (int)r0.x;
+  if (r0.x != 0) discard;
+  r0.xyz = log2(cb0[0].xyz);
+  r0.xyz = float3(2.20000005,2.20000005,2.20000005) * r0.xyz;
+  r0.xyz = exp2(r0.xyz);
+  r1.xyzw = t0.Sample(s0_s, v1.zw).xyzw;
+  o0.xyz = r1.xyz * r0.xyz;
+  o0.w = cb0[0].w * r1.w;
+
+  o0.xyz = saturate(o0.xyz);
+  if (injectedData.toneMapGammaCorrection) { // fix srgb 2.2 mismatch
+    o0.xyz = renodx::color::srgb::from::BT709(o0.xyz);
+    o0.xyz = pow(o0.xyz, 2.2f);
+  }
+  o0.xyz *= injectedData.toneMapUINits/80.f;
+  return;
+}

--- a/src/games/dyinglight/ui_0x379D46ED.ps_5_0.hlsl
+++ b/src/games/dyinglight/ui_0x379D46ED.ps_5_0.hlsl
@@ -1,0 +1,72 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sat May 25 22:39:03 2024
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[5];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  out float4 o0 : SV_TARGET0)
+{
+  float4 r0,r1;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = cb0[2].zy * v1.yx;
+  r0.xy = floor(r0.xy);
+  r0.zw = float2(1,1) / cb0[2].zy;
+  r0.xy = r0.xy * r0.zw + cb0[2].ww;
+  r0.z = 20 * cb0[1].x;
+  r0.z = floor(r0.z);
+  r0.xy = r0.zz * float2(0.00999999978,0.00999999978) + r0.xy;
+  r0.zw = float2(0.25,0.5) + r0.xx;
+  r0.z = t1.Sample(s1_s, r0.yz).y;
+  r0.w = t1.Sample(s1_s, r0.yw).y;
+  r0.zw = -cb0[3].yz + r0.zw;
+  r0.zw = cmp(float2(0,0) >= r0.zw);
+  r0.zw = r0.zw ? float2(0,0) : float2(1,1);
+  r0.z = r0.z + r0.w;
+  r1.xy = float2(0,0.75) + r0.yx;
+  r0.x = t1.Sample(s1_s, r0.yx).y;
+  r0.x = -cb0[3].x + r0.x;
+  r0.x = cmp(0 >= r0.x);
+  r0.y = t1.Sample(s1_s, r1.xy).y;
+  r0.y = -cb0[3].w + r0.y;
+  r0.y = cmp(0 >= r0.y);
+  r0.y = r0.y ? 0 : 1;
+  r0.y = r0.z + r0.y;
+  r0.z = r0.x ? 0 : 1;
+  r0.x = r0.x ? 1.000000 : 0;
+  r0.xy = cb0[4].xx * r0.xy;
+  r1.xyzw = t0.Sample(s0_s, v1.zw).xyzw;
+  r1.xyzw = r1.xyzw * r0.zzzz;
+  r0.y = saturate(r0.y * 0.166666999 + r1.w);
+  o0.w = cb0[0].w * r0.y;
+  r0.yzw = cb0[0].xyz * cb0[0].xyz;
+  o0.xyz = saturate(r0.yzw * r1.xyz + r0.xxx);
+
+  if (injectedData.toneMapGammaCorrection) { // fix srgb 2.2 mismatch
+    o0.xyz = renodx::color::srgb::from::BT709(o0.xyz);
+    o0.xyz = pow(o0.xyz, 2.2f);
+  }
+  o0.xyz *= injectedData.toneMapUINits/80.f;
+  return;
+}

--- a/src/games/dyinglight/ui_0x404A04C7.ps_5_0.hlsl
+++ b/src/games/dyinglight/ui_0x404A04C7.ps_5_0.hlsl
@@ -1,0 +1,62 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sat May 25 22:39:05 2024
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  out float4 o0 : SV_TARGET0)
+{
+  float4 r0,r1,r2,r3,r4,r5;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.x = t1.Sample(s3_s, v2.zw).x;
+  r0.x = r0.x * r0.x;
+  r0.y = r0.x * 0.200000003 + 0.600000024;
+  r0.z = t0.Sample(s2_s, v2.xy).y;
+  r0.w = -r0.z * 0.200000003 + 1;
+  r0.z = 0.200000003 * r0.z;
+  r1.x = 1 + -v3.z;
+  r2.xyzw = float4(0.729918897,0.263174742,0.00715503562,1) * v3.zzzz;
+  r1.xyzw = r1.xxxx * float4(0.875137568,0.18014428,0.00258582528,1) + r2.xyzw;
+  r2.xyz = saturate(r1.xyz * v1.xyz + float3(0.00499999989,0.00499999989,0.00499999989));
+  r1.xyzw = v1.xyzw * r1.xyzw;
+  r3.xyz = float3(-0.5,-0.5,-0.5) + r2.xyz;
+  r3.xyz = -r3.xyz * float3(2,2,2) + float3(1,1,1);
+  r3.xyz = -r3.xyz * r0.www + float3(1,1,1);
+  r0.w = saturate(dot(r0.zz, r2.xx));
+  r4.xyz = cmp(float3(0.5,0.5,0.5) >= r2.xyz);
+  r5.x = r4.x ? r0.w : r3.x;
+  r0.w = saturate(dot(r0.zz, r2.yy));
+  r0.z = saturate(dot(r0.zz, r2.zz));
+  r5.yz = r4.yz ? r0.wz : r3.yz;
+  r0.yzw = r5.xyz * r0.yyy;
+  r0.yzw = float3(0.800000012,0.800000012,0.800000012) * r0.yzw;
+  r0.yzw = r1.xyz * float3(0.800000012,0.800000012,0.800000012) + r0.yzw;
+  o0.w = saturate(r1.w);
+  o0.xyz = saturate(r0.xxx * float3(0.0170000009,0.0170000009,0.0170000009) + r0.yzw);
+
+  if (injectedData.toneMapGammaCorrection) { // fix srgb 2.2 mismatch
+    o0.xyz = renodx::color::srgb::from::BT709(o0.xyz);
+    o0.xyz = pow(o0.xyz, 2.2f);
+  }
+  o0.xyz *= injectedData.toneMapUINits/80.f;
+  return;
+}

--- a/src/games/dyinglight/ui_0x4D09799F.ps_5_0.hlsl
+++ b/src/games/dyinglight/ui_0x4D09799F.ps_5_0.hlsl
@@ -1,0 +1,53 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sat May 25 22:39:08 2024
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb2 : register(b2)
+{
+  float4 cb2[9];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float2 v2 : TEXCOORD1,
+  out float4 o0 : SV_TARGET0)
+{
+  float4 r0,r1;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = v0.xy * cb2[7].xy + cb2[7].zw;
+  r0.x = t0.SampleLevel(s0_s, r0.xy, 0).x;
+  r0.xy = r0.xx * cb2[8].xy + cb2[8].zw;
+  r0.x = r0.x / -r0.y;
+  r0.x = cmp(abs(r0.x) < v0.w);
+  r0.y = saturate(dot(v1.xyz, float3(0.333333343,0.333333343,0.333333343)));
+  r1.xyz = v1.xyz + -r0.yyy;
+  r1.xyz = r1.xyz * float3(0.330000013,0.330000013,0.330000013) + r0.yyy;
+  r1.w = 0.25 * v1.w;
+  r0.xyzw = r0.xxxx ? r1.xyzw : v1.xyzw;
+  r1.x = saturate(v2.y * 4 + -3);
+  r1.x = 1 + -r1.x;
+  r1.x = -v2.x * r1.x + 1;
+  o0.xyz = r1.xxx * r0.xyz;
+  o0.w = r0.w;
+
+  o0.xyz = saturate(o0.xyz);
+  if (injectedData.toneMapGammaCorrection) { // fix srgb 2.2 mismatch
+    o0.xyz = renodx::color::srgb::from::BT709(o0.xyz);
+    o0.xyz = pow(o0.xyz, 2.2f);
+  }
+  o0.xyz *= injectedData.toneMapUINits/80.f;
+  return;
+}

--- a/src/games/dyinglight/ui_0x637A1F5C.ps_5_0.hlsl
+++ b/src/games/dyinglight/ui_0x637A1F5C.ps_5_0.hlsl
@@ -1,0 +1,71 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sat May 25 22:39:14 2024
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[4];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  out float4 o0 : SV_TARGET0)
+{
+  float4 r0,r1;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = cb0[2].zz * v1.xy;
+  r0.xy = floor(r0.xy);
+  r0.z = 1 / cb0[2].z;
+  r0.yz = r0.xy * r0.zz + cb0[2].ww;
+  r0.w = 0.25 + r0.z;
+  r1.x = 20 * cb0[1].x;
+  r1.x = floor(r1.x);
+  r0.x = r1.x * 0.00999999978 + r0.y;
+  r0.y = t1.Sample(s1_s, r0.xw).y;
+  r0.y = -cb0[3].y + r0.y;
+  r0.y = cmp(0 >= r0.y);
+  r0.y = r0.y ? 0 : 1;
+  r1.xyzw = float4(0,0.5,0,0.75) + r0.xzxz;
+  r0.x = t1.Sample(s1_s, r0.xz).y;
+  r0.x = -cb0[3].x + r0.x;
+  r0.x = cmp(0 >= r0.x);
+  r0.x = r0.x ? 0 : 1;
+  r0.z = t1.Sample(s1_s, r1.xy).y;
+  r0.w = t1.Sample(s1_s, r1.zw).y;
+  r0.zw = -cb0[3].zw + r0.zw;
+  r0.zw = cmp(float2(0,0) >= r0.zw);
+  r0.zw = r0.zw ? float2(0,0) : float2(1,1);
+  r0.y = r0.y + r0.z;
+  r0.y = r0.y + r0.w;
+  r0.y = 0.166666999 * r0.y;
+  r1.xyzw = t0.Sample(s0_s, v1.zw).xyzw;
+  r0.x = saturate(r0.x * r1.w + r0.y);
+  r0.y = r0.y * r0.y;
+  o0.w = cb0[0].w * r0.x;
+  r0.xzw = cb0[0].xyz * cb0[0].xyz;
+  o0.xyz = saturate(r0.xzw * r1.xyz + r0.yyy);
+
+  if (injectedData.toneMapGammaCorrection) { // fix srgb 2.2 mismatch
+    o0.xyz = renodx::color::srgb::from::BT709(o0.xyz);
+    o0.xyz = pow(o0.xyz, 2.2f);
+  }
+  o0.xyz *= injectedData.toneMapUINits/80.f;
+  return;
+}

--- a/src/games/dyinglight/ui_0x6562755C.ps_5_0.hlsl
+++ b/src/games/dyinglight/ui_0x6562755C.ps_5_0.hlsl
@@ -1,0 +1,68 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sat May 25 22:39:14 2024
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[1];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  float2 v4 : TEXCOORD3,
+  out float4 o0 : SV_TARGET0)
+{
+  float4 r0,r1,r2,r3;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = v4.xyxy * float4(1,1,-1,-1) + float4(0,0,1,1);
+  r0.xyzw = cmp(r0.xyzw < float4(0,0,0,0));
+  r0.xy = (int2)r0.zw | (int2)r0.xy;
+  r0.x = (int)r0.y | (int)r0.x;
+  if (r0.x != 0) discard;
+  r0.x = t1.Sample(s1_s, v2.zw).y;
+  r0.y = 1 + -r0.x;
+  r1.xyzw = t0.Sample(s0_s, v3.zw).xyzw;
+  r2.xyz = saturate(r1.xyz * v1.xyz + float3(0.00499999989,0.00499999989,0.00499999989));
+  r1.xyzw = v1.xyzw * r1.xyzw;
+  r3.xyz = float3(-0.5,-0.5,-0.5) + r2.xyz;
+  r3.xyz = -r3.xyz * float3(2,2,2) + float3(1,1,1);
+  r0.yzw = -r3.xyz * r0.yyy + float3(1,1,1);
+  r3.xyz = r2.xyz + r2.xyz;
+  r2.xyz = cmp(float3(0.5,0.5,0.5) >= r2.xyz);
+  r3.xyz = saturate(r3.xyz * r0.xxx);
+  r0.xyz = r2.xyz ? r3.xyz : r0.yzw;
+  r0.xyz = float3(0.150000006,0.150000006,0.150000006) * r0.xyz;
+  o0.xyz = r1.xyz * float3(0.850000024,0.850000024,0.850000024) + r0.xyz;
+  r0.x = t0.Sample(s0_s, v3.xy).w;
+  r0.x = 1 + -r0.x;
+  r0.x = saturate(cb0[0].x + r0.x);
+  o0.w = r1.w * r0.x;
+  
+  o0.xyz = saturate(o0.xyz);
+  if (injectedData.toneMapGammaCorrection) { // fix srgb 2.2 mismatch
+    o0.xyz = renodx::color::srgb::from::BT709(o0.xyz);
+    o0.xyz = pow(o0.xyz, 2.2f);
+  }
+  o0.xyz *= injectedData.toneMapUINits/80.f;
+
+  return;
+}

--- a/src/games/dyinglight/ui_0x7D5191F6.ps_5_0.hlsl
+++ b/src/games/dyinglight/ui_0x7D5191F6.ps_5_0.hlsl
@@ -1,0 +1,54 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sat May 25 22:39:20 2024
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[2];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  out float4 o0 : SV_TARGET0)
+{
+  float4 r0,r1;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.x = 0.400000006 * cb0[1].y;
+  r0.x = frac(r0.x);
+  r0.xyz = float3(0.5,-0.0399999991,0.0399999991) + r0.xxx;
+  r0.w = -v1.y * 0.333299994 + v1.x;
+  r0.w = r0.w * 0.375 + 0.5;
+  r0.yz = cmp(r0.yw < r0.wz);
+  r0.x = frac(r0.x);
+  r1.xy = float2(-0.0399999991,0.0399999991) + r0.xx;
+  r0.x = r0.z ? r0.y : 0;
+  r0.y = cmp(r1.x < r0.w);
+  r0.z = cmp(r0.w < r1.y);
+  r0.y = r0.z ? r0.y : 0;
+  r0.x = (int)r0.y | (int)r0.x;
+  r0.x = r0.x ? 1 : 0.400000006;
+  o0.xyz = cb0[0].xyz * r0.xxx;
+  r0.x = t0.Sample(s0_s, v1.zw).w;
+  o0.w = cb0[0].w * r0.x;
+
+  o0.xyz = saturate(o0.xyz);
+  if (injectedData.toneMapGammaCorrection) { // fix srgb 2.2 mismatch
+    o0.xyz = renodx::color::srgb::from::BT709(o0.xyz);
+    o0.xyz = pow(o0.xyz, 2.2f);
+  }
+  o0.xyz *= injectedData.toneMapUINits/80.f;
+  return;
+}

--- a/src/games/dyinglight/ui_0x7E8358E3.ps_5_0.hlsl
+++ b/src/games/dyinglight/ui_0x7E8358E3.ps_5_0.hlsl
@@ -1,0 +1,51 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sat May 25 22:39:20 2024
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[1];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  out float4 o0 : SV_TARGET0)
+{
+  float4 r0,r1;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.x = t0.Sample(s0_s, v2.xy).w;
+  r0.x = log2(r0.x);
+  r0.x = 2.20000005 * r0.x;
+  r0.x = exp2(r0.x);
+  r0.x = 1 + -r0.x;
+  r0.x = saturate(cb0[0].x + r0.x);
+  r1.xyzw = t0.Sample(s0_s, v2.zw).xyzw;
+  r1.xyzw = v1.xyzw * r1.xyzw;
+  r0.y = log2(r1.w);
+  o0.xyz = r1.xyz;
+  r0.y = 2.20000005 * r0.y;
+  r0.y = exp2(r0.y);
+  o0.w = r0.y * r0.x;
+
+  o0.xyz = saturate(o0.xyz);
+  if (injectedData.toneMapGammaCorrection) { // fix srgb 2.2 mismatch
+    o0.xyz = renodx::color::srgb::from::BT709(o0.xyz);
+    o0.xyz = pow(o0.xyz, 2.2f);
+  }
+  o0.xyz *= injectedData.toneMapUINits/80.f;
+  return;
+}

--- a/src/games/dyinglight/ui_0x822D56FA.ps_5_0.hlsl
+++ b/src/games/dyinglight/ui_0x822D56FA.ps_5_0.hlsl
@@ -1,0 +1,41 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sat May 25 22:39:21 2024
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[2];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_TARGET0)
+{
+  float4 r0;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+return;
+  r0.xyz = t0.Sample(s0_s, v1.xy).xyz;
+  o0.xyz = cb0[1].xyz * r0.xyz;
+  o0.w = cb0[0].w;
+
+  o0.xyz = saturate(o0.xyz);
+  if (injectedData.toneMapGammaCorrection) { // fix srgb 2.2 mismatch
+    o0.xyz = renodx::color::srgb::from::BT709(o0.xyz);
+    o0.xyz = pow(o0.xyz, 2.2f);
+  }
+  o0.xyz *= injectedData.toneMapUINits/80.f;
+  return;
+}

--- a/src/games/dyinglight/ui_0x929C8CA5.ps_5_0.hlsl
+++ b/src/games/dyinglight/ui_0x929C8CA5.ps_5_0.hlsl
@@ -1,0 +1,49 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sat May 25 22:39:24 2024
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[1];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  out float4 o0 : SV_TARGET0)
+{
+  float4 r0,r1;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyz = log2(cb0[0].xyz);
+  r0.xyz = float3(2.20000005,2.20000005,2.20000005) * r0.xyz;
+  r0.xyz = exp2(r0.xyz);
+  r1.xyzw = t0.Sample(s0_s, v1.zw).xyzw;
+  o0.xyz = r1.xyz * r0.xyz;
+  r0.x = cb0[0].w * r1.w;
+  r0.y = t1.Sample(s1_s, v1.xy).w;
+  o0.w = r0.x * r0.y;
+  
+  o0.xyz = saturate(o0.xyz);
+  if (injectedData.toneMapGammaCorrection) { // fix srgb 2.2 mismatch
+    o0.xyz = renodx::color::srgb::from::BT709(o0.xyz);
+    o0.xyz = pow(o0.xyz, 2.2f);
+  }
+  o0.xyz *= injectedData.toneMapUINits/80.f;
+  return;
+}

--- a/src/games/dyinglight/ui_0x9F9A6B19.ps_5_0.hlsl
+++ b/src/games/dyinglight/ui_0x9F9A6B19.ps_5_0.hlsl
@@ -1,0 +1,62 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sat May 25 22:39:28 2024
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[1];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  float2 v4 : TEXCOORD3,
+  out float4 o0 : SV_TARGET0)
+{
+  float4 r0,r1,r2,r3;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.x = t1.Sample(s1_s, v2.zw).y;
+  r0.y = 1 + -r0.x;
+  r1.xyzw = t0.Sample(s0_s, v3.zw).xyzw;
+  r2.xyz = saturate(r1.xyz * v1.xyz + float3(0.00499999989,0.00499999989,0.00499999989));
+  r1.xyzw = v1.xyzw * r1.xyzw;
+  r3.xyz = float3(-0.5,-0.5,-0.5) + r2.xyz;
+  r3.xyz = -r3.xyz * float3(2,2,2) + float3(1,1,1);
+  r0.yzw = -r3.xyz * r0.yyy + float3(1,1,1);
+  r3.xyz = r2.xyz + r2.xyz;
+  r2.xyz = cmp(float3(0.5,0.5,0.5) >= r2.xyz);
+  r3.xyz = saturate(r3.xyz * r0.xxx);
+  r0.xyz = r2.xyz ? r3.xyz : r0.yzw;
+  r0.xyz = float3(0.150000006,0.150000006,0.150000006) * r0.xyz;
+  o0.xyz = r1.xyz * float3(0.850000024,0.850000024,0.850000024) + r0.xyz;
+  r0.x = t0.Sample(s0_s, v3.xy).w;
+  r0.x = 1 + -r0.x;
+  r0.x = saturate(cb0[0].x + r0.x);
+  o0.w = r1.w * r0.x;
+
+  o0.xyz = saturate(o0.xyz);
+  if (injectedData.toneMapGammaCorrection) { // fix srgb 2.2 mismatch
+    o0.xyz = renodx::color::srgb::from::BT709(o0.xyz);
+    o0.xyz = pow(o0.xyz, 2.2f);
+  }
+  o0.xyz *= injectedData.toneMapUINits/80.f;
+  return;
+}

--- a/src/games/dyinglight/ui_0xB917BF4E.ps_5_0.hlsl
+++ b/src/games/dyinglight/ui_0xB917BF4E.ps_5_0.hlsl
@@ -1,0 +1,40 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sat May 25 22:39:34 2024
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[1];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_TARGET0)
+{
+  float4 r0;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = t0.Sample(s0_s, v1.xy).xyzw;
+  o0.xyzw = cb0[0].xyzw * r0.xyzw;
+
+  o0.xyz = saturate(o0.xyz);
+  if (injectedData.toneMapGammaCorrection) { // fix srgb 2.2 mismatch
+    o0.xyz = renodx::color::srgb::from::BT709(o0.xyz);
+    o0.xyz = pow(o0.xyz, 2.2f);
+  }
+  o0.xyz *= injectedData.toneMapUINits/80.f;
+
+  return;
+}

--- a/src/games/dyinglight/ui_0xBCBEE1E5.ps_5_0.hlsl
+++ b/src/games/dyinglight/ui_0xBCBEE1E5.ps_5_0.hlsl
@@ -1,0 +1,45 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sat May 25 22:39:35 2024
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[1];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  out float4 o0 : SV_TARGET0)
+{
+  float4 r0,r1;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.x = t0.Sample(s0_s, v2.xy).w;
+  r0.x = 1 + -r0.x;
+  r0.x = saturate(cb0[0].x + r0.x);
+  r1.xyzw = t0.Sample(s0_s, v2.zw).xyzw;
+  r1.xyzw = v1.xyzw * r1.xyzw;
+  o0.w = r1.w * r0.x;
+  o0.xyz = r1.xyz;
+
+  o0.xyz = saturate(o0.xyz);
+  if (injectedData.toneMapGammaCorrection) { // fix srgb 2.2 mismatch
+    o0.xyz = renodx::color::srgb::from::BT709(o0.xyz);
+    o0.xyz = pow(o0.xyz, 2.2f);
+  }
+  o0.xyz *= injectedData.toneMapUINits/80.f;
+  return;
+}

--- a/src/games/dyinglight/ui_0xD292312D.ps_5_0.hlsl
+++ b/src/games/dyinglight/ui_0xD292312D.ps_5_0.hlsl
@@ -1,0 +1,35 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sat May 25 22:39:40 2024
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s0_s : register(s0);
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  out float4 o0 : SV_TARGET0)
+{
+  float4 r0;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = t0.Sample(s0_s, v2.zw).xyzw;
+  o0.xyzw = v1.xyzw * r0.xyzw;
+
+  o0.xyz = saturate(o0.xyz);
+  if (injectedData.toneMapGammaCorrection) { // fix srgb 2.2 mismatch
+    o0.xyz = renodx::color::srgb::from::BT709(o0.xyz);
+    o0.xyz = pow(o0.xyz, 2.2f);
+  }
+  o0.xyz *= injectedData.toneMapUINits/80.f;
+  return;
+}

--- a/src/games/dyinglight/ui_0xDC15A986.ps_5_0.hlsl
+++ b/src/games/dyinglight/ui_0xDC15A986.ps_5_0.hlsl
@@ -1,0 +1,65 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sat May 25 22:39:42 2024
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s0_s : register(s0);
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  out float4 o0 : SV_TARGET0)
+{
+  float4 r0,r1,r2,r3,r4,r5;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.x = t2.Sample(s3_s, v2.zw).x;
+  r0.x = r0.x * r0.x;
+  r0.y = r0.x * 0.200000003 + 0.600000024;
+  r0.z = t1.Sample(s2_s, v2.xy).y;
+  r0.w = -r0.z * 0.200000003 + 1;
+  r0.z = 0.200000003 * r0.z;
+  r1.xyzw = t0.Sample(s0_s, v3.xy).xyzw;
+  r2.xyz = saturate(r1.xyz * v1.xyz + float3(0.00499999989,0.00499999989,0.00499999989));
+  r1.xyzw = v1.xyzw * r1.xyzw;
+  r3.xyz = float3(-0.5,-0.5,-0.5) + r2.xyz;
+  r3.xyz = -r3.xyz * float3(2,2,2) + float3(1,1,1);
+  r3.xyz = -r3.xyz * r0.www + float3(1,1,1);
+  r0.w = saturate(dot(r0.zz, r2.xx));
+  r4.xyz = cmp(float3(0.5,0.5,0.5) >= r2.xyz);
+  r5.x = r4.x ? r0.w : r3.x;
+  r0.w = saturate(dot(r0.zz, r2.yy));
+  r0.z = saturate(dot(r0.zz, r2.zz));
+  r5.yz = r4.yz ? r0.wz : r3.yz;
+  r0.yzw = r5.xyz * r0.yyy;
+  r0.yzw = float3(0.800000012,0.800000012,0.800000012) * r0.yzw;
+  r0.yzw = r1.xyz * float3(0.800000012,0.800000012,0.800000012) + r0.yzw;
+  o0.w = r1.w;
+  o0.xyz = saturate(r0.xxx * float3(0.0170000009,0.0170000009,0.0170000009) + r0.yzw);
+
+  if (injectedData.toneMapGammaCorrection) { // fix srgb 2.2 mismatch
+    o0.xyz = renodx::color::srgb::from::BT709(o0.xyz);
+    o0.xyz = pow(o0.xyz, 2.2f);
+  }
+  o0.xyz *= injectedData.toneMapUINits/80.f;
+
+  return;
+}


### PR DESCRIPTION
### Pull Request: HDR Implementation and Enhancements for Dying Light

#### Summary
This pull request introduces HDR support to Dying Light, which previously did not support HDR. Key enhancements include upgrading render targets, upgrading the swapchain, and adding various tonemapping and color grading options to provide a more immersive and visually appealing experience.

#### Key Changes
1. **HDR Support**:
   - Upgraded clamped render targets to `RGBA16` format to accommodate HDR data.
   - Upgraded the swapchain to `scRGB`, enabling full HDR10 output and better color accuracy.

2. **Tonemapping Options**:
   - Added three distinct tonemapping options:
     - **Vanilla**: Retains the original SDR tonemapping.
     - **None**: Disables tonemapping and LUT entirely, allowing for a raw HDR output.
     - **Vanilla+ (DICE)**: Blends the original Vanilla tonemapping with DICE tonemapping, offering a balanced HDR experience that respects the original art direction.

3. **Adjustable Sliders**:
   - **Game and UI Brightness**: Separate sliders for game and UI brightness control.
   - **Gamma Correction**: Allows users to linearize with SRGB or 2.2 gamma formula.
   - **Hue Correction**: Allow DICE to emulate the hues of the Vanilla tonemapper.
   - **Color Grading Sliders**:
     - **Exposure**
     - **Highlights**
     - **Shadows**
     - **Contrast**
     - **Saturation**
     - **LUT Strength**
   - **Effects Strength Sliders**:
     - **Bloom**
     - **Lens Flare**
     - **Film Grain**

#### Notes
This HDR mod has been extensively tested across various areas of the game, with zero issues encountered during several hours of gameplay. The enhancements offer a significantly improved visual experience, leveraging the full potential of HDR while providing users with customizable settings to suit their preferences.
