### PR TITLE
Add Splinter Cell: Blacklist Support to RenoDX

### DIFF
--- a/src/games/scblacklist/addon.cpp
+++ b/src/games/scblacklist/addon.cpp
@@ -1,0 +1,289 @@
+/*
+ * Copyright (C) 2024 Musa Haji
+ * Copyright (C) 2024 Carlos Lopez
+ * SPDX-License-Identifier: MIT
+ */
+
+#define ImTextureID ImU64
+
+#define DEBUG_LEVEL_0
+
+#include <embed/shaders.h>
+
+#include <deps/imgui/imgui.h>
+#include <include/reshade.hpp>
+
+#include "../../mods/shader.hpp"
+#include "../../mods/swapchain.hpp"
+#include "../../utils/date.hpp"
+#include "../../utils/settings.hpp"
+#include "./shared.h"
+
+namespace {
+
+renodx::mods::shader::CustomShaders custom_shaders = {
+    CustomShaderEntry(0xB615F379),  // Lens Flare
+    CustomShaderEntry(0x03DBB3FD),  // Tonemap
+    CustomShaderEntry(0x1E767A42),  // Final
+};
+
+ShaderInjectData shader_injection;
+
+renodx::utils::settings::Settings settings = {
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapType",
+        .binding = &RENODX_TONE_MAP_TYPE,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 2.f,
+        .can_reset = true,
+        .label = "Tone Mapper",
+        .section = "Tone Mapping",
+        .tooltip = "Sets the tone mapper type",
+        .labels = {"Vanilla", "None", "Exponential Rolloff"},
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapPeakNits",
+        .binding = &RENODX_PEAK_WHITE_NITS,
+        .default_value = 1000.f,
+        .can_reset = false,
+        .label = "Peak Brightness",
+        .section = "Tone Mapping",
+        .tooltip = "Sets the value of peak white in nits",
+        .min = 48.f,
+        .max = 4000.f,
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapGameNits",
+        .binding = &RENODX_DIFFUSE_WHITE_NITS,
+        .default_value = 203.f,
+        .label = "Game Brightness",
+        .section = "Tone Mapping",
+        .tooltip = "Sets the value of 100% white in nits",
+        .min = 48.f,
+        .max = 500.f,
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeExposure",
+        .binding = &RENODX_TONE_MAP_EXPOSURE,
+        .default_value = 1.f,
+        .label = "Exposure",
+        .section = "Color Grading",
+        .max = 2.f,
+        .format = "%.2f",
+        .is_enabled = []() { return settings[0]->GetValue() >= 1; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeHighlights",
+        .binding = &RENODX_TONE_MAP_HIGHLIGHTS,
+        .default_value = 50.f,
+        .label = "Highlights",
+        .section = "Color Grading",
+        .max = 100.f,
+        .is_enabled = []() { return settings[0]->GetValue() >= 1; },
+        .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeShadows",
+        .binding = &RENODX_TONE_MAP_SHADOWS,
+        .default_value = 50.f,
+        .label = "Shadows",
+        .section = "Color Grading",
+        .max = 100.f,
+        .is_enabled = []() { return settings[0]->GetValue() >= 1; },
+        .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeContrast",
+        .binding = &RENODX_TONE_MAP_CONTRAST,
+        .default_value = 50.f,
+        .label = "Contrast",
+        .section = "Color Grading",
+        .max = 100.f,
+        .is_enabled = []() { return settings[0]->GetValue() >= 1; },
+        .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeSaturation",
+        .binding = &RENODX_TONE_MAP_SATURATION,
+        .default_value = 50.f,
+        .label = "Saturation",
+        .section = "Color Grading",
+        .max = 100.f,
+        .is_enabled = []() { return settings[0]->GetValue() >= 1; },
+        .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeBlowout",
+        .binding = &RENODX_TONE_MAP_BLOWOUT,
+        .default_value = 0.f,
+        .label = "Blowout",
+        .section = "Color Grading",
+        .tooltip = "Controls highlight desaturation due to overexposure.",
+        .max = 100.f,
+        .is_enabled = []() { return settings[0]->GetValue() >= 1; },
+        .parse = [](float value) { return value * 0.01f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeLUTStrength",
+        .binding = &CUSTOM_LUT_STRENGTH,
+        .default_value = 100.f,
+        .label = "Color Tint Strength",
+        .section = "Color Grading",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.01f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "fxLensFlare",
+        .binding = &CUSTOM_LENS_FLARE,
+        .default_value = 50.f,
+        .label = "Lens Flare",
+        .section = "Effects",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "fxNoise",
+        .binding = &CUSTOM_NOISE,
+        .default_value = 50.f,
+        .label = "Noise",
+        .section = "Effects",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::BUTTON,
+        .label = "Reset All",
+        .section = "Options",
+        .group = "button-line-1",
+        .on_change = []() {
+          for (auto setting : settings) {
+            if (setting->key.empty()) continue;
+            if (!setting->can_reset) continue;
+            renodx::utils::settings::UpdateSetting(setting->key, setting->default_value);
+          }
+        },
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::BUTTON,
+        .label = "Discord",
+        .section = "Links",
+        .group = "button-line-2",
+        .tint = 0x5865F2,
+        .on_change = []() {
+          renodx::utils::platform::Launch(
+              "https://discord.gg/"
+              "5WZXDpmbpP");
+        },
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::BUTTON,
+        .label = "More Mods",
+        .section = "Links",
+        .group = "button-line-2",
+        .tint = 0x2B3137,
+        .on_change = []() {
+          renodx::utils::platform::Launch("https://github.com/clshortfuse/renodx/wiki/Mods");
+        },
+
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::BUTTON,
+        .label = "Github",
+        .section = "Links",
+        .group = "button-line-2",
+        .tint = 0x2B3137,
+        .on_change = []() {
+          renodx::utils::platform::Launch("https://github.com/clshortfuse/renodx");
+        },
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::BUTTON,
+        .label = "Musa's Ko-Fi",
+        .section = "Links",
+        .group = "button-line-3",
+        .tint = 0xFF5A16,
+        .on_change = []() { renodx::utils::platform::Launch("https://ko-fi.com/musaqh"); },
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::TEXT,
+        .label = std::string("Build: ") + renodx::utils::date::ISO_DATE_TIME,
+        .section = "About",
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::TEXT,
+        .label = std::string("- Set in-game brightness to 5\n"
+                             "- Use borderless windowed mode"),
+        .section = "About",
+    },
+
+};
+
+void OnPresetOff() {
+  renodx::utils::settings::UpdateSetting("ToneMapType", 0.f);
+  renodx::utils::settings::UpdateSetting("toneMapPeakNits", 203.f);
+  renodx::utils::settings::UpdateSetting("toneMapGameNits", 203.f);
+  renodx::utils::settings::UpdateSetting("colorGradeExposure", 1.f);
+  renodx::utils::settings::UpdateSetting("colorGradeHighlights", 50.f);
+  renodx::utils::settings::UpdateSetting("colorGradeShadows", 50.f);
+  renodx::utils::settings::UpdateSetting("colorGradeContrast", 50.f);
+  renodx::utils::settings::UpdateSetting("colorGradeSaturation", 50.f);
+  renodx::utils::settings::UpdateSetting("colorGradeBlowout", 0.f);
+  renodx::utils::settings::UpdateSetting("colorGradeLUTStrength", 100.f);
+  renodx::utils::settings::UpdateSetting("fxLensFlare", 50.f);
+  renodx::utils::settings::UpdateSetting("fxNoise", 50.f);
+}
+
+bool fired_on_init_swapchain = false;
+void OnInitSwapchain(reshade::api::swapchain* swapchain) {
+  if (fired_on_init_swapchain) return;
+  fired_on_init_swapchain = true;
+  auto peak = renodx::utils::swapchain::GetPeakNits(swapchain);
+  if (peak.has_value()) {
+    settings[1]->default_value = peak.value();
+    settings[1]->can_reset = true;
+  }
+}
+
+}  // namespace
+
+// NOLINTBEGIN(readability-identifier-naming)
+
+extern "C" __declspec(dllexport) const char* name = "RenoDX";
+extern "C" __declspec(dllexport) const char* description = "RenoDX for Splinter Cell: Blacklist";
+
+// NOLINTEND(readability-identifier-naming)
+
+BOOL APIENTRY DllMain(HMODULE h_module, DWORD fdw_reason, LPVOID lpv_reserved) {
+  switch (fdw_reason) {
+    case DLL_PROCESS_ATTACH:
+      if (!reshade::register_addon(h_module)) return FALSE;
+
+      // renodx::mods::swapchain::use_resource_cloning = true;  // DESTROYS PERFORMANCE
+      // renodx::mods::shader::force_pipeline_cloning = true;
+      renodx::mods::shader::expected_constant_buffer_index = 10;
+      // renodx::mods::shader::trace_unmodified_shaders = true;
+
+      // FXAA, SSAA = 0;
+      // MSAA, TXAA = 1;
+      for (auto index : {0, 1}) {
+        renodx::mods::swapchain::swap_chain_upgrade_targets.push_back({
+            .old_format = reshade::api::format::r8g8b8a8_unorm,
+            .new_format = reshade::api::format::r16g16b16a16_typeless,
+            .index = index,
+        });
+      }
+      // peak nits
+      reshade::register_event<reshade::addon_event::init_swapchain>(OnInitSwapchain);
+
+      break;
+    case DLL_PROCESS_DETACH:
+      reshade::unregister_event<reshade::addon_event::init_swapchain>(OnInitSwapchain);
+      break;
+  }
+
+  renodx::utils::settings::Use(fdw_reason, &settings, &OnPresetOff);
+  renodx::mods::swapchain::Use(fdw_reason);
+  renodx::mods::shader::Use(fdw_reason, custom_shaders, &shader_injection);
+
+  return TRUE;
+}

--- a/src/games/scblacklist/addon.cpp
+++ b/src/games/scblacklist/addon.cpp
@@ -268,7 +268,7 @@ BOOL APIENTRY DllMain(HMODULE h_module, DWORD fdw_reason, LPVOID lpv_reserved) {
       for (auto index : {0, 1}) {
         renodx::mods::swapchain::swap_chain_upgrade_targets.push_back({
             .old_format = reshade::api::format::r8g8b8a8_unorm,
-            .new_format = reshade::api::format::r16g16b16a16_typeless,
+            .new_format = reshade::api::format::r16g16b16a16_float,
             .index = index,
         });
       }

--- a/src/games/scblacklist/colorgrade_0x03DBB3FD.ps_5_0.hlsl
+++ b/src/games/scblacklist/colorgrade_0x03DBB3FD.ps_5_0.hlsl
@@ -1,0 +1,116 @@
+#include "./common.hlsl"
+
+// ---- Created with 3Dmigoto v1.4.1 on Sat Jan 11 03:31:25 2025
+
+cbuffer CB_PerFrame : register(b13) {
+  float4 gCameraFadeAlpha : packoffset(c0);
+  float4 gCameraFadeShadow : packoffset(c1);
+  float4 gColorControl : packoffset(c2);
+  float3 cBoostCol : packoffset(c3);
+  float cHdrControl : packoffset(c3.w);
+  float gAOControl : packoffset(c4);
+}
+
+cbuffer CB_PS_PostFinal : register(b7) {
+  float4 cMiscTerms : packoffset(c0);
+  float4 cTint : packoffset(c1);
+  float4 cBloomWeights : packoffset(c2);
+  float4 cExtractTerms : packoffset(c3);
+  float4 cNoiseTerms : packoffset(c4);
+  float4 cNoiseOffsets : packoffset(c5);
+  float3 cLevelsScale : packoffset(c6);
+  float3 cLevelsBias : packoffset(c7);
+  float3 cLevelsGamma : packoffset(c8);
+  float4 cNightVisionTerms : packoffset(c9);
+  float4 cDebugShadedBrightness : packoffset(c10);
+  bool bPost : packoffset(c11);
+  bool bBloom : packoffset(c11.y);
+  bool bNoise : packoffset(c11.z);
+  bool bNoiseLum : packoffset(c11.w);
+  bool bWaves : packoffset(c12);
+}
+
+SamplerState sSceneTexPoint_s : register(s0);
+SamplerState sBloom_s : register(s1);
+SamplerState sNoise1_s : register(s2);
+SamplerState sTonemap_s : register(s4);
+Texture2D<float4> sSceneTexPoint : register(t0);
+Texture2D<float4> sTonemap : register(t1);
+Texture2D<float4> sBloom : register(t2);
+Texture2D<float4> sNoise1 : register(t3);
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(
+    float4 v0: SV_Position0,
+    float4 v1: TEXCOORD0,
+    out float4 o0: SV_Target0) {
+  float4 r0, r1, r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyz = sSceneTexPoint.Sample(sSceneTexPoint_s, v1.zw).xzy;
+  if (bWaves != 0) {
+    r1.xy = cMiscTerms.zw + v1.zw;
+    r0.x = sSceneTexPoint.Sample(sSceneTexPoint_s, r1.xy).x;
+    r1.xy = -cMiscTerms.zw + v1.zw;
+    r0.y = sSceneTexPoint.Sample(sSceneTexPoint_s, r1.xy).z;
+  }
+  r0.w = cmp(cHdrControl < 0);
+  r1.xyz = r0.www ? r0.xzy : float3(1, 1, 1);
+  r0.xyz = r1.xyz * r0.xzy;
+  r0.w = sTonemap.Sample(sTonemap_s, float2(0, 0)).x;  // exposure, used by sonar
+  r0.xyz = r0.xyz * r0.www;
+  if (bBloom != 0) {
+    r1.xyz = sBloom.Sample(sBloom_s, v1.xy).xyz;
+    r1.xyz = cBloomWeights.xxx * r1.xyz + r0.xyz; // sonar, lowering ruins visibility
+    r0.xyz = gColorControl.zzz * r1.xyz;
+  }
+  if (RENODX_TONE_MAP_TYPE == 0) {
+    r0.rgb = clamp(r0.rgb, 0, cExtractTerms.w);
+  } else {
+    r0.rgb = renodx::color::grade::UserColorGrading(
+        r0.rgb,
+        RENODX_TONE_MAP_EXPOSURE,
+        RENODX_TONE_MAP_HIGHLIGHTS,
+        RENODX_TONE_MAP_SHADOWS,
+        RENODX_TONE_MAP_CONTRAST,
+        RENODX_TONE_MAP_SATURATION,
+        RENODX_TONE_MAP_BLOWOUT);
+  }
+  if (bPost != 0) {
+    if (bNoise != 0) {
+      r1.zw = cNoiseTerms.xy * v1.zw;
+      r1.xy = v1.zw;
+      r2.xy = cNoiseTerms.xy;
+      r2.zw = float2(0.5, 0.5);
+      r1.xyzw = r1.xyzw * r2.xyzw + cNoiseOffsets.xyzw;
+      r2.xyz = sNoise1.Sample(sNoise1_s, r1.xy).xyz;
+      r1.xyz = sNoise1.Sample(sNoise1_s, r1.zw).xyz;
+      r1.xyz = r2.xyz + r1.xyz;
+      r1.xyz = r1.xyz * cNoiseTerms.zzz + -cNoiseTerms.zzz;
+      r1.yz = bNoiseLum ? r1.xx : r1.yz;
+      r0.xyz = r1.xyz * CUSTOM_NOISE + r0.xyz;
+    }
+
+    float3 tintInputColor = r0.rgb;
+
+    r0.w = dot(r0.xyz, float3(0.300000012, 0.600000024, 0.100000001));
+    r1.xyz = r0.xyz + -r0.www;
+    r1.xyz = cTint.www * r1.xyz + r0.www;
+    r1.xyz = r1.xyz * cMiscTerms.xxx + cMiscTerms.yyy;
+    r0.xyz = cTint.xyz * r1.xyz;
+
+    r0.rgb = lerp(tintInputColor, r0.rgb, CUSTOM_LUT_STRENGTH);
+  }
+  r0.xyz = (r0.xyz * cLevelsScale.xyz + cLevelsBias.xyz);
+  r0.rgb = max(0, r0.rgb);  // sonar goggles break otherwise
+  if (RENODX_TONE_MAP_TYPE == 0) r0.rgb = min(1, r0.rgb);
+  r0.rgb = pow(r0.rgb, cLevelsGamma.rgb); // can't hardcode to 2.2, sonar changes value
+
+  // fix luminance calculation
+  o0.w = renodx::color::y::from::BT709(r0.rgb);  // o0.w = renodx::color::y::from::BT601(r0.xyz);
+  o0.xyz = r0.xyz;
+  return;
+}

--- a/src/games/scblacklist/common.hlsl
+++ b/src/games/scblacklist/common.hlsl
@@ -1,0 +1,24 @@
+#include "./shared.h"
+
+//-----TONEMAP-----//
+float3 toneMap(float3 color) {
+  const float peakWhite = RENODX_PEAK_WHITE_NITS / RENODX_DIFFUSE_WHITE_NITS;
+  if (peakWhite <= 1.f) return saturate(color);
+  const float rolloff_start = 1.f;
+  return renodx::tonemap::ExponentialRollOff(color, rolloff_start, peakWhite);
+}
+
+//-----SCALING-----//
+float3 FinalizeOutput(float3 color) {
+  color = renodx::color::gamma::DecodeSafe(color, 2.2f);
+  color = renodx::color::bt709::clamp::BT2020(color);
+
+  if (RENODX_TONE_MAP_TYPE == 2.f) {
+    color = toneMap(color);
+  } else if (RENODX_TONE_MAP_TYPE == 0.f) {
+    color = saturate(color);
+  }
+
+  color *= RENODX_DIFFUSE_WHITE_NITS / 80.f;
+  return color;
+}

--- a/src/games/scblacklist/final_0x1E767A42.ps_5_0.hlsl
+++ b/src/games/scblacklist/final_0x1E767A42.ps_5_0.hlsl
@@ -1,0 +1,23 @@
+#include "./common.hlsl"
+
+// ---- Created with 3Dmigoto v1.4.1 on Sat Jan 11 03:31:30 2025
+
+SamplerState tex_s : register(s0);
+Texture2D<float4> tex : register(t0);
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(
+    float4 v0: SV_Position0,
+    float4 v1: TEXCOORD0,
+    float2 v2: TEXCOORD1,
+    out float4 o0: SV_Target0) {
+  float4 r0;
+
+  r0.xyzw = tex.Sample(tex_s, v2.xy).xyzw;
+  o0.xyzw = v1.xyzw * r0.xyzw;
+
+  o0.rgb = FinalizeOutput(o0.rgb);
+  return;
+}

--- a/src/games/scblacklist/lens_flare_0xB615F379.ps_5_0.hlsl
+++ b/src/games/scblacklist/lens_flare_0xB615F379.ps_5_0.hlsl
@@ -1,0 +1,43 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.4.1 on Sat Jan 11 03:32:00 2025
+
+cbuffer CB_PerFrame : register(b13) {
+  float4 gCameraFadeAlpha : packoffset(c0);
+  float4 gCameraFadeShadow : packoffset(c1);
+  float4 gColorControl : packoffset(c2);
+  float3 cBoostCol : packoffset(c3);
+  float cHdrControl : packoffset(c3.w);
+  float gAOControl : packoffset(c4);
+}
+
+cbuffer CB_PS_FlareMaterial_Static : register(b7) {
+  float4 cDiffCol : packoffset(c0);
+  float4 cDistance : packoffset(c1);
+  float cAlphaTest : packoffset(c2);
+}
+
+SamplerState sDiffuseMap_s : register(s0);
+Texture2D<float4> sDiffuseMap : register(t0);
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(
+    float4 v0: SV_Position0,
+    float2 v1: TEXCOORD0,
+    out float4 o0: SV_Target0) {
+  float4 r0, r1;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyz = sDiffuseMap.Sample(sDiffuseMap_s, v1.xy).xyz;
+  r0.xyw = r0.xyz * r0.xyz;
+  r1.x = r0.x + r0.y;
+  o0.xyz = cDiffCol.xyz * r0.xyw * CUSTOM_LENS_FLARE;
+  r0.x = r0.z * r0.z + r1.x;
+  r0.x = min(1, r0.x);
+  r0.x = cDiffCol.w * r0.x;
+  o0.w = gColorControl.w * r0.x;
+  return;
+}

--- a/src/games/scblacklist/shared.h
+++ b/src/games/scblacklist/shared.h
@@ -8,6 +8,7 @@
 #define RENODX_PEAK_WHITE_NITS     shader_injection.peak_white_nits
 #define RENODX_DIFFUSE_WHITE_NITS  shader_injection.diffuse_white_nits
 #define RENODX_TONE_MAP_TYPE       shader_injection.tone_map_type
+#define RENODX_TONE_MAP_SONAR      shader_injection.tone_map_sonar
 #define RENODX_TONE_MAP_EXPOSURE   shader_injection.tone_map_exposure
 #define RENODX_TONE_MAP_HIGHLIGHTS shader_injection.tone_map_highlights
 #define RENODX_TONE_MAP_SHADOWS    shader_injection.tone_map_shadows
@@ -24,6 +25,7 @@ struct ShaderInjectData {
   float peak_white_nits;
   float diffuse_white_nits;
   float tone_map_type;
+  float tone_map_sonar;
   float tone_map_exposure;
   float tone_map_highlights;
   float tone_map_shadows;

--- a/src/games/scblacklist/shared.h
+++ b/src/games/scblacklist/shared.h
@@ -1,0 +1,44 @@
+#ifndef SRC_SCBLACKLIST_SHARED_H_
+#define SRC_SCBLACKLIST_SHARED_H_
+
+#ifndef __cplusplus
+#include "../../shaders/renodx.hlsl"
+#endif
+
+#define RENODX_PEAK_WHITE_NITS     shader_injection.peak_white_nits
+#define RENODX_DIFFUSE_WHITE_NITS  shader_injection.diffuse_white_nits
+#define RENODX_TONE_MAP_TYPE       shader_injection.tone_map_type
+#define RENODX_TONE_MAP_EXPOSURE   shader_injection.tone_map_exposure
+#define RENODX_TONE_MAP_HIGHLIGHTS shader_injection.tone_map_highlights
+#define RENODX_TONE_MAP_SHADOWS    shader_injection.tone_map_shadows
+#define RENODX_TONE_MAP_CONTRAST   shader_injection.tone_map_contrast
+#define RENODX_TONE_MAP_SATURATION shader_injection.tone_map_saturation
+#define RENODX_TONE_MAP_BLOWOUT    shader_injection.tone_map_blowout
+#define CUSTOM_LUT_STRENGTH        shader_injection.custom_lut_strength
+#define CUSTOM_LENS_FLARE          shader_injection.custom_lens_flare
+#define CUSTOM_NOISE               shader_injection.custom_noise
+
+// Must be 32bit aligned
+// Should be 4x32
+struct ShaderInjectData {
+  float peak_white_nits;
+  float diffuse_white_nits;
+  float tone_map_type;
+  float tone_map_exposure;
+  float tone_map_highlights;
+  float tone_map_shadows;
+  float tone_map_contrast;
+  float tone_map_saturation;
+  float tone_map_blowout;
+  float custom_lut_strength;
+  float custom_lens_flare;
+  float custom_noise;
+};
+
+#ifndef __cplusplus
+cbuffer cb10 : register(b10) {
+  ShaderInjectData shader_injection : packoffset(c0);
+}
+#endif
+
+#endif  // SRC_SCBLACKLIST_SHARED_H_

--- a/src/games/scblacklist/sonar_0x81A1C030.ps_5_0.hlsl
+++ b/src/games/scblacklist/sonar_0x81A1C030.ps_5_0.hlsl
@@ -1,0 +1,42 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.4.1 on Sat Jan 11 03:31:50 2025
+
+cbuffer CB_PS_PostWaves : register(b7) {
+  float4 cWaveTerms : packoffset(c0);
+  float4 cWaveClamp : packoffset(c1);
+}
+
+SamplerState sSceneTexPoint_s : register(s0);
+SamplerState sWaveOffset_s : register(s1);
+Texture2D<float4> sWaveOffset : register(t0);
+Texture2D<float4> sSceneTexPoint : register(t1);
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(
+    float4 v0: SV_Position0,
+    float4 v1: TEXCOORD0,
+    out float4 o0: SV_Target0) {
+  float4 r0;
+
+  r0.y = dot(v1.zw, cWaveClamp.zw);
+  r0.x = 0.5;
+  r0.x = sWaveOffset.Sample(sWaveOffset_s, r0.xy).x;
+  r0.x = r0.x * 2 + -1;
+  r0.xy = r0.xx * cWaveTerms.xx + v1.zw;
+  r0.xy = max(float2(0, 0), r0.xy);
+  r0.xy = min(cWaveClamp.xx, r0.xy);
+  r0.zw = v1.zw + -r0.xy;
+  r0.xy = cWaveClamp.zw * r0.zw + r0.xy;
+  o0.xyzw = sSceneTexPoint.Sample(sSceneTexPoint_s, r0.xy).xyzw;
+
+  if (RENODX_TONE_MAP_SONAR && RENODX_TONE_MAP_TYPE == 2.f) {
+    o0.rgb = renodx::tonemap::frostbite::BT709(o0.rgb, 1.f);
+  } else if (RENODX_TONE_MAP_TYPE == 0.f) {
+    o0.rgb = saturate(o0.rgb);
+  }
+
+  return;
+}


### PR DESCRIPTION
# Add Splinter Cell: Blacklist Support to RenoDX

This pull request integrates **Splinter Cell: Blacklist** with RenoDX by editing the game’s tonemap, sonar, and post-processing shaders. It adds **HDR** capabilities, extensive color grading controls, and a dedicated option to **tone map** the sonar goggles. Although Blacklist merges UI elements into its scene rendering (lens flare, sonar, etc.), this mod still allows for meaningful HDR customization.

## Highlights

1. **Tone Mapping Options**  
   - **Vanilla**: Retains the original `saturate()`-based clamping.  
   - **None**: Leaves the image unmodified (no compression).  
   - **Exponential Rolloff**: Compresses highlights **above 1.0**, preserving the entire SDR range.  
   - **Tone Map Sonar**: A toggle to clamp or apply Frostbite tonemapper to the sonar goggles.

2. **Color Grading Sliders**  
   - **Exposure**, **Highlights**, **Shadows**, **Contrast**, **Saturation**, **Blowout**  
   - **Color Tint Strength**  
   - **Lens Flare**
   - **Noise**

3. **Render Target Upgrades**  
   - Manually upgrades multiple **`r8g8b8a8_unorm`** targets (`index = 0, 1, 2, 3, 4, 7`) to **`r16g16b16a16_float`**.  
   - Different indices are used based on anti-aliasing mode (FXAA, SSAA, TXAA, MSAA) and whether sonar goggles are active.  
   - This prevents brightness clamping and preserves HDR detail above 1.0.

4. **Automatic Peak Brightness**  
   - Reads **DirectX** peak brightness and uses it as the default for `ToneMapPeakNits`, making HDR setup simpler.

5. **Known Limitations**  
   - **Merged UI & Scene**: No separate UI slider, because lens effects share the same pipeline.
   - **In-Game Brightness**: Setting the game’s brightness slider to **5** is gamma 2.2, but the value can't be hardcoded as it changes dynamically when sonar goggles are used.  
   - **Clamping**: Negative color values (outside BT.709) are clipped, preventing sonar visuals from breaking.

By merging this pull request, **Splinter Cell: Blacklist** gains HDR support, and a suite of color grading tools.
