### PR TITLE
HDR Enhancements for God of War (2018)

### DIFF
--- a/src/games/gow2018/final_gamma_0xB59D6558.ps_5_0.hlsl
+++ b/src/games/gow2018/final_gamma_0xB59D6558.ps_5_0.hlsl
@@ -24,25 +24,17 @@ void main
   
   float4 inputColor = inputTexture.Load(positionAsUint);
   
-  SV_TARGET0 = float4(pow(inputColor.rgb, resourceTables__passData.gamma), inputColor.a);
-  
-  if (injectedData.toneMapType) { // Not Vanilla
-    // PQ to BT.2020 for paper white scaling 
-    SV_TARGET0.rgb = renodx::color::bt2020::from::PQ(SV_TARGET0.rgb);
-    SV_TARGET0.rgb *= injectedData.toneMapUINits/308.f;
+  SV_TARGET0.a = inputColor.a;
 
-    if (injectedData.toneMapType > 1) { // DICE
-      SV_TARGET0.rgb = renodx::color::bt709::from::BT2020(SV_TARGET0.rgb * 10000.f);
-      float3 untonemapped = SV_TARGET0.rgb;
+  SV_TARGET0.rgb = renodx::color::bt2020::from::PQ(inputColor);
+  SV_TARGET0.rgb = renodx::color::bt709::from::BT2020(SV_TARGET0.rgb/80.f) * 10000.f;
+  if (injectedData.toneMapType) {
+    SV_TARGET0.rgb *= injectedData.toneMapUINits/308.f;
+    if (injectedData.toneMapType > 1) { // DICE tonemap
       DICESettings config = DefaultDICESettings();
       config.Type = 3u;
       config.ShoulderStart = 0.5f;
-      SV_TARGET0.rgb = DICETonemap(SV_TARGET0.rgb, injectedData.toneMapPeakNits, config);
-      SV_TARGET0.rgb = renodx::color::bt2020::from::BT709(SV_TARGET0.rgb / 10000.f);
+      SV_TARGET0.rgb = DICETonemap(SV_TARGET0.rgb, injectedData.toneMapPeakNits / 80.f, config);
     }
-
-    SV_TARGET0.rgb = renodx::color::pq::from::BT2020(SV_TARGET0.rgb);
   }
-
-
 }

--- a/src/games/gow2018/game_pq_0x279D11F6.ps_5_0.hlsl
+++ b/src/games/gow2018/game_pq_0x279D11F6.ps_5_0.hlsl
@@ -109,6 +109,7 @@ void main(
     r2.xyz = r0.xyz * r2.xyz + float3(10668.4043,10668.4043,10668.4043);
     r0.xyz = r0.xyz * r2.xyz + float3(1,1,1);
     o0.xyz = r1.xyz / r0.xyz;
+    o0.xyz = saturate(o0.xyz);  // previously clamped by unorm 
   }
   o0.w = 1;
   return;

--- a/src/games/gow2018/lut_0x7818463E.ps_5_0.hlsl
+++ b/src/games/gow2018/lut_0x7818463E.ps_5_0.hlsl
@@ -159,51 +159,71 @@ void main(
   r1.xyz = r2.xyz * r1.xyz;
   r0.z = cmp(0 != cb0[0].w);
   r1.xyz = r0.zzz ? float3(0,0,0) : r1.xyz;
+    
+  float3 lutInputColor = r1.xyz;
+  if (injectedData.toneMapType == 0) {
+    // convert arri logc800
+    r2.xyz = cmp(float3(0.0105910003,0.0105910003,0.0105910003) < r1.xyz);
+    r3.xyzw = r1.xxyy * float4(5.55555582,5.3676548,5.55555582,5.3676548) + float4(0.0522719994,0.0928089991,0.0522719994,0.0928089991);
+    r1.xy = log2(r3.xz);
+    r1.xy = r1.xy * float2(0.0744116008,0.0744116008) + float2(0.385536999,0.385536999);
+    r3.xy = r2.xy ? r1.xy : r3.yw;
+    r1.xy = r1.zz * float2(5.55555582,5.3676548) + float2(0.0522719994,0.0928089991);
+    r0.z = log2(r1.x);
+    r0.z = r0.z * 0.0744116008 + 0.385536999;
+    r3.z = r2.z ? r0.z : r1.y;
+    // Sample 64x64x64 LUT
+    r1.xyz = r3.xyz * float3(0.984375,0.984375,0.984375) + float3(0.0078125,0.0078125,0.0078125);
+    r1.xyz = t0.SampleLevel(s1_s, r1.xyz, 0).xyz;
+    // back to linear
+    r2.xyz = cmp(float3(0.149658203,0.149658203,0.149658203) < r1.xyz);
+    r3.xyzw = float4(-0.385536999,-0.0928089991,-0.385536999,-0.0928089991) + r1.xxyy;
+    r3.xyzw = float4(13.4387865,0.186301097,13.4387865,0.186301097) * r3.xyzw;
+    r1.xy = exp2(r3.xz);
+    r1.xy = float2(-0.0522719994,-0.0522719994) + r1.xy;
+    r1.xy = float2(0.179999992,0.179999992) * r1.xy;
+    r3.xy = r2.xy ? r1.xy : r3.yw;
+    r1.xy = float2(-0.385536999,-0.0928089991) + r1.zz;
+    r1.xy = float2(13.4387865,0.186301097) * r1.xy;
+    r0.z = exp2(r1.x);
+    r0.z = -0.0522719994 + r0.z;
+    r0.z = 0.179999992 * r0.z;
+    r3.z = r2.z ? r0.z : r1.y;
 
-  if (injectedData.toneMapType) {
-    r1.xyz = renodx::color::grade::UserColorGrading(
-        r1.xyz,
+    r3.xyz = lerp(lutInputColor, r3.xyz, injectedData.colorGradeLUTStrength);  // LUT Strength
+    r1.xyz = max(0, r3.xyz);
+  } else {
+    lutInputColor = renodx::color::grade::UserColorGrading(
+        lutInputColor,
         injectedData.colorGradeExposure,              // exposure
         injectedData.colorGradeHighlights,            // highlights
         injectedData.colorGradeShadows,               // shadows
         injectedData.colorGradeContrast,              // contrast
-        injectedData.colorGradeSaturation,            // saturation
-        injectedData.colorGradeBlowout,               // dechroma
-        injectedData.toneMapHueCorrection,            // hue correction
-        renodx::tonemap::uncharted2::BT709(r1.xyz));  // Uncharted2
+        1.f,                                          // saturation, applied later
+        0.f);                                         // dechroma, applied later
+
+    renodx::lut::Config lut_config = renodx::lut::config::Create(
+        s1_s,
+        1.f,  // do LUT strength after
+        0.f,  // do LUT scaling after
+        renodx::lut::config::type::ARRI_C800,
+        renodx::lut::config::type::ARRI_C800,
+        64);
+    float3 lutOutputColor = renodx::lut::Sample(t0, lut_config, lutInputColor);
+
+    // Cleans up raised black floor
+    if (injectedData.colorGradeLUTScaling && injectedData.colorGradeLUTStrength) {
+      float3 minBlack = renodx::color::arri::logc::c800::Decode(t0.SampleLevel(s1_s, renodx::color::arri::logc::c800::Encode((0.f).xxx), 0.0f).rgb);
+      const float lutMinY = renodx::color::y::from::BT709(minBlack);
+      if (lutMinY > 0) {
+        float3 correctedBlack = renodx::lut::CorrectBlack(lutInputColor, lutOutputColor, lutMinY, 0.f);
+        lutOutputColor = lerp(lutOutputColor, correctedBlack, injectedData.colorGradeLUTScaling);
+      }
+    }
+
+    r1.xyz = lerp(lutInputColor, lutOutputColor, injectedData.colorGradeLUTStrength);
   }
 
-  float3 lutInputColor = r1.xyz;
-
-  r2.xyz = cmp(float3(0.0105910003,0.0105910003,0.0105910003) < r1.xyz);
-  r3.xyzw = r1.xxyy * float4(5.55555582,5.3676548,5.55555582,5.3676548) + float4(0.0522719994,0.0928089991,0.0522719994,0.0928089991);
-  r1.xy = log2(r3.xz);
-  r1.xy = r1.xy * float2(0.0744116008,0.0744116008) + float2(0.385536999,0.385536999);
-  r3.xy = r2.xy ? r1.xy : r3.yw;
-  r1.xy = r1.zz * float2(5.55555582,5.3676548) + float2(0.0522719994,0.0928089991);
-  r0.z = log2(r1.x);
-  r0.z = r0.z * 0.0744116008 + 0.385536999;
-  r3.z = r2.z ? r0.z : r1.y;
-  // Sample 64x64x64 LUT
-  r1.xyz = r3.xyz * float3(0.984375,0.984375,0.984375) + float3(0.0078125,0.0078125,0.0078125);
-  r1.xyz = t0.SampleLevel(s1_s, r1.xyz, 0).xyz;
-  r2.xyz = cmp(float3(0.149658203,0.149658203,0.149658203) < r1.xyz);
-  r3.xyzw = float4(-0.385536999,-0.0928089991,-0.385536999,-0.0928089991) + r1.xxyy;
-  r3.xyzw = float4(13.4387865,0.186301097,13.4387865,0.186301097) * r3.xyzw;
-  r1.xy = exp2(r3.xz);
-  r1.xy = float2(-0.0522719994,-0.0522719994) + r1.xy;
-  r1.xy = float2(0.179999992,0.179999992) * r1.xy;
-  r3.xy = r2.xy ? r1.xy : r3.yw;
-  r1.xy = float2(-0.385536999,-0.0928089991) + r1.zz;
-  r1.xy = float2(13.4387865,0.186301097) * r1.xy;
-  r0.z = exp2(r1.x);
-  r0.z = -0.0522719994 + r0.z;
-  r0.z = 0.179999992 * r0.z;
-  r3.z = r2.z ? r0.z : r1.y;
-
-  r3.xyz = lerp(lutInputColor, r3.xyz, injectedData.colorGradeLUTStrength);  // LUT Strength
-
-  r1.xyz = r3.xyz;  // r1.xyz = max(float3(0,0,0), r3.xyz);  
   r0.z = max(r1.y, r1.z);
   r0.z = max(r1.x, r0.z);
   r2.xyz = cmp(r1.xyz < float3(0.180000007,0.180000007,0.180000007));
@@ -225,12 +245,15 @@ void main(
   } else {
     o0.rgb = renodx::color::grade::UserColorGrading(  // apply saturation adjustment after LUT
         o0.rgb,
-        1.f,                                // exposure
-        1.f,                                // highlights
-        1.f,                                // shadows
-        1.f,                                // contrast
-        injectedData.colorGradeSaturation,  // saturation
-        injectedData.colorGradeBlowout);     // dechroma
+        1.f,                                            // exposure, applied earlier
+        1.f,                                            // highlights, applied earlier
+        1.f,                                            // shadows, applied earlier
+        1.f,                                            // contrast, applied earlier
+        injectedData.colorGradeSaturation,              // saturation
+        injectedData.colorGradeBlowout,                 // dechroma
+        injectedData.toneMapHueCorrection,              // hue correction
+        renodx::tonemap::uncharted2::BT709(lutInputColor));
+
   }
   r0.z = saturate(r1.w * 4 + -1);
   r0.z = -cb0[29].w * r0.z;

--- a/src/games/gow2018/shared.h
+++ b/src/games/gow2018/shared.h
@@ -20,6 +20,7 @@ struct ShaderInjectData {
   float colorGradeSaturation;
   float colorGradeBlowout;
   float colorGradeLUTStrength;
+  float colorGradeLUTScaling;
 };
 
 #ifndef __cplusplus


### PR DESCRIPTION
This pull request introduces additional improvements and fixes for the HDR implementation in *God of War (2018)*, building on previous changes related to tonemapping, gamma correction, and brightness control. The new features and fixes further refine the HDR experience and offer expanded LUT support.

---

## Key Changes

### HDR Fixes and Improvements:

- **LUT Scaling**: Added functionality to scale LUTs that have raised black levels.
- **UI Brightness Fix**: Fixed an issue where UI brightness scaling affected peak brightness. Now, lowering UI brightness will not reduce the peak brightness of the game content.
- **Hue Emulation Position**: Moved the hue emulation process to occur after LUT application, improving parity between HDR and SDR.
- **scRGB Format**: Upgraded the pipeline to use scRGB format for better HDR support and color precision.
- **Tonemap Input Scaling**: Fixed issues related to scaling input for tonemapping, ensuring highlights remains properly tonemapped.
- **Paper White Correction**: Corrected a slight inaccuracy in the handling of paper white levels for HDR output.
