### PR TITLE
HDR Enhancements for God of War (2018)

### DIFF
--- a/src/games/gow2018/DICE.hlsl
+++ b/src/games/gow2018/DICE.hlsl
@@ -1,10 +1,10 @@
-float max3(float a, float b, float c)
-{
+#include "./shared.h"
+
+float max3(float a, float b, float c) {
   return max(a, max(b, c));
 }
 
-float max3(float3 v)
-{
+float max3(float3 v) {
   return max3(v.x, v.y, v.z);
 }
 
@@ -20,63 +20,48 @@ static const float PQ_constant_C3 = 18.6875f;
 // 1 Remove negative numbers
 // 2 Remove numbers beyond 0-1
 // 3 Mirror negative numbers
-float3 Linear_to_PQ(float3 LinearColor, int clampType = 0)
-{
-    float3 LinearColorSign = sign(LinearColor);
-    if (clampType == 1)
-    {
-        LinearColor = max(LinearColor, 0.f);
-    }
-    else if (clampType == 2)
-    {
-        LinearColor = saturate(LinearColor);
-    }
-    else if (clampType == 3)
-    {
-        LinearColor = abs(LinearColor);
-    }
-    float3 colorPow = pow(LinearColor, PQ_constant_M1);
-    float3 numerator = PQ_constant_C1 + PQ_constant_C2 * colorPow;
-    float3 denominator = 1.f + PQ_constant_C3 * colorPow;
-    float3 pq = pow(numerator / denominator, PQ_constant_M2);
-    if (clampType == 3)
-    {
-        return pq * LinearColorSign;
-    }
-    return pq;
+float3 Linear_to_PQ(float3 LinearColor, int clampType = 0) {
+  float3 LinearColorSign = sign(LinearColor);
+  if (clampType == 1) {
+    LinearColor = max(LinearColor, 0.f);
+  } else if (clampType == 2) {
+    LinearColor = saturate(LinearColor);
+  } else if (clampType == 3) {
+    LinearColor = abs(LinearColor);
+  }
+  float3 colorPow = pow(LinearColor, PQ_constant_M1);
+  float3 numerator = PQ_constant_C1 + PQ_constant_C2 * colorPow;
+  float3 denominator = 1.f + PQ_constant_C3 * colorPow;
+  float3 pq = pow(numerator / denominator, PQ_constant_M2);
+  if (clampType == 3) {
+    return pq * LinearColorSign;
+  }
+  return pq;
 }
 
-float3 PQ_to_Linear(float3 ST2084Color, int clampType = 0)
-{
-    float3 ST2084ColorSign = sign(ST2084Color);
-    if (clampType == 1)
-    {
-        ST2084Color = max(ST2084Color, 0.f);
-    }
-    else if (clampType == 2)
-    {
-        ST2084Color = saturate(ST2084Color);
-    }
-    else if (clampType == 3)
-    {
-        ST2084Color = abs(ST2084Color);
-    }
-    float3 colorPow = pow(ST2084Color, 1.f / PQ_constant_M2);
-    float3 numerator = max(colorPow - PQ_constant_C1, 0.f);
-    float3 denominator = PQ_constant_C2 - (PQ_constant_C3 * colorPow);
-    float3 linearColor = pow(numerator / denominator, 1.f / PQ_constant_M1);
-    if (clampType == 3)
-    {
-        return linearColor * ST2084ColorSign;
-    }
-    return linearColor;
+float3 PQ_to_Linear(float3 ST2084Color, int clampType = 0) {
+  float3 ST2084ColorSign = sign(ST2084Color);
+  if (clampType == 1) {
+    ST2084Color = max(ST2084Color, 0.f);
+  } else if (clampType == 2) {
+    ST2084Color = saturate(ST2084Color);
+  } else if (clampType == 3) {
+    ST2084Color = abs(ST2084Color);
+  }
+  float3 colorPow = pow(ST2084Color, 1.f / PQ_constant_M2);
+  float3 numerator = max(colorPow - PQ_constant_C1, 0.f);
+  float3 denominator = PQ_constant_C2 - (PQ_constant_C3 * colorPow);
+  float3 linearColor = pow(numerator / denominator, 1.f / PQ_constant_M1);
+  if (clampType == 3) {
+    return linearColor * ST2084ColorSign;
+  }
+  return linearColor;
 }
 
 // Aplies exponential ("Photographic") luminance/luma compression.
 // The pow can modulate the curve without changing the values around the edges.
 // The max is the max possible range to compress from, to not lose any output range if the input range was limited.
-float rangeCompress(float X, float Max = asfloat(0x7F7FFFFF))
-{
+float rangeCompress(float X, float Max = asfloat(0x7F7FFFFF)) {
   // Branches are for static parameters optimizations
   if (Max == renodx::math::FLT_MAX) {
     // This does e^X. We expect X to be between 0 and 1.
@@ -90,19 +75,18 @@ float rangeCompress(float X, float Max = asfloat(0x7F7FFFFF))
 // Refurbished DICE HDR tonemapper (per channel or luminance).
 // Expects "InValue" to be >= "ShoulderStart" and "OutMaxValue" to be > "ShoulderStart".
 float luminanceCompress(
-  float InValue,
-  float OutMaxValue,
-  float ShoulderStart = 0.f,
-  bool considerMaxValue = false,
-  float InMaxValue = asfloat(0x7F7FFFFF))
-{
+    float InValue,
+    float OutMaxValue,
+    float ShoulderStart = 0.f,
+    bool considerMaxValue = false,
+    float InMaxValue = asfloat(0x7F7FFFFF)) {
   const float compressableValue = InValue - ShoulderStart;
   const float compressableRange = InMaxValue - ShoulderStart;
   const float compressedRange = OutMaxValue - ShoulderStart;
   const float possibleOutValue = ShoulderStart + compressedRange * rangeCompress(compressableValue / compressedRange, considerMaxValue ? (compressableRange / compressedRange) : renodx::math::FLT_MAX);
 #if 1
   return possibleOutValue;
-#else // Enable this branch if "InValue" can be smaller than "ShoulderStart"
+#else  // Enable this branch if "InValue" can be smaller than "ShoulderStart"
   return (InValue <= ShoulderStart) ? InValue : possibleOutValue;
 #endif
 }
@@ -120,8 +104,7 @@ float luminanceCompress(
 // Overall, this seems to handle bright gradients more smoothly, even if it shifts hues more (and generally desaturating).
 #define DICE_TYPE_BY_CHANNEL_PQ 3
 
-struct DICESettings
-{
+struct DICESettings {
   uint Type;
   // Determines where the highlights curve (shoulder) starts.
   // Values between 0.25 and 0.5 are good with DICE by PQ (any type).
@@ -136,8 +119,7 @@ struct DICESettings
   float DarkeningAmount;
 };
 
-DICESettings DefaultDICESettings()
-{
+DICESettings DefaultDICESettings() {
   DICESettings Settings;
   Settings.Type = DICE_TYPE_BY_CHANNEL_PQ;
   Settings.ShoulderStart = (Settings.Type >= DICE_TYPE_BY_LUMINANCE_RGB) ? (1.f / 4.f) : 0.f;
@@ -150,23 +132,20 @@ DICESettings DefaultDICESettings()
 // Takes scRGB colors with a white level (the value of 1 1 1) of 80 nits (sRGB) (to not be confused with paper white).
 // Paper white is expected to have already been multiplied in.
 float3 DICETonemap(
-  float3 Color,
-  float PeakWhite,
-  const DICESettings Settings)
-{
+    float3 Color,
+    float PeakWhite,
+    const DICESettings Settings) {
   const float sourceLuminance = renodx::color::y::from::BT709(Color);
 
-  if (Settings.Type != DICE_TYPE_BY_LUMINANCE_RGB)
-  {
+  if (Settings.Type != DICE_TYPE_BY_LUMINANCE_RGB) {
     static const float HDR10_MaxWhite = 10000.f / 80.f;
 
     const float shoulderStartPQ = Linear_to_PQ((Settings.ShoulderStart * PeakWhite) / HDR10_MaxWhite).x;
-    if (Settings.Type == DICE_TYPE_BY_LUMINANCE_PQ || Settings.Type == DICE_TYPE_BY_LUMINANCE_PQ_CORRECT_CHANNELS_BEYOND_PEAK_WHITE)
-    {
+    if (Settings.Type == DICE_TYPE_BY_LUMINANCE_PQ || Settings.Type == DICE_TYPE_BY_LUMINANCE_PQ_CORRECT_CHANNELS_BEYOND_PEAK_WHITE) {
       const float sourceLuminanceNormalized = sourceLuminance / HDR10_MaxWhite;
       const float sourceLuminancePQ = Linear_to_PQ(sourceLuminanceNormalized, 1).x;
 
-      if (sourceLuminancePQ > shoulderStartPQ) // Luminance below the shoulder (or below zero) don't need to be adjusted
+      if (sourceLuminancePQ > shoulderStartPQ)  // Luminance below the shoulder (or below zero) don't need to be adjusted
       {
         const float peakWhitePQ = Linear_to_PQ(PeakWhite / HDR10_MaxWhite).x;
 
@@ -174,24 +153,22 @@ float3 DICETonemap(
         const float compressedLuminanceNormalized = PQ_to_Linear(compressedLuminancePQ).x;
         Color *= compressedLuminanceNormalized / sourceLuminanceNormalized;
 
-        if (Settings.Type == DICE_TYPE_BY_LUMINANCE_PQ_CORRECT_CHANNELS_BEYOND_PEAK_WHITE)
-        {
+        if (Settings.Type == DICE_TYPE_BY_LUMINANCE_PQ_CORRECT_CHANNELS_BEYOND_PEAK_WHITE) {
           float3 Color_BT2020 = renodx::color::bt2020::from::BT709(Color);
-          if (any(Color_BT2020 > PeakWhite)) // Optional "optimization" branch
+          if (any(Color_BT2020 > PeakWhite))  // Optional "optimization" branch
           {
             float colorLuminance = renodx::color::y::from::BT2020(Color_BT2020);
             float colorLuminanceInExcess = colorLuminance - PeakWhite;
-            float maxColorInExcess = max3(Color_BT2020) - PeakWhite; // This is guaranteed to be >= "colorLuminanceInExcess"
-            float brightnessReduction = saturate(renodx::math::SafeDivision(PeakWhite, max3(Color_BT2020), 1)); // Fall back to one in case of division by zero
-            float desaturateAlpha = saturate(renodx::math::SafeDivision(maxColorInExcess, maxColorInExcess - colorLuminanceInExcess, 0)); // Fall back to zero in case of division by zero
+            float maxColorInExcess = max3(Color_BT2020) - PeakWhite;                                                                       // This is guaranteed to be >= "colorLuminanceInExcess"
+            float brightnessReduction = saturate(renodx::math::SafeDivision(PeakWhite, max3(Color_BT2020), 1));                            // Fall back to one in case of division by zero
+            float desaturateAlpha = saturate(renodx::math::SafeDivision(maxColorInExcess, maxColorInExcess - colorLuminanceInExcess, 0));  // Fall back to zero in case of division by zero
             Color_BT2020 = lerp(Color_BT2020, colorLuminance, desaturateAlpha * Settings.DesaturationAmount);
-            Color_BT2020 = lerp(Color_BT2020, Color_BT2020 * brightnessReduction, Settings.DarkeningAmount); // Also reduce the brightness to partially maintain the hue, at the cost of brightness
+            Color_BT2020 = lerp(Color_BT2020, Color_BT2020 * brightnessReduction, Settings.DarkeningAmount);  // Also reduce the brightness to partially maintain the hue, at the cost of brightness
             Color = renodx::color::bt709::from::BT2020(Color_BT2020);
           }
         }
       }
-    }
-    else // DICE_TYPE_BY_CHANNEL_PQ
+    } else  // DICE_TYPE_BY_CHANNEL_PQ
     {
       const float peakWhitePQ = Linear_to_PQ(PeakWhite / HDR10_MaxWhite).x;
 
@@ -199,9 +176,9 @@ float3 DICETonemap(
       const float3 sourceColorNormalized = renodx::color::bt2020::from::BT709(Color) / HDR10_MaxWhite;
       const float3 sourceColorPQ = Linear_to_PQ(sourceColorNormalized, 1);
 
-      for (uint i = 0; i < 3; i++) //TODO LUMA: optimize? will the shader compile already convert this to float3? Or should we already make a version with no branches that works in float3?
+      for (uint i = 0; i < 3; i++)  // TODO LUMA: optimize? will the shader compile already convert this to float3? Or should we already make a version with no branches that works in float3?
       {
-        if (sourceColorPQ[i] > shoulderStartPQ) // Colors below the shoulder (or below zero) don't need to be adjusted
+        if (sourceColorPQ[i] > shoulderStartPQ)  // Colors below the shoulder (or below zero) don't need to be adjusted
         {
           const float compressedColorPQ = luminanceCompress(sourceColorPQ[i], peakWhitePQ, shoulderStartPQ);
           const float compressedColorNormalized = PQ_to_Linear(compressedColorPQ).x;
@@ -209,10 +186,9 @@ float3 DICETonemap(
         }
       }
     }
-  }
-  else // DICE_TYPE_BY_LUMINANCE_RGB
+  } else  // DICE_TYPE_BY_LUMINANCE_RGB
   {
-    if (sourceLuminance > Settings.ShoulderStart) // Luminance below the shoulder (or below zero) don't need to be adjusted
+    if (sourceLuminance > Settings.ShoulderStart)  // Luminance below the shoulder (or below zero) don't need to be adjusted
     {
       const float compressedLuminance = luminanceCompress(sourceLuminance, PeakWhite, PeakWhite * Settings.ShoulderStart);
       Color *= compressedLuminance / sourceLuminance;

--- a/src/games/gow2018/addon.cpp
+++ b/src/games/gow2018/addon.cpp
@@ -12,9 +12,11 @@
 #include <deps/imgui/imgui.h>
 #include <include/reshade.hpp>
 
-#include <embed/0x7818463E.h>   // LUT
-#include <embed/0x279D11F6.h>   // Game BT.2020 Conversion + PQ Encoding
-#include <embed/0xB59D6558.h>   // Gamma Slider + Paper White + Tonemap
+#include <embed/0x279D11F6.h>  // Game BT.2020 Conversion + PQ Encoding w/ DLSS/FSR
+#include <embed/0x6FE3FEEA.h>  // LUT w/ TAA
+#include <embed/0x7818463E.h>  // LUT w/ DLSS/FSR
+#include <embed/0xB59D6558.h>  // Gamma Slider + Paper White + Tonemap
+#include <embed/0xF4EFA04D.h>  // Game BT.2020 Conversion + PQ Encoding w/ TAA
 
 #include <include/reshade.hpp>
 #include "../../mods/shader.hpp"
@@ -26,8 +28,10 @@ namespace {
 
 renodx::mods::shader::CustomShaders custom_shaders = {
 
-    CustomShaderEntry(0x7818463E),  // LUT
-    CustomShaderEntry(0x279D11F6),  // Game BT.2020 Conversion + PQ Encoding
+    CustomShaderEntry(0x7818463E),  // LUT w/ DLSS/FSR
+    CustomShaderEntry(0x6FE3FEEA),  // LUT w/ TAA
+    CustomShaderEntry(0x279D11F6),  // Game BT.2020 Conversion + PQ Encoding w/ DLSS/FSR
+    CustomShaderEntry(0xF4EFA04D),  // Game BT.2020 Conversion + PQ Encoding w/ TAA
     CustomShaderEntry(0xB59D6558),  // Gamma Slider + Paper White + Tonemap
 };
 
@@ -166,7 +170,7 @@ renodx::utils::settings::Settings settings = {
     new renodx::utils::settings::Setting{
         .key = "colorGradeLUTScaling",
         .binding = &shader_injection.colorGradeLUTScaling,
-        .default_value = 0.f,
+        .default_value = 100.f,
         .label = "LUT Scaling",
         .section = "Color Grading",
         .tooltip = "Scales the color grade LUT to full range when size is clamped.",
@@ -206,11 +210,9 @@ BOOL APIENTRY DllMain(HMODULE h_module, DWORD fdw_reason, LPVOID lpv_reserved) {
       renodx::mods::shader::force_pipeline_cloning = true;
       renodx::mods::shader::expected_constant_buffer_index = 11;
 
-      renodx::mods::swapchain::swap_chain_upgrade_targets.push_back({
-          .old_format = reshade::api::format::r10g10b10a2_unorm,
-          .new_format = reshade::api::format::r16g16b16a16_float,
-          .index = 0
-      });
+      renodx::mods::swapchain::swap_chain_upgrade_targets.push_back({.old_format = reshade::api::format::r10g10b10a2_unorm,
+                                                                     .new_format = reshade::api::format::r16g16b16a16_float,
+                                                                     .index = 0});
 
       if (!reshade::register_addon(h_module)) return FALSE;
 
@@ -221,7 +223,7 @@ BOOL APIENTRY DllMain(HMODULE h_module, DWORD fdw_reason, LPVOID lpv_reserved) {
   }
 
   renodx::utils::settings::Use(fdw_reason, &settings, &OnPresetOff);
-  renodx::mods::swapchain::Use(fdw_reason); // scRGB swapchain
+  renodx::mods::swapchain::Use(fdw_reason);  // scRGB swapchain
   renodx::mods::shader::Use(fdw_reason, custom_shaders, &shader_injection);
 
   return TRUE;

--- a/src/games/gow2018/final_gamma_0xB59D6558.ps_5_0.hlsl
+++ b/src/games/gow2018/final_gamma_0xB59D6558.ps_5_0.hlsl
@@ -1,36 +1,31 @@
-#include "./shared.h"
 #include "./DICE.hlsl"
+#include "./shared.h"
 
-cbuffer ConstBuf__passData : register(b0)
-{
-  struct GammaAdjustPassData
-  {
+cbuffer ConstBuf__passData : register(b0) {
+  struct GammaAdjustPassData {
     float gamma;
-  } resourceTables__passData;
+  }
+  resourceTables__passData;
 }
 
 Texture2D<float4> inputTexture : register(t0);
 
-
-void main
-(
-  in  float4 SV_POSITION : SV_POSITION,
-  in  float2 TEXCOORD0   : TEXCOORD0,
-  in  float2 TEXCOORD1   : TEXCOORD1,
-  out float4 SV_TARGET0  : SV_TARGET0
-)
-{
+void main(
+    in float4 SV_POSITION: SV_POSITION,
+    in float2 TEXCOORD0: TEXCOORD0,
+    in float2 TEXCOORD1: TEXCOORD1,
+    out float4 SV_TARGET0: SV_TARGET0) {
   uint3 positionAsUint = uint3(uint2(SV_POSITION.xy), 0u);
-  
+
   float4 inputColor = inputTexture.Load(positionAsUint);
-  
+
   SV_TARGET0.a = inputColor.a;
 
-  SV_TARGET0.rgb = renodx::color::bt2020::from::PQ(inputColor);
-  SV_TARGET0.rgb = renodx::color::bt709::from::BT2020(SV_TARGET0.rgb/80.f) * 10000.f;
-  if (injectedData.toneMapType) {
-    SV_TARGET0.rgb *= injectedData.toneMapUINits/308.f;
-    if (injectedData.toneMapType > 1) { // DICE tonemap
+  SV_TARGET0.rgb = renodx::color::bt2020::from::PQ(inputColor.rgb);
+  SV_TARGET0.rgb = renodx::color::bt709::from::BT2020(SV_TARGET0.rgb / 80.f) * 10000.f;
+  if (injectedData.toneMapType != 0) {
+    SV_TARGET0.rgb *= injectedData.toneMapUINits / 306.f;
+    if (injectedData.toneMapType > 1) {  // DICE tonemap
       DICESettings config = DefaultDICESettings();
       config.Type = 3u;
       config.ShoulderStart = 0.5f;

--- a/src/games/gow2018/game_pq_taa_0xF4EFA04D.ps_5_0.hlsl
+++ b/src/games/gow2018/game_pq_taa_0xF4EFA04D.ps_5_0.hlsl
@@ -1,6 +1,6 @@
 #include "./shared.h"
 
-// ---- Created with 3Dmigoto v1.3.16 on Fri Aug 30 19:53:29 2024
+// ---- Created with 3Dmigoto v1.3.16 on Sun Oct 13 15:49:48 2024
 Texture2D<float4> t16 : register(t16);
 
 Texture2D<float4> t11 : register(t11);
@@ -14,62 +14,86 @@ cbuffer cb0 : register(b0) {
 // 3Dmigoto declarations
 #define cmp -
 
-float ColorGradeSmoothClamp(float x) {
-  const float u = 0.525;
-
-  float q = (2.0 - u - 1.0 / u + x * (2.0 + 2.0 / u - x / u)) / 4.0;
-
-  return (abs(1.0 - x) < u) ? q : saturate(x);
-}
-float3 ColorGradeSmoothClamp(float3 color) {
-  float3 outputColor;
-  outputColor.r = ColorGradeSmoothClamp(color.r);
-  outputColor.g = ColorGradeSmoothClamp(color.g);
-  outputColor.b = ColorGradeSmoothClamp(color.b);
-  return outputColor;
-}
-
 void main(
     float4 v0: SV_POSITION0,
     float2 v1: TEXCOORD0,
     float2 w1: TEXCOORD1,
     out float4 o0: SV_Target0) {
-  float4 r0, r1, r2;
+  float4 r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10;
   uint4 bitmask, uiDest;
   float4 fDest;
 
-  r0.xy = (int2)v0.xy;
-  r0.zw = (int2)cb0[8].xy;
+  r0.xy = (uint2)v0.xy;
+  r0.zw = (uint2)cb0[8].xy;
   r0.xy = (int2)-r0.zw + (int2)r0.xy;
-  r0.xy = (int2)r0.xy;
+  r0.xy = (uint2)r0.xy;
   r0.xy = cb0[7].zw * r0.xy;
-  r0.xy = float2(0.5, 0.5) * r0.xy;
-  r1.xy = (int2)r0.xy;
-  r0.xy = trunc(r0.xy);
-  r0.xy = cmp(r0.xy >= cb0[7].xy);
-  r0.zw = cmp((int2)r1.xy < int2(0, 0));
-  r0.z = (int)r0.w | (int)r0.z;
-  r0.x = (int)r0.x | (int)r0.z;
-  r0.x = (int)r0.y | (int)r0.x;
-  r1.zw = float2(0, 0);
-  r0.yzw = t11.Load(r1.xyz).xyz;
-  r0.xyz = r0.xxx ? float3(0, 0, 0) : r0.yzw;
-  r1.xyz = saturate(r0.xyz);
-  r0.w = dot(r1.xyz, float3(0.298999995, 0.587000012, 0.114));
-  r1.x = -r0.w * 4 + 1;
-  r0.w = saturate(r0.w * 8 + -1);
-  r1.x = max(0, r1.x);
-  r1.y = 1 + -r1.x;
-  r1.y = r1.y + -r0.w;
-  r0.w = cb0[16].z * r0.w;
-  r0.w = r1.x * cb0[16].x + r0.w;
-  r1.x = max(0, r1.y);
-  r0.w = r1.x * cb0[16].y + r0.w;
-  r1.xy = v1.xy * cb0[15].xy + cb0[15].zw;
-  r1.x = t16.SampleLevel(s2_s, r1.xy, 0).x;
-  r1.x = r1.x * 2 + -1;
-  r0.xyz = r1.xxx * r0.www + r0.xyz;
-
+  r0.xy = (uint2)r0.xy;
+  r0.zw = float2(0, 0);
+  r1.xyz = t11.Load(r0.xyz).xyz;
+  r1.xyz = r1.xyz * r1.xyz;
+  r1.xyz = r1.xyz * r1.xyz;
+  r2.xyz = float3(7, 7, 7) * r1.xyz;
+  r0.z = cmp(0 != cb0[16].w);
+  if (r0.z != 0) {
+    r3.xyzw = (int4)r0.xyxy + int4(1, 0, -1, 0);
+    r4.xy = r3.zw;
+    r4.zw = float2(0, 0);
+    r4.xyz = t11.Load(r4.xyz).xyz;
+    r4.xyz = r4.xyz * r4.xyz;
+    r4.xyz = r4.xyz * r4.xyz;
+    r5.xyz = float3(7, 7, 7) * r4.xyz;
+    r3.zw = float2(0, 0);
+    r3.xyz = t11.Load(r3.xyz).xyz;
+    r3.xyz = r3.xyz * r3.xyz;
+    r3.xyz = r3.xyz * r3.xyz;
+    r3.xyz = float3(7, 7, 7) * r3.xyz;
+    r0.xyzw = (int4)r0.xyxy + int4(0, -1, 0, 1);
+    r6.xy = r0.zw;
+    r6.zw = float2(0, 0);
+    r6.xyz = t11.Load(r6.xyz).xyz;
+    r6.xyz = r6.xyz * r6.xyz;
+    r6.xyz = r6.xyz * r6.xyz;
+    r7.xyz = float3(7, 7, 7) * r6.xyz;
+    r0.zw = float2(0, 0);
+    r0.xyz = t11.Load(r0.xyz).xyz;
+    r0.xyz = r0.xyz * r0.xyz;
+    r0.xyz = r0.xyz * r0.xyz;
+    r8.xyz = float3(7, 7, 7) * r0.xyz;
+    r9.xyz = min(r5.xyz, r3.xyz);
+    r9.xyz = min(r9.xyz, r2.xyz);
+    r10.xyz = min(r8.xyz, r7.xyz);
+    r9.xyz = min(r10.xyz, r9.xyz);
+    r5.xyz = max(r5.xyz, r3.xyz);
+    r5.xyz = max(r5.xyz, r2.xyz);
+    r7.xyz = max(r8.xyz, r7.xyz);
+    r5.xyz = max(r7.xyz, r5.xyz);
+    r3.xyz = r4.xyz * float3(7, 7, 7) + r3.xyz;
+    r3.xyz = r6.xyz * float3(7, 7, 7) + r3.xyz;
+    r0.xyz = r0.xyz * float3(7, 7, 7) + r3.xyz;
+    r0.xyz = float3(0.25, 0.25, 0.25) * r0.xyz;
+    r1.xyz = r1.xyz * float3(7, 7, 7) + -r0.xyz;
+    r0.xyz = cb0[17].xxx * r1.xyz + r0.xyz;
+    r1.xyz = min(r0.xyz, r9.xyz);
+    r0.xyz = max(r0.xyz, r9.xyz);
+    r0.xyz = min(r0.xyz, r5.xyz);
+    r2.xyz = max(r1.xyz, r0.xyz);
+  }
+  r0.xyz = saturate(r2.xyz);
+  r0.x = dot(r0.xyz, float3(0.298999995, 0.587000012, 0.114));
+  r0.y = -r0.x * 4 + 1;
+  r0.y = max(0, r0.y);
+  r0.x = saturate(r0.x * 8 + -1);
+  r0.z = 1 + -r0.y;
+  r0.z = r0.z + -r0.x;
+  r0.z = max(0, r0.z);
+  r0.x = cb0[16].z * r0.x;
+  r0.x = r0.y * cb0[16].x + r0.x;
+  r0.x = r0.z * cb0[16].y + r0.x;
+  r0.yz = v1.xy * cb0[15].xy + cb0[15].zw;
+  r0.y = t16.SampleLevel(s2_s, r0.yz, 0).x;
+  r0.y = r0.y * 2 + -1;
+  r0.xyz = r0.yyy * r0.xxx + r2.xyz;
   if (injectedData.toneMapType != 0) {
     r0.rgb = renodx::color::grade::UserColorGrading(  // apply saturation and hue after LUT
         r0.rgb,
@@ -89,21 +113,15 @@ void main(
     o0.xyz = renodx::color::pq::Encode(r0.xyz, 306.f);  // Set paper white to match UI
   } else {                                              //  Original BT.2020 + PQ code
     r0.xyz = max(float3(0, 0, 0), r0.xyz);
-    // BT.2020
     r0.w = dot(float3(0.627403915, 0.329283029, 0.0433130674), r0.xyz);
-    r1.x = log2(r0.w);
-    r0.w = dot(float3(0.069097288, 0.919540405, 0.0113623161), r0.xyz);
+    r1.x = dot(float3(0.069097288, 0.919540405, 0.0113623161), r0.xyz);
     r0.x = dot(float3(0.0163914394, 0.0880133063, 0.895595253), r0.xyz);
-    r1.z = log2(r0.x);
-    r1.y = log2(r0.w);
-
-    r0.xyz = cb0[25].zzz * r1.xyz;  // contrast slider
+    r2.x = log2(r0.w);
+    r2.y = log2(r1.x);
+    r2.z = log2(r0.x);
+    r0.xyz = cb0[25].zzz * r2.xyz;
     r0.xyz = exp2(r0.xyz);
-    r0.xyz = cb0[24].yyy * r0.xyz;  // game brightness slider
-
-    // Fast PQ encoding. Input is assumed to be positive and scaled such that 1.0 corresponds to 100 nits. Accurate over range
-    //  0.01 - 1400 nits (and reasonable behavior outside of that range).
-    //  https://www.glowybits.com/blog/2017/01/04/ifl_iss_hdr_2/
+    r0.xyz = cb0[24].yyy * r0.xyz;
     r1.xyz = r0.xyz * float3(533095.75, 533095.75, 533095.75) + float3(47438308, 47438308, 47438308);
     r1.xyz = r0.xyz * r1.xyz + float3(29063622, 29063622, 29063622);
     r1.xyz = r0.xyz * r1.xyz + float3(575216.75, 575216.75, 575216.75);
@@ -114,7 +132,6 @@ void main(
     r2.xyz = r0.xyz * r2.xyz + float3(10668.4043, 10668.4043, 10668.4043);
     r0.xyz = r0.xyz * r2.xyz + float3(1, 1, 1);
     o0.xyz = r1.xyz / r0.xyz;
-    o0.xyz = saturate(o0.xyz);  // previously clamped by unorm
   }
   o0.w = 1;
   return;

--- a/src/games/gow2018/lut_0x7818463E.ps_5_0.hlsl
+++ b/src/games/gow2018/lut_0x7818463E.ps_5_0.hlsl
@@ -31,40 +31,35 @@ SamplerState s1_s : register(s1);
 
 SamplerState s0_s : register(s0);
 
-cbuffer cb0 : register(b0)
-{
+cbuffer cb0 : register(b0) {
   float4 cb0[31];
 }
-
-
-
 
 // 3Dmigoto declarations
 #define cmp -
 
 void main(
-  float4 v0 : SV_POSITION0,
-  float2 v1 : TEXCOORD0,
-  float2 w1 : TEXCOORD1,
-  out float4 o0 : SV_Target0)
-{
-// Needs manual fix for instruction:
-// unknown dcl_: dcl_uav_typed_texture2d (float,float,float,float) u9
-  float4 r0,r1,r2,r3,r4,r5;
+    float4 v0: SV_POSITION0,
+    float2 v1: TEXCOORD0,
+    float2 w1: TEXCOORD1,
+    out float4 o0: SV_Target0) {
+  // Needs manual fix for instruction:
+  // unknown dcl_: dcl_uav_typed_texture2d (float,float,float,float) u9
+  float4 r0, r1, r2, r3, r4, r5;
   uint4 bitmask, uiDest;
   float4 fDest;
 
   r0.xy = (uint2)v0.xy;
-  r0.zw = float2(0,0);
+  r0.zw = float2(0, 0);
   r0.zw = t18.Load(r0.xyz).xy;
   r0.zw = cb0[2].zw * r0.zw;
   r1.xyz = t6.SampleLevel(s1_s, v1.xy, 0).xyz;
-  r0.zw = r0.zw * float2(8,8) + v1.xy;
+  r0.zw = r0.zw * float2(8, 8) + v1.xy;
   r1.w = t6.SampleLevel(s1_s, r0.zw, 0).w;
   r2.x = cmp(r1.w < 1);
   if (r2.x != 0) {
     r2.xyz = t14.SampleLevel(s1_s, r0.zw, 0).xyw;
-    r3.xy = float2(1,-1) * r2.xy;
+    r3.xy = float2(1, -1) * r2.xy;
     r2.x = dot(r2.xy, r2.xy);
     r2.x = cmp(r2.x != 0.000000);
     if (r2.x != 0) {
@@ -74,20 +69,20 @@ void main(
       r2.x = min(r2.x, r4.w);
       r2.x = max(1, -r2.x);
       r2.x = r2.z / r2.x;
-      r4.xy = (int2)r0.xy & int2(63,63);
+      r4.xy = (int2)r0.xy & int2(63, 63);
       r4.z = 7 & asint(cb0[14].w);
       r4.w = 0;
       r2.y = t17.Load(r4.xyzw).x;
       r2.z = 0.25 * r2.y;
       r3.zw = r3.xy * r2.zz + v1.xy;
       r2.w = t2.SampleCmpLevelZero(s3_s, r3.zw, r2.x).x;
-      r4.xyz = r2.yyy * float3(0.25,0.25,0.25) + float3(0.25,0.5,0.75);
+      r4.xyz = r2.yyy * float3(0.25, 0.25, 0.25) + float3(0.25, 0.5, 0.75);
       r5.xyzw = r3.xyxy * r4.xxyy + v1.xyxy;
       r2.y = t2.SampleCmpLevelZero(s3_s, r5.xy, r2.x).x;
       r3.z = t2.SampleCmpLevelZero(s3_s, r5.zw, r2.x).x;
       r5.xy = r3.xy * r4.zz + v1.xy;
       r2.x = t2.SampleCmpLevelZero(s3_s, r5.xy, r2.x).x;
-      r2.xyw = cmp(float3(0,0,0) >= r2.xyw);
+      r2.xyw = cmp(float3(0, 0, 0) >= r2.xyw);
       r2.z = r2.w ? r2.z : 0;
       r2.y = r2.y ? r4.x : r2.z;
       r2.z = cmp(0 >= r3.z);
@@ -99,9 +94,9 @@ void main(
     r2.xy = r3.xy * r2.xx + v1.xy;
     r2.xyz = t3.SampleLevel(s1_s, r2.xy, 0).xyz;
     r3.xyzw = t12.SampleLevel(s1_s, v1.xy, 0).xyzw;
-    r3.xyzw = max(float4(0,0,0,0), r3.xyzw);
+    r3.xyzw = max(float4(0, 0, 0, 0), r3.xyzw);
     r4.xyzw = t13.SampleLevel(s1_s, r0.zw, 0).xyzw;
-    r4.xyzw = max(float4(0,0,0,0), r4.xyzw);
+    r4.xyzw = max(float4(0, 0, 0, 0), r4.xyzw);
     r0.z = r4.w * r3.w;
     r3.xyz = r3.xyz * r4.www + r4.xyz;
     r0.w = r3.y + -r2.y;
@@ -144,11 +139,11 @@ void main(
   r2.xyz = cb0[20].xyz * r1.yyy;
   r2.xyz = r1.xxx * cb0[19].xyz + r2.xyz;
   r1.xyz = r1.zzz * cb0[21].xyz + r2.xyz;
-  r1.xyz = max(float3(0,0,0), r1.xyz);
-  r2.xyzw = -cb0[12].wxyz + float4(1,1,1,1);
+  r1.xyz = max(float3(0, 0, 0), r1.xyz);
+  r2.xyzw = -cb0[12].wxyz + float4(1, 1, 1, 1);
   r0.z = cb0[13].y * v1.x;
   r0.z = v1.y * r0.z;
-  r3.xy = float2(1,1) + -v1.xy;
+  r3.xy = float2(1, 1) + -v1.xy;
   r0.z = r3.x * r0.z;
   r0.z = r0.z * r3.y;
   r0.z = log2(abs(r0.z));
@@ -158,33 +153,33 @@ void main(
   r2.xyz = r0.zzz * r2.yzw + cb0[12].xyz;
   r1.xyz = r2.xyz * r1.xyz;
   r0.z = cmp(0 != cb0[0].w);
-  r1.xyz = r0.zzz ? float3(0,0,0) : r1.xyz;
-    
+  r1.xyz = r0.zzz ? float3(0, 0, 0) : r1.xyz;
+
   float3 lutInputColor = r1.xyz;
   if (injectedData.toneMapType == 0) {
     // convert arri logc800
-    r2.xyz = cmp(float3(0.0105910003,0.0105910003,0.0105910003) < r1.xyz);
-    r3.xyzw = r1.xxyy * float4(5.55555582,5.3676548,5.55555582,5.3676548) + float4(0.0522719994,0.0928089991,0.0522719994,0.0928089991);
+    r2.xyz = cmp(float3(0.0105910003, 0.0105910003, 0.0105910003) < r1.xyz);
+    r3.xyzw = r1.xxyy * float4(5.55555582, 5.3676548, 5.55555582, 5.3676548) + float4(0.0522719994, 0.0928089991, 0.0522719994, 0.0928089991);
     r1.xy = log2(r3.xz);
-    r1.xy = r1.xy * float2(0.0744116008,0.0744116008) + float2(0.385536999,0.385536999);
+    r1.xy = r1.xy * float2(0.0744116008, 0.0744116008) + float2(0.385536999, 0.385536999);
     r3.xy = r2.xy ? r1.xy : r3.yw;
-    r1.xy = r1.zz * float2(5.55555582,5.3676548) + float2(0.0522719994,0.0928089991);
+    r1.xy = r1.zz * float2(5.55555582, 5.3676548) + float2(0.0522719994, 0.0928089991);
     r0.z = log2(r1.x);
     r0.z = r0.z * 0.0744116008 + 0.385536999;
     r3.z = r2.z ? r0.z : r1.y;
     // Sample 64x64x64 LUT
-    r1.xyz = r3.xyz * float3(0.984375,0.984375,0.984375) + float3(0.0078125,0.0078125,0.0078125);
+    r1.xyz = r3.xyz * float3(0.984375, 0.984375, 0.984375) + float3(0.0078125, 0.0078125, 0.0078125);
     r1.xyz = t0.SampleLevel(s1_s, r1.xyz, 0).xyz;
     // back to linear
-    r2.xyz = cmp(float3(0.149658203,0.149658203,0.149658203) < r1.xyz);
-    r3.xyzw = float4(-0.385536999,-0.0928089991,-0.385536999,-0.0928089991) + r1.xxyy;
-    r3.xyzw = float4(13.4387865,0.186301097,13.4387865,0.186301097) * r3.xyzw;
+    r2.xyz = cmp(float3(0.149658203, 0.149658203, 0.149658203) < r1.xyz);
+    r3.xyzw = float4(-0.385536999, -0.0928089991, -0.385536999, -0.0928089991) + r1.xxyy;
+    r3.xyzw = float4(13.4387865, 0.186301097, 13.4387865, 0.186301097) * r3.xyzw;
     r1.xy = exp2(r3.xz);
-    r1.xy = float2(-0.0522719994,-0.0522719994) + r1.xy;
-    r1.xy = float2(0.179999992,0.179999992) * r1.xy;
+    r1.xy = float2(-0.0522719994, -0.0522719994) + r1.xy;
+    r1.xy = float2(0.179999992, 0.179999992) * r1.xy;
     r3.xy = r2.xy ? r1.xy : r3.yw;
-    r1.xy = float2(-0.385536999,-0.0928089991) + r1.zz;
-    r1.xy = float2(13.4387865,0.186301097) * r1.xy;
+    r1.xy = float2(-0.385536999, -0.0928089991) + r1.zz;
+    r1.xy = float2(13.4387865, 0.186301097) * r1.xy;
     r0.z = exp2(r1.x);
     r0.z = -0.0522719994 + r0.z;
     r0.z = 0.179999992 * r0.z;
@@ -195,12 +190,12 @@ void main(
   } else {
     lutInputColor = renodx::color::grade::UserColorGrading(
         lutInputColor,
-        injectedData.colorGradeExposure,              // exposure
-        injectedData.colorGradeHighlights,            // highlights
-        injectedData.colorGradeShadows,               // shadows
-        injectedData.colorGradeContrast,              // contrast
-        1.f,                                          // saturation, applied later
-        0.f);                                         // dechroma, applied later
+        injectedData.colorGradeExposure,    // exposure
+        injectedData.colorGradeHighlights,  // highlights
+        injectedData.colorGradeShadows,     // shadows
+        injectedData.colorGradeContrast,    // contrast
+        1.f,                                // saturation, applied later
+        0.f);                               // dechroma, applied later
 
     renodx::lut::Config lut_config = renodx::lut::config::Create(
         s1_s,
@@ -214,7 +209,7 @@ void main(
     // Cleans up raised black floor
     if (injectedData.colorGradeLUTScaling && injectedData.colorGradeLUTStrength) {
       float3 minBlack = renodx::color::arri::logc::c800::Decode(t0.SampleLevel(s1_s, renodx::color::arri::logc::c800::Encode((0.f).xxx), 0.0f).rgb);
-      const float lutMinY = renodx::color::y::from::BT709(minBlack);
+      const float lutMinY = renodx::color::y::from::BT709(max(0, minBlack));
       if (lutMinY > 0) {
         float3 correctedBlack = renodx::lut::CorrectBlack(lutInputColor, lutOutputColor, lutMinY, 0.f);
         lutOutputColor = lerp(lutOutputColor, correctedBlack, injectedData.colorGradeLUTScaling);
@@ -222,14 +217,16 @@ void main(
     }
 
     r1.xyz = lerp(lutInputColor, lutOutputColor, injectedData.colorGradeLUTStrength);
+
+    r1.xyz = max(0, r1.xyz);  // DLSS/FSR clamps to BT.709
   }
 
   r0.z = max(r1.y, r1.z);
   r0.z = max(r1.x, r0.z);
-  r2.xyz = cmp(r1.xyz < float3(0.180000007,0.180000007,0.180000007));
+  r2.xyz = cmp(r1.xyz < float3(0.180000007, 0.180000007, 0.180000007));
   r3.xyz = min(cb0[24].xxx, r1.xyz);
-  r4.xyz = sign(r3.xyz) * pow(abs(r3.xyz), cb0[23].www);  // r4.xyz = exp2(cb0[23].www * log2(r3.xyz));
-  r3.xyz = sign(r3.xyz) * pow(abs(r3.xyz), cb0[24].zzz);  // r3.xyz = exp2(cb0[24].zzz * log2(r3.xyz));
+  r4.xyz = pow(r3.xyz, cb0[23].www);  // r4.xyz = exp2(cb0[23].www * log2(r3.xyz));
+  r3.xyz = pow(r3.xyz, cb0[24].zzz);  // r3.xyz = exp2(cb0[24].zzz * log2(r3.xyz));
   r3.xyz = r3.xyz * cb0[25].xxx + cb0[25].yyy;
   r3.xyz = r4.xyz / r3.xyz;
   r2.xyz = r2.xyz ? r3.xyz : r1.xyz;
@@ -239,22 +236,7 @@ void main(
   r1.xyz = r1.xyz / r0.zzz;
   r2.xyz = r2.xyz + -r1.xyz;
   r1.xyz = cb0[24].www * r2.xyz + r1.xyz;
-  o0.xyz = r1.xyz;  // o0.xyz = max(float3(0,0,0), r1.xyz);
-  if (injectedData.toneMapType == 0) {
-    o0.xyz = max(0, o0.xyz);
-  } else {
-    o0.rgb = renodx::color::grade::UserColorGrading(  // apply saturation adjustment after LUT
-        o0.rgb,
-        1.f,                                            // exposure, applied earlier
-        1.f,                                            // highlights, applied earlier
-        1.f,                                            // shadows, applied earlier
-        1.f,                                            // contrast, applied earlier
-        injectedData.colorGradeSaturation,              // saturation
-        injectedData.colorGradeBlowout,                 // dechroma
-        injectedData.toneMapHueCorrection,              // hue correction
-        renodx::tonemap::uncharted2::BT709(lutInputColor));
-
-  }
+  o0.xyz = max(0, r1.xyz);  // DLSS/FSR clamps to BT.709
   r0.z = saturate(r1.w * 4 + -1);
   r0.z = -cb0[29].w * r0.z;
   r1.x = cmp(-0.100000001 < r0.z);
@@ -263,7 +245,7 @@ void main(
   r0.z = cb0[29].w + r0.z;
   r0.z = cb0[30].z * r0.z;
   // Store the value r0.zzzz at the location r0.xy in the UAV u9
-  u9[r0.xy] = float4(r0.zzzz);    // store_uav_typed u9.xyzw, r0.xyyy, r0.zzzz
+  u9[r0.xy] = float4(r0.zzzz);  // store_uav_typed u9.xyzw, r0.xyyy, r0.zzzz
   o0.w = 1;
   return;
 }

--- a/src/games/gow2018/lut_taa_0x6FE3FEEA.ps_5_0.hlsl
+++ b/src/games/gow2018/lut_taa_0x6FE3FEEA.ps_5_0.hlsl
@@ -1,0 +1,282 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Sun Oct 13 17:20:36 2024
+RWTexture2D<float4> u9 : register(u9);  // decompiler missed this
+
+Texture2D<float4> t21 : register(t21);
+
+Texture2D<float4> t18 : register(t18);
+
+Texture2DArray<float4> t17 : register(t17);
+
+Texture2D<float4> t14 : register(t14);
+
+Texture2D<float4> t13 : register(t13);
+
+Texture2D<float4> t12 : register(t12);
+
+Texture2D<float4> t6 : register(t6);
+
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture3D<float4> t0 : register(t0);
+
+SamplerComparisonState s3_s : register(s3);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0) {
+  float4 cb0[31];
+}
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(
+    float4 v0: SV_POSITION0,
+    float2 v1: TEXCOORD0,
+    float2 w1: TEXCOORD1,
+    out float4 o0: SV_Target0) {
+  // Needs manual fix for instruction:
+  // unknown dcl_: dcl_uav_typed_texture2d (float,float,float,float) u9
+  float4 r0, r1, r2, r3, r4, r5, r6;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = (uint2)v0.xy;
+  r0.zw = float2(0, 0);
+  r1.xy = t18.Load(r0.xyw).xy;
+  r1.xy = cb0[2].zw * r1.xy;
+  r2.xyz = t6.SampleLevel(s1_s, v1.xy, 0).xyz;
+  r1.xy = r1.xy * float2(8, 8) + v1.xy;
+  r1.z = t6.SampleLevel(s1_s, r1.xy, 0).w;
+  r1.w = cmp(r1.z < 1);
+  if (r1.w != 0) {
+    r3.xyz = t14.SampleLevel(s1_s, r1.xy, 0).xyw;
+    r4.xy = float2(1, -1) * r3.xy;
+    r1.w = dot(r3.xy, r3.xy);
+    r1.w = cmp(r1.w != 0.000000);
+    if (r1.w != 0) {
+      r5.xyzw = t14.Gather(s0_s, v1.xy).xyzw;
+      r1.w = min(r5.y, r5.z);
+      r1.w = min(r5.x, r1.w);
+      r1.w = min(r1.w, r5.w);
+      r1.w = max(1, -r1.w);
+      r1.w = r3.z / r1.w;
+      r3.xy = (int2)r0.xy & int2(63, 63);
+      r3.z = 7 & asint(cb0[14].w);
+      r3.w = 0;
+      r2.w = t17.Load(r3.xyzw).x;
+      r3.x = 0.25 * r2.w;
+      r3.yz = r4.xy * r3.xx + v1.xy;
+      r3.y = t2.SampleCmpLevelZero(s3_s, r3.yz, r1.w).x;
+      r5.xyz = r2.www * float3(0.25, 0.25, 0.25) + float3(0.25, 0.5, 0.75);
+      r6.xyzw = r4.xyxy * r5.xxyy + v1.xyxy;
+      r2.w = t2.SampleCmpLevelZero(s3_s, r6.xy, r1.w).x;
+      r3.z = t2.SampleCmpLevelZero(s3_s, r6.zw, r1.w).x;
+      r4.zw = r4.xy * r5.zz + v1.xy;
+      r1.w = t2.SampleCmpLevelZero(s3_s, r4.zw, r1.w).x;
+      r3.y = cmp(0 >= r3.y);
+      r3.x = r3.y ? r3.x : 0;
+      r2.w = cmp(0 >= r2.w);
+      r2.w = r2.w ? r5.x : r3.x;
+      r3.x = cmp(0 >= r3.z);
+      r2.w = r3.x ? r5.y : r2.w;
+      r1.w = cmp(0 >= r1.w);
+      r1.w = r1.w ? r5.z : r2.w;
+    } else {
+      r1.w = 0;
+    }
+    r3.xy = r4.xy * r1.ww + v1.xy;
+    r3.xyz = t3.SampleLevel(s1_s, r3.xy, 0).xyz;
+    r4.xyzw = t12.SampleLevel(s1_s, v1.xy, 0).xyzw;
+    r4.xyzw = max(float4(0, 0, 0, 0), r4.xyzw);
+    r5.xyzw = t13.SampleLevel(s1_s, r1.xy, 0).xyzw;
+    r5.xyzw = max(float4(0, 0, 0, 0), r5.xyzw);
+    r1.x = r5.w * r4.w;
+    r4.xyz = r4.xyz * r5.www + r5.xyz;
+    r1.y = r4.y + -r3.y;
+    r1.y = saturate(cb0[29].z * r1.y);
+    r1.x = min(1, r1.x);
+    r3.xyz = r3.xyz * r1.xxx + r4.xyz;
+    r1.z = saturate(r1.z);
+    r1.x = max(r3.y, r3.z);
+    r1.x = max(r3.x, r1.x);
+    r1.x = 1 + r1.x;
+    r1.x = rcp(r1.x);
+    r4.xyz = r3.xyz * r1.xxx;
+    r3.xyz = -r3.xyz * r1.xxx + r2.xyz;
+    r2.xyz = r1.zzz * r3.xyz + r4.xyz;
+  } else {
+    r1.y = 0;
+  }
+  r1.x = max(r2.y, r2.z);
+  r1.x = max(r2.x, r1.x);
+  r1.x = 1 + -r1.x;
+  r1.x = rcp(r1.x);
+  r2.xyz = r2.xyz * r1.xxx;
+  r1.x = cmp(0 != cb0[21].w);
+  if (r1.x != 0) {
+    r1.x = t1.SampleLevel(s1_s, v1.xy, 0).x;
+    r1.x = exp2(r1.x);
+    r3.xyz = r2.xyz * r1.xxx;
+  } else {
+    r3.xyz = cb0[22].xxx * r2.xyz;
+  }
+  r2.xyz = t4.SampleLevel(s1_s, v1.xy, 0).xyz;
+  r2.xyz = cb0[1].zzz * r2.xyz + r3.xyz;
+  r1.xw = -cb0[14].yz + v0.xy;
+  r1.x = dot(r1.xw, r1.xw);
+  r1.x = cb0[14].x * r1.x;
+  r1.x = r1.x * r1.x;
+  r1.x = cb0[13].z * r1.x;
+  r1.x = exp2(-r1.x);
+  r2.xyz = r2.xyz * r1.xxx;
+  r3.xyz = cb0[20].xyz * r2.yyy;
+  r2.xyw = r2.xxx * cb0[19].xyz + r3.xyz;
+  r2.xyz = r2.zzz * cb0[21].xyz + r2.xyw;
+  r2.xyz = max(float3(0, 0, 0), r2.xyz);
+  r3.xyzw = -cb0[12].wxyz + float4(1, 1, 1, 1);
+  r1.x = cb0[13].y * v1.x;
+  r1.x = v1.y * r1.x;
+  r4.xy = float2(1, 1) + -v1.xy;
+  r1.x = r4.x * r1.x;
+  r1.x = r1.x * r4.y;
+  r1.x = log2(abs(r1.x));
+  r1.x = cb0[13].x * r1.x;
+  r1.x = exp2(r1.x);
+  r1.x = saturate(r3.x * r1.x + cb0[12].w);
+  r3.xyz = r1.xxx * r3.yzw + cb0[12].xyz;
+  r2.xyz = r3.xyz * r2.xyz;
+  r1.x = cmp(0 != cb0[0].w);
+  r2.xyz = r1.xxx ? float3(0, 0, 0) : r2.xyz;
+
+  if (injectedData.toneMapType != 0) {
+    r2.xyz = renodx::color::grade::UserColorGrading(
+        r2.xyz,
+        injectedData.colorGradeExposure,    // exposure
+        injectedData.colorGradeHighlights,  // highlights
+        injectedData.colorGradeShadows,     // shadows
+        injectedData.colorGradeContrast,    // contrast
+        1.f,                                // saturation, applied later
+        0.f,                                // dechroma, applied later
+        0.f);                               // hue correction, applied later
+  }
+  float3 lutInputColor = r2.xyz;
+
+  // convert arri logc800
+  r3.xyz = cmp(float3(0.0105910003, 0.0105910003, 0.0105910003) < r2.xyz);
+  r4.xyzw = r2.xxyy * float4(5.55555582, 5.3676548, 5.55555582, 5.3676548) + float4(0.0522719994, 0.0928089991, 0.0522719994, 0.0928089991);
+  r1.xw = log2(r4.xz);
+  r1.xw = r1.xw * float2(0.0744116008, 0.0744116008) + float2(0.385536999, 0.385536999);
+  r4.xy = r3.xy ? r1.xw : r4.yw;
+  r1.xw = r2.zz * float2(5.55555582, 5.3676548) + float2(0.0522719994, 0.0928089991);
+  r1.x = log2(r1.x);
+  r1.x = r1.x * 0.0744116008 + 0.385536999;
+  r4.z = r3.z ? r1.x : r1.w;
+  // Sample 64x64x64 LUT
+  r2.xyz = r4.xyz * float3(0.984375, 0.984375, 0.984375) + float3(0.0078125, 0.0078125, 0.0078125);
+  r2.xyz = t0.SampleLevel(s1_s, r2.xyz, 0).xyz;
+  // back to linear
+  r3.xyz = cmp(float3(0.149658203, 0.149658203, 0.149658203) < r2.xyz);
+  r4.xyzw = float4(-0.385536999, -0.0928089991, -0.385536999, -0.0928089991) + r2.xxyy;
+  r4.xyzw = float4(13.4387865, 0.186301097, 13.4387865, 0.186301097) * r4.xyzw;
+  r2.xyw = exp2(r4.xzx);
+  r2.xyw = float3(-0.0522719994, -0.0522719994, -0.0522719994) + r2.xyw;
+  r2.xyw = float3(0.179999992, 0.179999992, 0.179999992) * r2.xyw;
+  r4.xyw = r3.xyx ? r2.xyw : r4.ywy;
+  r1.xw = float2(-0.385536999, -0.0928089991) + r2.zz;
+  r1.xw = float2(13.4387865, 0.186301097) * r1.xw;
+  r1.x = exp2(r1.x);
+  r1.x = -0.0522719994 + r1.x;
+  r1.x = 0.179999992 * r1.x;
+  r4.z = r3.z ? r1.x : r1.w;
+
+  r2.xyzw = max(0, r4.xyzw);
+
+  float3 lutOutputColor = r2.wyz;
+
+  if (injectedData.toneMapType != 0 && injectedData.colorGradeLUTScaling > 0 && injectedData.colorGradeLUTStrength > 0) {
+    float3 minBlack = renodx::color::arri::logc::c800::Decode(t0.SampleLevel(s1_s, renodx::color::arri::logc::c800::Encode((0.f).xxx), 0.0f).rgb);
+
+    float lutMinY = renodx::color::y::from::BT709(max(0, minBlack));
+    if (lutMinY > 0) {
+      float3 correctedBlack = renodx::lut::CorrectBlack(lutInputColor, lutOutputColor, lutMinY, 0.f);
+      lutOutputColor = lerp(lutOutputColor, correctedBlack, injectedData.colorGradeLUTScaling);
+    }
+  }
+  r2.wyz = lerp(lutInputColor.rgb, lutOutputColor, injectedData.colorGradeLUTStrength);  // LUT Strength
+  r2.wyz = max(0, r2.wyz);                                                               // TAA clamps to BT.709 anyway
+
+  r1.x = max(r2.y, r2.z);
+  r1.x = max(r2.w, r1.x);
+  r3.xyzw = cmp(r2.wyzw < float4(0.180000007, 0.180000007, 0.180000007, 0.180000007));
+  r4.xyzw = min(cb0[24].xxxx, r2.wyzw);
+  r4.xyzw = log2(r4.xyzw);
+  r5.xyzw = cb0[23].wwww * r4.wyzw;
+  r5.xyzw = exp2(r5.xyzw);
+  r4.xyzw = cb0[24].zzzz * r4.xyzw;
+  r4.xyzw = exp2(r4.xyzw);
+  r4.xyzw = r4.xyzw * cb0[25].xxxx + cb0[25].yyyy;
+  r4.xyzw = r5.xyzw / r4.xyzw;
+  r3.xyzw = r3.xyzw ? r4.xyzw : r2.xyzw;
+  r1.w = max(r3.y, r3.z);
+  r1.w = max(r3.w, r1.w);
+  r2.xyzw = r2.xyzw * r1.wwww;
+  r2.xyzw = r2.xyzw / r1.xxxx;
+  r3.xyzw = r3.xyzw + -r2.wyzw;
+  r2.xyzw = cb0[24].wwww * r3.xyzw + r2.xyzw;
+  r2.xyzw = max(float4(0, 0, 0, 0), r2.xyzw);
+  r2.xyzw = min(float4(7, 7, 7, 7), r2.xyzw);
+  r3.xyz = float3(0.25, 0.5, -0.25) * r2.xyw;
+  r1.xw = r3.xz + r3.yy;
+  r3.x = r2.z * 0.25 + r1.x;
+  r3.y = dot(r2.wz, float2(0.5, -0.5));
+  r3.z = r2.z * -0.25 + r1.w;
+  r1.x = saturate(r1.z * 4 + -1);
+  r1.x = -cb0[29].w * r1.x;
+  r1.w = cmp(-0.100000001 < r1.x);
+  r1.y = cb0[30].x * r1.y;
+  r1.x = r1.w ? r1.y : r1.x;
+  r1.x = cb0[29].w + r1.x;
+  r1.x = cb0[30].z * r1.x;
+  r0.z = t21.Load(r0.xyz).w;
+  r0.z = r0.z * 255 + 0.5;
+  r0.z = (uint)r0.z;
+  r0.w = 255 * r1.x;
+  r0.w = (int)r0.w;
+  r0.zw = (int2)r0.zw & int2(1, 252);
+  r0.z = r0.z ? 1 : 0;
+  r0.z = (int)r0.w + (int)r0.z;
+  r0.w = cmp(0.100000001 < r1.z);
+  r0.w = r0.w ? 0.000000 : 0;
+  r0.z = (int)r0.w + (int)r0.z;
+  r0.z = (int)r0.z;
+  r0.z = 0.00392156886 * r0.z;
+  // No code for instruction (needs manual fix):
+  u9[r0.xy] = float4(r0.zzzz);  // store_uav_typed u9.xyzw, r0.xyyy, r0.zzzz
+  r0.xyz = float3(0.142857149, 0.142857149, 0.142857149) * r3.xyz;
+  r0.x = sqrt(r0.x);
+  r0.x = sqrt(r0.x);
+  r0.x = 4095 * r0.x;
+  r0.x = floor(r0.x);
+  r0.xw = float2(0.000244200259, 0.25) * r0.xx;
+  r1.x = r0.x * r0.x;
+  r1.x = r1.x * r1.x;
+  r1.x = rcp(r1.x);
+  r1.x = 0.5 * r1.x;
+  r0.yz = r1.xx * r0.yz;
+  o0.yz = saturate(r0.yz * float2(0.499511242, 0.499511242) + float2(0.499511242, 0.499511242));
+  r0.y = frac(r0.w);
+  o0.w = 1.33333337 * r0.y;
+  o0.x = r0.x;
+  return;
+}


### PR DESCRIPTION
# Pull Request: HDR and Color Enhancement for *God of War (2018)*

This pull request introduces further refinements to the HDR and color grading functionalities of *God of War (2018)*. These changes expand the previous HDR enhancements by adding support for the LUT and PQ conversion shaders used with the game's standard TAA, improvements to color grading controls, and a fix for incorrect paper white values.
---

## Key Changes

### HDR and Color Pipeline Enhancements:

- **TAA LUT and PQ Shaders Addition**: Implemented LUT and PQ conversion shaders for the game's TAA pathway, aligning it with the previously established improvements for DLSS and FSR. This ensures a consistent HDR experience across different upscaling technologies.
- **Hue Correction/Saturation/Blowout Integration in PQ Shader**: Moved hue correction, saturation, and blowout processes into the PQ shader. This adjustment maintains wide color gamut integrity post-upscaling, preventing the clamping of hues to BT.709 and preserving vibrant and accurate colors.

### Fixes:

- **LUT Scaling Negatives Resolution**: Addressed an issue where negative values disrupted the Y channel calculations within the game's LUT scaling, leading to incorrect scaling behavior. This fix ensures reliable and accurate LUT scaling across the board.
- **Paper White Scaling Factor Correction**: Corrected an imprecision in the paper white scaling factor, ensuring that brightness levels are accurately represented relative to user settings.

### Code Quality Improvements:

- **Clang-Format Application**: Applied Clang-Format to the project's source files to ensure code cleanliness and maintainability, which helps in easing future enhancements and bug fixes.

---

**Additional Notes**

The game's standard TAA clamps to ~6.33, so DLSS and FSR are recommended over standard TAA.