### PR TITLE
some clean up and performance improvements

### DIFF
--- a/src/shaders/colorcorrect.hlsl
+++ b/src/shaders/colorcorrect.hlsl
@@ -8,46 +8,40 @@ namespace renodx {
 namespace color {
 namespace correct {
 
-float Gamma(float x, bool pow_to_srgb = false) {
-  if (pow_to_srgb) {
-    return srgb::Decode(gamma::Encode(x));
+#define GAMMA(T)                             \
+  T Gamma(T c, bool pow_to_srgb = false) {   \
+    if (pow_to_srgb) {                       \
+      return srgb::Decode(gamma::Encode(c)); \
+    }                                        \
+    return gamma::Decode(srgb::Encode(c));   \
   }
-  // srgb2pow
-  return gamma::Decode(srgb::Encode(x));
+
+GAMMA(float)
+GAMMA(float2)
+GAMMA(float3)
+
+float4 Gamma(float4 color, bool pow_to_srgb = false) {
+  return float4(Gamma(color.rgb), color.a);
 }
 
-float GammaSafe(float x, bool pow_to_srgb = false) {
-  if (pow_to_srgb) {
-    return renodx::math::Sign(x) * srgb::Decode(gamma::Encode(abs(x)));
+#define GAMMA_SAFE(T)                                                     \
+  T GammaSafe(T c, bool pow_to_srgb = false) {                            \
+    if (pow_to_srgb) {                                                    \
+      return renodx::math::Sign(c) * srgb::Decode(gamma::Encode(abs(c))); \
+    }                                                                     \
+    return renodx::math::Sign(c) * gamma::Decode(srgb::Encode(abs(c)));   \
   }
-  return renodx::math::Sign(x) * gamma::Decode(srgb::Encode(abs(x)));
+
+GAMMA_SAFE(float)
+GAMMA_SAFE(float2)
+GAMMA_SAFE(float3)
+
+float4 GammaSafe(float4 color, bool pow_to_srgb = false) {
+  return float4(Gamma(color.rgb), color.a);
 }
 
-float3 Gamma(float3 color, bool pow_to_srgb = false) {
-  return float3(
-      Gamma(color.r, pow_to_srgb),
-      Gamma(color.g, pow_to_srgb),
-      Gamma(color.b, pow_to_srgb));
-}
-
-float4 Gamma(float4 color, bool pow2srgb = false) {
-  return float4(Gamma(color.rgb, pow2srgb), color.a);
-}
-
-float3 GammaSafe(float3 color, bool pow2srgb = false) {
-  float3 signs = renodx::math::Sign(color);
-  color = abs(color);
-  color = float3(
-      Gamma(color.r, pow2srgb),
-      Gamma(color.g, pow2srgb),
-      Gamma(color.b, pow2srgb));
-  color *= signs;
-  return color;
-}
-
-float4 GammaSafe(float4 color, bool pow2srgb = false) {
-  return float4(GammaSafe(color.rgb, pow2srgb), color.a);
-}
+#undef GAMMA
+#undef GAMMA_SAFE
 
 float3 HueOKLab(float3 incorrect_color, float3 correct_color, float strength = 1.f) {
   if (strength == 0.f) return incorrect_color;


### PR DESCRIPTION
use component wise ternary operator for shader model 5.X and lower and select for above where it's possible