### PR TITLE
Fixes and Enhancements for Dying Light HDR Mod

### DIFF
--- a/src/games/dyinglight/DICE.hlsl
+++ b/src/games/dyinglight/DICE.hlsl
@@ -1,0 +1,225 @@
+#include "./shared.h"
+
+float max3(float a, float b, float c)
+{
+  return max(a, max(b, c));
+}
+
+float max3(float3 v)
+{
+  return max3(v.x, v.y, v.z);
+}
+
+static const float PQ_constant_M1 = 0.1593017578125f;
+static const float PQ_constant_M2 = 78.84375f;
+static const float PQ_constant_C1 = 0.8359375f;
+static const float PQ_constant_C2 = 18.8515625f;
+static const float PQ_constant_C3 = 18.6875f;
+
+// PQ (Perceptual Quantizer - ST.2084) encode/decode used for HDR10 BT.2100.
+// Clamp type:
+// 0 None
+// 1 Remove negative numbers
+// 2 Remove numbers beyond 0-1
+// 3 Mirror negative numbers
+float3 Linear_to_PQ(float3 LinearColor, int clampType = 0)
+{
+    float3 LinearColorSign = sign(LinearColor);
+    if (clampType == 1)
+    {
+        LinearColor = max(LinearColor, 0.f);
+    }
+    else if (clampType == 2)
+    {
+        LinearColor = saturate(LinearColor);
+    }
+    else if (clampType == 3)
+    {
+        LinearColor = abs(LinearColor);
+    }
+    float3 colorPow = pow(LinearColor, PQ_constant_M1);
+    float3 numerator = PQ_constant_C1 + PQ_constant_C2 * colorPow;
+    float3 denominator = 1.f + PQ_constant_C3 * colorPow;
+    float3 pq = pow(numerator / denominator, PQ_constant_M2);
+    if (clampType == 3)
+    {
+        return pq * LinearColorSign;
+    }
+    return pq;
+}
+
+float3 PQ_to_Linear(float3 ST2084Color, int clampType = 0)
+{
+    float3 ST2084ColorSign = sign(ST2084Color);
+    if (clampType == 1)
+    {
+        ST2084Color = max(ST2084Color, 0.f);
+    }
+    else if (clampType == 2)
+    {
+        ST2084Color = saturate(ST2084Color);
+    }
+    else if (clampType == 3)
+    {
+        ST2084Color = abs(ST2084Color);
+    }
+    float3 colorPow = pow(ST2084Color, 1.f / PQ_constant_M2);
+    float3 numerator = max(colorPow - PQ_constant_C1, 0.f);
+    float3 denominator = PQ_constant_C2 - (PQ_constant_C3 * colorPow);
+    float3 linearColor = pow(numerator / denominator, 1.f / PQ_constant_M1);
+    if (clampType == 3)
+    {
+        return linearColor * ST2084ColorSign;
+    }
+    return linearColor;
+}
+
+// Aplies exponential ("Photographic") luminance/luma compression.
+// The pow can modulate the curve without changing the values around the edges.
+// The max is the max possible range to compress from, to not lose any output range if the input range was limited.
+float rangeCompress(float X, float Max = asfloat(0x7F7FFFFF))
+{
+  // Branches are for static parameters optimizations
+  if (Max == renodx::math::FLT_MAX) {
+    // This does e^X. We expect X to be between 0 and 1.
+    return 1.f - exp(-X);
+  }
+  const float lostRange = exp(-Max);
+  const float restoreRangeScale = 1.f / (1.f - lostRange);
+  return (1.f - exp(-X)) * restoreRangeScale;
+}
+
+// Refurbished DICE HDR tonemapper (per channel or luminance).
+// Expects "InValue" to be >= "ShoulderStart" and "OutMaxValue" to be > "ShoulderStart".
+float luminanceCompress(
+  float InValue,
+  float OutMaxValue,
+  float ShoulderStart = 0.f,
+  bool considerMaxValue = false,
+  float InMaxValue = asfloat(0x7F7FFFFF))
+{
+  const float compressableValue = InValue - ShoulderStart;
+  const float compressableRange = InMaxValue - ShoulderStart;
+  const float compressedRange = OutMaxValue - ShoulderStart;
+  const float possibleOutValue = ShoulderStart + compressedRange * rangeCompress(compressableValue / compressedRange, considerMaxValue ? (compressableRange / compressedRange) : renodx::math::FLT_MAX);
+#if 1
+  return possibleOutValue;
+#else // Enable this branch if "InValue" can be smaller than "ShoulderStart"
+  return (InValue <= ShoulderStart) ? InValue : possibleOutValue;
+#endif
+}
+
+#define DICE_TYPE_BY_LUMINANCE_RGB 0
+// Doing the DICE compression in PQ (either on luminance or each color channel) produces a curve that is closer to our "perception" and leaves more detail highlights without overly compressing them
+#define DICE_TYPE_BY_LUMINANCE_PQ 1
+// Modern HDR displays clip individual rgb channels beyond their "white" peak brightness,
+// like, if the peak brightness is 700 nits, any r g b color beyond a value of 700/80 will be clipped (not acknowledged, it won't make a difference).
+// Tonemapping by luminance, is generally more perception accurate but can then generate rgb colors "out of range". This setting fixes them up,
+// though it's optional as it's working based on assumptions on how current displays work, which might not be true anymore in the future.
+// Note that this can create some steep (rough, quickly changing) gradients on very bright colors.
+#define DICE_TYPE_BY_LUMINANCE_PQ_CORRECT_CHANNELS_BEYOND_PEAK_WHITE 2
+// This might look more like classic SDR tonemappers and is closer to how modern TVs and Monitors play back colors (usually they clip each individual channel to the peak brightness value, though in their native panel color space, or current SDR/HDR mode color space).
+// Overall, this seems to handle bright gradients more smoothly, even if it shifts hues more (and generally desaturating).
+#define DICE_TYPE_BY_CHANNEL_PQ 3
+
+struct DICESettings
+{
+  uint Type;
+  // Determines where the highlights curve (shoulder) starts.
+  // Values between 0.25 and 0.5 are good with DICE by PQ (any type).
+  // With linear/rgb DICE this barely makes a difference, zero is a good default but (e.g.) 0.5 would also work.
+  // This should always be between 0 and 1.
+  float ShoulderStart;
+
+  // For "Type == DICE_TYPE_BY_LUMINANCE_PQ_CORRECT_CHANNELS_BEYOND_PEAK_WHITE" only:
+  // The sum of these needs to be <= 1, both within 0 and 1.
+  // The closer the sum is to 1, the more each color channel will be containted within its peak range.
+  float DesaturationAmount;
+  float DarkeningAmount;
+};
+
+DICESettings DefaultDICESettings()
+{
+  DICESettings Settings;
+  Settings.Type = DICE_TYPE_BY_CHANNEL_PQ;
+  Settings.ShoulderStart = (Settings.Type >= DICE_TYPE_BY_LUMINANCE_RGB) ? (1.f / 4.f) : 0.f;
+  Settings.DesaturationAmount = 1.0 / 3.0;
+  Settings.DarkeningAmount = 1.0 / 3.0;
+  return Settings;
+}
+
+// Tonemapper inspired from DICE. Can work by luminance to maintain hue.
+// Takes scRGB colors with a white level (the value of 1 1 1) of 80 nits (sRGB) (to not be confused with paper white).
+// Paper white is expected to have already been multiplied in.
+float3 DICETonemap(
+  float3 Color,
+  float PeakWhite,
+  const DICESettings Settings)
+{
+  const float sourceLuminance = renodx::color::y::from::BT709(Color);
+
+  if (Settings.Type != DICE_TYPE_BY_LUMINANCE_RGB)
+  {
+    static const float HDR10_MaxWhite = 10000.f / 80.f;
+
+    const float shoulderStartPQ = Linear_to_PQ((Settings.ShoulderStart * PeakWhite) / HDR10_MaxWhite).x;
+    if (Settings.Type == DICE_TYPE_BY_LUMINANCE_PQ || Settings.Type == DICE_TYPE_BY_LUMINANCE_PQ_CORRECT_CHANNELS_BEYOND_PEAK_WHITE)
+    {
+      const float sourceLuminanceNormalized = sourceLuminance / HDR10_MaxWhite;
+      const float sourceLuminancePQ = Linear_to_PQ(sourceLuminanceNormalized, 1).x;
+
+      if (sourceLuminancePQ > shoulderStartPQ) // Luminance below the shoulder (or below zero) don't need to be adjusted
+      {
+        const float peakWhitePQ = Linear_to_PQ(PeakWhite / HDR10_MaxWhite).x;
+
+        const float compressedLuminancePQ = luminanceCompress(sourceLuminancePQ, peakWhitePQ, shoulderStartPQ);
+        const float compressedLuminanceNormalized = PQ_to_Linear(compressedLuminancePQ).x;
+        Color *= compressedLuminanceNormalized / sourceLuminanceNormalized;
+
+        if (Settings.Type == DICE_TYPE_BY_LUMINANCE_PQ_CORRECT_CHANNELS_BEYOND_PEAK_WHITE)
+        {
+          float3 Color_BT2020 = renodx::color::bt2020::from::BT709(Color);
+          if (any(Color_BT2020 > PeakWhite)) // Optional "optimization" branch
+          {
+            float colorLuminance = renodx::color::y::from::BT2020(Color_BT2020);
+            float colorLuminanceInExcess = colorLuminance - PeakWhite;
+            float maxColorInExcess = max3(Color_BT2020) - PeakWhite; // This is guaranteed to be >= "colorLuminanceInExcess"
+            float brightnessReduction = saturate(renodx::math::SafeDivision(PeakWhite, max3(Color_BT2020), 1)); // Fall back to one in case of division by zero
+            float desaturateAlpha = saturate(renodx::math::SafeDivision(maxColorInExcess, maxColorInExcess - colorLuminanceInExcess, 0)); // Fall back to zero in case of division by zero
+            Color_BT2020 = lerp(Color_BT2020, colorLuminance, desaturateAlpha * Settings.DesaturationAmount);
+            Color_BT2020 = lerp(Color_BT2020, Color_BT2020 * brightnessReduction, Settings.DarkeningAmount); // Also reduce the brightness to partially maintain the hue, at the cost of brightness
+            Color = renodx::color::bt709::from::BT2020(Color_BT2020);
+          }
+        }
+      }
+    }
+    else // DICE_TYPE_BY_CHANNEL_PQ
+    {
+      const float peakWhitePQ = Linear_to_PQ(PeakWhite / HDR10_MaxWhite).x;
+
+      // Tonemap in BT.2020 to more closely match the primaries of modern displays
+      const float3 sourceColorNormalized = renodx::color::bt2020::from::BT709(Color) / HDR10_MaxWhite;
+      const float3 sourceColorPQ = Linear_to_PQ(sourceColorNormalized, 1);
+
+      for (uint i = 0; i < 3; i++) //TODO LUMA: optimize? will the shader compile already convert this to float3? Or should we already make a version with no branches that works in float3?
+      {
+        if (sourceColorPQ[i] > shoulderStartPQ) // Colors below the shoulder (or below zero) don't need to be adjusted
+        {
+          const float compressedColorPQ = luminanceCompress(sourceColorPQ[i], peakWhitePQ, shoulderStartPQ);
+          const float compressedColorNormalized = PQ_to_Linear(compressedColorPQ).x;
+          Color[i] = renodx::color::bt709::from::BT2020(Color[i] * (compressedColorNormalized / sourceColorNormalized[i])).x;
+        }
+      }
+    }
+  }
+  else // DICE_TYPE_BY_LUMINANCE_RGB
+  {
+    if (sourceLuminance > Settings.ShoulderStart) // Luminance below the shoulder (or below zero) don't need to be adjusted
+    {
+      const float compressedLuminance = luminanceCompress(sourceLuminance, PeakWhite, PeakWhite * Settings.ShoulderStart);
+      Color *= compressedLuminance / sourceLuminance;
+    }
+  }
+
+  return Color;
+}

--- a/src/games/dyinglight/addon.cpp
+++ b/src/games/dyinglight/addon.cpp
@@ -225,6 +225,17 @@ renodx::utils::settings::Settings settings = {
         .parse = [](float value) { return value * 0.01f; },
     },
     new renodx::utils::settings::Setting{
+        .key = "colorGradeGamutExpansion",
+        .binding = &shader_injection.colorGradeGamutExpansion,
+        .default_value = 0.f,
+        .label = "Gamut Expansion",
+        .section = "Color Grading",
+        .tooltip = "Generates HDR colors (BT.2020) from bright saturated SDR (BT.709) ones.",   // Description taken from pumboautohdr
+        .max = 100.f,
+        .is_enabled = []() { return shader_injection.toneMapType == 2; },
+        .parse = [](float value) { return value * 0.01f; },
+    },
+    new renodx::utils::settings::Setting{
         .key = "fxBloom",
         .binding = &shader_injection.fxBloom,
         .default_value = 50.f,

--- a/src/games/dyinglight/extendGamut.hlsl
+++ b/src/games/dyinglight/extendGamut.hlsl
@@ -1,0 +1,36 @@
+#include "./shared.h"
+
+// from Musa
+float3 extendGamut(float3 color, float extendGamutAmount)
+{
+  if (extendGamutAmount == 0) {
+    return color;
+  }
+
+  float3 colorOKLab = renodx::color::oklab::from::BT709(color);
+
+  // Extract L, C, h from OKLab
+  float L = colorOKLab[0];
+  float a = colorOKLab[1];
+  float b = colorOKLab[2];
+  float C = sqrt(a * a + b * b);
+  float h = atan2(b, a);
+
+  // Calculate the exponential weighting factor based on luminance and chroma
+  float chromaWeight = 1.0f - exp(-4.0f * C);
+  float luminanceWeight = 1.0f - exp(-4.0f * L * L);
+  float weight = chromaWeight * luminanceWeight * extendGamutAmount;
+
+  // Apply the expansion factor
+  C *= (1.0f + weight);
+
+  // Convert back to OKLab with adjusted chroma
+  a = C * cos(h);
+  b = C * sin(h);
+  float3 adjustedOKLab = float3(L, a, b);
+
+  float3 adjustedColor = renodx::color::bt709::from::OkLab(adjustedOKLab);
+  float3 colorAP1 = renodx::color::ap1::from::BT709(adjustedColor);
+  colorAP1 = max(0, colorAP1); // Clamp to AP1
+  return renodx::color::bt709::from::AP1(colorAP1);
+}

--- a/src/games/dyinglight/gamma_0x558540C8.ps_5_0.hlsl
+++ b/src/games/dyinglight/gamma_0x558540C8.ps_5_0.hlsl
@@ -1,4 +1,5 @@
 #include "./shared.h"
+#include "./extendGamut.hlsl"
 
 // ---- Created with 3Dmigoto v1.3.16 on Sat May 25 22:39:10 2024
 Texture2D<float4> t0 : register(t0);
@@ -29,9 +30,6 @@ void main(
   r0.xyzw = t0.SampleLevel(s0_s, v1.xy, 0).xyzw;
   o0.xyzw = r0.xyzw;
 
-  if (injectedData.toneMapType == 0) {  // vanilla tonemap flickers if left unclamped
-    o0.xyz = saturate(o0.xyz);
-  }
 
   if (injectedData.toneMapGammaCorrection) { // fix srgb 2.2 mismatch
     o0.xyz = renodx::color::srgb::from::BT709(o0.xyz);
@@ -40,6 +38,11 @@ void main(
   // apply game gamma adjustment slider
   o0.xyz = sign(o0.xyz) * pow(abs(o0.xyz), cb0[0].xxx);
 
+  if (injectedData.toneMapType == 0) {  // vanilla tonemap flickers if left unclamped
+    o0.xyz = saturate(o0.xyz);
+  } else if (injectedData.toneMapType == 2) {
+    o0.rgb = extendGamut(o0.rgb, injectedData.colorGradeGamutExpansion);
+  }
   o0.xyz *= injectedData.toneMapGameNits/80.f;
   o0.w = saturate(o0.w);
   return;

--- a/src/games/dyinglight/shared.h
+++ b/src/games/dyinglight/shared.h
@@ -20,7 +20,7 @@ struct ShaderInjectData {
   float colorGradeContrast;
   float colorGradeSaturation;
   float colorGradeLUTStrength;
-  float colorGradeLUTScaling;
+  float colorGradeGamutExpansion;
   float fxBloom;
   float fxLensFlare;
   float fxFilmGrain;

--- a/src/games/dyinglight/tonemap_0xA67ABF78.ps_5_0.hlsl
+++ b/src/games/dyinglight/tonemap_0xA67ABF78.ps_5_0.hlsl
@@ -63,6 +63,7 @@ void main(
         1.f,
         1.f,
         1.f,
+        0.f,
         injectedData.toneMapHueCorrection,
         vanillaColor);
     float vanillaLum = renodx::color::y::from::BT709(vanillaColor.rgb);
@@ -73,7 +74,8 @@ void main(
         1.f,
         injectedData.colorGradeShadows,
         injectedData.colorGradeContrast,
-        injectedData.colorGradeSaturation);
+        injectedData.colorGradeSaturation,
+        0.f);
   } else if (injectedData.toneMapType == 1) {
     o0.xyz = untonemapped;
   }


### PR DESCRIPTION
#### Key Changes
1. **User Color Grading Fix**:
   - Fixed issues related to blowout being added as a parameter in the middle of the UserColorGrading function.

2. **Integration of New DICE Tonemapper**:
   - Updated the mod to use a newer version of DICE tonemapper

3. **Gamut Expansion**:
   - Added a new gamut expansion slider. Generates HDR colors (BT.2020) from bright saturated SDR (BT.709) ones.

4. **Optimization**:
   - Removed the unused `LUTScaling` variable from the injected buffer.

#### Notes
These updates have been thoroughly tested to ensure compatibility and stability across various gameplay scenarios. The fixes and enhancements significantly improve the visual fidelity and customization options available to players using the HDR mod.
