### PR TITLE
refactor(jedisurvivor): use new defines, reconfigure RenoDRT

### DIFF
--- a/src/games/jedisurvivor/03_vignette_0x0B7B2D74.ps_6_1.hlsl
+++ b/src/games/jedisurvivor/03_vignette_0x0B7B2D74.ps_6_1.hlsl
@@ -21,7 +21,7 @@ float4 main(float4 gl_FragCoord : SV_Position) : SV_Target {
                       _16_m0[6u].z),
                   min(max((_66 * _16_m0[5u].y) + _16_m0[4u].y, _16_m0[6u].y),
                       _16_m0[6u].w)));
-  if (injectedData.fxFishEye == 0.f) {
+  if (CUSTOM_FISHEYE == 0.f) {
     return float4(_96.rgb, 1.f);
   }
   float _99 = _96.x;
@@ -157,7 +157,7 @@ float4 main(float4 gl_FragCoord : SV_Position) : SV_Target {
   SV_Target.z = max(((_26_m0[1u].z - _317) * _26_m0[7u].x) + _317, 0.0f);
   SV_Target.w = 1.0f;
 
-  SV_Target.rgb = lerp(_96.rgb, SV_Target.rgb, injectedData.fxFishEye);
+  SV_Target.rgb = lerp(_96.rgb, SV_Target.rgb, CUSTOM_FISHEYE);
 
   return SV_Target;
 }

--- a/src/games/jedisurvivor/05_lower_vignette_0xD023A69B.ps_6_1.hlsl
+++ b/src/games/jedisurvivor/05_lower_vignette_0xD023A69B.ps_6_1.hlsl
@@ -17,7 +17,7 @@ float4 main(float4 gl_FragCoord : SV_Position, float4 TEXCOORD : TEXCOORD0) : SV
                   min(max((_56 * _15_m0[5u].y) + _15_m0[4u].y, _15_m0[6u].y),
                       _15_m0[6u].w)));
 
-  if (injectedData.fxVignette == 0.f) {
+  if (CUSTOM_VIGNETTE == 0.f) {
     return float4(_86.rgb, 1.f);
   }
 
@@ -48,7 +48,7 @@ float4 main(float4 gl_FragCoord : SV_Position, float4 TEXCOORD : TEXCOORD0) : SV
   SV_Target.z = max(((_20_m0[2u].z - _176) * _20_m0[6u].x) + _176, 0.0f);
   SV_Target.w = 1.0f;
 
-  SV_Target.rgb = lerp(_86.rgb, SV_Target.rgb, injectedData.fxVignette);
+  SV_Target.rgb = lerp(_86.rgb, SV_Target.rgb, CUSTOM_VIGNETTE);
 
   return SV_Target;
 }

--- a/src/games/jedisurvivor/08_lutbuilder_0x90BEE5D9.ps_6_1.hlsl
+++ b/src/games/jedisurvivor/08_lutbuilder_0x90BEE5D9.ps_6_1.hlsl
@@ -1,4 +1,5 @@
 #include "./shared.h"
+#include "./common.hlsl"
 
 static const float _35[6] = {-4.0f, -4.0f, -3.1573765277862548828125f, -0.485249996185302734375f, 1.84773242473602294921875f, 1.84773242473602294921875f};
 static const float _42[6] = {-0.718548238277435302734375f, 2.0810306072235107421875f, 3.66812419891357421875f, 4.0f, 4.0f, 4.0f};
@@ -692,64 +693,18 @@ void frag_main() {
   float _2241;
 
   testColor = float3(_1750, _1751, _1752);
-  // testColor = untonemapped;
+  
+  float exposureScale = 1.f;
+  float vanillaMidGray = 0.18 * exposureScale;
 
-  float renoDRTHighlights = 1.20f;
-  float renoDRTShadows = 1.0f;
-  float renoDRTContrast = 1.80f;
-  float renoDRTSaturation = 1.40f;
-  float renoDRTDechroma = 0.60f;
-  float renoDRTFlare = 0.f;
+  // custom tonemap
+  testColor = applyUserToneMap(testColor, vanillaMidGray);  
 
-  float vanillaMidGray = 0.18 * 1.5f;
-
-  testColor = renodx::tonemap::config::Apply(
-      testColor,
-      renodx::tonemap::config::Create(
-          injectedData.toneMapType,
-          injectedData.toneMapPeakNits,
-          injectedData.toneMapGameNits,
-          injectedData.toneMapGammaCorrection,
-          injectedData.colorGradeExposure,
-          injectedData.colorGradeHighlights,
-          injectedData.colorGradeShadows,
-          injectedData.colorGradeContrast,
-          injectedData.colorGradeSaturation,
-          vanillaMidGray,
-          vanillaMidGray * 100.f,
-          renoDRTHighlights,
-          renoDRTShadows,
-          renoDRTContrast,
-          renoDRTSaturation,
-          renoDRTDechroma,
-          renoDRTFlare)
-      // renodx::lut::config::Create(
-      //     _19,
-      //     injectedData.colorGradeLUTStrength,
-      //     injectedData.colorGradeLUTScaling,
-      //     renodx::lut::config::type::ARRI_C800,
-      //     renodx::lut::config::type::ARRI_C800,
-      //     _16_m0[67u].y),
-      // _8
-  );
   testColor = renodx::color::bt2020::from::BT709(testColor);
-  testColor = renodx::color::pq::Encode(testColor, injectedData.toneMapGameNits);
-  // if (injectedData.toneMapType == 0.f) {
-  //   // testColor = untonemapped;
-  //   testColor = renodx::color::bt2020::from::BT709(testColor);
-  // } else if (injectedData.toneMapType == 2.f) {
-  //   float hdrScale = (injectedData.toneMapPeakNits / injectedData.toneMapGameNits);
-  //   testColor = renodx::tonemap::aces::RGCAndRRTAndODT(
-  //                   testColor,
-  //                   0.0001f / (injectedData.toneMapGameNits / 48.f),
-  //                   48.f * hdrScale,
-  //                   renodx::color::AP1_TO_BT2020_MAT)
-  //               / 48.f;
-  //   // testColor = renodx::color::bt2020::from::BT709(testColor);
-  // }
+  testColor = renodx::color::pq::Encode(testColor, RENODX_DIFFUSE_WHITE_NITS);
 
   // _16_m0[41u].y = 1u
-  if (injectedData.toneMapType == 1.f) {
+  if (RENODX_TONE_MAP_TYPE == 1.f) {
     if (_1772 == 0u) {  // TONEMAPPER_OUTPUT_sRGB
       float _1854;
       float _1856;

--- a/src/games/jedisurvivor/common.hlsl
+++ b/src/games/jedisurvivor/common.hlsl
@@ -1,0 +1,48 @@
+#include "./shared.h"
+
+float3 applyUserToneMap(float3 untonemapped, float vanillaMidGray) {
+  renodx::tonemap::Config tm_config = renodx::tonemap::config::Create();
+
+  // ShortFuse's previous values
+  // float renoDRTHighlights = 1.20f;
+  // float renoDRTShadows = 1.0f;
+  // float renoDRTContrast = 1.80f;
+  // float renoDRTSaturation = 1.40f;
+  // float renoDRTDechroma = 0.60f;
+  // float renoDRTFlare = 0.f;
+
+  // RENOCES
+  float renoDRTHighlights = 0.925f;
+  float renoDRTShadows = 1.f;
+  float renoDRTContrast = 1.485f;
+  float renoDRTSaturation = 1.225f;
+  float renoDRTDechroma = 0.f;
+  float renoDRTFlare = 0.0205f;
+
+  tm_config.reno_drt_tone_map_method = renodx::tonemap::renodrt::config::tone_map_method::REINHARD;
+  tm_config.hue_correction_strength = RENODX_TONE_MAP_HUE_CORRECTION;
+  tm_config.hue_correction_type = renodx::tonemap::renodrt::config::hue_correction_type::CUSTOM;
+  tm_config.hue_correction_color = renodx::tonemap::ACESFittedAP1(untonemapped);
+  tm_config.reno_drt_per_channel = RENODX_TONE_MAP_PER_CHANNEL;
+  tm_config.type = RENODX_TONE_MAP_TYPE;
+  tm_config.peak_nits = RENODX_PEAK_WHITE_NITS;
+  tm_config.game_nits = RENODX_DIFFUSE_WHITE_NITS;
+  tm_config.gamma_correction = RENODX_GAMMA_CORRECTION;
+  tm_config.exposure = RENODX_TONE_MAP_EXPOSURE;
+  tm_config.highlights = RENODX_TONE_MAP_HIGHLIGHTS;
+  tm_config.shadows = RENODX_TONE_MAP_SHADOWS;
+  tm_config.contrast = RENODX_TONE_MAP_CONTRAST;
+  tm_config.saturation = RENODX_TONE_MAP_SATURATION;
+  tm_config.reno_drt_highlights = renoDRTHighlights;
+  tm_config.reno_drt_shadows = renoDRTShadows;
+  tm_config.reno_drt_contrast = renoDRTContrast;
+  tm_config.reno_drt_saturation = renoDRTSaturation;
+  tm_config.reno_drt_dechroma = renoDRTDechroma;
+  tm_config.reno_drt_blowout = RENODX_TONE_MAP_HIGHLIGHT_SATURATION;
+  tm_config.mid_gray_value = vanillaMidGray;
+  tm_config.mid_gray_nits = vanillaMidGray * 100.f;
+  tm_config.reno_drt_flare = renoDRTFlare;
+  tm_config.reno_drt_working_color_space = RENODX_TONE_MAP_WORKING_COLOR_SPACE;
+
+  return renodx::tonemap::config::Apply(untonemapped, tm_config);
+}

--- a/src/games/jedisurvivor/shared.h
+++ b/src/games/jedisurvivor/shared.h
@@ -1,6 +1,30 @@
 #ifndef SRC_GAMES_JEDISURVIVOR_SHARED_H_
 #define SRC_GAMES_JEDISURVIVOR_SHARED_H_
 
+#define RENODX_PEAK_WHITE_NITS               1000
+#define RENODX_DIFFUSE_WHITE_NITS            203
+#define RENODX_GRAPHICS_WHITE_NITS           203
+#define RENODX_TONE_MAP_TYPE                 3
+#define RENODX_TONE_MAP_EXPOSURE             1
+#define RENODX_TONE_MAP_HIGHLIGHTS           1
+#define RENODX_TONE_MAP_SHADOWS              1
+#define RENODX_TONE_MAP_CONTRAST             1
+#define RENODX_TONE_MAP_SATURATION           1
+#define RENODX_TONE_MAP_HIGHLIGHT_SATURATION 0.025
+#define RENODX_TONE_MAP_BLOWOUT              0
+#define RENODX_TONE_MAP_FLARE                0
+#define RENODX_TONE_MAP_HUE_CORRECTION       0.6
+#define RENODX_TONE_MAP_HUE_SHIFT            0
+#define RENODX_TONE_MAP_WORKING_COLOR_SPACE  2
+#define RENODX_TONE_MAP_HUE_PROCESSOR        0
+#define RENODX_TONE_MAP_PER_CHANNEL          1
+#define RENODX_GAMMA_CORRECTION              0
+#define RENODX_GAMMA_CORRECTION_UI           0
+#define CUSTOM_LUT_STRENGTH                  1
+#define CUSTOM_LUT_SCALING                   0
+#define CUSTOM_FISHEYE                       1
+#define CUSTOM_VIGNETTE                      1
+
 #ifndef __cplusplus
 #include "../../shaders/renodx.hlsl"
 #endif
@@ -8,42 +32,21 @@
 // Must be 32bit aligned
 // Should be 4x32
 struct ShaderInjectData {
-  float toneMapType;
-  float toneMapPeakNits;
-  float toneMapGameNits;
-  float toneMapUINits;
-  float toneMapGammaCorrection;
-  float toneMapGammaCorrectionUI;
-  float colorGradeExposure;
-  float colorGradeHighlights;
-  float colorGradeShadows;
-  float colorGradeContrast;
-  float colorGradeSaturation;
-  float colorGradeLUTStrength;
-  float colorGradeLUTScaling;
-  float fxFishEye;
-  float fxVignette;
+  float tone_map_type;
+  float peak_white_nits;
+  float diffuse_white_nits;
+  float graphics_white_nits;
+  float gamma_correction;
+  float gamma_correction_ui;
+  float tone_map_exposure;
+  float tone_map_highlights;
+  float tone_map_shadows;
+  float tone_map_contrast;
+  float tone_map_saturation;
+  float custom_lut_strength;
+  float custom_lut_scaling;
+  float custom_fisheye;
+  float custom_vignette;
 };
-
-#ifndef __cplusplus
-static const ShaderInjectData injectedData = {
-  3.f, // toneMapType
-  800.f, // toneMapPeakNits
-  203.f, // toneMapGameNits
-  100.f, // toneMapUINits
-  0.f, // toneMapGammaCorrection
-  0.f, // toneMapGammaCorrectionUI
-  1.f, // colorGradeExposure
-  1.f, // colorGradeHighlights
-  1.f, // colorGradeShadows
-  1.f, // colorGradeContrast
-  1.f, // colorGradeSaturation
-  1.f, // colorGradeLUTStrength
-  1.f, // colorGradeLUTScaling
-  1.f, // fxFishEye
-  1.f, // fxVignette
-};
-#endif
-
 
 #endif  // SRC_GAMES_JEDISURVIVOR_SHARED_H_


### PR DESCRIPTION
Jedi Survivor has now been updated to use the new defines, code has been cleaned up, and RenoDRT defaults have been configured to more closely match ACES.