### PR TITLE
HDR Enhancements for Red Dead Redemption and minor improvements for Batman: Arkham Knight

### DIFF
--- a/src/games/batmanak/addon.cpp
+++ b/src/games/batmanak/addon.cpp
@@ -41,6 +41,7 @@
 
 #include "../../mods/shader.hpp"
 #include "../../mods/swapchain.hpp"
+#include "../../utils/date.hpp"
 #include "../../utils/settings.hpp"
 #include "./shared.h"
 
@@ -78,8 +79,6 @@ renodx::mods::shader::CustomShaders custom_shaders = {
 };
 
 ShaderInjectData shader_injection;
-const std::string build_date = __DATE__;
-const std::string build_time = __TIME__;
 
 renodx::utils::settings::Settings settings = {
     new renodx::utils::settings::Setting{
@@ -386,7 +385,7 @@ renodx::utils::settings::Settings settings = {
     },
     new renodx::utils::settings::Setting{
         .value_type = renodx::utils::settings::SettingValueType::TEXT,
-        .label = "This build was compiled on " + build_date + " at " + build_time + ".",
+        .label = std::string("Build: ") + renodx::utils::date::ISO_DATE_TIME,
         .section = "About",
     },
 };

--- a/src/games/batmanak/addon.cpp
+++ b/src/games/batmanak/addon.cpp
@@ -78,6 +78,8 @@ renodx::mods::shader::CustomShaders custom_shaders = {
 };
 
 ShaderInjectData shader_injection;
+const std::string build_date = __DATE__;
+const std::string build_time = __TIME__;
 
 renodx::utils::settings::Settings settings = {
     new renodx::utils::settings::Setting{
@@ -379,6 +381,11 @@ renodx::utils::settings::Settings settings = {
         .on_change = []() {
           ShellExecute(0, "open", (std::string("https://ko-fi.com/") + "shortfuse").c_str(), 0, 0, SW_SHOW);
         },
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::TEXT,
+        .label = "This build was compiled on " + build_date + " at " + build_time + ".",
+        .section = "About",
     },
 };
 

--- a/src/games/batmanak/addon.cpp
+++ b/src/games/batmanak/addon.cpp
@@ -359,6 +359,7 @@ renodx::utils::settings::Settings settings = {
         .label = "More Mods",
         .section = "Links",
         .group = "button-line-1",
+        .tint = 0x2B3137,
         .on_change = []() {
           ShellExecute(0, "open", (std::string("https://github.com/") + "clshortfuse/renodx/wiki/Mods").c_str(), 0, 0, SW_SHOW);
         },
@@ -368,6 +369,7 @@ renodx::utils::settings::Settings settings = {
         .label = "Github",
         .section = "Links",
         .group = "button-line-1",
+        .tint = 0x2B3137,
         .on_change = []() {
           ShellExecute(0, "open", (std::string("https://github.com/") + "clshortfuse/renodx").c_str(), 0, 0, SW_SHOW);
         },
@@ -377,7 +379,7 @@ renodx::utils::settings::Settings settings = {
         .label = "ShortFuse's Ko-Fi",
         .section = "Links",
         .group = "button-line-1",
-        .tint = 0xFF5F5F,
+        .tint = 0xFF5A16,
         .on_change = []() {
           ShellExecute(0, "open", (std::string("https://ko-fi.com/") + "shortfuse").c_str(), 0, 0, SW_SHOW);
         },

--- a/src/games/rdr1/PSApplyHDR10PQGammaCorrect.0x56F79BAD.ps_6_0.hlsl
+++ b/src/games/rdr1/PSApplyHDR10PQGammaCorrect.0x56F79BAD.ps_6_0.hlsl
@@ -1,3 +1,4 @@
+#include "./hueHelper.hlsl"
 #include "./shared.h"
 
 Texture2D<float4> g_textures2D[] : register(t0, space2);
@@ -32,6 +33,8 @@ float4 main(
   float3 linearColor = renodx::color::gamma::DecodeSafe(gammaColor, 2.8);
 
   if (injectedData.toneMapType != 0) {
+    linearColor = clampedHueOKLab(linearColor, injectedData.toneMapHueCorrection);
+
     const float paperWhite = gameNits / renodx::color::srgb::REFERENCE_WHITE;
     linearColor *= paperWhite;
     const float peakWhite = injectedData.toneMapPeakNits / renodx::color::srgb::REFERENCE_WHITE;

--- a/src/games/rdr1/PSMiniAdapt.0xE033AAAD.ps_6_0.hlsl
+++ b/src/games/rdr1/PSMiniAdapt.0xE033AAAD.ps_6_0.hlsl
@@ -154,15 +154,7 @@ float4 main(
   float midGrayScale = RDR1ReinhardMidgrayScale(White);
   float3 untonemapped_scaled = color_scaled * midGrayScale;
 
-  float3 untonemappedBlendWeight;
-  if (injectedData.toneMapType == 0) {  // Vanilla
-    untonemappedBlendWeight = 0;
-  } else if (injectedData.toneMapType == 1) {
-    untonemappedBlendWeight = 0.5;
-  } else {
-    untonemappedBlendWeight = 1;  // Vanilla+ Boosted
-  }
-  float3 blendedColor = lerp(vanillaColor, lerp(vanillaColor, untonemapped_scaled, untonemappedBlendWeight), saturate(vanillaColor));
+  float3 blendedColor = injectedData.toneMapType ? lerp(vanillaColor, untonemapped_scaled, saturate(vanillaColor)) : vanillaColor;
 
   _37 = blendedColor.r;
   _38 = blendedColor.g;
@@ -198,21 +190,20 @@ float4 main(
   if (injectedData.toneMapType == 0) {
     desaturatedColorSDR = saturate(desaturatedColorHDR);
   } else {
-    desaturatedColorSDR = saturate(renodx::tonemap::dice::BT709(desaturatedColorHDR, 1.0));
+    desaturatedColorSDR = renoDRTSmoothClamp(desaturatedColorHDR);
   }
   float3 contrastedColor = desaturatedColorSDR - (((desaturatedColorSDR * Contrast) * (desaturatedColorSDR - 1.0)) * (desaturatedColorSDR - 0.5));
 
   float3 outputColor = contrastedColor;
 
-#if 1  // use upgradetonemap() to apply SDR contrast to HDR
-  float3 upgradedColor = renodx::tonemap::UpgradeToneMap(desaturatedColorHDR, desaturatedColorSDR, outputColor, 1.f);
+  if (injectedData.toneMapType) {
+    float3 upgradedColor = renodx::tonemap::UpgradeToneMap(desaturatedColorHDR, desaturatedColorSDR, outputColor, 1.f);
 
-  // blend vanillaColor back in to fix differences in contrast
-  float3 vanillaDesaturatedColor = saturate(desaturatedColorHDR);
-  float3 vanillaContrastedColor = vanillaDesaturatedColor - (((vanillaDesaturatedColor * Contrast) * (vanillaDesaturatedColor - 1.0)) * (vanillaDesaturatedColor - 0.5));
-  outputColor = lerp(saturate(vanillaContrastedColor), upgradedColor, saturate(vanillaContrastedColor));
-#endif
-
+    // blend vanillaColor back in to fix differences in contrast
+    float3 vanillaDesaturatedColor = saturate(desaturatedColorHDR);
+    float3 vanillaContrastedColor = vanillaDesaturatedColor - (((vanillaDesaturatedColor * Contrast) * (vanillaDesaturatedColor - 1.0)) * (vanillaDesaturatedColor - 0.5));
+    outputColor = lerp((vanillaContrastedColor), upgradedColor, saturate(vanillaContrastedColor));
+  }
   float3 gammaEncodedColor = renodx::color::gamma::Encode(max(0, outputColor), 2.2f);
   return float4(gammaEncodedColor, IntensityBloom);
 }

--- a/src/games/rdr1/PSRDR2PostfxOptics_0xEEEE53C5.ps_6_0.hlsl
+++ b/src/games/rdr1/PSRDR2PostfxOptics_0xEEEE53C5.ps_6_0.hlsl
@@ -263,15 +263,7 @@ float4 main(
   float midGrayScale = RDR1ReinhardMidgrayScale(White);
   float3 untonemapped_scaled = color_scaled * midGrayScale;
 
-  float3 untonemappedBlendWeight;
-  if (injectedData.toneMapType == 0) {  // Vanilla
-    untonemappedBlendWeight = 0;
-  } else if (injectedData.toneMapType == 1) {
-    untonemappedBlendWeight = 0.5;
-  } else {
-    untonemappedBlendWeight = 1;  // Vanilla+ Boosted
-  }
-  float3 blendedColor = lerp(vanillaColor, lerp(vanillaColor, untonemapped_scaled, untonemappedBlendWeight), saturate(vanillaColor));
+  float3 blendedColor = injectedData.toneMapType ? lerp(vanillaColor, untonemapped_scaled, saturate(vanillaColor)) : vanillaColor;
 
   _191 = blendedColor.r;
   _192 = blendedColor.g;
@@ -311,21 +303,20 @@ float4 main(
   if (injectedData.toneMapType == 0) {
     desaturatedColorSDR = saturate(desaturatedColorHDR);
   } else {
-    desaturatedColorSDR = saturate(renodx::tonemap::dice::BT709(desaturatedColorHDR, 1.0));
+    desaturatedColorSDR = renoDRTSmoothClamp(desaturatedColorHDR);
   }
   float3 contrastedColor = desaturatedColorSDR - (((desaturatedColorSDR * Contrast) * (desaturatedColorSDR - 1.0)) * (desaturatedColorSDR - 0.5));
 
   float3 outputColor = contrastedColor;
 
-#if 1  // use upgradetonemap() to apply SDR contrast to HDR
-  float3 upgradedColor = renodx::tonemap::UpgradeToneMap(desaturatedColorHDR, desaturatedColorSDR, outputColor, 1.f);
+  if (injectedData.toneMapType) {
+    float3 upgradedColor = renodx::tonemap::UpgradeToneMap(desaturatedColorHDR, desaturatedColorSDR, outputColor, 1.f);
 
-  // blend vanillaColor back in to fix differences in contrast
-  float3 vanillaDesaturatedColor = saturate(desaturatedColorHDR);
-  float3 vanillaContrastedColor = vanillaDesaturatedColor - (((vanillaDesaturatedColor * Contrast) * (vanillaDesaturatedColor - 1.0)) * (vanillaDesaturatedColor - 0.5));
-  outputColor = lerp(saturate(vanillaContrastedColor), upgradedColor, saturate(vanillaContrastedColor));
-#endif
-
+    // blend vanillaColor back in to fix differences in contrast
+    float3 vanillaDesaturatedColor = saturate(desaturatedColorHDR);
+    float3 vanillaContrastedColor = vanillaDesaturatedColor - (((vanillaDesaturatedColor * Contrast) * (vanillaDesaturatedColor - 1.0)) * (vanillaDesaturatedColor - 0.5));
+    outputColor = lerp((vanillaContrastedColor), upgradedColor, saturate(vanillaContrastedColor));
+  }
   float3 gammaEncodedColor = renodx::color::gamma::Encode(max(0, outputColor), 2.2f);
 
   return float4(gammaEncodedColor, 1.0);

--- a/src/games/rdr1/PSRDR2PostfxSoftCutsceneDof.0x9761FB07.ps_6_0.hlsl
+++ b/src/games/rdr1/PSRDR2PostfxSoftCutsceneDof.0x9761FB07.ps_6_0.hlsl
@@ -237,15 +237,7 @@ float4 main(float4 SV_Position: SV_POSITION,
   float midGrayScale = RDR1ReinhardMidgrayScale(White);
   float3 untonemapped_scaled = color_scaled * midGrayScale;
 
-  float3 untonemappedBlendWeight;
-  if (injectedData.toneMapType == 0) {  // Vanilla
-    untonemappedBlendWeight = 0;
-  } else if (injectedData.toneMapType == 1) {
-    untonemappedBlendWeight = 0.5;
-  } else {
-    untonemappedBlendWeight = 1;  // Vanilla+ Boosted
-  }
-  float3 blendedColor = lerp(vanillaColor, lerp(vanillaColor, untonemapped_scaled, untonemappedBlendWeight), saturate(vanillaColor));
+  float3 blendedColor = injectedData.toneMapType ? lerp(vanillaColor, untonemapped_scaled, saturate(vanillaColor)) : vanillaColor;
 
   _140 = blendedColor.r;
   _141 = blendedColor.g;
@@ -294,21 +286,20 @@ float4 main(float4 SV_Position: SV_POSITION,
   if (injectedData.toneMapType == 0) {
     desaturatedColorSDR = saturate(desaturatedColorHDR);
   } else {
-    desaturatedColorSDR = saturate(renodx::tonemap::dice::BT709(desaturatedColorHDR, 1.0));
+    desaturatedColorSDR = renoDRTSmoothClamp(desaturatedColorHDR);
   }
   float3 contrastedColor = desaturatedColorSDR - (((desaturatedColorSDR * Contrast) * (desaturatedColorSDR - 1.0)) * (desaturatedColorSDR - 0.5));
 
   float3 outputColor = contrastedColor;
 
-#if 1  // use upgradetonemap() to apply SDR contrast to HDR
-  float3 upgradedColor = renodx::tonemap::UpgradeToneMap(desaturatedColorHDR, desaturatedColorSDR, outputColor, 1.f);
+  if (injectedData.toneMapType) {
+    float3 upgradedColor = renodx::tonemap::UpgradeToneMap(desaturatedColorHDR, desaturatedColorSDR, outputColor, 1.f);
 
-  // blend vanillaColor back in to fix differences in contrast
-  float3 vanillaDesaturatedColor = saturate(desaturatedColorHDR);
-  float3 vanillaContrastedColor = vanillaDesaturatedColor - (((vanillaDesaturatedColor * Contrast) * (vanillaDesaturatedColor - 1.0)) * (vanillaDesaturatedColor - 0.5));
-  outputColor = lerp(saturate(vanillaContrastedColor), upgradedColor, saturate(vanillaContrastedColor));
-#endif
-
+    // blend vanillaColor back in to fix differences in contrast
+    float3 vanillaDesaturatedColor = saturate(desaturatedColorHDR);
+    float3 vanillaContrastedColor = vanillaDesaturatedColor - (((vanillaDesaturatedColor * Contrast) * (vanillaDesaturatedColor - 1.0)) * (vanillaDesaturatedColor - 0.5));
+    outputColor = lerp((vanillaContrastedColor), upgradedColor, saturate(vanillaContrastedColor));
+  }
   float3 gammaEncodedColor = renodx::color::gamma::Encode(max(0, outputColor), 2.2f);
 
   return float4(gammaEncodedColor, 1.0);

--- a/src/games/rdr1/PSRDR2PostfxSoftCutsceneDofOptics.0x632ABCB2.ps_6_0.hlsl
+++ b/src/games/rdr1/PSRDR2PostfxSoftCutsceneDofOptics.0x632ABCB2.ps_6_0.hlsl
@@ -294,15 +294,7 @@ float4 main(float4 SV_Position: SV_POSITION,
   float midGrayScale = RDR1ReinhardMidgrayScale(White);
   float3 untonemapped_scaled = color_scaled * midGrayScale;
 
-  float3 untonemappedBlendWeight;
-  if (injectedData.toneMapType == 0) {  // Vanilla
-    untonemappedBlendWeight = 0;
-  } else if (injectedData.toneMapType == 1) {
-    untonemappedBlendWeight = 0.5;
-  } else {
-    untonemappedBlendWeight = 1;  // Vanilla+ Boosted
-  }
-  float3 blendedColor = lerp(vanillaColor, lerp(vanillaColor, untonemapped_scaled, untonemappedBlendWeight), saturate(vanillaColor));
+  float3 blendedColor = injectedData.toneMapType ? lerp(vanillaColor, untonemapped_scaled, saturate(vanillaColor)) : vanillaColor;
 
   _211 = blendedColor.r;
   _212 = blendedColor.g;
@@ -381,21 +373,20 @@ float4 main(float4 SV_Position: SV_POSITION,
   if (injectedData.toneMapType == 0) {
     desaturatedColorSDR = saturate(desaturatedColorHDR);
   } else {
-    desaturatedColorSDR = saturate(renodx::tonemap::dice::BT709(desaturatedColorHDR, 1.0));
+    desaturatedColorSDR = renoDRTSmoothClamp(desaturatedColorHDR);
   }
   float3 contrastedColor = desaturatedColorSDR - (((desaturatedColorSDR * Contrast) * (desaturatedColorSDR - 1.0)) * (desaturatedColorSDR - 0.5));
 
   float3 outputColor = contrastedColor;
 
-#if 1  // use upgradetonemap() to apply SDR contrast to HDR
-  float3 upgradedColor = renodx::tonemap::UpgradeToneMap(desaturatedColorHDR, desaturatedColorSDR, outputColor, 1.f);
+  if (injectedData.toneMapType) {
+    float3 upgradedColor = renodx::tonemap::UpgradeToneMap(desaturatedColorHDR, desaturatedColorSDR, outputColor, 1.f);
 
-  // blend vanillaColor back in to fix differences in contrast
-  float3 vanillaDesaturatedColor = saturate(desaturatedColorHDR);
-  float3 vanillaContrastedColor = vanillaDesaturatedColor - (((vanillaDesaturatedColor * Contrast) * (vanillaDesaturatedColor - 1.0)) * (vanillaDesaturatedColor - 0.5));
-  outputColor = lerp(saturate(vanillaContrastedColor), upgradedColor, saturate(vanillaContrastedColor));
-#endif
-
+    // blend vanillaColor back in to fix differences in contrast
+    float3 vanillaDesaturatedColor = saturate(desaturatedColorHDR);
+    float3 vanillaContrastedColor = vanillaDesaturatedColor - (((vanillaDesaturatedColor * Contrast) * (vanillaDesaturatedColor - 1.0)) * (vanillaDesaturatedColor - 0.5));
+    outputColor = lerp((vanillaContrastedColor), upgradedColor, saturate(vanillaContrastedColor));
+  }
   float3 gammaEncodedColor = renodx::color::gamma::Encode(max(0, outputColor), 2.2f);
 
   return float4(gammaEncodedColor, 1.0);

--- a/src/games/rdr1/PSRDR2PostfxSoftDof.0xCCC43328.ps_6_0.hlsl
+++ b/src/games/rdr1/PSRDR2PostfxSoftDof.0xCCC43328.ps_6_0.hlsl
@@ -186,15 +186,7 @@ float4 main(float4 SV_Position: SV_POSITION,
   float midGrayScale = RDR1ReinhardMidgrayScale(White);
   float3 untonemapped_scaled = color_scaled * midGrayScale;
 
-  float3 untonemappedBlendWeight;
-  if (injectedData.toneMapType == 0) {  // Vanilla
-    untonemappedBlendWeight = 0;
-  } else if (injectedData.toneMapType == 1) {
-    untonemappedBlendWeight = 0.5;
-  } else {
-    untonemappedBlendWeight = 1;  // Vanilla+ Boosted
-  }
-  float3 blendedColor = lerp(vanillaColor, lerp(vanillaColor, untonemapped_scaled, untonemappedBlendWeight), saturate(vanillaColor));
+  float3 blendedColor = injectedData.toneMapType ? lerp(vanillaColor, untonemapped_scaled, saturate(vanillaColor)) : vanillaColor;
 
   _93 = blendedColor.r;
   _94 = blendedColor.g;
@@ -236,21 +228,20 @@ float4 main(float4 SV_Position: SV_POSITION,
   if (injectedData.toneMapType == 0) {
     desaturatedColorSDR = saturate(desaturatedColorHDR);
   } else {
-    desaturatedColorSDR = saturate(renodx::tonemap::dice::BT709(desaturatedColorHDR, 1.0));
+    desaturatedColorSDR = renoDRTSmoothClamp(desaturatedColorHDR);
   }
   float3 contrastedColor = desaturatedColorSDR - (((desaturatedColorSDR * Contrast) * (desaturatedColorSDR - 1.0)) * (desaturatedColorSDR - 0.5));
 
   float3 outputColor = contrastedColor;
 
-#if 1  // use upgradetonemap() to apply SDR contrast to HDR
-  float3 upgradedColor = renodx::tonemap::UpgradeToneMap(desaturatedColorHDR, desaturatedColorSDR, outputColor, 1.f);
+  if (injectedData.toneMapType) {
+    float3 upgradedColor = renodx::tonemap::UpgradeToneMap(desaturatedColorHDR, desaturatedColorSDR, outputColor, 1.f);
 
-  // blend vanillaColor back in to fix differences in contrast
-  float3 vanillaDesaturatedColor = saturate(desaturatedColorHDR);
-  float3 vanillaContrastedColor = vanillaDesaturatedColor - (((vanillaDesaturatedColor * Contrast) * (vanillaDesaturatedColor - 1.0)) * (vanillaDesaturatedColor - 0.5));
-  outputColor = lerp(saturate(vanillaContrastedColor), upgradedColor, saturate(vanillaContrastedColor));
-#endif
-
+    // blend vanillaColor back in to fix differences in contrast
+    float3 vanillaDesaturatedColor = saturate(desaturatedColorHDR);
+    float3 vanillaContrastedColor = vanillaDesaturatedColor - (((vanillaDesaturatedColor * Contrast) * (vanillaDesaturatedColor - 1.0)) * (vanillaDesaturatedColor - 0.5));
+    outputColor = lerp((vanillaContrastedColor), upgradedColor, saturate(vanillaContrastedColor));
+  }
   // allowing negatives adds no wcg while causing artifacts in pause menu
   float3 gammaEncodedColor = renodx::color::gamma::Encode(max(0, outputColor), 2.2f);
 

--- a/src/games/rdr1/PSRDR2Postfx_0x4EAF2BC7.ps_6_0.hlsl
+++ b/src/games/rdr1/PSRDR2Postfx_0x4EAF2BC7.ps_6_0.hlsl
@@ -142,15 +142,7 @@ float4 main(float4 SV_Position: SV_POSITION,
   float midGrayScale = RDR1ReinhardMidgrayScale(White);
   float3 untonemapped_scaled = color_scaled * midGrayScale;
 
-  float3 untonemappedBlendWeight;
-  if (injectedData.toneMapType == 0) {  // Vanilla
-    untonemappedBlendWeight = 0;
-  } else if (injectedData.toneMapType == 1) {
-    untonemappedBlendWeight = 0.5;
-  } else {
-    untonemappedBlendWeight = 1;  // Vanilla+ Boosted
-  }
-  float3 blendedColor = lerp(vanillaColor, lerp(vanillaColor, untonemapped_scaled, untonemappedBlendWeight), saturate(vanillaColor));
+  float3 blendedColor = injectedData.toneMapType ? lerp(vanillaColor, untonemapped_scaled, saturate(vanillaColor)) : vanillaColor;
 
   tonemappedColor = blendedColor;
 #endif
@@ -173,20 +165,20 @@ float4 main(float4 SV_Position: SV_POSITION,
   if (injectedData.toneMapType == 0) {
     desaturatedColorSDR = saturate(desaturatedColorHDR);
   } else {
-    desaturatedColorSDR = saturate(renodx::tonemap::dice::BT709(desaturatedColorHDR, 1.0));
+    desaturatedColorSDR = renoDRTSmoothClamp(desaturatedColorHDR);
   }
   float3 contrastedColor = desaturatedColorSDR - (((desaturatedColorSDR * Contrast) * (desaturatedColorSDR - 1.0)) * (desaturatedColorSDR - 0.5));
 
   float3 outputColor = contrastedColor;
 
-#if 1  // use upgradetonemap() to apply SDR contrast to HDR
-  float3 upgradedColor = renodx::tonemap::UpgradeToneMap(desaturatedColorHDR, desaturatedColorSDR, outputColor, 1.f);
-
-  // blend vanillaColor back in to fix differences in contrast
-  float3 vanillaDesaturatedColor = saturate(desaturatedColorHDR);
-  float3 vanillaContrastedColor = vanillaDesaturatedColor - (((vanillaDesaturatedColor * Contrast) * (vanillaDesaturatedColor - 1.0)) * (vanillaDesaturatedColor - 0.5));
-  outputColor = lerp(saturate(vanillaContrastedColor), upgradedColor, saturate(vanillaContrastedColor));
-#endif
+  if (injectedData.toneMapType) {
+    float3 upgradedColor = renodx::tonemap::UpgradeToneMap(desaturatedColorHDR, desaturatedColorSDR, outputColor, 1.f);
+    
+    // blend vanillaColor back in to fix differences in contrast
+    float3 vanillaDesaturatedColor = saturate(desaturatedColorHDR);
+    float3 vanillaContrastedColor = vanillaDesaturatedColor - (((vanillaDesaturatedColor * Contrast) * (vanillaDesaturatedColor - 1.0)) * (vanillaDesaturatedColor - 0.5));
+    outputColor = lerp((vanillaContrastedColor), upgradedColor, saturate(vanillaContrastedColor));
+  }
 
   // allowing negatives adds no wcg while causing artifacts in pause menu
   float3 gammaEncodedColor = renodx::color::gamma::Encode(max(0, outputColor), 2.2f);

--- a/src/games/rdr1/addon.cpp
+++ b/src/games/rdr1/addon.cpp
@@ -46,6 +46,8 @@ renodx::mods::shader::CustomShaders custom_shaders = {
 };
 
 ShaderInjectData shader_injection;
+const std::string build_date = __DATE__;
+const std::string build_time = __TIME__;
 
 renodx::utils::settings::Settings settings = {
     new renodx::utils::settings::Setting{
@@ -57,7 +59,7 @@ renodx::utils::settings::Settings settings = {
         .label = "Tone Mapper",
         .section = "Tone Mapping",
         .tooltip = "Sets the tone mapper type",
-        .labels = {"Vanilla", "Vanilla+", "Vanilla+ Boosted"},
+        .labels = {"Vanilla", "Vanilla+"},
     },
     new renodx::utils::settings::Setting{
         .key = "toneMapPeakNits",
@@ -71,11 +73,39 @@ renodx::utils::settings::Settings settings = {
         .max = 4000.f,
         .is_enabled = []() { return shader_injection.toneMapType != 0; },
     },
+    new renodx::utils::settings::Setting{
+        .key = "toneMapHueCorrection",
+        .binding = &shader_injection.toneMapHueCorrection,
+        .default_value = 75.f,
+        .label = "Hue Correction",
+        .section = "Tone Mapping",
+        .tooltip = "Emulates hue shifting from the vanilla tonemapper",
+        .max = 100.f,
+        .is_enabled = []() { return shader_injection.toneMapType != 0; },
+        .parse = [](float value) { return value * 0.01f; },
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::TEXT,
+        .label = "This build was compiled on " + build_date + " at " + build_time + ".",
+        .section = "About",
+    },
 };
 
 void OnPresetOff() {
   renodx::utils::settings::UpdateSetting("toneMapType", 0.f);
   renodx::utils::settings::UpdateSetting("toneMapPeakNits", 203.f);
+}
+
+bool fired_on_init_swapchain = false;
+
+void OnInitSwapchain(reshade::api::swapchain* swapchain) {
+  if (fired_on_init_swapchain) return;
+  fired_on_init_swapchain = true;
+  auto peak = renodx::utils::swapchain::GetPeakNits(swapchain);
+  if (peak.has_value()) {
+    settings[1]->default_value = peak.value();
+    settings[1]->can_reset = true;
+  }
 }
 
 }  // namespace
@@ -95,9 +125,10 @@ BOOL APIENTRY DllMain(HMODULE h_module, DWORD fdw_reason, LPVOID lpv_reserved) {
       renodx::mods::shader::expected_constant_buffer_space = 50;
 
       if (!reshade::register_addon(h_module)) return FALSE;
-
+      reshade::register_event<reshade::addon_event::init_swapchain>(OnInitSwapchain);
       break;
     case DLL_PROCESS_DETACH:
+      reshade::unregister_event<reshade::addon_event::init_swapchain>(OnInitSwapchain);
       reshade::unregister_addon(h_module);
       break;
   }

--- a/src/games/rdr1/addon.cpp
+++ b/src/games/rdr1/addon.cpp
@@ -25,6 +25,7 @@
 #include <embed/0x56F79BAD.h>  // PQ Encoding
 
 #include "../../mods/shader.hpp"
+#include "../../utils/date.hpp"
 #include "../../utils/settings.hpp"
 #include "./shared.h"
 
@@ -46,8 +47,6 @@ renodx::mods::shader::CustomShaders custom_shaders = {
 };
 
 ShaderInjectData shader_injection;
-const std::string build_date = __DATE__;
-const std::string build_time = __TIME__;
 
 renodx::utils::settings::Settings settings = {
     new renodx::utils::settings::Setting{
@@ -116,7 +115,7 @@ renodx::utils::settings::Settings settings = {
     },
     new renodx::utils::settings::Setting{
         .value_type = renodx::utils::settings::SettingValueType::TEXT,
-        .label = "This build was compiled on " + build_date + " at " + build_time + ".",
+        .label = std::string("Build: ") + renodx::utils::date::ISO_DATE_TIME,
         .section = "About",
     },
 };

--- a/src/games/rdr1/addon.cpp
+++ b/src/games/rdr1/addon.cpp
@@ -85,6 +85,36 @@ renodx::utils::settings::Settings settings = {
         .parse = [](float value) { return value * 0.01f; },
     },
     new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::BUTTON,
+        .label = "Discord",
+        .section = "Links",
+        .group = "button-line-1",
+        .tint = 0x5865F2,
+        .on_change = []() {
+          ShellExecute(0, "open", (std::string("https://discord.gg/") + "5WZXDpmbpP").c_str(), 0, 0, SW_SHOW);
+        },
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::BUTTON,
+        .label = "More Mods",
+        .section = "Links",
+        .group = "button-line-1",
+        .tint = 0x2B3137,
+        .on_change = []() {
+          ShellExecute(0, "open", (std::string("https://github.com/") + "clshortfuse/renodx/wiki/Mods").c_str(), 0, 0, SW_SHOW);
+        },
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::BUTTON,
+        .label = "Github",
+        .section = "Links",
+        .group = "button-line-1",
+        .tint = 0x2B3137,
+        .on_change = []() {
+          ShellExecute(0, "open", (std::string("https://github.com/") + "clshortfuse/renodx").c_str(), 0, 0, SW_SHOW);
+        },
+    },
+    new renodx::utils::settings::Setting{
         .value_type = renodx::utils::settings::SettingValueType::TEXT,
         .label = "This build was compiled on " + build_date + " at " + build_time + ".",
         .section = "About",

--- a/src/games/rdr1/hueHelper.hlsl
+++ b/src/games/rdr1/hueHelper.hlsl
@@ -1,0 +1,86 @@
+#include "./shared.h"
+
+// Applies the hue shifts from clamping input_color while minimizing broken gradients
+float3 clampedHueOKLab(float3 input_color, float correct_amount = 1.f) {
+  // If no correction is needed, return the original color
+  if (correct_amount == 0) {
+    return input_color;
+  } else {
+    // Calculate average channel values of the original (unclamped) input_color
+    float avg_unclamped = renodx::math::Average(input_color);
+
+    // calculate average channel values for the clamped input_color
+    float3 clamped_color = saturate(input_color);
+    float avg_clamped = renodx::math::Average(clamped_color);
+
+    // Compute the hue clipping percentage based on the difference in averages
+    float hue_clip_percentage = saturate((avg_unclamped - avg_clamped) / max(avg_unclamped, renodx::math::FLT_MIN));  // Prevent division by zero
+
+    // Interpolate hue components (a, b in OkLab) based on correct_amount using clamped_color
+    float3 correct_lab = renodx::color::oklab::from::BT709(clamped_color);
+    float3 incorrect_lab = renodx::color::oklab::from::BT709(input_color);
+    float3 new_lab = incorrect_lab;
+
+    // Apply hue correction based on clipping percentage and interpolate based on correct_amount
+    new_lab.yz = lerp(incorrect_lab.yz, correct_lab.yz, hue_clip_percentage);
+    new_lab.yz = lerp(incorrect_lab.yz, new_lab.yz, abs(correct_amount));
+
+    // Restore original chrominance from input_color in OkLCh space
+    float3 incorrect_lch = renodx::color::oklch::from::OkLab(incorrect_lab);
+    float3 new_lch = renodx::color::oklch::from::OkLab(new_lab);
+    new_lch[1] = incorrect_lch[1];
+
+    // Convert back to linear BT.709 space
+    float3 color = renodx::color::bt709::from::OkLCh(new_lch);
+    return color;
+  }
+}
+
+// Emulates hue shifts caused by clamping to SDR while minimizing artifacts.
+// This function dynamically adjusts the hue of the HDR input color to align
+// with the hue shifts observed in clamped SDR colors, while preserving luminance
+// and chrominance balance to avoid broken gradients or oversaturation.
+float3 clampedHueICtCp(float3 input_color, float correct_amount = 1.f) {
+  // Return the original color if no correction is needed.
+  if (correct_amount == 0.f) return input_color;
+
+  // Calculate the average luminance of the unclamped (HDR) input color.
+  float avg_unclamped = renodx::color::y::from::BT709(input_color);
+
+  // Clamp the input color to SDR range [0, 1] and calculate its average luminance.
+  float3 clamped_color = saturate(input_color);
+  float avg_clamped = renodx::color::y::from::BT709(clamped_color);
+
+  // Compute the hue clipping percentage by comparing the luminance difference
+  // between the unclamped and clamped colors. Use safe division to avoid divide-by-zero.
+  float hue_clip_percentage = saturate(renodx::math::DivideSafe(avg_unclamped - avg_clamped, avg_unclamped, 0.f));
+
+  // Convert the clamped and input colors to the ICTCP color space for hue manipulation.
+  float3 correct_perceptual = renodx::color::ictcp::from::BT709(clamped_color);
+  float3 incorrect_perceptual = renodx::color::ictcp::from::BT709(input_color);
+
+  // Measure the initial chrominance magnitude of the input color (distance from neutral).
+  float chrominance_pre_adjust = distance(incorrect_perceptual.yz, 0);
+
+  // Interpolate the chroma components (CT, CP) of the input color towards the clamped color's chroma.
+  // This creates a smooth hue transition proportional to the clipping percentage.
+  incorrect_perceptual.yz = lerp(incorrect_perceptual.yz, correct_perceptual.yz, hue_clip_percentage);
+
+  // Further interpolate based on the correction strength to control the intensity of the hue shift.
+  incorrect_perceptual.yz = lerp(incorrect_perceptual.yz, correct_perceptual.yz, abs(correct_amount));
+
+  // Recalculate the chrominance magnitude after adjustment to ensure it remains balanced.
+  float chrominance_post_adjust = distance(incorrect_perceptual.yz, 0);
+
+  // Scale the chroma components to preserve the original chrominance magnitude, preventing oversaturation.
+  incorrect_perceptual.yz *= renodx::math::DivideSafe(chrominance_pre_adjust, chrominance_post_adjust, 1.f);
+
+  // Convert the adjusted ICTCP color back to the linear BT.709 color space.
+  float3 color = renodx::color::bt709::from::ICtCp(incorrect_perceptual);
+
+  // Clamp the final output to ensure it remains within the valid gamut of BT.709/AP1.
+  color = renodx::color::bt709::clamp::AP1(color);
+
+  return color;
+}
+

--- a/src/games/rdr1/shared.h
+++ b/src/games/rdr1/shared.h
@@ -10,6 +10,7 @@
 struct ShaderInjectData {
   float toneMapType;
   float toneMapPeakNits;
+  float toneMapHueCorrection;
 };
 
 #ifndef __cplusplus

--- a/src/games/rdr1/tonemaphelper.hlsl
+++ b/src/games/rdr1/tonemaphelper.hlsl
@@ -1,3 +1,5 @@
+#include "./shared.h"
+
 /// Inverse of the Reinhard tonemapping function used in RDR1.
 ///
 /// Reconstructs the original linear HDR value from its Extended Reinhard
@@ -32,12 +34,40 @@ float RDR1ReinhardMidgray(float whitePoint) {
 /// Computes the scale factor for aligning mid-gray levels in RDR1.
 ///
 /// This function returns a scaling factor to map the untonemapped image's scene referred
-/// mid-gray to align with the Reinhard tone-mapped's scene referred mid-gray. 
+/// mid-gray to align with the Reinhard tone-mapped's scene referred mid-gray.
 /// This ensures that the blended result retains the original game's visual art direction
 /// while enabling HDR highlights.
 ///
 /// @param whitePoint - The white point scaling factor used in the tonemapping.
 /// @return The scale factor for aligning mid-gray levels.
 float RDR1ReinhardMidgrayScale(float whitePoint) {
-  return RDR1ReinhardMidgray(whitePoint) / 0.18;
+  return 0.18 / RDR1ReinhardMidgray(whitePoint);
+}
+
+/// Applies a customized version of RenoDRT tonemapper that tonemaps down to 1.0.
+/// This function is used to compress HDR color to SDR range for use alongside `UpgradeToneMap`.
+///
+/// @param untonemapped The color input that needs to be tonemapped.
+/// @return The tonemapped color compressed to the SDR range, ensuring that it can be applied to SDR color grading with `UpgradeToneMap`.
+float3 renoDRTSmoothClamp(float3 untonemapped) {
+  renodx::tonemap::renodrt::Config renodrt_config = renodx::tonemap::renodrt::config::Create();
+  renodrt_config.nits_peak = 100.f;
+  renodrt_config.mid_gray_value = 0.18f;
+  renodrt_config.mid_gray_nits = 18.f;
+  renodrt_config.exposure = 1.f;
+  renodrt_config.highlights = 1.f;
+  renodrt_config.shadows = 1.f;
+  renodrt_config.contrast = 1.05f;
+  renodrt_config.saturation = 1.f;
+  renodrt_config.dechroma = 0.05f;
+  renodrt_config.flare = 0.f;
+  renodrt_config.hue_correction_strength = 0.f;
+  renodrt_config.hue_correction_method = renodx::tonemap::renodrt::config::hue_correction_method::OKLAB;
+  renodrt_config.tone_map_method = renodx::tonemap::renodrt::config::tone_map_method::DANIELE;
+  renodrt_config.hue_correction_type = renodx::tonemap::renodrt::config::hue_correction_type::INPUT;
+  renodrt_config.working_color_space = 2u;
+
+  float3 renoDRTColor = renodx::tonemap::renodrt::BT709(untonemapped, renodrt_config);
+
+  return saturate(renoDRTColor);
 }

--- a/src/games/rdr1/tonemaphelper.hlsl
+++ b/src/games/rdr1/tonemaphelper.hlsl
@@ -58,16 +58,19 @@ float3 renoDRTSmoothClamp(float3 untonemapped) {
   renodrt_config.highlights = 1.f;
   renodrt_config.shadows = 1.f;
   renodrt_config.contrast = 1.05f;
-  renodrt_config.saturation = 1.f;
-  renodrt_config.dechroma = 0.05f;
+  renodrt_config.saturation = 1.03f;
+  renodrt_config.dechroma = 0.f;
   renodrt_config.flare = 0.f;
+  renodrt_config.blowout = -1.f;
   renodrt_config.hue_correction_strength = 0.f;
-  renodrt_config.hue_correction_method = renodx::tonemap::renodrt::config::hue_correction_method::OKLAB;
+  renodrt_config.hue_correction_method = renodx::tonemap::renodrt::config::hue_correction_method::ICTCP;
   renodrt_config.tone_map_method = renodx::tonemap::renodrt::config::tone_map_method::DANIELE;
   renodrt_config.hue_correction_type = renodx::tonemap::renodrt::config::hue_correction_type::INPUT;
-  renodrt_config.working_color_space = 2u;
+  renodrt_config.working_color_space = 0u;
+  renodrt_config.per_channel = true;
 
   float3 renoDRTColor = renodx::tonemap::renodrt::BT709(untonemapped, renodrt_config);
+  renoDRTColor = lerp(untonemapped, renoDRTColor, saturate(renodx::color::y::from::BT709(untonemapped)));
 
   return saturate(renoDRTColor);
 }


### PR DESCRIPTION
**Red Dead Redemption:**
- add `RenoDRTSmoothClamp()` for use with `UpgradeToneMap()`
- add hue correction
- add links
- add build date and time

**Batman Arkham Knight:**
- add build date and time
- add tints to links