### PR TITLE
Add Bioshock (Remastered)

### DIFF
--- a/src/games/bioshock/AntiAliasing_0xEC834D82.ps_4_0.hlsl
+++ b/src/games/bioshock/AntiAliasing_0xEC834D82.ps_4_0.hlsl
@@ -1,0 +1,93 @@
+cbuffer _Globals : register(b0)
+{
+  float2 resolution : packoffset(c0);
+  float2 invResolution : packoffset(c0.z);
+}
+
+SamplerState s_framebuffer_s : register(s0);
+Texture2D<float4> s_framebuffer : register(t0);
+
+#define cmp -
+
+static const float3 Rec709_Luminance = float3(0.2126f, 0.7152f, 0.0722f);
+
+float GetLuminance( float3 color )
+{
+	return dot( color, Rec709_Luminance );
+}
+
+void main(
+  float4 v0 : SV_Position0,
+  float2 v1 : TEXCOORD0,
+  float2 w1 : TEXCOORD1,
+  float2 v2 : TEXCOORD2,
+  float2 w2 : TEXCOORD3,
+  float2 v3 : TEXCOORD4,
+  out float4 o0 : SV_Target0)
+{
+#if 0 // Disable AA
+  o0 = s_framebuffer.Load(v0.xyz);
+#else
+  //TODO: implemented more modern spatial AA
+  float4 r0,r1,r2,r3,r4,r5;
+  r0.xyzw = resolution.xyxy * v1.xyxy;
+  r1.xyzw = s_framebuffer.Sample(s_framebuffer_s, v1.xy).xyzw;
+  r2.xyzw = s_framebuffer.Sample(s_framebuffer_s, w1.xy).xyzw;
+  r3.xyzw = s_framebuffer.Sample(s_framebuffer_s, v2.xy).xyzw;
+  r4.xyzw = s_framebuffer.Sample(s_framebuffer_s, w2.xy).xyzw;
+  r5.xyzw = s_framebuffer.Sample(s_framebuffer_s, v3.xy).xyzw;
+  // RenoDX: fixed BT.601 luminance coeffs //TODO: fix more of these (e.g. bloom?)
+  r1.x = GetLuminance(r1.xyz);
+  r1.y = GetLuminance(r2.xyz);
+  r1.z = GetLuminance(r3.xyz);
+  r1.w = GetLuminance(r4.xyz);
+  r2.x = GetLuminance(r5.xyz);
+  r2.y = min(r1.y, r1.z);
+  r2.z = min(r2.x, r1.w);
+  r2.y = min(r2.y, r2.z);
+  r2.y = min(r2.y, r1.x);
+  r2.z = max(r1.y, r1.z);
+  r2.w = max(r2.x, r1.w);
+  r2.z = max(r2.z, r2.w);
+  r2.z = max(r2.z, r1.x);
+  r2.w = r1.y + r1.z;
+  r3.x = r2.x + r1.w;
+  r3.x = -r3.x + r2.w;
+  r4.xz = -r3.xx;
+  r1.y = r1.y + r1.w;
+  r1.z = r2.x + r1.z;
+  r4.yw = r1.yy + -r1.zz;
+  r1.y = r2.w + r1.w;
+  r1.y = r1.y + r2.x;
+  r1.y = 0.03125 * r1.y;
+  r1.y = max(0.0078125, r1.y);
+  r1.z = min(abs(r4.w), abs(r3.x));
+  r1.y = r1.z + r1.y;
+  r1.y = 1 / r1.y;
+  r3.xyzw = r4.xyzw * r1.yyyy;
+  r3.xyzw = max(float4(-8,-8,-8,-8), r3.xyzw);
+  r3.xyzw = min(float4(8,8,8,8), r3.xyzw);
+  r3.xyzw = invResolution.xyxy * r3.xyzw;
+  r0.xyzw = invResolution.xyxy * r0.xyzw;
+  r4.xyzw = r3.zwzw * float4(-0.166666672,-0.166666672,0.166666672,0.166666672) + r0.zwzw;
+  r5.xyzw = s_framebuffer.Sample(s_framebuffer_s, r4.xy).xyzw;
+  r4.xyzw = s_framebuffer.Sample(s_framebuffer_s, r4.zw).xyzw;
+  r1.yzw = r5.xyz + r4.xyz;
+  r0.xyzw = r3.xyzw * float4(-0.5,-0.5,0.5,0.5) + r0.xyzw;
+  r3.xyzw = s_framebuffer.Sample(s_framebuffer_s, r0.xy).xyzw;
+  r0.xyzw = s_framebuffer.Sample(s_framebuffer_s, r0.zw).xyzw;
+  r0.xyz = r3.xyz + r0.xyz;
+  r0.xyz = float3(0.25,0.25,0.25) * r0.xyz;
+  r0.xyz = r1.yzw * float3(0.25,0.25,0.25) + r0.xyz;
+  r0.w = dot(r0.xyz, r1.xxx);
+  r1.x = cmp(r0.w < r2.y);
+  r0.w = cmp(r2.z < r0.w);
+  r0.w = (int)r0.w | (int)r1.x;
+  if (r0.w != 0) {
+    o0.xyz = float3(0.5,0.5,0.5) * r1.yzw;
+  } else {
+    o0.xyz = r0.xyz;
+  }
+  o0.w = 0;
+#endif
+}

--- a/src/games/bioshock/Bloom_Tonemap_0x6457104F.ps_4_0.hlsl
+++ b/src/games/bioshock/Bloom_Tonemap_0x6457104F.ps_4_0.hlsl
@@ -1,0 +1,41 @@
+cbuffer _Globals : register(b0)
+{
+  float ImageSpace_hlsl_ToneMapPixelShader011_4bits : packoffset(c0) = {0};
+  float4 fogColor : packoffset(c1);
+  float3 fogTransform : packoffset(c2);
+  float4x3 screenDataToCamera : packoffset(c3);
+  float globalScale : packoffset(c6);
+  float sceneDepthAlphaMask : packoffset(c6.y);
+  float globalOpacity : packoffset(c6.z);
+  float distortionBufferScale : packoffset(c6.w);
+  float2 wToZScaleAndBias : packoffset(c7);
+  float4 screenTransform[2] : packoffset(c8);
+  float4 textureToPixel : packoffset(c10);
+  float4 pixelToTexture : packoffset(c11);
+  float maxScale : packoffset(c12) = {0};
+  float bloomAlpha : packoffset(c12.y) = {0};
+  float sceneBias : packoffset(c12.z) = {1};
+  float exposure : packoffset(c12.w) = {0};
+  float deltaExposure : packoffset(c13) = {0};
+  float4 ColorFill : packoffset(c14);
+}
+
+SamplerState s_framebuffer_s : register(s0);
+SamplerState s_bloom_s : register(s1);
+Texture2D<float4> s_framebuffer : register(t0);
+Texture2D<float4> s_bloom : register(t1);
+
+void main(
+  float4 v0 : SV_Position0,
+  float2 v1 : TEXCOORD0,
+  float2 w1 : TEXCOORD1,
+  out float4 outColor : SV_Target0)
+{
+  float3 bloomColor = s_bloom.Sample(s_bloom_s, w1.xy).rgb;
+  float4 sceneColor = s_framebuffer.Sample(s_framebuffer_s, v1.xy).rgba;
+  bloomColor *= bloomAlpha; // Scale down (or up) the bloom intensity
+  sceneColor.rgb += bloomColor; // Bloom is 100% additive here
+  sceneColor.rgb *= sceneBias; // Exposure?
+  //TODO: add dice tonemap here, the game had none (it's not particularly needed either given it was heavily clipped)
+  outColor = float4(pow(abs(sceneColor.rgb), 1.0 / 2.2) * sign(sceneColor.rgb), sceneColor.a); // Gamma 2.2
+}

--- a/src/games/bioshock/X_Final_0xFFFFFFFD.vs_5_0.hlsl
+++ b/src/games/bioshock/X_Final_0xFFFFFFFD.vs_5_0.hlsl
@@ -1,0 +1,5 @@
+void main(uint id: SV_VERTEXID, out float4 pos: SV_POSITION, out float2 uv: TEXCOORD0) {
+  uv.x = (id == 1) ? 2.0 : 0.0;
+  uv.y = (id == 2) ? 2.0 : 0.0;
+  pos = float4(uv * float2(2.0, -2.0) + float2(-1.0, 1.0), 0.0, 1.0);
+}

--- a/src/games/bioshock/X_Final_0xFFFFFFFE.ps_5_0.hlsl
+++ b/src/games/bioshock/X_Final_0xFFFFFFFE.ps_5_0.hlsl
@@ -1,0 +1,17 @@
+#include "./shared.h"
+
+SamplerState sourceSampler_s : register(s0);
+Texture2D<float4> sourceTexture : register(t0);
+
+void main(
+    float4 vpos: SV_Position,
+    float2 texcoord: TEXCOORD,
+    out float4 output: SV_Target0) {
+  float4 color = sourceTexture.Sample(sourceSampler_s, texcoord.xy);
+
+  // Linearize with 2.2 Gamma and scale paper white
+  float3 linearizedColor = renodx::color::gamma::DecodeSafe(color.rgb, 2.2);
+  linearizedColor *= injectedData.PaperWhiteNits / renodx::color::srgb::REFERENCE_WHITE;
+
+  output.rgba = float4(linearizedColor, color.a);
+}

--- a/src/games/bioshock/addon.cpp
+++ b/src/games/bioshock/addon.cpp
@@ -1,0 +1,335 @@
+/*
+ * Copyright (C) 2024 Filippo Tarpini
+ * SPDX-License-Identifier: MIT
+ */
+
+#define ImTextureID ImU64
+
+#define DEBUG_LEVEL_0
+
+#include <embed/0xEC834D82.h>
+#include <embed/0x6457104F.h>
+
+#include <embed/0xFFFFFFFD.h>  // Custom final VS
+#include <embed/0xFFFFFFFE.h>  // Custom final PS
+
+#include <deps/imgui/imgui.h>
+#include <include/reshade.hpp>
+
+#include "../../mods/shader.hpp"
+#include "../../mods/swapchain.hpp"
+#include "../../utils/settings.hpp"
+#include "./shared.h"
+
+namespace {
+
+renodx::mods::shader::CustomShaders custom_shaders = {
+    CustomShaderEntry(0xEC834D82),
+    CustomShaderEntry(0x6457104F),
+};
+
+ShaderInjectData shader_injection;
+
+renodx::utils::settings::Settings settings = {
+    new renodx::utils::settings::Setting{
+        .key = "PaperWhiteNits",
+        .binding = &shader_injection.PaperWhiteNits,
+        .default_value = 203.f,
+        .can_reset = true,
+        .label = "Paper White Brightness",
+        .section = "Display Mapping",
+        .tooltip = "Sets the value of paper white in nits",
+        .min = 80.f,
+        .max = 500.f,
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::BUTTON,
+        .label = "Discord",
+        .section = "Links",
+        .group = "button-line-1",
+        .tint = 0x5865F2,
+        .on_change = []() {
+          static const std::string obfuscated_link = std::string("start https://discord.gg/J9fM") + std::string("3EVuEZ");
+          system(obfuscated_link.c_str());
+        },
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::BUTTON,
+        .label = "Github",
+        .section = "Links",
+        .group = "button-line-1",
+        .on_change = []() {
+          system("start https://github.com/clshortfuse/renodx");
+        },
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::BUTTON,
+        .label = "Buy Pumbo a Coffee",
+        .section = "Links",
+        .group = "button-line-1",
+        .tint = 0xFF5F5F,
+        .on_change = []() {
+          system("start https://buymeacoffee.com/realfiloppi");
+        },
+    },
+};
+}  // namespace
+
+// NOLINTBEGIN(readability-identifier-naming)
+
+// NOTE: Bioshock is x32 not x64
+extern "C" __declspec(dllexport) const char* NAME = "RenoDX";
+extern "C" __declspec(dllexport) const char* DESCRIPTION = "RenoDX for BioShock (Remastered)";
+
+// NOLINTEND(readability-identifier-naming)
+
+// Final shader [ty Ersh/FF14]
+struct __declspec(uuid("1228220F-364A-46A2-BB29-1CCE591A018A")) DeviceData {
+  reshade::api::effect_runtime* main_runtime = nullptr;
+  std::atomic_bool rendered_effects = false;
+  std::vector<reshade::api::resource_view> swapchain_rtvs;
+  reshade::api::pipeline final_pipeline = {};
+  reshade::api::resource final_texture = {};
+  reshade::api::resource_view final_texture_view = {};
+  reshade::api::sampler final_texture_sampler = {};
+  reshade::api::pipeline_layout final_layout = {};
+};
+
+constexpr reshade::api::pipeline_layout PIPELINE_LAYOUT{0};
+
+void OnInitDevice(reshade::api::device* device) {
+  auto& data = device->create_private_data<DeviceData>();
+
+  // create pipeline
+  {
+    std::vector<reshade::api::pipeline_subobject> subobjects;
+
+    reshade::api::shader_desc vs_desc = {};
+    vs_desc.code = _0xFFFFFFFD;
+    vs_desc.code_size = sizeof(_0xFFFFFFFD);
+    subobjects.push_back({reshade::api::pipeline_subobject_type::vertex_shader, 1, &vs_desc});
+
+    reshade::api::shader_desc ps_desc = {};
+    ps_desc.code = _0xFFFFFFFE;
+    ps_desc.code_size = sizeof(_0xFFFFFFFE);
+    subobjects.push_back({reshade::api::pipeline_subobject_type::pixel_shader, 1, &ps_desc});
+
+    reshade::api::format format = reshade::api::format::r16g16b16a16_float;
+    subobjects.push_back({reshade::api::pipeline_subobject_type::render_target_formats, 1, &format});
+
+    uint32_t num_vertices = 3;
+    subobjects.push_back({reshade::api::pipeline_subobject_type::max_vertex_count, 1, &num_vertices});
+
+    auto topology = reshade::api::primitive_topology::triangle_list;
+    subobjects.push_back({reshade::api::pipeline_subobject_type::primitive_topology, 1, &topology});
+
+    reshade::api::blend_desc blend_state = {};
+    subobjects.push_back({reshade::api::pipeline_subobject_type::blend_state, 1, &blend_state});
+
+    reshade::api::rasterizer_desc rasterizer_state = {};
+    rasterizer_state.cull_mode = reshade::api::cull_mode::none;
+    subobjects.push_back({reshade::api::pipeline_subobject_type::rasterizer_state, 1, &rasterizer_state});
+
+    reshade::api::depth_stencil_desc depth_stencil_state = {};
+    depth_stencil_state.depth_enable = false;
+    depth_stencil_state.depth_write_mask = false;
+    depth_stencil_state.depth_func = reshade::api::compare_op::always;
+    depth_stencil_state.stencil_enable = false;
+    depth_stencil_state.front_stencil_read_mask = 0xFF;
+    depth_stencil_state.front_stencil_write_mask = 0xFF;
+    depth_stencil_state.front_stencil_func = depth_stencil_state.back_stencil_func;
+    depth_stencil_state.front_stencil_fail_op = depth_stencil_state.back_stencil_fail_op;
+    depth_stencil_state.front_stencil_depth_fail_op = depth_stencil_state.back_stencil_depth_fail_op;
+    depth_stencil_state.front_stencil_pass_op = depth_stencil_state.back_stencil_pass_op;
+    depth_stencil_state.back_stencil_read_mask = 0xFF;
+    depth_stencil_state.back_stencil_write_mask = 0xFF;
+    depth_stencil_state.back_stencil_func = reshade::api::compare_op::always;
+    depth_stencil_state.back_stencil_fail_op = reshade::api::stencil_op::keep;
+    depth_stencil_state.back_stencil_depth_fail_op = reshade::api::stencil_op::keep;
+    depth_stencil_state.back_stencil_pass_op = reshade::api::stencil_op::keep;
+
+    subobjects.push_back({reshade::api::pipeline_subobject_type::depth_stencil_state, 1, &depth_stencil_state});
+
+    device->create_pipeline(PIPELINE_LAYOUT, static_cast<uint32_t>(subobjects.size()), subobjects.data(), &data.final_pipeline);
+  }
+
+  // create layout
+  {
+    reshade::api::pipeline_layout_param new_params;
+    new_params.type = reshade::api::pipeline_layout_param_type::push_constants;
+    new_params.push_constants.count = 1;
+    new_params.push_constants.dx_register_index = 13;
+    new_params.push_constants.visibility = reshade::api::shader_stage::vertex | reshade::api::shader_stage::pixel | reshade::api::shader_stage::compute;
+    device->create_pipeline_layout(1, &new_params, &data.final_layout);
+  }
+}
+
+void OnDestroyDevice(reshade::api::device* device) {
+  auto& data = device->get_private_data<DeviceData>();
+
+  device->destroy_pipeline(data.final_pipeline);
+  device->destroy_pipeline_layout(data.final_layout);
+
+  device->destroy_private_data<DeviceData>();
+}
+
+void OnInitSwapchain(reshade::api::swapchain* swapchain) {
+  auto device = swapchain->get_device();
+  auto& data = device->get_private_data<DeviceData>();
+
+  for (int i = 0; i < swapchain->get_back_buffer_count(); ++i) {
+    auto back_buffer_resource = swapchain->get_back_buffer(i);
+    auto back_buffer_desc = device->get_resource_desc(back_buffer_resource);
+    auto desc = reshade::api::resource_view_desc(reshade::api::resource_view_type::texture_2d, reshade::api::format_to_default_typed(back_buffer_desc.texture.format), 0, 1, 0, 1);
+    device->create_resource_view(back_buffer_resource, reshade::api::resource_usage::render_target, desc, &data.swapchain_rtvs.emplace_back());
+  }
+
+  // create copy target
+  {
+    auto back_buffer_resource = swapchain->get_back_buffer(0);
+    auto back_buffer_desc = device->get_resource_desc(back_buffer_resource);
+    reshade::api::resource_desc desc = {};
+    desc.type = reshade::api::resource_type::texture_2d;
+    desc.texture = {
+        back_buffer_desc.texture.width,
+        back_buffer_desc.texture.height,
+        1,
+        1,
+        reshade::api::format_to_typeless(back_buffer_desc.texture.format),
+        1,
+    };
+    desc.heap = reshade::api::memory_heap::gpu_only;
+    desc.usage = reshade::api::resource_usage::copy_dest | reshade::api::resource_usage::shader_resource;
+    desc.flags = reshade::api::resource_flags::none;
+    device->create_resource(desc, nullptr, reshade::api::resource_usage::shader_resource, &data.final_texture);
+    device->create_resource_view(data.final_texture, reshade::api::resource_usage::shader_resource, reshade::api::resource_view_desc(reshade::api::format_to_default_typed(desc.texture.format)), &data.final_texture_view);
+    device->create_sampler({}, &data.final_texture_sampler);
+  }
+}
+
+void OnDestroySwapchain(reshade::api::swapchain* swapchain) {
+  auto device = swapchain->get_device();
+  auto& data = device->get_private_data<DeviceData>();
+
+  for (const auto& rtv : data.swapchain_rtvs) {
+    device->destroy_resource_view(rtv);
+  }
+
+  data.swapchain_rtvs.clear();
+
+  device->destroy_sampler(data.final_texture_sampler);
+  device->destroy_resource_view(data.final_texture_view);
+  device->destroy_resource(data.final_texture);
+}
+
+// more or less the same as what reshade does to render its techniques
+void OnPresent(reshade::api::command_queue* queue, reshade::api::swapchain* swapchain, const reshade::api::rect* source_rect, const reshade::api::rect* dest_rect, uint32_t dirty_rect_count, const reshade::api::rect* dirty_rects) {
+  auto device = queue->get_device();
+  auto cmd_list = queue->get_immediate_command_list();
+
+  auto& data = device->get_private_data<DeviceData>();
+
+  auto back_buffer_resource = swapchain->get_current_back_buffer();
+  auto back_buffer_desc = device->get_resource_desc(back_buffer_resource);
+
+  // copy backbuffer
+  {
+    const reshade::api::resource resources[2] = {back_buffer_resource, data.final_texture};
+    const reshade::api::resource_usage state_old[2] = {reshade::api::resource_usage::render_target, reshade::api::resource_usage::shader_resource};
+    const reshade::api::resource_usage state_new[2] = {reshade::api::resource_usage::copy_source, reshade::api::resource_usage::copy_dest};
+
+    cmd_list->barrier(2, resources, state_old, state_new);
+    cmd_list->copy_texture_region(back_buffer_resource, 0, nullptr, data.final_texture, 0, nullptr);
+    cmd_list->barrier(2, resources, state_new, state_old);
+  }
+
+  cmd_list->bind_pipeline(reshade::api::pipeline_stage::all_graphics, data.final_pipeline);
+
+  cmd_list->barrier(back_buffer_resource, reshade::api::resource_usage::shader_resource, reshade::api::resource_usage::render_target);
+
+  reshade::api::render_pass_render_target_desc render_target = {};
+  render_target.view = data.swapchain_rtvs.at(swapchain->get_current_back_buffer_index());
+  cmd_list->begin_render_pass(1, &render_target, nullptr);
+
+  cmd_list->push_descriptors(reshade::api::shader_stage::all_graphics, PIPELINE_LAYOUT, 0, reshade::api::descriptor_table_update{{}, 0, 0, 1, reshade::api::descriptor_type::texture_shader_resource_view, &data.final_texture_view});
+  cmd_list->push_descriptors(reshade::api::shader_stage::all_graphics, PIPELINE_LAYOUT, 0, reshade::api::descriptor_table_update{{}, 0, 0, 1, reshade::api::descriptor_type::sampler, &data.final_texture_sampler});
+
+  // push the renodx settings
+  cmd_list->push_constants(reshade::api::shader_stage::all_graphics, data.final_layout, 0, 0, sizeof(shader_injection) / 4, &shader_injection);
+
+  const reshade::api::viewport viewport = {
+      0.0f, 0.0f,
+      static_cast<float>(back_buffer_desc.texture.width),
+      static_cast<float>(back_buffer_desc.texture.height),
+      0.0f, 1.0f};
+  cmd_list->bind_viewports(0, 1, &viewport);
+
+  cmd_list->draw(3, 1, 0, 0);
+  cmd_list->end_render_pass();
+
+  cmd_list->barrier(back_buffer_resource, reshade::api::resource_usage::render_target, reshade::api::resource_usage::shader_resource);
+}
+
+BOOL APIENTRY DllMain(HMODULE h_module, DWORD fdw_reason, LPVOID lpv_reserved) {
+  switch (fdw_reason) {
+    case DLL_PROCESS_ATTACH:
+      if (!reshade::register_addon(h_module)) return FALSE;
+
+      renodx::mods::shader::expected_constant_buffer_index = 13;
+
+      renodx::mods::swapchain::force_borderless = false;
+
+      // Final shader
+      reshade::register_event<reshade::addon_event::init_device>(OnInitDevice);
+      reshade::register_event<reshade::addon_event::destroy_device>(OnDestroyDevice);
+      reshade::register_event<reshade::addon_event::init_swapchain>(OnInitSwapchain);
+      reshade::register_event<reshade::addon_event::destroy_swapchain>(OnDestroySwapchain);
+      reshade::register_event<reshade::addon_event::present>(OnPresent);
+      
+      // TODO: figure out why this doesn't work, most of the scene rendering is still R11G11B10F (does it have a different size from the swapchain?)
+      renodx::mods::swapchain::swap_chain_upgrade_targets.push_back({
+          .old_format = reshade::api::format::r11g11b10_float,
+          .new_format = reshade::api::format::r16g16b16a16_float,
+      });
+      renodx::mods::swapchain::swap_chain_upgrade_targets.push_back({
+          .old_format = reshade::api::format::r8g8b8a8_unorm,
+          .new_format = reshade::api::format::r16g16b16a16_float,
+      });
+      renodx::mods::swapchain::swap_chain_upgrade_targets.push_back({
+          .old_format = reshade::api::format::r8g8b8a8_typeless,
+          .new_format = reshade::api::format::r16g16b16a16_float,
+      });
+      renodx::mods::swapchain::swap_chain_upgrade_targets.push_back({
+          .old_format = reshade::api::format::r8g8b8a8_unorm_srgb,
+          .new_format = reshade::api::format::r16g16b16a16_float,
+      });
+      renodx::mods::swapchain::swap_chain_upgrade_targets.push_back({
+          .old_format = reshade::api::format::b8g8r8a8_typeless,
+          .new_format = reshade::api::format::r16g16b16a16_float,
+      });
+      renodx::mods::swapchain::swap_chain_upgrade_targets.push_back({
+          .old_format = reshade::api::format::b8g8r8a8_unorm,
+          .new_format = reshade::api::format::r16g16b16a16_float,
+      });
+      renodx::mods::swapchain::swap_chain_upgrade_targets.push_back({
+          .old_format = reshade::api::format::b8g8r8a8_unorm_srgb,
+          .new_format = reshade::api::format::r16g16b16a16_float,
+      });
+
+      break;
+    case DLL_PROCESS_DETACH:
+      reshade::unregister_event<reshade::addon_event::init_device>(OnInitDevice);
+      reshade::unregister_event<reshade::addon_event::destroy_device>(OnDestroyDevice);
+      reshade::unregister_event<reshade::addon_event::init_swapchain>(OnInitSwapchain);
+      reshade::unregister_event<reshade::addon_event::destroy_swapchain>(OnDestroySwapchain);
+      reshade::unregister_event<reshade::addon_event::present>(OnPresent);
+      reshade::unregister_addon(h_module);
+      break;
+  }
+
+  renodx::utils::settings::Use(fdw_reason, &settings);
+  renodx::mods::shader::Use(fdw_reason, custom_shaders, &shader_injection);
+  renodx::mods::swapchain::Use(fdw_reason);
+
+  return TRUE;
+}

--- a/src/games/bioshock/shared.h
+++ b/src/games/bioshock/shared.h
@@ -1,0 +1,23 @@
+#ifndef SRC_BIOSHOCK_SHARED_H_
+#define SRC_BIOSHOCK_SHARED_H_
+
+#ifndef __cplusplus
+#include "../../shaders/renodx.hlsl"
+#endif
+
+// Must be 32bit aligned
+// Should be 4x32
+struct ShaderInjectData {
+  float PaperWhiteNits;
+  float Padding01;
+  float Padding02;
+  float Padding03;
+};
+
+#ifndef __cplusplus
+cbuffer cb13 : register(b13) {
+  ShaderInjectData injectedData : packoffset(c0);
+}
+#endif
+
+#endif  // SRC_BIOSHOCK_SHARED_H_


### PR DESCRIPTION
Upgrading textures and removing a saturate() was all I had to do. The game was clipped, there was no tonemapping (and there still isn't). Bioshock 2 is probably the same.

Some of the render target textures are still not upgraded and are still R11G11B10F, unclear why.