### PR TITLE
Gamma Correction and Brightness Scaling improvements for Uncharted: Legacy of Thieves Collection

### DIFF
--- a/src/games/unchartedlotc/addon.cpp
+++ b/src/games/unchartedlotc/addon.cpp
@@ -4,58 +4,16 @@
  * SPDX-License-Identifier: MIT
  */
 
-#define ImTextureID ImU64
-
-#define DEBUG_LEVEL_0
-#define DEBUG_SLIDERS_OFF
-
-#include <deps/imgui/imgui.h>
-
-#include <embed/0x545B3706.h>   // Linearization + DICE + BT.2020 + PQ Encoding
+#include <embed/0x545B3706.h>  // Linearization + BT.2020 + PQ Encoding
 
 #include <include/reshade.hpp>
 #include "../../mods/shader.hpp"
-#include "../../utils/settings.hpp"
-#include "./shared.h"
 
 namespace {
 
 renodx::mods::shader::CustomShaders custom_shaders = {
-    CustomShaderEntry(0x545B3706),  // Linearization + DICE + BT.2020 + PQ Encoding
+    CustomShaderEntry(0x545B3706),  // Linearization + BT.2020 + PQ Encoding
 };
-
-ShaderInjectData shader_injection;
-
-renodx::utils::settings::Settings settings = {
-    new renodx::utils::settings::Setting{
-        .key = "toneMapType",
-        .binding = &shader_injection.toneMapType,
-        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
-        .default_value = 3.f,
-        .can_reset = false,
-        .label = "Tone Mapper",
-        .section = "Tone Mapping",
-        .tooltip = "Sets the tone mapper type",
-        .labels = {"None", "DICE"},
-    },
-    new renodx::utils::settings::Setting{
-        .key = "toneMapPeakNits",
-        .binding = &shader_injection.toneMapPeakNits,
-        .default_value = 1000.f,
-        .can_reset = false,
-        .label = "Peak Brightness",
-        .section = "Tone Mapping",
-        .tooltip = "Sets the value of peak white in nits",
-        .min = 48.f,
-        .max = 4000.f,
-        .is_enabled = []() { return shader_injection.toneMapType != 0; },
-    },
-};
-
-void OnPresetOff() {
-  renodx::utils::settings::UpdateSetting("toneMapType", 0.f);
-  renodx::utils::settings::UpdateSetting("toneMapPeakNits", 1000.f);
-}
 
 }  // namespace
 
@@ -69,21 +27,14 @@ extern "C" __declspec(dllexport) const char* DESCRIPTION = "RenoDX for Uncharted
 BOOL APIENTRY DllMain(HMODULE h_module, DWORD fdw_reason, LPVOID lpv_reserved) {
   switch (fdw_reason) {
     case DLL_PROCESS_ATTACH:
-      renodx::mods::shader::expected_constant_buffer_space = 18;
-      renodx::mods::shader::trace_unmodified_shaders = true;
-
-
       if (!reshade::register_addon(h_module)) return FALSE;
-
       break;
     case DLL_PROCESS_DETACH:
       reshade::unregister_addon(h_module);
       break;
   }
 
-  renodx::utils::settings::Use(fdw_reason, &settings, &OnPresetOff);
-
-  renodx::mods::shader::Use(fdw_reason, custom_shaders, &shader_injection);
+  renodx::mods::shader::Use(fdw_reason, custom_shaders);
 
   return TRUE;
 }

--- a/src/games/unchartedlotc/addon.cpp
+++ b/src/games/unchartedlotc/addon.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2024 Musa Haji
+ * Copyright (C) 2024 Carlos Lopez
+ * SPDX-License-Identifier: MIT
+ */
+
+#define ImTextureID ImU64
+
+#define DEBUG_LEVEL_0
+#define DEBUG_SLIDERS_OFF
+
+#include <deps/imgui/imgui.h>
+
+#include <embed/0x545B3706.h>   // Linearization + DICE + BT.2020 + PQ Encoding
+
+#include <include/reshade.hpp>
+#include "../../mods/shader.hpp"
+#include "../../utils/settings.hpp"
+#include "./shared.h"
+
+namespace {
+
+renodx::mods::shader::CustomShaders custom_shaders = {
+    CustomShaderEntry(0x545B3706),  // Linearization + DICE + BT.2020 + PQ Encoding
+};
+
+ShaderInjectData shader_injection;
+
+renodx::utils::settings::Settings settings = {
+    new renodx::utils::settings::Setting{
+        .key = "toneMapType",
+        .binding = &shader_injection.toneMapType,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 3.f,
+        .can_reset = false,
+        .label = "Tone Mapper",
+        .section = "Tone Mapping",
+        .tooltip = "Sets the tone mapper type",
+        .labels = {"None", "DICE"},
+    },
+    new renodx::utils::settings::Setting{
+        .key = "toneMapPeakNits",
+        .binding = &shader_injection.toneMapPeakNits,
+        .default_value = 1000.f,
+        .can_reset = false,
+        .label = "Peak Brightness",
+        .section = "Tone Mapping",
+        .tooltip = "Sets the value of peak white in nits",
+        .min = 48.f,
+        .max = 4000.f,
+        .is_enabled = []() { return shader_injection.toneMapType != 0; },
+    },
+};
+
+void OnPresetOff() {
+  renodx::utils::settings::UpdateSetting("toneMapType", 0.f);
+  renodx::utils::settings::UpdateSetting("toneMapPeakNits", 1000.f);
+}
+
+}  // namespace
+
+// NOLINTBEGIN(readability-identifier-naming)
+
+extern "C" __declspec(dllexport) const char* NAME = "RenoDX";
+extern "C" __declspec(dllexport) const char* DESCRIPTION = "RenoDX for Uncharted: Legacy of Thieves Collection";
+
+// NOLINTEND(readability-identifier-naming)
+
+BOOL APIENTRY DllMain(HMODULE h_module, DWORD fdw_reason, LPVOID lpv_reserved) {
+  switch (fdw_reason) {
+    case DLL_PROCESS_ATTACH:
+      renodx::mods::shader::expected_constant_buffer_space = 18;
+      renodx::mods::shader::trace_unmodified_shaders = true;
+
+
+      if (!reshade::register_addon(h_module)) return FALSE;
+
+      break;
+    case DLL_PROCESS_DETACH:
+      reshade::unregister_addon(h_module);
+      break;
+  }
+
+  renodx::utils::settings::Use(fdw_reason, &settings, &OnPresetOff);
+
+  renodx::mods::shader::Use(fdw_reason, custom_shaders, &shader_injection);
+
+  return TRUE;
+}

--- a/src/games/unchartedlotc/final_0x545B3706.ps_6_0.hlsl
+++ b/src/games/unchartedlotc/final_0x545B3706.ps_6_0.hlsl
@@ -21,6 +21,15 @@ float4 main(PSInput IN) : SV_Target
     // Linearize with 2.2 Gamma
     float3 linearColor = renodx::math::SafePow(inputColor, 2.2);
 
+    // Adjust paperWhite based on the brightness setting (m_params.x)
+    float paperWhite = m_params.x;
+    // Check brightness levels and adjust paperWhite accordingly
+    if (m_params.x == 220) {
+        paperWhite = 203.0f; // Brightness level 3
+    } else if (m_params.x == 260) {
+        paperWhite = 250.0f; // Brightness level 4
+    }
+
     // if (injectedData.toneMapType) { // Apply DICE Tonemap
         // const float peakWhite = injectedData.toneMapPeakNits / renodx::color::srgb::REFERENCE_WHITE;
         // const float paperWhite = m_params.x / renodx::color::srgb::REFERENCE_WHITE;
@@ -33,7 +42,7 @@ float4 main(PSInput IN) : SV_Target
     
     // Convert from BT.709 to BT.2020 PQ with paper white based on brightness slider
     float3 bt2020Color = renodx::color::bt2020::from::BT709(linearColor);
-    float3 pqEncodedColor = renodx::color::pq::from::BT2020(bt2020Color, m_params.x);
+    float3 pqEncodedColor = renodx::color::pq::from::BT2020(bt2020Color, paperWhite);
 
     // Return the final PQ-encoded color with alpha set to 1.0
     return float4(pqEncodedColor, 1.0);

--- a/src/games/unchartedlotc/final_0x545B3706.ps_6_0.hlsl
+++ b/src/games/unchartedlotc/final_0x545B3706.ps_6_0.hlsl
@@ -3,47 +3,35 @@
 Texture2D<float4> g_applyHdrCodingSrcTmpBuffer : register(t0, space0);
 SamplerState g_applyHdrCodingSamplerState : register(s0, space0);
 
-cbuffer g_applyHdrCodingConstants : register(b0, space1)
-{
-    float4 m_params;
+cbuffer g_applyHdrCodingConstants : register(b0, space1) {
+  float4 m_params;
 };
 
-struct PSInput
-{
-    float4 SV_Position : SV_POSITION;
-    float2 TEXCOORD : TEXCOORD;
+struct PSInput {
+  float4 SV_Position : SV_POSITION;
+  float2 TEXCOORD : TEXCOORD;
 };
 
-float4 main(PSInput IN) : SV_Target
-{
-    float3 inputColor = g_applyHdrCodingSrcTmpBuffer.Sample(g_applyHdrCodingSamplerState, IN.TEXCOORD).xyz;
-    
-    // Linearize with 2.2 Gamma
-    float3 linearColor = renodx::math::SafePow(inputColor, 2.2);
+float4 main(PSInput IN)
+    : SV_Target {
+  float3 inputColor = g_applyHdrCodingSrcTmpBuffer.Sample(g_applyHdrCodingSamplerState, IN.TEXCOORD).xyz;
 
-    // Adjust paperWhite based on the brightness setting (m_params.x)
-    float paperWhite = m_params.x;
-    // Check brightness levels and adjust paperWhite accordingly
-    if (m_params.x == 220) {
-        paperWhite = 203.0f; // Brightness level 3
-    } else if (m_params.x == 260) {
-        paperWhite = 250.0f; // Brightness level 4
-    }
+  // Linearize with 2.2 Gamma
+  float3 linearColor = renodx::math::SafePow(inputColor, 2.2);
 
-    // if (injectedData.toneMapType) { // Apply DICE Tonemap
-        // const float peakWhite = injectedData.toneMapPeakNits / renodx::color::srgb::REFERENCE_WHITE;
-        // const float paperWhite = m_params.x / renodx::color::srgb::REFERENCE_WHITE;
-        // const float highlightsShoulderStart = paperWhite;
+  // Custom paper white values based on the brightness setting (m_params.x)
+  float paperWhite = m_params.x;
+  // Check brightness levels and adjust paper white accordingly
+  if (m_params.x == 220) {
+    paperWhite = 203.0f;  // Brightness level 3
+  } else if (m_params.x == 260) {
+    paperWhite = 250.0f;  // Brightness level 4
+  }
 
-        // linearColor *= paperWhite;
-        // linearColor = renodx::tonemap::dice::BT709(linearColor, peakWhite, highlightsShoulderStart);
-        // linearColor /= paperWhite;
-    // }
-    
-    // Convert from BT.709 to BT.2020 PQ with paper white based on brightness slider
-    float3 bt2020Color = renodx::color::bt2020::from::BT709(linearColor);
-    float3 pqEncodedColor = renodx::color::pq::from::BT2020(bt2020Color, paperWhite);
+  // Convert from BT.709 to BT.2020 PQ with paper white based on brightness slider
+  float3 bt2020Color = renodx::color::bt2020::from::BT709(linearColor);
+  float3 pqEncodedColor = renodx::color::pq::from::BT2020(bt2020Color, paperWhite);
 
-    // Return the final PQ-encoded color with alpha set to 1.0
-    return float4(pqEncodedColor, 1.0);
+  // Return the final PQ-encoded color with alpha set to 1.0
+  return float4(pqEncodedColor, 1.0);
 }

--- a/src/games/unchartedlotc/final_0x545B3706.ps_6_0.hlsl
+++ b/src/games/unchartedlotc/final_0x545B3706.ps_6_0.hlsl
@@ -17,20 +17,20 @@ float4 main(PSInput IN)
   float3 inputColor = g_applyHdrCodingSrcTmpBuffer.Sample(g_applyHdrCodingSamplerState, IN.TEXCOORD).xyz;
 
   // Linearize with 2.2 Gamma
-  float3 linearColor = renodx::math::SafePow(inputColor, 2.2);
+  float3 linearColor = renodx::color::gamma::DecodeSafe(inputColor, 2.2);
 
-  // Custom paper white values based on the brightness setting (m_params.x)
+  // Use custom paper white values based on the brightness setting (m_params.x)
   float paperWhite = m_params.x;
   // Check brightness levels and adjust paper white accordingly
   if (m_params.x == 220) {
-    paperWhite = 203.0f;  // Brightness level 3
+    paperWhite = 203.0f;  // Brightness level 3 (set to BT.2408 reference white)
   } else if (m_params.x == 260) {
     paperWhite = 250.0f;  // Brightness level 4
   }
 
   // Convert from BT.709 to BT.2020 PQ with paper white based on brightness slider
   float3 bt2020Color = renodx::color::bt2020::from::BT709(linearColor);
-  float3 pqEncodedColor = renodx::color::pq::from::BT2020(bt2020Color, paperWhite);
+  float3 pqEncodedColor = renodx::color::pq::Encode(bt2020Color, paperWhite);
 
   // Return the final PQ-encoded color with alpha set to 1.0
   return float4(pqEncodedColor, 1.0);

--- a/src/games/unchartedlotc/final_0x545B3706.ps_6_0.hlsl
+++ b/src/games/unchartedlotc/final_0x545B3706.ps_6_0.hlsl
@@ -1,0 +1,40 @@
+#include "./shared.h"
+
+Texture2D<float4> g_applyHdrCodingSrcTmpBuffer : register(t0, space0);
+SamplerState g_applyHdrCodingSamplerState : register(s0, space0);
+
+cbuffer g_applyHdrCodingConstants : register(b0, space1)
+{
+    float4 m_params;
+};
+
+struct PSInput
+{
+    float4 SV_Position : SV_POSITION;
+    float2 TEXCOORD : TEXCOORD;
+};
+
+float4 main(PSInput IN) : SV_Target
+{
+    float3 inputColor = g_applyHdrCodingSrcTmpBuffer.Sample(g_applyHdrCodingSamplerState, IN.TEXCOORD).xyz;
+    
+    // Linearize with 2.2 Gamma
+    float3 linearColor = renodx::math::SafePow(inputColor, 2.2);
+
+    // if (injectedData.toneMapType) { // Apply DICE Tonemap
+        // const float peakWhite = injectedData.toneMapPeakNits / renodx::color::srgb::REFERENCE_WHITE;
+        // const float paperWhite = m_params.x / renodx::color::srgb::REFERENCE_WHITE;
+        // const float highlightsShoulderStart = paperWhite;
+
+        // linearColor *= paperWhite;
+        // linearColor = renodx::tonemap::dice::BT709(linearColor, peakWhite, highlightsShoulderStart);
+        // linearColor /= paperWhite;
+    // }
+    
+    // Convert from BT.709 to BT.2020 PQ with paper white based on brightness slider
+    float3 bt2020Color = renodx::color::bt2020::from::BT709(linearColor);
+    float3 pqEncodedColor = renodx::color::pq::from::BT2020(bt2020Color, m_params.x);
+
+    // Return the final PQ-encoded color with alpha set to 1.0
+    return float4(pqEncodedColor, 1.0);
+}

--- a/src/games/unchartedlotc/shared.h
+++ b/src/games/unchartedlotc/shared.h
@@ -1,0 +1,21 @@
+#ifndef SRC_UNCHARTEDLOTC_SHARED_H_
+#define SRC_UNCHARTEDLOTC_SHARED_H_
+
+#ifndef __cplusplus
+#include "../../shaders/renodx.hlsl"
+#endif
+
+// Must be 32bit aligned
+// Should be 4x32
+struct ShaderInjectData {
+  float toneMapType;
+  float toneMapPeakNits;
+};
+
+#ifndef __cplusplus
+cbuffer injectedBuffer : register(b0,space18) {
+  ShaderInjectData injectedData : packoffset(c0);
+}
+#endif
+
+#endif  // SRC_UNCHARTEDLOTC_SHARED_H_

--- a/src/games/unchartedlotc/shared.h
+++ b/src/games/unchartedlotc/shared.h
@@ -5,17 +5,4 @@
 #include "../../shaders/renodx.hlsl"
 #endif
 
-// Must be 32bit aligned
-// Should be 4x32
-struct ShaderInjectData {
-  float toneMapType;
-  float toneMapPeakNits;
-};
-
-#ifndef __cplusplus
-cbuffer injectedBuffer : register(b0,space18) {
-  ShaderInjectData injectedData : packoffset(c0);
-}
-#endif
-
 #endif  // SRC_UNCHARTEDLOTC_SHARED_H_


### PR DESCRIPTION
This pull request introduces crucial enhancements to the HDR processing pipeline of *Uncharted: Legacy of Thieves Collection*. The existing implementation involved several steps that led to significant color management issues, particularly when adjusting the brightness slider away from its default setting. These issues include improper gamma correction and slight oversaturation due to performing gamma correction in an incorrect color space.

#### Existing HDR Implementation Steps:

1. **Linearization:** The image is linearized using the sRGB gamma formula.
2. **Paper White Scaling:** Paper white is scaled based on a brightness slider set by default to 300 nits.
3. **Color Space Conversion:** The image is converted to BT.2020.
4. **Gamma Correction:** The sRGB decoded image is converted to one decoded with 2.2 gamma based on the 300 nits value.
5. **PQ Encoding:** The image is encoded in PQ.

#### Key Changes Introduced

**Gamma Correction and Color Space Handling:**
- **Corrected Gamma Handling:** The initial linearization process has been altered to utilize a 2.2 gamma directly in BT.709 space, which more accurately matches the game's working color space. Additionally, the `DecodeSafe()` function has been implemented to preserve negative values that represent colors outside of BT.709.
- **Updated Brightness Slider Values:** The brightness slider has been recalibrated to provide more accurate luminance settings:
  - A setting of `3` now corresponds to 203 nits, aligning with BT.2408 reference white.
  - A setting of `4` adjusts the output to 250 nits.

These adjustments not only correct the technical inaccuracies in the HDR implementation but also ensure the game's visual presentation is more faithful to the original artistic intent across different display settings.