### PR TITLE
Gamma Correction for Resident Evil 4

### DIFF
--- a/src/games/re4remake/ConvertRec2020PS_0x6737588D.ps_6_6.hlsl
+++ b/src/games/re4remake/ConvertRec2020PS_0x6737588D.ps_6_6.hlsl
@@ -39,12 +39,15 @@ float4 main(noperspective float4 SV_Position: SV_Position,
             linear float2 TEXCOORD: TEXCOORD)
     : SV_Target {
   if (injectedData.toneMapType != 0) {
-    float4 bt709Color = tLinearImage.SampleLevel(PointBorder, TEXCOORD.xy, 0.0f);
+    float3 bt709Color = tLinearImage.SampleLevel(PointBorder, TEXCOORD.xy, 0.0f).rgb;
 
+    if (injectedData.toneMapGammaCorrection == 1.f) {
+      bt709Color = renodx::color::correct::GammaSafe(bt709Color);
+    }
 #if 1
     DICESettings config = DefaultDICESettings();
     config.Type = 3;
-    config.ShoulderStart = 0.35;
+    config.ShoulderStart = 0.45;
     const float dicePaperWhite = whitePaperNits / renodx::color::srgb::REFERENCE_WHITE;
     const float dicePeakWhite = max(displayMaxNits, whitePaperNits) / renodx::color::srgb::REFERENCE_WHITE;
     bt709Color.rgb = DICETonemap(bt709Color.rgb * dicePaperWhite, dicePeakWhite, config) / dicePaperWhite;

--- a/src/games/re4remake/addon.cpp
+++ b/src/games/re4remake/addon.cpp
@@ -55,7 +55,7 @@ renodx::utils::settings::Settings settings = {
         .can_reset = false,
         .label = "Gamma Correction",
         .section = "Tone Mapping",
-        .tooltip = "Emulates a 2.2 EOTF (use with HDR or sRGB)",
+        .tooltip = "Emulates a 2.2 EOTF, this is likely what the developers tried to approximate with the vanilla gamma adjustment",
         .is_enabled = []() { return shader_injection.toneMapType != 0; },
     },
     new renodx::utils::settings::Setting{

--- a/src/games/re4remake/addon.cpp
+++ b/src/games/re4remake/addon.cpp
@@ -48,6 +48,29 @@ renodx::utils::settings::Settings settings = {
         .labels = {"Vanilla", "Vanilla+"},
     },
     new renodx::utils::settings::Setting{
+        .key = "toneMapGammaCorrection",
+        .binding = &shader_injection.toneMapGammaCorrection,
+        .value_type = renodx::utils::settings::SettingValueType::BOOLEAN,
+        .default_value = 1.f,
+        .can_reset = false,
+        .label = "Gamma Correction",
+        .section = "Tone Mapping",
+        .tooltip = "Emulates a 2.2 EOTF (use with HDR or sRGB)",
+        .is_enabled = []() { return shader_injection.toneMapType != 0; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "toneMapGammaAdjust",
+        .binding = &shader_injection.toneMapGammaAdjust,
+        .default_value = 1.f,
+        .label = "Gamma Adjustment",
+        .section = "Tone Mapping",
+        .tooltip = "Adjusts gamma",
+        .min = 0.75f,
+        .max = 1.25f,
+        .format = "%.2f",
+        .is_enabled = []() { return shader_injection.toneMapType != 0; },
+    },
+    new renodx::utils::settings::Setting{
         .key = "colorGradeHighlightContrast",
         .binding = &shader_injection.colorGradeHighlightContrast,
         .default_value = 50.f,
@@ -99,18 +122,6 @@ renodx::utils::settings::Settings settings = {
         .parse = [](float value) { return value * 0.01f; },
     },
     new renodx::utils::settings::Setting{
-        .key = "colorGradeGammaAdjust",
-        .binding = &shader_injection.colorGradeGammaAdjust,
-        .default_value = 1.f,
-        .label = "Gamma Adjustment (Hue Preserving)",
-        .section = "Color Grading",
-        .tooltip = "Adjusts gamma on luminance, only affects luminance values below 1.",
-        .min = 0.75f,
-        .max = 1.25f,
-        .format = "%.2f",
-        .is_enabled = []() { return shader_injection.toneMapType != 0; },
-    },
-    new renodx::utils::settings::Setting{
         .key = "processingInternalSampling",
         .binding = &shader_injection.processingInternalSampling,
         .value_type = renodx::utils::settings::SettingValueType::INTEGER,
@@ -150,6 +161,7 @@ renodx::utils::settings::Settings settings = {
 
 void OnPresetOff() {
   renodx::utils::settings::UpdateSetting("toneMapType", 0.f);
+  renodx::utils::settings::UpdateSetting("toneMapGammaCorrection", 0.f);
   renodx::utils::settings::UpdateSetting("colorGradeToeAdjustmentType", 0.f);
   renodx::utils::settings::UpdateSetting("colorGradeShadowToe", 1.f);
   renodx::utils::settings::UpdateSetting("colorGradeHighlightContrast", 50.f);

--- a/src/games/re4remake/shared.h
+++ b/src/games/re4remake/shared.h
@@ -9,12 +9,13 @@
 // Should be 4x32
 struct ShaderInjectData {
   float toneMapType;
+  float toneMapGammaCorrection;
+  float toneMapGammaAdjust;
   float colorGradeHighlightContrast;
   float colorGradeToeAdjustmentType;
   float colorGradeShadowToe;
   float colorGradeLUTStrength;
   float colorGradeLUTScaling;
-  float colorGradeGammaAdjust;
   float processingInternalSampling;
 };
 

--- a/src/games/re4remake/tonemap_inside_0x1F9104F3.ps_6_6.hlsl
+++ b/src/games/re4remake/tonemap_inside_0x1F9104F3.ps_6_6.hlsl
@@ -1416,7 +1416,7 @@ void frag_main()
     SV_Target.w = 0.0f;
 
     if (injectedData.toneMapType != 0) {
-        SV_Target.rgb = AdjustGammaOnLuminance(SV_Target.rgb, injectedData.colorGradeGammaAdjust);
+      SV_Target.rgb = AdjustGammaByChannel(SV_Target.rgb, injectedData.toneMapGammaAdjust);
     }
 }
 

--- a/src/games/re4remake/tonemap_outside_HDRPostProcess_WithTonemap_0x973A39FC.ps_6_6.hlsl
+++ b/src/games/re4remake/tonemap_outside_HDRPostProcess_WithTonemap_0x973A39FC.ps_6_6.hlsl
@@ -1447,7 +1447,7 @@ void frag_main()
     SV_Target.w = 0.0f;
 
     if (injectedData.toneMapType != 0) {
-      SV_Target.rgb = AdjustGammaOnLuminance(SV_Target.rgb, injectedData.colorGradeGammaAdjust);
+      SV_Target.rgb = AdjustGammaByChannel(SV_Target.rgb, injectedData.toneMapGammaAdjust);
     }
 }
 


### PR DESCRIPTION
### **Summary**
- sRGB -> 2.2 Gamma Correction has been added to Resident Evil 4 Remake
- The gamma adjustment slider is no longer by luminance, it is now by channel
- LUT Scaling has been modified to reduce black crush when paired with gamma correction
- DICE `ShoulderStart` has been increased as it was too low before and gamma correction also lowers highlights

### **Justification for Changes**
- Gamma Correction: The display I was originally using at the time of creating these mods was crushing blacks. Blacks are actually not crushed with 2.2 gamma correction. The gamma calibration menus in SDR also seem to imply 2.2 gamma is expected for these games.
- Gamma Adjustment Slider: The gamma adjustment slider is now an alternative to gamma correction, as emulating 2.2 gamma often looks  crushed (though that seems to be the intention of the developers)