### PR TITLE
HDR Enhancements for Dying Light

### DIFF
--- a/src/games/dyinglight/DICE.hlsl
+++ b/src/games/dyinglight/DICE.hlsl
@@ -1,12 +1,13 @@
 #include "./shared.h"
 
-float max3(float a, float b, float c)
-{
+static const float HDR10_MaxWhiteNits = 10000.0f;
+static const float FLT_MAX = asfloat(0x7F7FFFFF);  // 3.402823466e+38f
+
+float max3(float a, float b, float c) {
   return max(a, max(b, c));
 }
 
-float max3(float3 v)
-{
+float max3(float3 v) {
   return max3(v.x, v.y, v.z);
 }
 
@@ -22,65 +23,51 @@ static const float PQ_constant_C3 = 18.6875f;
 // 1 Remove negative numbers
 // 2 Remove numbers beyond 0-1
 // 3 Mirror negative numbers
-float3 Linear_to_PQ(float3 LinearColor, int clampType = 0)
-{
-    float3 LinearColorSign = sign(LinearColor);
-    if (clampType == 1)
-    {
-        LinearColor = max(LinearColor, 0.f);
-    }
-    else if (clampType == 2)
-    {
-        LinearColor = saturate(LinearColor);
-    }
-    else if (clampType == 3)
-    {
-        LinearColor = abs(LinearColor);
-    }
-    float3 colorPow = pow(LinearColor, PQ_constant_M1);
-    float3 numerator = PQ_constant_C1 + PQ_constant_C2 * colorPow;
-    float3 denominator = 1.f + PQ_constant_C3 * colorPow;
-    float3 pq = pow(numerator / denominator, PQ_constant_M2);
-    if (clampType == 3)
-    {
-        return pq * LinearColorSign;
-    }
-    return pq;
+float3 Linear_to_PQ(float3 LinearColor, int clampType = 0) {
+  float3 LinearColorSign = sign(LinearColor);
+  if (clampType == 1) {
+    LinearColor = max(LinearColor, 0.f);
+  } else if (clampType == 2) {
+    LinearColor = saturate(LinearColor);
+  } else if (clampType == 3) {
+    LinearColor = abs(LinearColor);
+  }
+  float3 colorPow = pow(LinearColor, PQ_constant_M1);
+  float3 numerator = PQ_constant_C1 + PQ_constant_C2 * colorPow;
+  float3 denominator = 1.f + PQ_constant_C3 * colorPow;
+  float3 pq = pow(numerator / denominator, PQ_constant_M2);
+  if (clampType == 3) {
+    return pq * LinearColorSign;
+  }
+  return pq;
 }
 
-float3 PQ_to_Linear(float3 ST2084Color, int clampType = 0)
-{
-    float3 ST2084ColorSign = sign(ST2084Color);
-    if (clampType == 1)
-    {
-        ST2084Color = max(ST2084Color, 0.f);
-    }
-    else if (clampType == 2)
-    {
-        ST2084Color = saturate(ST2084Color);
-    }
-    else if (clampType == 3)
-    {
-        ST2084Color = abs(ST2084Color);
-    }
-    float3 colorPow = pow(ST2084Color, 1.f / PQ_constant_M2);
-    float3 numerator = max(colorPow - PQ_constant_C1, 0.f);
-    float3 denominator = PQ_constant_C2 - (PQ_constant_C3 * colorPow);
-    float3 linearColor = pow(numerator / denominator, 1.f / PQ_constant_M1);
-    if (clampType == 3)
-    {
-        return linearColor * ST2084ColorSign;
-    }
-    return linearColor;
+float3 PQ_to_Linear(float3 ST2084Color, int clampType = 0) {
+  float3 ST2084ColorSign = sign(ST2084Color);
+  if (clampType == 1) {
+    ST2084Color = max(ST2084Color, 0.f);
+  } else if (clampType == 2) {
+    ST2084Color = saturate(ST2084Color);
+  } else if (clampType == 3) {
+    ST2084Color = abs(ST2084Color);
+  }
+  float3 colorPow = pow(ST2084Color, 1.f / PQ_constant_M2);
+  float3 numerator = max(colorPow - PQ_constant_C1, 0.f);
+  float3 denominator = PQ_constant_C2 - (PQ_constant_C3 * colorPow);
+  float3 linearColor = pow(numerator / denominator, 1.f / PQ_constant_M1);
+  if (clampType == 3) {
+    return linearColor * ST2084ColorSign;
+  }
+  return linearColor;
 }
 
-// Aplies exponential ("Photographic") luminance/luma compression.
+// Applies exponential ("Photographic") luminance/luma compression.
 // The pow can modulate the curve without changing the values around the edges.
-// The max is the max possible range to compress from, to not lose any output range if the input range was limited.
-float rangeCompress(float X, float Max = asfloat(0x7F7FFFFF))
-{
+// The max is the max possible range to compress from, to not lose any output
+// range if the input range was limited.
+float rangeCompress(float X, float Max = asfloat(0x7F7FFFFF)) {
   // Branches are for static parameters optimizations
-  if (Max == renodx::math::FLT_MAX) {
+  if (Max == FLT_MAX) {
     // This does e^X. We expect X to be between 0 and 1.
     return 1.f - exp(-X);
   }
@@ -90,133 +77,173 @@ float rangeCompress(float X, float Max = asfloat(0x7F7FFFFF))
 }
 
 // Refurbished DICE HDR tonemapper (per channel or luminance).
-// Expects "InValue" to be >= "ShoulderStart" and "OutMaxValue" to be > "ShoulderStart".
-float luminanceCompress(
-  float InValue,
-  float OutMaxValue,
-  float ShoulderStart = 0.f,
-  bool considerMaxValue = false,
-  float InMaxValue = asfloat(0x7F7FFFFF))
-{
+// Expects "InValue" to be >= "ShoulderStart" and "OutMaxValue" to be >
+// "ShoulderStart".
+float luminanceCompress(float InValue, float OutMaxValue,
+                        float ShoulderStart = 0.f,
+                        bool ConsiderMaxValue = false,
+                        float InMaxValue = asfloat(0x7F7FFFFF)) {
   const float compressableValue = InValue - ShoulderStart;
   const float compressableRange = InMaxValue - ShoulderStart;
   const float compressedRange = OutMaxValue - ShoulderStart;
-  const float possibleOutValue = ShoulderStart + compressedRange * rangeCompress(compressableValue / compressedRange, considerMaxValue ? (compressableRange / compressedRange) : renodx::math::FLT_MAX);
+  const float possibleOutValue =
+      ShoulderStart + compressedRange * rangeCompress(compressableValue / compressedRange, ConsiderMaxValue ? (compressableRange / compressedRange) : FLT_MAX);
 #if 1
   return possibleOutValue;
-#else // Enable this branch if "InValue" can be smaller than "ShoulderStart"
+#else  // Enable this branch if "InValue" can be smaller than "ShoulderStart"
   return (InValue <= ShoulderStart) ? InValue : possibleOutValue;
 #endif
 }
 
 #define DICE_TYPE_BY_LUMINANCE_RGB 0
-// Doing the DICE compression in PQ (either on luminance or each color channel) produces a curve that is closer to our "perception" and leaves more detail highlights without overly compressing them
+// Doing the DICE compression in PQ (either on luminance or each color channel)
+// produces a curve that is closer to our "perception" and leaves more detail
+// highlights without overly compressing them
 #define DICE_TYPE_BY_LUMINANCE_PQ 1
-// Modern HDR displays clip individual rgb channels beyond their "white" peak brightness,
-// like, if the peak brightness is 700 nits, any r g b color beyond a value of 700/80 will be clipped (not acknowledged, it won't make a difference).
-// Tonemapping by luminance, is generally more perception accurate but can then generate rgb colors "out of range". This setting fixes them up,
-// though it's optional as it's working based on assumptions on how current displays work, which might not be true anymore in the future.
-// Note that this can create some steep (rough, quickly changing) gradients on very bright colors.
+// Modern HDR displays clip individual rgb channels beyond their "white" peak
+// brightness, like, if the peak brightness is 700 nits, any r g b color beyond
+// a value of 700/80 will be clipped (not acknowledged, it won't make a
+// difference). Tonemapping by luminance, is generally more perception accurate
+// but can then generate rgb colors "out of range". This setting fixes them up,
+// though it's optional as it's working based on assumptions on how current
+// displays work, which might not be true anymore in the future. Note that this
+// can create some steep (rough, quickly changing) gradients on very bright
+// colors.
 #define DICE_TYPE_BY_LUMINANCE_PQ_CORRECT_CHANNELS_BEYOND_PEAK_WHITE 2
-// This might look more like classic SDR tonemappers and is closer to how modern TVs and Monitors play back colors (usually they clip each individual channel to the peak brightness value, though in their native panel color space, or current SDR/HDR mode color space).
-// Overall, this seems to handle bright gradients more smoothly, even if it shifts hues more (and generally desaturating).
+// This might look more like classic SDR tonemappers and is closer to how modern
+// TVs and Monitors play back colors (usually they clip each individual channel
+// to the peak brightness value, though in their native panel color space, or
+// current SDR/HDR mode color space). Overall, this seems to handle bright
+// gradients more smoothly, even if it shifts hues more (and generally
+// desaturating).
 #define DICE_TYPE_BY_CHANNEL_PQ 3
 
-struct DICESettings
-{
+struct DICESettings {
   uint Type;
   // Determines where the highlights curve (shoulder) starts.
   // Values between 0.25 and 0.5 are good with DICE by PQ (any type).
-  // With linear/rgb DICE this barely makes a difference, zero is a good default but (e.g.) 0.5 would also work.
-  // This should always be between 0 and 1.
+  // With linear/rgb DICE this barely makes a difference, zero is a good default
+  // but (e.g.) 0.5 would also work. This should always be between 0 and 1.
   float ShoulderStart;
 
-  // For "Type == DICE_TYPE_BY_LUMINANCE_PQ_CORRECT_CHANNELS_BEYOND_PEAK_WHITE" only:
-  // The sum of these needs to be <= 1, both within 0 and 1.
-  // The closer the sum is to 1, the more each color channel will be containted within its peak range.
+  // For "Type == DICE_TYPE_BY_LUMINANCE_PQ_CORRECT_CHANNELS_BEYOND_PEAK_WHITE"
+  // only: The sum of these needs to be <= 1, both within 0 and 1. The closer
+  // the sum is to 1, the more each color channel will be containted within its
+  // peak range.
   float DesaturationAmount;
   float DarkeningAmount;
 };
 
-DICESettings DefaultDICESettings()
-{
+DICESettings DefaultDICESettings() {
   DICESettings Settings;
   Settings.Type = DICE_TYPE_BY_CHANNEL_PQ;
-  Settings.ShoulderStart = (Settings.Type >= DICE_TYPE_BY_LUMINANCE_RGB) ? (1.f / 4.f) : 0.f;
+  Settings.ShoulderStart =
+      (Settings.Type > DICE_TYPE_BY_LUMINANCE_RGB)
+          ? (1.f / 3.f)
+          : 0.f;  // TODOFT3: increase value!!! (did I already?)
   Settings.DesaturationAmount = 1.0 / 3.0;
   Settings.DarkeningAmount = 1.0 / 3.0;
   return Settings;
 }
 
 // Tonemapper inspired from DICE. Can work by luminance to maintain hue.
-// Takes scRGB colors with a white level (the value of 1 1 1) of 80 nits (sRGB) (to not be confused with paper white).
-// Paper white is expected to have already been multiplied in.
-float3 DICETonemap(
-  float3 Color,
-  float PeakWhite,
-  const DICESettings Settings)
-{
+// Takes scRGB colors with a white level (the value of 1 1 1) of 80 nits (sRGB)
+// (to not be confused with paper white). Paper white is expected to have
+// already been multiplied in.
+float3 DICETonemap(float3 Color, float PeakWhite,
+                   const DICESettings Settings /*= DefaultDICESettings()*/) {
   const float sourceLuminance = renodx::color::y::from::BT709(Color);
 
-  if (Settings.Type != DICE_TYPE_BY_LUMINANCE_RGB)
-  {
-    static const float HDR10_MaxWhite = 10000.f / 80.f;
+  if (Settings.Type != DICE_TYPE_BY_LUMINANCE_RGB) {
+    static const float HDR10_MaxWhite =
+        HDR10_MaxWhiteNits / renodx::color::srgb::REFERENCE_WHITE;
 
-    const float shoulderStartPQ = Linear_to_PQ((Settings.ShoulderStart * PeakWhite) / HDR10_MaxWhite).x;
-    if (Settings.Type == DICE_TYPE_BY_LUMINANCE_PQ || Settings.Type == DICE_TYPE_BY_LUMINANCE_PQ_CORRECT_CHANNELS_BEYOND_PEAK_WHITE)
-    {
+    // We could first convert the peak white to PQ and then apply the "shoulder
+    // start" alpha to it (in PQ), but tests showed scaling it in linear
+    // actually produces a better curve and more consistently follows the peak
+    // across different values
+    const float shoulderStartPQ =
+        Linear_to_PQ((Settings.ShoulderStart * PeakWhite) / HDR10_MaxWhite).x;
+    if (Settings.Type == DICE_TYPE_BY_LUMINANCE_PQ || Settings.Type == DICE_TYPE_BY_LUMINANCE_PQ_CORRECT_CHANNELS_BEYOND_PEAK_WHITE) {
       const float sourceLuminanceNormalized = sourceLuminance / HDR10_MaxWhite;
-      const float sourceLuminancePQ = Linear_to_PQ(sourceLuminanceNormalized, 1).x;
+      const float sourceLuminancePQ =
+          Linear_to_PQ(sourceLuminanceNormalized, 1).x;
 
-      if (sourceLuminancePQ > shoulderStartPQ) // Luminance below the shoulder (or below zero) don't need to be adjusted
+      if (sourceLuminancePQ > shoulderStartPQ)  // Luminance below the shoulder (or below zero) don't
+                                                // need to be adjusted
       {
         const float peakWhitePQ = Linear_to_PQ(PeakWhite / HDR10_MaxWhite).x;
 
-        const float compressedLuminancePQ = luminanceCompress(sourceLuminancePQ, peakWhitePQ, shoulderStartPQ);
-        const float compressedLuminanceNormalized = PQ_to_Linear(compressedLuminancePQ).x;
+        const float compressedLuminancePQ =
+            luminanceCompress(sourceLuminancePQ, peakWhitePQ, shoulderStartPQ);
+        const float compressedLuminanceNormalized =
+            PQ_to_Linear(compressedLuminancePQ).x;
         Color *= compressedLuminanceNormalized / sourceLuminanceNormalized;
 
-        if (Settings.Type == DICE_TYPE_BY_LUMINANCE_PQ_CORRECT_CHANNELS_BEYOND_PEAK_WHITE)
-        {
+        if (Settings.Type == DICE_TYPE_BY_LUMINANCE_PQ_CORRECT_CHANNELS_BEYOND_PEAK_WHITE) {
           float3 Color_BT2020 = renodx::color::bt2020::from::BT709(Color);
-          if (any(Color_BT2020 > PeakWhite)) // Optional "optimization" branch
+          if (any(Color_BT2020 > PeakWhite))  // Optional "optimization" branch
           {
             float colorLuminance = renodx::color::y::from::BT2020(Color_BT2020);
             float colorLuminanceInExcess = colorLuminance - PeakWhite;
-            float maxColorInExcess = max3(Color_BT2020) - PeakWhite; // This is guaranteed to be >= "colorLuminanceInExcess"
-            float brightnessReduction = saturate(renodx::math::SafeDivision(PeakWhite, max3(Color_BT2020), 1)); // Fall back to one in case of division by zero
-            float desaturateAlpha = saturate(renodx::math::SafeDivision(maxColorInExcess, maxColorInExcess - colorLuminanceInExcess, 0)); // Fall back to zero in case of division by zero
-            Color_BT2020 = lerp(Color_BT2020, colorLuminance, desaturateAlpha * Settings.DesaturationAmount);
-            Color_BT2020 = lerp(Color_BT2020, Color_BT2020 * brightnessReduction, Settings.DarkeningAmount); // Also reduce the brightness to partially maintain the hue, at the cost of brightness
+            float maxColorInExcess =
+                max3(Color_BT2020) - PeakWhite;  // This is guaranteed to be >=
+                                                 // "colorLuminanceInExcess"
+            float brightnessReduction = saturate(renodx::math::SafeDivision(
+                PeakWhite, max3(Color_BT2020),
+                1));  // Fall back to one in case of division by zero
+            float desaturateAlpha = saturate(renodx::math::SafeDivision(
+                maxColorInExcess, maxColorInExcess - colorLuminanceInExcess,
+                0));  // Fall back to zero in case of division by zero
+            Color_BT2020 = lerp(Color_BT2020, colorLuminance,
+                                desaturateAlpha * Settings.DesaturationAmount);
+            Color_BT2020 =
+                lerp(Color_BT2020, Color_BT2020 * brightnessReduction,
+                     Settings.DarkeningAmount);  // Also reduce the brightness to
+                                                 // partially maintain the hue,
+                                                 // at the cost of brightness
             Color = renodx::color::bt709::from::BT2020(Color_BT2020);
           }
         }
       }
-    }
-    else // DICE_TYPE_BY_CHANNEL_PQ
+    } else  // DICE_TYPE_BY_CHANNEL_PQ
     {
       const float peakWhitePQ = Linear_to_PQ(PeakWhite / HDR10_MaxWhite).x;
 
-      // Tonemap in BT.2020 to more closely match the primaries of modern displays
-      const float3 sourceColorNormalized = renodx::color::bt2020::from::BT709(Color) / HDR10_MaxWhite;
+      // Tonemap in BT.2020 to more closely match the primaries of modern
+      // displays
+      const float3 sourceColorNormalized =
+          renodx::color::bt2020::from::BT709(Color) / HDR10_MaxWhite;
       const float3 sourceColorPQ = Linear_to_PQ(sourceColorNormalized, 1);
 
-      for (uint i = 0; i < 3; i++) //TODO LUMA: optimize? will the shader compile already convert this to float3? Or should we already make a version with no branches that works in float3?
+      [unroll]
+      for (uint i = 0; i < 3;
+           i++)  // TODO LUMA: optimize? will the shader compile already convert
+                 // this to float3? Or should we already make a version with no
+                 // branches that works in float3?
       {
-        if (sourceColorPQ[i] > shoulderStartPQ) // Colors below the shoulder (or below zero) don't need to be adjusted
+        if (sourceColorPQ[i] > shoulderStartPQ)  // Colors below the shoulder (or below zero) don't
+                                                 // need to be adjusted
         {
-          const float compressedColorPQ = luminanceCompress(sourceColorPQ[i], peakWhitePQ, shoulderStartPQ);
-          const float compressedColorNormalized = PQ_to_Linear(compressedColorPQ).x;
-          Color[i] = renodx::color::bt709::from::BT2020(Color[i] * (compressedColorNormalized / sourceColorNormalized[i])).x;
+          const float compressedColorPQ =
+              luminanceCompress(sourceColorPQ[i], peakWhitePQ, shoulderStartPQ);
+          const float compressedColorNormalized =
+              PQ_to_Linear(compressedColorPQ).x;
+          Color[i] = renodx::color::bt709::from::BT2020(
+                         Color[i] * (compressedColorNormalized / sourceColorNormalized[i]))
+                         .x;
         }
       }
     }
-  }
-  else // DICE_TYPE_BY_LUMINANCE_RGB
+  } else  // DICE_TYPE_BY_LUMINANCE_RGB
   {
-    if (sourceLuminance > Settings.ShoulderStart) // Luminance below the shoulder (or below zero) don't need to be adjusted
+    const float shoulderStart =
+        PeakWhite * Settings.ShoulderStart;  // From alpha to linear range
+    if (sourceLuminance > shoulderStart)     // Luminances below the shoulder (or below zero) don't
+                                             // need to be adjusted
     {
-      const float compressedLuminance = luminanceCompress(sourceLuminance, PeakWhite, PeakWhite * Settings.ShoulderStart);
+      const float compressedLuminance =
+          luminanceCompress(sourceLuminance, PeakWhite, shoulderStart);
       Color *= compressedLuminance / sourceLuminance;
     }
   }

--- a/src/games/dyinglight/RenoDRTSmoothClamp.hlsl
+++ b/src/games/dyinglight/RenoDRTSmoothClamp.hlsl
@@ -1,0 +1,32 @@
+#include "./shared.h"
+
+/// Applies a customized version of RenoDRT tonemapper that tonemaps down to 1.0.
+/// This function is used to compress HDR color to SDR range for use alongside `UpgradeToneMap`.
+///
+/// @param lutInputColor The color input that needs to be tonemapped.
+/// @return The tonemapped color compressed to the SDR range, ensuring that it can be applied to SDR color grading with `UpgradeToneMap`.
+float3 renoDRTSmoothClamp(float3 untonemapped) {
+  renodx::tonemap::renodrt::Config renodrt_config = renodx::tonemap::renodrt::config::Create();
+  renodrt_config.nits_peak = 100.f;
+  renodrt_config.mid_gray_value = 0.18f;
+  renodrt_config.mid_gray_nits = 18.f;
+  renodrt_config.exposure = 1.f;
+  renodrt_config.highlights = 1.f;
+  renodrt_config.shadows = 1.f;
+  renodrt_config.contrast = 1.05f;
+  renodrt_config.saturation = 1.025f;
+  renodrt_config.dechroma = 0.f;
+  renodrt_config.flare = 0.f;
+  renodrt_config.hue_correction_strength = 0.f;
+  // renodrt_config.hue_correction_source = renodx::tonemap::uncharted2::BT709(untonemapped);
+  renodrt_config.hue_correction_method = renodx::tonemap::renodrt::config::hue_correction_method::OKLAB;
+  renodrt_config.tone_map_method = renodx::tonemap::renodrt::config::tone_map_method::DANIELE;
+  renodrt_config.hue_correction_type = renodx::tonemap::renodrt::config::hue_correction_type::INPUT;
+  renodrt_config.working_color_space = 2u;
+  renodrt_config.per_channel = false;
+
+  float3 renoDRTColor = renodx::tonemap::renodrt::BT709(untonemapped, renodrt_config);
+  renoDRTColor = lerp(untonemapped, renoDRTColor, saturate(renodx::color::y::from::BT709(untonemapped) / renodrt_config.mid_gray_value));
+
+  return renoDRTColor;
+}

--- a/src/games/dyinglight/addon.cpp
+++ b/src/games/dyinglight/addon.cpp
@@ -160,7 +160,6 @@ renodx::utils::settings::Settings settings = {
         .key = "toneMapHueCorrection",
         .binding = &shader_injection.toneMapHueCorrection,
         .default_value = 50.f,
-        .can_reset = false,
         .label = "Hue Correction",
         .section = "Tone Mapping",
         .tooltip = "Emulates hue shifting from the vanilla tonemapper",

--- a/src/games/dyinglight/gamma_0x558540C8.ps_5_0.hlsl
+++ b/src/games/dyinglight/gamma_0x558540C8.ps_5_0.hlsl
@@ -1,47 +1,108 @@
-#include "./shared.h"
+#include "./DICE.hlsl"
 #include "./extendGamut.hlsl"
+#include "./shared.h"
 
 // ---- Created with 3Dmigoto v1.3.16 on Sat May 25 22:39:10 2024
 Texture2D<float4> t0 : register(t0);
 
 SamplerState s0_s : register(s0);
 
-cbuffer cb0 : register(b0)
-{
+cbuffer cb0 : register(b0) {
   float4 cb0[1];
 }
-
-
-
 
 // 3Dmigoto declarations
 #define cmp -
 
+// Applies the hue shifts from clamping input_color while minimizing broken gradients
+float3 Hue(float3 input_color, float correct_amount = 1.f) {
+  // If no correction is needed, return the original color
+  if (correct_amount == 0) {
+    return input_color;
+  } else {
+    // Calculate average channel values of the original (unclamped) input_color
+    float avg_unclamped = renodx::math::Average(input_color);
+
+    // calculate average channel values for the clamped input_color
+    float3 clamped_color = saturate(input_color);
+    float avg_clamped = renodx::math::Average(clamped_color);
+
+    // Compute the hue clipping percentage based on the difference in averages
+    float hue_clip_percentage = saturate((avg_unclamped - avg_clamped) / max(avg_unclamped, renodx::math::FLT_MIN));  // Prevent division by zero
+
+    // Interpolate hue components (a, b in OkLab) based on correct_amount using clamped_color
+    float3 correct_lab = renodx::color::oklab::from::BT709(clamped_color);
+    float3 incorrect_lab = renodx::color::oklab::from::BT709(input_color);
+    float3 new_lab = incorrect_lab;
+
+    // Apply hue correction based on clipping percentage and interpolate based on correct_amount
+    new_lab.yz = lerp(incorrect_lab.yz, correct_lab.yz, hue_clip_percentage);
+    new_lab.yz = lerp(incorrect_lab.yz, new_lab.yz, abs(correct_amount));
+
+    // Restore original chrominance from input_color in OkLCh space
+    float3 incorrect_lch = renodx::color::oklch::from::OkLab(incorrect_lab);
+    float3 new_lch = renodx::color::oklch::from::OkLab(new_lab);
+    new_lch[1] = incorrect_lch[1];
+
+    // Convert back to linear BT.709 space
+    float3 color = renodx::color::bt709::from::OkLCh(new_lch);
+    return color;
+  }
+}
+
+/// Applies DICE tonemapper to the untonemapped HDR color.
+///
+/// @param untonemapped - The untonemapped color.
+/// @return The HDR color tonemapped with DICE.
+float3 applyDICE(float3 untonemapped) {
+  // Declare DICE parameters
+  DICESettings config = DefaultDICESettings();
+  config.Type = 2u;
+  config.ShoulderStart = 0.5f;
+  config.DesaturationAmount = 0.f;
+  config.DarkeningAmount = 0.f;
+
+  const float dicePaperWhite = injectedData.toneMapGameNits / renodx::color::srgb::REFERENCE_WHITE;
+  const float dicePeakWhite = injectedData.toneMapPeakNits / renodx::color::srgb::REFERENCE_WHITE;
+
+  // multiply paper white in for tonemapping and out for output
+  return DICETonemap(untonemapped * dicePaperWhite, dicePeakWhite, config) / dicePaperWhite;
+}
 
 void main(
-  float4 v0 : SV_POSITION0,
-  float2 v1 : TEXCOORD0,
-  out float4 o0 : SV_TARGET0)
-{
+    float4 v0: SV_POSITION0,
+    float2 v1: TEXCOORD0,
+    out float4 o0: SV_TARGET0) {
   float4 r0;
-  uint4 bitmask, uiDest;
-  float4 fDest;
 
   r0.xyzw = t0.SampleLevel(s0_s, v1.xy, 0).xyzw;
   o0.xyzw = r0.xyzw;
 
   // o0.xyz = sign(o0.xyz) * pow(abs(o0.xyz), cb0[0].xxx);  // disable in game gamma slider
 
-  if (injectedData.toneMapType == 0) {  // vanilla tonemap flickers if left unclamped
-    o0.xyz = saturate(o0.xyz);
-  } else if (injectedData.toneMapType == 2) {
-    o0.rgb = extendGamut(o0.rgb, injectedData.colorGradeGamutExpansion);
-  }
-  if (injectedData.toneMapGammaCorrection) { // fix srgb 2.2 mismatch
+  if (injectedData.toneMapGammaCorrection) {  // 2.2 Gamma
     o0.xyz = renodx::color::correct::GammaSafe(o0.xyz);
+
+    if (injectedData.toneMapType == 0) {  // vanilla tonemap flickers if left unclamped
+      o0.xyz = saturate(o0.xyz);
+    } else if (injectedData.toneMapType == 2) {  // tonemap after gamma correction for correct highlights
+      o0.rgb = Hue(o0.rgb, injectedData.toneMapHueCorrection);
+      o0.rgb = extendGamut(o0.rgb, injectedData.colorGradeGamutExpansion);
+      o0.rgb = applyDICE(o0.rgb);
+    }
+
     o0.xyz *= injectedData.toneMapGameNits / injectedData.toneMapUINits;
     o0.xyz = renodx::color::correct::GammaSafe(o0.xyz, true);
-  } else {
+
+  } else {                                // sRGB Gamma
+    if (injectedData.toneMapType == 0) {  // vanilla tonemap flickers if left unclamped
+      o0.xyz = saturate(o0.xyz);
+    } else if (injectedData.toneMapType == 2) {
+      o0.rgb = Hue(o0.rgb, injectedData.toneMapHueCorrection);
+      o0.rgb = extendGamut(o0.rgb, injectedData.colorGradeGamutExpansion);
+      o0.rgb = applyDICE(o0.rgb);
+    }
+
     o0.xyz *= injectedData.toneMapGameNits / injectedData.toneMapUINits;
   }
   o0.w = saturate(o0.w);

--- a/src/games/dyinglight/lut2_grain_0xC20255E1.ps_5_0.hlsl
+++ b/src/games/dyinglight/lut2_grain_0xC20255E1.ps_5_0.hlsl
@@ -1,5 +1,5 @@
+#include "./RenoDRTSmoothClamp.hlsl"
 #include "./shared.h"
-#include "./DICE.hlsl"
 
 // ---- Created with 3Dmigoto v1.3.16 on Sat May 25 22:39:36 2024
 Texture2D<float4> t4 : register(t4);
@@ -88,22 +88,9 @@ void main(
   float3 hdrColor = outputColor;
   float3 sdrColor = outputColor;
   const float vanillaMidGray = 0.178f;
-  if (injectedData.toneMapType == 2) {    
-    const float paperWhite = injectedData.toneMapGameNits / renodx::color::srgb::REFERENCE_WHITE;
-    const float peakWhite = injectedData.toneMapPeakNits / renodx::color::srgb::REFERENCE_WHITE;
-    const float highlightsShoulderStart = min(0.5, vanillaMidGray * paperWhite);  // Don't tonemap the blended part of the tonemapper
-
-    DICESettings config = DefaultDICESettings();
-    config.Type = 1;
-    config.ShoulderStart = highlightsShoulderStart;
-
-    hdrColor = outputColor * paperWhite;  // scale paper white for PQ DICE
-    hdrColor = DICETonemap(hdrColor, peakWhite, config);
-    sdrColor = DICETonemap(hdrColor, paperWhite, config);
-
-    // back to 80 nits
-    hdrColor /= paperWhite;
-    sdrColor /= paperWhite;
+  if (injectedData.toneMapType == 2) {
+    hdrColor = outputColor;
+    sdrColor = renoDRTSmoothClamp(outputColor);
   }
   r0.xyz = sdrColor;
 

--- a/src/games/dyinglight/lut2_no_grain_0xD42BAD58.ps_5_0.hlsl
+++ b/src/games/dyinglight/lut2_no_grain_0xD42BAD58.ps_5_0.hlsl
@@ -1,5 +1,5 @@
+#include "./RenoDRTSmoothClamp.hlsl"
 #include "./shared.h"
-#include "./DICE.hlsl"
 
 // ---- Created with 3Dmigoto v1.3.16 on Sat May 25 22:39:40 2024
 Texture2D<float4> t2 : register(t2);
@@ -55,22 +55,9 @@ void main(
   float3 hdrColor = outputColor;
   float3 sdrColor = outputColor;
   const float vanillaMidGray = 0.178f;
-  if (injectedData.toneMapType == 2) {    
-    const float paperWhite = injectedData.toneMapGameNits / renodx::color::srgb::REFERENCE_WHITE;
-    const float peakWhite = injectedData.toneMapPeakNits / renodx::color::srgb::REFERENCE_WHITE;
-    const float highlightsShoulderStart = min(0.5, vanillaMidGray * paperWhite);  // Don't tonemap the blended part of the tonemapper
-
-    DICESettings config = DefaultDICESettings();
-    config.Type = 1;
-    config.ShoulderStart = highlightsShoulderStart;
-
-    hdrColor = outputColor * paperWhite;  // scale paper white for PQ DICE
-    hdrColor = DICETonemap(hdrColor, peakWhite, config);
-    sdrColor = DICETonemap(hdrColor, paperWhite, config);
-
-    // back to 80 nits
-    hdrColor /= paperWhite;
-    sdrColor /= paperWhite;
+  if (injectedData.toneMapType == 2) {
+    hdrColor = outputColor;
+    sdrColor = renoDRTSmoothClamp(outputColor);
   }
   r0.xyz = sdrColor;
 

--- a/src/games/dyinglight/lut_bw_grain_0x45D95DCB.ps_5_0.hlsl
+++ b/src/games/dyinglight/lut_bw_grain_0x45D95DCB.ps_5_0.hlsl
@@ -1,5 +1,6 @@
 #include "./shared.h"
-#include "./DICE.hlsl"
+#include "./RenoDRTSmoothClamp.hlsl"
+
 
 // ---- Created with 3Dmigoto v1.3.16 on Sat May 25 22:39:06 2024
 Texture2D<float4> t4 : register(t4);
@@ -75,7 +76,7 @@ void main(
   r1.xyz = r0.xyz * r0.xyz;
   r0.xyz = cmp(r0.xyz >= float3(0,0,0));
   r0.xyz = r0.xyz ? r1.xyz : -r1.xyz;
-  r0.xyz = r0.xyz + r2.xyz; //  r0.xyz = saturate(r0.xyz + r2.xyz);
+  r0.xyz = r0.xyz * injectedData.fxFilmGrain + r2.xyz; //  r0.xyz = saturate(r0.xyz + r2.xyz);
   r0.w = dot(float3(0.212500006,0.715399981,0.0720999986), r0.xyz);
   r1.xyz = r0.www + -r0.xyz;
   r0.w = saturate(r0.w * cb0[0].y + cb0[0].z);
@@ -94,22 +95,9 @@ void main(
   float3 hdrColor = outputColor;
   float3 sdrColor = outputColor;
   const float vanillaMidGray = 0.178f;
-  if (injectedData.toneMapType == 2) {    
-    const float paperWhite = injectedData.toneMapGameNits / renodx::color::srgb::REFERENCE_WHITE;
-    const float peakWhite = injectedData.toneMapPeakNits / renodx::color::srgb::REFERENCE_WHITE;
-    const float highlightsShoulderStart = min(0.5, vanillaMidGray * paperWhite);  // Don't tonemap the blended part of the tonemapper
-
-    DICESettings config = DefaultDICESettings();
-    config.Type = 1;
-    config.ShoulderStart = highlightsShoulderStart;
-
-    hdrColor = outputColor * paperWhite;  // scale paper white for PQ DICE
-    hdrColor = DICETonemap(hdrColor, peakWhite, config);
-    sdrColor = DICETonemap(hdrColor, paperWhite, config);
-
-    // back to 80 nits
-    hdrColor /= paperWhite;
-    sdrColor /= paperWhite;
+  if (injectedData.toneMapType == 2) {
+    hdrColor = outputColor;
+    sdrColor = renoDRTSmoothClamp(outputColor);
   }
   r0.xyz = sdrColor;
 

--- a/src/games/dyinglight/lut_bw_no_grain_0xBA423838.ps_5_0.hlsl
+++ b/src/games/dyinglight/lut_bw_no_grain_0xBA423838.ps_5_0.hlsl
@@ -1,5 +1,5 @@
+#include "./RenoDRTSmoothClamp.hlsl"
 #include "./shared.h"
-#include "./DICE.hlsl"
 
 // ---- Created with 3Dmigoto v1.3.16 on Sat May 25 22:39:34 2024
 Texture2D<float4> t2 : register(t2);
@@ -64,22 +64,9 @@ void main(
   float3 hdrColor = outputColor;
   float3 sdrColor = outputColor;
   const float vanillaMidGray = 0.178f;
-  if (injectedData.toneMapType == 2) {    
-    const float paperWhite = injectedData.toneMapGameNits / renodx::color::srgb::REFERENCE_WHITE;
-    const float peakWhite = injectedData.toneMapPeakNits / renodx::color::srgb::REFERENCE_WHITE;
-    const float highlightsShoulderStart = min(0.5, vanillaMidGray * paperWhite);  // Don't tonemap the blended part of the tonemapper
-
-    DICESettings config = DefaultDICESettings();
-    config.Type = 1;
-    config.ShoulderStart = highlightsShoulderStart;
-
-    hdrColor = outputColor * paperWhite;  // scale paper white for PQ DICE
-    hdrColor = DICETonemap(hdrColor, peakWhite, config);
-    sdrColor = DICETonemap(hdrColor, paperWhite, config);
-
-    // back to 80 nits
-    hdrColor /= paperWhite;
-    sdrColor /= paperWhite;
+  if (injectedData.toneMapType == 2) {
+    hdrColor = outputColor;
+    sdrColor = renoDRTSmoothClamp(outputColor);
   }
   r0.xyz = sdrColor;
 

--- a/src/games/dyinglight/tonemap_0xA67ABF78.ps_5_0.hlsl
+++ b/src/games/dyinglight/tonemap_0xA67ABF78.ps_5_0.hlsl
@@ -59,12 +59,12 @@ void main(
     untonemapped = renodx::color::grade::UserColorGrading(
         untonemapped,
         1.f,
-        1.04 * injectedData.colorGradeHighlights,
+        1.f * injectedData.colorGradeHighlights,
         1.f,
         1.f,
         1.f,
         0.f,
-        injectedData.toneMapHueCorrection,
+        0.f,  // hue correction strength
         vanillaColor);
     float vanillaLum = renodx::color::y::from::BT709(vanillaColor.rgb);
     o0.xyz = lerp(vanillaColor.rgb, untonemapped, saturate(vanillaLum / vanillaMidGray));  // combine tonemappers


### PR DESCRIPTION
#### Summary
This update brings several crucial enhancements to the Dying Light RenoDX HDR mod. It introduces more sophisticated color management and tonemapping techniques that improve overall image quality and color accuracy.

#### Key Changes Introduced
1. **Updated DICE Tonemapping:**
   - The DICE tonemapper has been updated to the latest version from Pumbo's Prey mod, which includes bug fixes.

2. **Advanced LUT Sampling and Tonemapping Adjustments:**
   - `RenoDRTSmoothClamp()` is now used for LUT sampling with `UpgradeToneMap()`, instead of DICE. Applying the SDR LUT using this results in much better retention in highlight details.
   - Tonemapping has been moved to the very end of the pipeline, after gamma correction, ensuring that peak brightness is not changed after tonemapping.
   - DICE `ShoulderStart` has been adjusted to better preserve highlight detail.

3. **Improved Workflow and Hue Correction:**
   - Hue correction has been moved later in the processing pipeline, allowing for the wider range of colors from hue corrections without being clamped to BT.709.
   - Added functionality to reset the hue correction slider to its default value of 50, enhancing user control and customization.

#### Justification for Changes
- These updates address previous limitations in color processing, particularly in how highlights and color grading were handled.
- By updating the DICE tonemapper and refining the use of `RenoDRTSmoothClamp()` and `UpgradeToneMap()`, the mod now delivers a more nuanced and vibrant HDR experience that still matches the game's intended visual style.

#### Conclusion
The enhancements in this update significantly improve the HDR rendering in Dying Light, making it essential for players seeking the best visual quality. The mod has been thoroughly tested, showing marked improvements in color accuracy, highlight handling, and overall visual appeal.