### PR TITLE
Gamma Correction and Other Enhancements to Resident Evil 2, 3, and 7

### DIFF
--- a/src/games/re2remake/ConvertRec2020PS_0xAF0777E5.ps_6_5.hlsl
+++ b/src/games/re2remake/ConvertRec2020PS_0xAF0777E5.ps_6_5.hlsl
@@ -46,7 +46,7 @@ float4 main(noperspective float4 SV_Position: SV_Position,
 #if 1
   DICESettings config = DefaultDICESettings();
   config.Type = 3;
-  config.ShoulderStart = 0.4f;
+  config.ShoulderStart = 0.5f;
   const float dicePaperWhite = whitePaperNits / renodx::color::srgb::REFERENCE_WHITE;
   const float dicePeakWhite = max(displayMaxNits, whitePaperNits) / renodx::color::srgb::REFERENCE_WHITE;
   bt709Color.rgb = DICETonemap(bt709Color.rgb * dicePaperWhite, dicePeakWhite, config) / dicePaperWhite;

--- a/src/games/re2remake/ConvertRec2020PS_0xAF0777E5.ps_6_5.hlsl
+++ b/src/games/re2remake/ConvertRec2020PS_0xAF0777E5.ps_6_5.hlsl
@@ -37,7 +37,11 @@ SamplerState PointBorder : register(s2, space32);
 float4 main(noperspective float4 SV_Position: SV_Position,
             linear float2 TEXCOORD: TEXCOORD)
     : SV_Target {
-  float4 bt709Color = tLinearImage.SampleLevel(PointBorder, TEXCOORD.xy, 0.0f);
+  float3 bt709Color = tLinearImage.SampleLevel(PointBorder, TEXCOORD.xy, 0.0f).rgb;
+
+#if 1
+  bt709Color = renodx::color::correct::GammaSafe(bt709Color);
+#endif
 
 #if 1
   DICESettings config = DefaultDICESettings();

--- a/src/games/re2remake/LUTBlackCorrection.hlsl
+++ b/src/games/re2remake/LUTBlackCorrection.hlsl
@@ -29,6 +29,9 @@ float3 LUTBlackCorrection(float3 color_input, Texture3D lut_texture, renodx::lut
   float3 lutInputColor = renodx::lut::ConvertInput(color_input, lut_config);
   float3 lutOutputColor = renodx::lut::SampleColor(lutInputColor, lut_config, lut_texture);
   float3 color_output = renodx::lut::LinearOutput(lutOutputColor, lut_config);
+
+  float3 original_output = color_output;
+
   if (lut_config.scaling != 0) {
     float3 lutBlack = renodx::lut::SampleColor(renodx::lut::ConvertInput(0, lut_config), lut_config, lut_texture);
     float3 lutMid = renodx::lut::SampleColor(renodx::lut::ConvertInput(0.18f, lut_config), lut_config, lut_texture);
@@ -40,6 +43,9 @@ float3 LUTBlackCorrection(float3 color_input, Texture3D lut_texture, renodx::lut
         renodx::lut::GammaInput(color_input, lutInputColor, lut_config));
     float3 recolored = renodx::lut::RecolorUnclamped(color_output, renodx::lut::LinearUnclampedOutput(unclamped, lut_config));
     color_output = lerp(color_output, recolored, lut_config.scaling);
+#if 1  // fixes crushed blacks with 2.2 gamma correction
+    color_output = lerp(color_output, original_output, saturate(pow(color_output, lutMid)));
+#endif
   }
   color_output = renodx::lut::RestoreSaturationLoss(color_input, color_output, lut_config);
   if (lut_config.strength != 1.f) {

--- a/src/games/re3remake/ConvertRec2020PS_0x52248E59.ps_6_5.hlsl
+++ b/src/games/re3remake/ConvertRec2020PS_0x52248E59.ps_6_5.hlsl
@@ -16,12 +16,15 @@ SamplerState PointBorder : register(s2, space32);
 float4 main(noperspective float4 SV_Position: SV_Position,
             linear float2 TEXCOORD: TEXCOORD)
     : SV_Target {
-  float4 bt709Color = tLinearImage.SampleLevel(PointBorder, TEXCOORD.xy, 0.0f);
+  float3 bt709Color = tLinearImage.SampleLevel(PointBorder, TEXCOORD.xy, 0.0f).rgb;
+#if 1
+  bt709Color = renodx::color::correct::GammaSafe(bt709Color);
+#endif
 
 #if 1
   DICESettings config = DefaultDICESettings();
   config.Type = 3;
-  config.ShoulderStart = 0.4f;
+  config.ShoulderStart = 0.5f;
   const float dicePaperWhite = whitePaperNits / renodx::color::srgb::REFERENCE_WHITE;
   const float dicePeakWhite = max(displayMaxNits, whitePaperNits) / renodx::color::srgb::REFERENCE_WHITE;
   bt709Color.rgb = DICETonemap(bt709Color.rgb * dicePaperWhite, dicePeakWhite, config) / dicePaperWhite;

--- a/src/games/re3remake/LUTBlackCorrection.hlsl
+++ b/src/games/re3remake/LUTBlackCorrection.hlsl
@@ -29,6 +29,9 @@ float3 LUTBlackCorrection(float3 color_input, Texture3D lut_texture, renodx::lut
   float3 lutInputColor = renodx::lut::ConvertInput(color_input, lut_config);
   float3 lutOutputColor = renodx::lut::SampleColor(lutInputColor, lut_config, lut_texture);
   float3 color_output = renodx::lut::LinearOutput(lutOutputColor, lut_config);
+
+  float3 original_output = color_output;
+
   if (lut_config.scaling != 0) {
     float3 lutBlack = renodx::lut::SampleColor(renodx::lut::ConvertInput(0, lut_config), lut_config, lut_texture);
     float3 lutMid = renodx::lut::SampleColor(renodx::lut::ConvertInput(0.18f, lut_config), lut_config, lut_texture);
@@ -40,6 +43,9 @@ float3 LUTBlackCorrection(float3 color_input, Texture3D lut_texture, renodx::lut
         renodx::lut::GammaInput(color_input, lutInputColor, lut_config));
     float3 recolored = renodx::lut::RecolorUnclamped(color_output, renodx::lut::LinearUnclampedOutput(unclamped, lut_config));
     color_output = lerp(color_output, recolored, lut_config.scaling);
+#if 1  // fixes crushed blacks with 2.2 gamma correction
+    color_output = lerp(color_output, original_output, saturate(pow(color_output, lutMid)));
+#endif
   }
   color_output = renodx::lut::RestoreSaturationLoss(color_input, color_output, lut_config);
   if (lut_config.strength != 1.f) {

--- a/src/games/re7/ConvertRec2020PS_0x52248E59.ps_6_5.hlsl
+++ b/src/games/re7/ConvertRec2020PS_0x52248E59.ps_6_5.hlsl
@@ -17,57 +17,61 @@ float4 main(noperspective float4 SV_Position: SV_Position,
             linear float2 TEXCOORD: TEXCOORD)
     : SV_Target {
 #if 1
-    float4 bt709Color = tLinearImage.SampleLevel(PointBorder, TEXCOORD.xy, 0.0f);
-
+  float3 bt709Color = tLinearImage.SampleLevel(PointBorder, TEXCOORD.xy, 0.0f).rgb;
 #if 1
-    DICESettings config = DefaultDICESettings();
-    config.Type = 3;
-    config.ShoulderStart = 0.35f;
-    const float dicePaperWhite = whitePaperNits / renodx::color::srgb::REFERENCE_WHITE;
-    const float dicePeakWhite = max(displayMaxNits, whitePaperNits) / renodx::color::srgb::REFERENCE_WHITE;
-    bt709Color.rgb = DICETonemap(bt709Color.rgb * dicePaperWhite, dicePeakWhite, config) / dicePaperWhite;
+  bt709Color = renodx::color::correct::GammaSafe(bt709Color);
 #endif
 
-    float3 bt2020Color =
-        renodx::color::bt2020::from::BT709(bt709Color.rgb);
+#if 1
+  DICESettings config = DefaultDICESettings();
+  config.Type = 3;
+  config.ShoulderStart = 0.5f;
+  const float dicePaperWhite = whitePaperNits / renodx::color::srgb::REFERENCE_WHITE;
+  const float dicePeakWhite = max(displayMaxNits, whitePaperNits) / renodx::color::srgb::REFERENCE_WHITE;
+  bt709Color.rgb = min(125, bt709Color);
+  bt709Color.rgb = DICETonemap(bt709Color.rgb * dicePaperWhite, dicePeakWhite, config) / dicePaperWhite;
+#endif
 
-    float3 pqColor = renodx::color::pq::Encode(bt2020Color, whitePaperNits);
+  float3 bt2020Color =
+      renodx::color::bt2020::from::BT709(bt709Color.rgb);
 
-    return float4(pqColor, 1.0);
+  float3 pqColor = renodx::color::pq::Encode(bt2020Color, whitePaperNits);
+
+  return float4(pqColor, 1.0);
 #else
-    float4 SV_Target;
-    float4 _6 = tLinearImage.SampleLevel(PointBorder, float2((TEXCOORD.x), (TEXCOORD.y)), 0.0f);
-    float _7 = _6.x;
-    float _8 = _6.y;
-    float _9 = _6.z;
-    float _20 = HDRMapping_004y;
-    float _32 = 4761.90478515625f / (whitePaperNits);
-    float _45 = exp2(((log2((saturate(((exp2(((log2((mad(0.04331360012292862f, (_6.z), (mad(0.3292819857597351f, (_6.y), ((_6.x) * 0.627403974533081f))))))) * (HDRMapping_004y)))) / _32))))) * 0.17156982421875f));
-    float _46 = exp2(((log2((saturate(((exp2(((log2((mad(0.011361200362443924f, (_6.z), (mad(0.9195399880409241f, (_6.y), ((_6.x) * 0.06909699738025665f))))))) * (HDRMapping_004y)))) / _32))))) * 0.17156982421875f));
-    float _47 = exp2(((log2((saturate(((exp2(((log2((mad(0.8955950140953064f, (_6.z), (mad(0.08801320195198059f, (_6.y), ((_6.x) * 0.01639159955084324f))))))) * (HDRMapping_004y)))) / _32))))) * 0.17156982421875f));
-    float _72 = saturate((exp2(((log2((((_45 * 16.71875f) + 0.84375f) / ((_45 * 16.5625f) + 1.0f)))) * 82.53125f))));
-    float _73 = saturate((exp2(((log2((((_46 * 16.71875f) + 0.84375f) / ((_46 * 16.5625f) + 1.0f)))) * 82.53125f))));
-    float _74 = saturate((exp2(((log2((((_47 * 16.71875f) + 0.84375f) / ((_47 * 16.5625f) + 1.0f)))) * 82.53125f))));
+  float4 SV_Target;
+  float4 _6 = tLinearImage.SampleLevel(PointBorder, float2((TEXCOORD.x), (TEXCOORD.y)), 0.0f);
+  float _7 = _6.x;
+  float _8 = _6.y;
+  float _9 = _6.z;
+  float _20 = HDRMapping_004y;
+  float _32 = 4761.90478515625f / (whitePaperNits);
+  float _45 = exp2(((log2((saturate(((exp2(((log2((mad(0.04331360012292862f, (_6.z), (mad(0.3292819857597351f, (_6.y), ((_6.x) * 0.627403974533081f))))))) * (HDRMapping_004y)))) / _32))))) * 0.17156982421875f));
+  float _46 = exp2(((log2((saturate(((exp2(((log2((mad(0.011361200362443924f, (_6.z), (mad(0.9195399880409241f, (_6.y), ((_6.x) * 0.06909699738025665f))))))) * (HDRMapping_004y)))) / _32))))) * 0.17156982421875f));
+  float _47 = exp2(((log2((saturate(((exp2(((log2((mad(0.8955950140953064f, (_6.z), (mad(0.08801320195198059f, (_6.y), ((_6.x) * 0.01639159955084324f))))))) * (HDRMapping_004y)))) / _32))))) * 0.17156982421875f));
+  float _72 = saturate((exp2(((log2((((_45 * 16.71875f) + 0.84375f) / ((_45 * 16.5625f) + 1.0f)))) * 82.53125f))));
+  float _73 = saturate((exp2(((log2((((_46 * 16.71875f) + 0.84375f) / ((_46 * 16.5625f) + 1.0f)))) * 82.53125f))));
+  float _74 = saturate((exp2(((log2((((_47 * 16.71875f) + 0.84375f) / ((_47 * 16.5625f) + 1.0f)))) * 82.53125f))));
 
-    float _139 = _72;
-    float _140 = _73;
-    float _141 = _74;
-    if (!(((((uint)(HDRMapping_004x)) & 2) == 0))) {
-      float _85 = exp2(((log2((saturate(((displayMaxNits) * 9.999999747378752e-05f))))) * 0.1593017578125f));
-      float _94 = saturate((exp2(((log2((((_85 * 18.8515625f) + 0.8359375f) / ((_85 * 18.6875f) + 1.0f)))) * 78.84375f))));
-      float _100 = exp2(((log2((saturate(((HDRMapping_000w) * 9.999999747378752e-05f))))) * 0.1593017578125f));
-      float _110 = _94 - (saturate((exp2(((log2((((_100 * 18.8515625f) + 0.8359375f) / ((_100 * 18.6875f) + 1.0f)))) * 78.84375f)))));
-      float _114 = saturate((_72 / _94));
-      float _115 = saturate((_73 / _94));
-      float _116 = saturate((_74 / _94));
-      _139 = (min(((((2.0f - (_114 + _114)) * _110) + (_114 * _94)) * _114), _72));
-      _140 = (min(((((2.0f - (_115 + _115)) * _110) + (_115 * _94)) * _115), _73));
-      _141 = (min(((((2.0f - (_116 + _116)) * _110) + (_116 * _94)) * _116), _74));
-    }
-    SV_Target.x = _139;
-    SV_Target.y = _140;
-    SV_Target.z = _141;
-    SV_Target.w = 1.0f;
-    return SV_Target;
+  float _139 = _72;
+  float _140 = _73;
+  float _141 = _74;
+  if (!(((((uint)(HDRMapping_004x)) & 2) == 0))) {
+    float _85 = exp2(((log2((saturate(((displayMaxNits) * 9.999999747378752e-05f))))) * 0.1593017578125f));
+    float _94 = saturate((exp2(((log2((((_85 * 18.8515625f) + 0.8359375f) / ((_85 * 18.6875f) + 1.0f)))) * 78.84375f))));
+    float _100 = exp2(((log2((saturate(((HDRMapping_000w) * 9.999999747378752e-05f))))) * 0.1593017578125f));
+    float _110 = _94 - (saturate((exp2(((log2((((_100 * 18.8515625f) + 0.8359375f) / ((_100 * 18.6875f) + 1.0f)))) * 78.84375f)))));
+    float _114 = saturate((_72 / _94));
+    float _115 = saturate((_73 / _94));
+    float _116 = saturate((_74 / _94));
+    _139 = (min(((((2.0f - (_114 + _114)) * _110) + (_114 * _94)) * _114), _72));
+    _140 = (min(((((2.0f - (_115 + _115)) * _110) + (_115 * _94)) * _115), _73));
+    _141 = (min(((((2.0f - (_116 + _116)) * _110) + (_116 * _94)) * _116), _74));
+  }
+  SV_Target.x = _139;
+  SV_Target.y = _140;
+  SV_Target.z = _141;
+  SV_Target.w = 1.0f;
+  return SV_Target;
 #endif
 }

--- a/src/games/re7/tonemap_0xAD20915B.ps_6_5.hlsl
+++ b/src/games/re7/tonemap_0xAD20915B.ps_6_5.hlsl
@@ -807,16 +807,11 @@ void frag_main()
     float _623;
     float _626;
 
-#if 1
+#if 1  // use UpgradeToneMap() for LUT sampling
     untonemapped = float3(_404, _406, _408);
-    // hdrColor = min(125, hdrColor);
-    DICESettings config = DefaultDICESettings();
-    config.Type = 2;
-    config.ShoulderStart = 0.25f;
-    config.DesaturationAmount = 0.f;
-    config.DarkeningAmount = 0.f;
-    sdrColor = saturate(DICETonemap(untonemapped, 1, config));
-    hdrColor = (DICETonemap(untonemapped, 125, config));
+    hdrColor = untonemapped;
+
+    sdrColor = renoDRTSmoothClamp(untonemapped);  // use neutral RenoDRT as a smoothclamp
 #endif
     if ((_112 & 4u) == 0u)
     {


### PR DESCRIPTION
### **Summary**
- sRGB -> 2.2 Gamma Correction has been added to Resident Evil 2, 3, and 7
- RenoDRTSmoothClamp() has been added to Resident Evil 7
- LUT Scaling has been modified to reduce black crush when paired with gamma correction
- DICE `ShoulderStart` has been increased as gamma correction lowers highlights

### **Justification for Changes**
- Gamma Correction: The display I was originally using at the time of creating these mods was crushing blacks. Blacks are actually not crushed with 2.2 gamma correction. The gamma calibration menus in SDR also seem to imply 2.2 gamma is expected for these games.
- Adding `RenoDRTSmoothClamp()`: `RenoDRTSmoothClamp()` better preserves highlight detail, adding this to Resident Evil 7 brings it in line with the changes also made to Resident Evil 2, 3, and 4