### PR TITLE
HDR Gamma Override for Spider-Man: Miles Morales

### DIFF
--- a/src/games/spidermanmilesmorales/addon.cpp
+++ b/src/games/spidermanmilesmorales/addon.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2024 Musa Haji
+ * Copyright (C) 2024 Carlos Lopez
+ * SPDX-License-Identifier: MIT
+ */
+
+#define ImTextureID ImU64
+
+#define DEBUG_LEVEL_0
+
+#include <deps/imgui/imgui.h>
+#include <include/reshade.hpp>
+
+#include <embed/0xB5DBD65C.h>  // Tonemap + Postfx
+
+#include "../../mods/shader.hpp"
+#include "../../utils/date.hpp"
+#include "../../utils/settings.hpp"
+#include "./shared.h"
+
+namespace {
+
+renodx::mods::shader::CustomShaders custom_shaders = {
+    CustomShaderEntry(0xB5DBD65C),  // Tonemap + Postfx
+};
+
+ShaderInjectData shader_injection;
+
+renodx::utils::settings::Settings settings = {
+    new renodx::utils::settings::Setting{
+        .key = "toneMapGammaAdjustType",
+        .binding = &RENODX_GAMMA_ADJUST_TYPE,
+        .value_type = renodx::utils::settings::SettingValueType::BOOLEAN,
+        .default_value = 1.f,
+        .can_reset = false,
+        .label = "Gamma Adjustment Type",
+        .section = "Tone Mapper Parameters",
+        .tooltip = "Sets the style of Gamma Adjustment, multiplier multiplies the value set by the game by the slider, while fixed overrides it to the value set by the slider",
+        .labels = {"Multiplier", "Fixed"},
+    },
+    new renodx::utils::settings::Setting{
+        .key = "toneMapGammaAdjust",
+        .binding = &RENODX_GAMMA_ADJUST_VALUE,
+        .default_value = 2.2f,
+        .label = "Gamma Adjustment",
+        .section = "Tone Mapping",
+        .tooltip = "Adjusts gamma",
+        .min = 1.f,
+        .max = 3.f,
+        .format = "%.1f",
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::BUTTON,
+        .label = "Get more RenoDX mods!",
+        .section = "About",
+        .group = "button-line-1",
+        .tint = 0x5865F2,
+        .on_change = []() {
+          system("start https://github.com/clshortfuse/renodx/wiki/Mods");
+        },
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::TEXT,
+        .label = std::string("Build: ") + renodx::utils::date::ISO_DATE_TIME,
+        .section = "About",
+    },
+};
+
+void OnPresetOff() {
+  renodx::utils::settings::UpdateSetting("toneMapGammaAdjust", 1.f);
+  renodx::utils::settings::UpdateSetting("toneMapGammaAdjustType", 0.f);
+}
+}  // namespace
+
+// NOLINTBEGIN(readability-identifier-naming)
+
+extern "C" __declspec(dllexport) const char* NAME = "RenoDX";
+extern "C" __declspec(dllexport) const char* DESCRIPTION = "RenoDX for Spider-Man: Miles Morales";
+
+// NOLINTEND(readability-identifier-naming)
+
+BOOL APIENTRY DllMain(HMODULE h_module, DWORD fdw_reason, LPVOID lpv_reserved) {
+  switch (fdw_reason) {
+    case DLL_PROCESS_ATTACH:
+
+    //   renodx::mods::shader::allow_multiple_push_constants = true;
+      renodx::mods::shader::expected_constant_buffer_space = 50;
+
+      if (!reshade::register_addon(h_module)) return FALSE;
+      break;
+    case DLL_PROCESS_DETACH:
+      reshade::unregister_addon(h_module);
+      break;
+  }
+
+  renodx::utils::settings::Use(fdw_reason, &settings, &OnPresetOff);
+  renodx::mods::shader::Use(fdw_reason, custom_shaders, &shader_injection);
+
+  return TRUE;
+}

--- a/src/games/spidermanmilesmorales/addon.cpp
+++ b/src/games/spidermanmilesmorales/addon.cpp
@@ -11,7 +11,7 @@
 #include <deps/imgui/imgui.h>
 #include <include/reshade.hpp>
 
-#include <embed/0xB5DBD65C.h>  // Tonemap + Postfx
+#include <embed/shaders.h>
 
 #include "../../mods/shader.hpp"
 #include "../../utils/date.hpp"
@@ -22,54 +22,59 @@ namespace {
 
 renodx::mods::shader::CustomShaders custom_shaders = {
     CustomShaderEntry(0xB5DBD65C),  // Tonemap + Postfx
+    CustomShaderEntry(0xECBD5D23),  // Tonemap + Postfx - Chromatic Aberration Off
 };
-
-ShaderInjectData shader_injection;
 
 renodx::utils::settings::Settings settings = {
     new renodx::utils::settings::Setting{
-        .key = "toneMapGammaAdjustType",
-        .binding = &RENODX_GAMMA_ADJUST_TYPE,
-        .value_type = renodx::utils::settings::SettingValueType::BOOLEAN,
-        .default_value = 1.f,
-        .can_reset = false,
-        .label = "Gamma Adjustment Type",
-        .section = "Tone Mapper Parameters",
-        .tooltip = "Sets the style of Gamma Adjustment, multiplier multiplies the value set by the game by the slider, while fixed overrides it to the value set by the slider",
-        .labels = {"Multiplier", "Fixed"},
-    },
-    new renodx::utils::settings::Setting{
-        .key = "toneMapGammaAdjust",
-        .binding = &RENODX_GAMMA_ADJUST_VALUE,
-        .default_value = 2.2f,
-        .label = "Gamma Adjustment",
-        .section = "Tone Mapping",
-        .tooltip = "Adjusts gamma",
-        .min = 1.f,
-        .max = 3.f,
-        .format = "%.1f",
-    },
-    new renodx::utils::settings::Setting{
         .value_type = renodx::utils::settings::SettingValueType::BUTTON,
-        .label = "Get more RenoDX mods!",
-        .section = "About",
-        .group = "button-line-1",
+        .label = "Discord",
+        .section = "Links",
+        .group = "button-line-2",
         .tint = 0x5865F2,
         .on_change = []() {
-          system("start https://github.com/clshortfuse/renodx/wiki/Mods");
+          renodx::utils::platform::Launch(
+              "https://discord.gg/"
+              "5WZXDpmbpP");
         },
     },
     new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::BUTTON,
+        .label = "More Mods",
+        .section = "Links",
+        .group = "button-line-2",
+        .tint = 0x2B3137,
+        .on_change = []() {
+          renodx::utils::platform::Launch("https://github.com/clshortfuse/renodx/wiki/Mods");
+        },
+
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::BUTTON,
+        .label = "Github",
+        .section = "Links",
+        .group = "button-line-2",
+        .tint = 0x2B3137,
+        .on_change = []() {
+          renodx::utils::platform::Launch("https://github.com/clshortfuse/renodx");
+        },
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::BUTTON,
+        .label = "Musa's Ko-Fi",
+        .section = "Links",
+        .group = "button-line-3",
+        .tint = 0xFF5A16,
+        .on_change = []() { renodx::utils::platform::Launch("https://ko-fi.com/musaqh"); },
+    },
+    new renodx::utils::settings::Setting{
         .value_type = renodx::utils::settings::SettingValueType::TEXT,
-        .label = std::string("Build: ") + renodx::utils::date::ISO_DATE_TIME,
+        .label = std::string("Adding sliders was causing the game to crash so I hardcoded the fixes."
+                             "\nCheck the mod page for details about the fixes."),
         .section = "About",
     },
 };
 
-void OnPresetOff() {
-  renodx::utils::settings::UpdateSetting("toneMapGammaAdjust", 1.f);
-  renodx::utils::settings::UpdateSetting("toneMapGammaAdjustType", 0.f);
-}
 }  // namespace
 
 // NOLINTBEGIN(readability-identifier-naming)
@@ -83,8 +88,8 @@ BOOL APIENTRY DllMain(HMODULE h_module, DWORD fdw_reason, LPVOID lpv_reserved) {
   switch (fdw_reason) {
     case DLL_PROCESS_ATTACH:
 
-    //   renodx::mods::shader::allow_multiple_push_constants = true;
       renodx::mods::shader::expected_constant_buffer_space = 50;
+      renodx::utils::settings::use_presets = false;
 
       if (!reshade::register_addon(h_module)) return FALSE;
       break;
@@ -93,8 +98,8 @@ BOOL APIENTRY DllMain(HMODULE h_module, DWORD fdw_reason, LPVOID lpv_reserved) {
       break;
   }
 
-  renodx::utils::settings::Use(fdw_reason, &settings, &OnPresetOff);
-  renodx::mods::shader::Use(fdw_reason, custom_shaders, &shader_injection);
+  renodx::utils::settings::Use(fdw_reason, &settings);
+  renodx::mods::shader::Use(fdw_reason, custom_shaders);
 
   return TRUE;
 }

--- a/src/games/spidermanmilesmorales/common.hlsl
+++ b/src/games/spidermanmilesmorales/common.hlsl
@@ -1,0 +1,126 @@
+#include "./include/ToneMapCB.hlsl"
+#include "./shared.h"
+
+float3 UpgradeToneMapPerceptual(float3 untonemapped, float3 tonemapped, float3 post_processed, float strength) {
+  float3 lab_untonemapped = renodx::color::ictcp::from::BT709(untonemapped);
+  float3 lab_tonemapped = renodx::color::ictcp::from::BT709(tonemapped);
+  float3 lab_post_processed = renodx::color::ictcp::from::BT709(post_processed);
+
+  float3 lch_untonemapped = renodx::color::oklch::from::OkLab(lab_untonemapped);
+  float3 lch_tonemapped = renodx::color::oklch::from::OkLab(lab_tonemapped);
+  float3 lch_post_processed = renodx::color::oklch::from::OkLab(lab_post_processed);
+
+  float3 lch_upgraded = lch_untonemapped;
+  lch_upgraded.xz *= renodx::math::DivideSafe(lch_post_processed.xz, lch_tonemapped.xz, 0.f);
+
+  float3 lab_upgraded = renodx::color::oklab::from::OkLCh(lch_upgraded);
+
+  float c_untonemapped = length(lab_untonemapped.yz);
+  float c_tonemapped = length(lab_tonemapped.yz);
+  float c_post_processed = length(lab_post_processed.yz);
+
+  if (c_untonemapped > 0) {
+    float new_chrominance = c_untonemapped;
+    new_chrominance = min(max(c_untonemapped, 0.25f), c_untonemapped * (c_post_processed / c_tonemapped));
+    if (new_chrominance > 0) {
+      lab_upgraded.yz *= new_chrominance / c_untonemapped;
+    }
+  }
+
+  float3 upgraded = renodx::color::bt709::from::ICtCp(lab_upgraded);
+  return lerp(untonemapped, upgraded, strength);
+}
+
+float UpgradeToneMapRatio(float color_hdr, float color_sdr, float post_process_color) {
+  [branch]
+  if (color_hdr < color_sdr) {
+    // If subtracting (user contrast or paperwhite) scale down instead
+    // Should only apply on mismatched HDR
+    return color_hdr / color_sdr;
+  } else {
+    float delta = color_hdr - color_sdr;
+    delta = max(0, delta);  // Cleans up NaN
+    const float ap1_new = post_process_color + delta;
+
+    const bool ap1_valid = (post_process_color > 0);  // Cleans up NaN and ignore black
+    return ap1_valid ? (ap1_new / post_process_color) : 0;
+  }
+}
+
+float3 UpgradeToneMapPerChannel(float3 color_hdr, float3 color_sdr, float3 post_process_color, float post_process_strength, uint working_color_space = 2u, uint hue_processor = 2u) {
+  // float ratio = 1.f;
+
+  float3 working_hdr, working_sdr, working_post_process;
+
+  [branch]
+  if (working_color_space == 2u) {
+    working_hdr = max(0, renodx::color::ap1::from::BT709(color_hdr));
+    working_sdr = max(0, renodx::color::ap1::from::BT709(color_sdr));
+    working_post_process = max(0, renodx::color::ap1::from::BT709(post_process_color));
+  } else
+    [branch] if (working_color_space == 1u) {
+      working_hdr = max(0, renodx::color::bt2020::from::BT709(color_hdr));
+      working_sdr = max(0, renodx::color::bt2020::from::BT709(color_sdr));
+      working_post_process = max(0, renodx::color::bt2020::from::BT709(post_process_color));
+    }
+  else {
+    working_hdr = max(0, color_hdr);
+    working_sdr = max(0, color_sdr);
+    working_post_process = max(0, post_process_color);
+  }
+
+  float3 ratio = float3(
+      UpgradeToneMapRatio(working_hdr.r, working_sdr.r, working_post_process.r),
+      UpgradeToneMapRatio(working_hdr.g, working_sdr.g, working_post_process.g),
+      UpgradeToneMapRatio(working_hdr.b, working_sdr.b, working_post_process.b));
+
+  float3 color_scaled = max(0, working_post_process * ratio);
+
+  [branch]
+  if (working_color_space == 2u) {
+    color_scaled = renodx::color::bt709::from::AP1(color_scaled);
+  } else
+    [branch] if (working_color_space == 1u) {
+      color_scaled = renodx::color::bt709::from::BT2020(color_scaled);
+    }
+
+  float peak_correction;
+  [branch]
+  if (working_color_space == 2u) {
+    peak_correction = saturate(1.f - renodx::color::y::from::AP1(working_post_process));
+  } else
+    [branch] if (working_color_space == 1u) {
+      peak_correction = saturate(1.f - renodx::color::y::from::BT2020(working_post_process));
+    }
+  else {
+    peak_correction = saturate(1.f - renodx::color::y::from::BT709(working_post_process));
+  }
+
+  [branch]
+  if (hue_processor == 2u) {
+    color_scaled = renodx::color::correct::HuedtUCS(color_scaled, post_process_color, peak_correction);
+  } else
+    [branch] if (hue_processor == 1u) {
+      color_scaled = renodx::color::correct::HueICtCp(color_scaled, post_process_color, peak_correction);
+    }
+  else {
+    color_scaled = renodx::color::correct::HueOKLab(color_scaled, post_process_color, peak_correction);
+  }
+  return lerp(color_hdr, color_scaled, post_process_strength);
+}
+
+float3 UpgradeToneMap(float3 color_hdr, float3 color_sdr, float3 post_process_color, float post_process_strength, uint upgradeMethod) {
+  if (upgradeMethod == 0u)
+    return renodx::tonemap::UpgradeToneMap(color_hdr, color_sdr, post_process_color, post_process_strength);
+  else if (upgradeMethod == 1u)
+    return UpgradeToneMapPerChannel(color_hdr, color_sdr, post_process_color, post_process_strength);
+  else
+    return UpgradeToneMapPerceptual(color_hdr, color_sdr, post_process_color, post_process_strength);
+}
+
+float OverrideGamma() {
+  if (RENODX_GAMMA_ADJUST_TYPE) return RENODX_GAMMA_ADJUST_VALUE;
+  return ToneMapCBuffer_m0[3u].w * RENODX_GAMMA_ADJUST_VALUE;
+}
+
+static float m_HdrGamma = OverrideGamma();

--- a/src/games/spidermanmilesmorales/common.hlsl
+++ b/src/games/spidermanmilesmorales/common.hlsl
@@ -119,8 +119,12 @@ float3 UpgradeToneMap(float3 color_hdr, float3 color_sdr, float3 post_process_co
 }
 
 float OverrideGamma() {
-  if (RENODX_GAMMA_ADJUST_TYPE) return RENODX_GAMMA_ADJUST_VALUE;
-  return ToneMapCBuffer_m0[3u].w * RENODX_GAMMA_ADJUST_VALUE;
+  [branch]
+  if (RENODX_GAMMA_ADJUST_TYPE) {
+    return RENODX_GAMMA_ADJUST_VALUE;
+  } else {
+    return ToneMapCBuffer_m0[3u].w * RENODX_GAMMA_ADJUST_VALUE;
+  }
 }
 
 static float m_HdrGamma = OverrideGamma();

--- a/src/games/spidermanmilesmorales/include/ToneMapCB.hlsl
+++ b/src/games/spidermanmilesmorales/include/ToneMapCB.hlsl
@@ -1,0 +1,43 @@
+/*
+struct ToneMapCBuffer {
+  struct ToneMapCB {
+    float4 m_PixelScale;
+    float m_GrainUvScale;
+    float m_GrainStrength;
+    float m_GrainRandom;
+    float m_InvAspectRatio;
+    float m_AcesMiddleGray;
+    float m_VignetteHorzScale;
+    float m_VignetteVertScale;
+    float m_VignetteCenterClear;
+    float m_SharpenCenter;
+    float m_SharpenSide;
+    float m_SharpenCorner;
+    float m_HdrGamma;
+    float m_IsOffscreen;
+    float m_ChromAbUvScale;
+    float m_ChromAbRadScale;
+    float m_ChromAbRadBias;
+    float2 m_VignetteOffset;
+    float m_FrostedHudScale;
+    float m_FrostedHudBias;
+    float2 m_SrgbOverlayScale;
+    float2 m_SrgbOverlayBias;
+    float m_ColorFilterStrength;
+    float m_Contrast;
+    float m_ToneMappingScale;
+    float m_ApplyToneMappingScale;
+    float m_HdrWhitePoint;
+    float m_AspectBlurStart;
+    float m_AspectBlurEnd;
+    float m_AspectBlurRadius;
+    float m_AspectBlurTapScale;
+    float m_InvAdaptationLum;
+    float m_WriteHudless;
+    float m_Pad;
+  } g_TM;
+}
+*/
+cbuffer ToneMapCBufferUBO : register(b2, space0) {
+  float4 ToneMapCBuffer_m0[10] : packoffset(c0);
+};

--- a/src/games/spidermanmilesmorales/shared.h
+++ b/src/games/spidermanmilesmorales/shared.h
@@ -1,20 +1,10 @@
 #ifndef SRC_SPIDERMANMILESMORALES_SHARED_H_
 #define SRC_SPIDERMANMILESMORALES_SHARED_H_
 
-#define RENODX_GAMMA_ADJUST_TYPE  shader_injection.tone_map_gamma_adjust_type
-#define RENODX_GAMMA_ADJUST_VALUE shader_injection.tone_map_gamma_adjust
-
-// Must be 32bit aligned
-// Should be 4x32
-struct ShaderInjectData {
-  float tone_map_gamma_adjust_type;
-  float tone_map_gamma_adjust;
-};
+#define RENODX_GAMMA_ADJUST_TYPE  1u    // 0 - multiplier, 1 - fixed
+#define RENODX_GAMMA_ADJUST_VALUE 2.2f
 
 #ifndef __cplusplus
-cbuffer shader_injection : register(b0, space50) {
-  ShaderInjectData shader_injection : packoffset(c0);
-}
 
 #include "../../shaders/renodx.hlsl"
 

--- a/src/games/spidermanmilesmorales/shared.h
+++ b/src/games/spidermanmilesmorales/shared.h
@@ -1,0 +1,23 @@
+#ifndef SRC_SPIDERMANMILESMORALES_SHARED_H_
+#define SRC_SPIDERMANMILESMORALES_SHARED_H_
+
+#define RENODX_GAMMA_ADJUST_TYPE  shader_injection.tone_map_gamma_adjust_type
+#define RENODX_GAMMA_ADJUST_VALUE shader_injection.tone_map_gamma_adjust
+
+// Must be 32bit aligned
+// Should be 4x32
+struct ShaderInjectData {
+  float tone_map_gamma_adjust_type;
+  float tone_map_gamma_adjust;
+};
+
+#ifndef __cplusplus
+cbuffer shader_injection : register(b0, space50) {
+  ShaderInjectData shader_injection : packoffset(c0);
+}
+
+#include "../../shaders/renodx.hlsl"
+
+#endif
+
+#endif  // SRC_SPIDERMANMILESMORALES_SHARED_H_

--- a/src/games/spidermanmilesmorales/tonemap_0xB5DBD65C.cs_6_6.hlsl
+++ b/src/games/spidermanmilesmorales/tonemap_0xB5DBD65C.cs_6_6.hlsl
@@ -1,0 +1,295 @@
+#include "./shared.h"
+/*
+struct ToneMapCBuffer {
+  struct ToneMapCB {
+    float4 m_PixelScale;
+    float m_GrainUvScale;
+    float m_GrainStrength;
+    float m_GrainRandom;
+    float m_InvAspectRatio;
+    float m_AcesMiddleGray;
+    float m_VignetteHorzScale;
+    float m_VignetteVertScale;
+    float m_VignetteCenterClear;
+    float m_SharpenCenter;
+    float m_SharpenSide;
+    float m_SharpenCorner;
+    float m_HdrGamma;
+    float m_IsOffscreen;
+    float m_ChromAbUvScale;
+    float m_ChromAbRadScale;
+    float m_ChromAbRadBias;
+    float2 m_VignetteOffset;
+    float m_FrostedHudScale;
+    float m_FrostedHudBias;
+    float2 m_SrgbOverlayScale;
+    float2 m_SrgbOverlayBias;
+    float m_ColorFilterStrength;
+    float m_Contrast;
+    float m_ToneMappingScale;
+    float m_ApplyToneMappingScale;
+    float m_HdrWhitePoint;
+    float m_AspectBlurStart;
+    float m_AspectBlurEnd;
+    float m_AspectBlurRadius;
+    float m_AspectBlurTapScale;
+    float m_InvAdaptationLum;
+    float m_WriteHudless;
+    float m_Pad;
+  } g_TM;
+}
+*/
+cbuffer ToneMapCBufferUBO : register(b2, space0)
+{
+    float4 ToneMapCBuffer_m0[10] : packoffset(c0);
+};
+
+Texture3D<float4> g_TmToneMapLookup : register(t5, space0);
+Texture2D<float4> g_TmRadianceMap : register(t6, space0);
+Texture2D<float4> g_TmBloomMap : register(t7, space0);
+Texture2D<float4> g_TmChromaticAbMap : register(t8, space0);
+Texture3D<float4> g_TmColorFilterMap : register(t9, space0);
+Texture2D<float4> g_TmFilmGrainNoise : register(t10, space0);
+Buffer<uint4> g_TmAdaptedLumBuffer : register(t11, space0);
+Texture2D<float4> g_TmSrgbOverlayMap : register(t12, space0);
+Texture2D<float4> g_TmRadianceBlurMap : register(t13, space0);
+RWTexture2D<float4> g_TmOutput : register(u0, space0);
+RWTexture2D<float4> g_TmOutputHudless : register(u1, space0);
+SamplerState g_PointClampSampler : register(s0, space0);
+SamplerState g_LinearClampSampler : register(s2, space0);
+SamplerState g_LinearWrapSampler : register(s3, space0);
+
+static uint3 gl_GlobalInvocationID;
+struct SPIRV_Cross_Input
+{
+    uint3 gl_GlobalInvocationID : SV_DispatchThreadID;
+};
+
+groupshared float _40[128];
+
+void comp_main()
+{
+    uint _51 = gl_GlobalInvocationID.x & 7u;
+    uint _53 = gl_GlobalInvocationID.y & 7u;
+    uint _56 = (_53 << 3u) | _51;
+    uint _59 = (_56 * 3277u) >> 14u;
+    uint _66 = ((_59 * 4294967291u) + _56) << 1u;
+    float _79 = (float((gl_GlobalInvocationID.x - _51) + _66) + 0.5f) * ToneMapCBuffer_m0[0u].x;
+    float _80 = (float((gl_GlobalInvocationID.y - _53) + _59) + 0.5f) * ToneMapCBuffer_m0[0u].y;
+    uint _120 = _66 + (_59 * 10u);
+    _40[_120] = log2(max(dot(float3(g_TmRadianceMap.SampleLevel(g_PointClampSampler, float2(_79, _80), 0.0f, int2(-1, -1)).xyz), float3(0.2125999927520751953125f, 0.715200006961822509765625f, 0.072200000286102294921875f)), 9.9999997473787516355514526367188e-06f));
+    _40[_120 | 1u] = log2(max(dot(float3(g_TmRadianceMap.SampleLevel(g_PointClampSampler, float2(_79, _80), 0.0f, int2(0, -1)).xyz), float3(0.2125999927520751953125f, 0.715200006961822509765625f, 0.072200000286102294921875f)), 9.9999997473787516355514526367188e-06f));
+    GroupMemoryBarrierWithGroupSync();
+    uint _128 = (_53 * 10u) + _51;
+    uint _129 = _128 + 11u;
+    float _137 = _40[_129] + (-0.60000002384185791015625f);
+    float _139 = _40[_129] + 0.60000002384185791015625f;
+    float _223 = ((((((((ToneMapCBuffer_m0[3u].x * _40[_129]) - _40[_129]) + (ToneMapCBuffer_m0[3u].z * min(max(_40[_128], _137), _139))) + (ToneMapCBuffer_m0[3u].y * min(max(_40[_128 + 1u], _137), _139))) + (ToneMapCBuffer_m0[3u].z * min(max(_40[_128 + 2u], _137), _139))) + (ToneMapCBuffer_m0[3u].y * min(max(_40[_128 + 10u], _137), _139))) + (ToneMapCBuffer_m0[3u].y * min(max(_40[_128 + 12u], _137), _139))) + (ToneMapCBuffer_m0[3u].z * min(max(_40[_128 + 20u], _137), _139))) + (ToneMapCBuffer_m0[3u].y * min(max(_40[_128 + 21u], _137), _139));
+    float _225 = exp2(_223 + (ToneMapCBuffer_m0[3u].z * min(max(_40[_128 + 22u], _137), _139)));
+    float _234 = ToneMapCBuffer_m0[0u].x * (float(gl_GlobalInvocationID.x) + 0.5f);
+    float _235 = ToneMapCBuffer_m0[0u].y * (float(gl_GlobalInvocationID.y) + 0.5f);
+    float4 _239 = g_TmRadianceMap.SampleLevel(g_LinearClampSampler, float2(_234, _235), 0.0f);
+    float _244 = _239.x * _225;
+    float _245 = _239.y * _225;
+    float _246 = _239.z * _225;
+
+    float _250 = _234 * 2.0f;
+    float _252 = _235 * 2.0f;
+    float _254 = _250 + (-1.0f);
+    float _256 = (_252 * ToneMapCBuffer_m0[1u].w) - ToneMapCBuffer_m0[1u].w;
+    float _268 = clamp((ToneMapCBuffer_m0[4u].z * dot(float2(_254, _256), float2(_254, _256))) - ToneMapCBuffer_m0[4u].w, 0.0f, 1.0f);
+    float _270 = ToneMapCBuffer_m0[4u].y * _268;
+    float _276 = _270 * 0.5f;
+    float _293 = clamp(_268 * 1.6665999889373779296875f, 0.0f, 1.0f);
+    float4 _305 = g_TmBloomMap.SampleLevel(g_LinearClampSampler, float2(_234, _235), 0.0f);
+    float _310 = ((_293 * (g_TmChromaticAbMap.SampleLevel(g_LinearClampSampler, float2(_234, _235), 0.0f).x - _244)) + _244) + _305.x;
+    float _311 = ((_293 * (g_TmChromaticAbMap.SampleLevel(g_LinearClampSampler, float2(_234 - (_276 * _254), _235 - (_276 * _256)), 0.0f).y - _245)) + _245) + _305.y;
+    float _312 = (((g_TmChromaticAbMap.SampleLevel(g_LinearClampSampler, float2(_234 - (_270 * _254), _235 - (_270 * _256)), 0.0f).z - _246) * _293) + _246) + _305.z;
+    float _342;
+    float _343;
+    float _344;
+    if (ToneMapCBuffer_m0[7u].y != 0.0f)
+    {
+        float _323 = clamp(dot(float3(_310, _311, _312), float3(0.300000011920928955078125f, 0.5f, 0.20000000298023223876953125f)), 0.0f, 1.0f);
+        float _338 = ((((((_323 * _323) * _323) * ((((_323 * 6.0f) + (-15.0f)) * _323) + 10.0f)) - _323) * ToneMapCBuffer_m0[7u].y) + _323) / max(_323, 9.9999997473787516355514526367188e-06f);
+        _342 = _338 * _310;
+        _343 = _338 * _311;
+        _344 = _338 * _312;
+    }
+    else
+    {
+        _342 = _310;
+        _343 = _311;
+        _344 = _312;
+    }
+    float _354 = (_234 * ToneMapCBuffer_m0[6u].x) + ToneMapCBuffer_m0[6u].z;
+    float _355 = (_235 * ToneMapCBuffer_m0[6u].y) + ToneMapCBuffer_m0[6u].w;
+    float _362 = clamp((1.0f - max(abs(_354), abs(_355))) * 4096.0f, 0.0f, 1.0f);
+    float4 _369 = g_TmSrgbOverlayMap.SampleLevel(g_LinearClampSampler, float2((_354 * 0.5f) + 0.5f, (_355 * 0.5f) + 0.5f), 0.0f);
+    float _375 = _369.x * _362;
+    float _376 = _369.y * _362;
+    float _377 = _369.z * _362;
+    float _379 = (_369.w + (-1.0f)) * _362;
+    float _397 = min(clamp((ToneMapCBuffer_m0[5u].z * dot(float3(_375, _376, _377), float3(0.2125999927520751953125f, 0.715200006961822509765625f, 0.072200000286102294921875f))) - ToneMapCBuffer_m0[5u].w, 0.0f, 1.0f), clamp(19.5f - ((_379 + 1.0f) * 20.0f), 0.0f, 1.0f));
+    float _498;
+    float _499;
+    float _500;
+    if (_397 > 0.0f)
+    {
+        float4 _401 = g_TmRadianceBlurMap.SampleLevel(g_LinearClampSampler, float2(_234, _235), 0.0f);
+        float4 _410 = g_TmRadianceBlurMap.SampleLevel(g_LinearClampSampler, float2(_234, _235), 0.0f, int2(-1, -1));
+        float4 _415 = g_TmRadianceBlurMap.SampleLevel(g_LinearClampSampler, float2(_234, _235), 0.0f, int2(0, -1));
+        float4 _421 = g_TmRadianceBlurMap.SampleLevel(g_LinearClampSampler, float2(_234, _235), 0.0f, int2(1, -1));
+        float4 _427 = g_TmRadianceBlurMap.SampleLevel(g_LinearClampSampler, float2(_234, _235), 0.0f, int2(-1, 0));
+        float4 _433 = g_TmRadianceBlurMap.SampleLevel(g_LinearClampSampler, float2(_234, _235), 0.0f, int2(1, 0));
+        float4 _439 = g_TmRadianceBlurMap.SampleLevel(g_LinearClampSampler, float2(_234, _235), 0.0f, int2(-1, 1));
+        float4 _445 = g_TmRadianceBlurMap.SampleLevel(g_LinearClampSampler, float2(_234, _235), 0.0f, int2(0, 1));
+        float4 _451 = g_TmRadianceBlurMap.SampleLevel(g_LinearClampSampler, float2(_234, _235), 0.0f, int2(1, 1));
+        _498 = (((((_401.x * 0.25f) - _342) + ((((_427.x + _415.x) + _433.x) + _445.x) * 0.125f)) + ((((_421.x + _410.x) + _439.x) + _451.x) * 0.0625f)) * _397) + _342;
+        _499 = (((((_401.y * 0.25f) - _343) + ((((_427.y + _415.y) + _433.y) + _445.y) * 0.125f)) + ((((_421.y + _410.y) + _439.y) + _451.y) * 0.0625f)) * _397) + _343;
+        _500 = (((((_401.z * 0.25f) - _344) + ((((_427.z + _415.z) + _433.z) + _445.z) * 0.125f)) + ((((_421.z + _410.z) + _439.z) + _451.z) * 0.0625f)) * _397) + _344;
+    }
+    else
+    {
+        _498 = _342;
+        _499 = _343;
+        _500 = _344;
+    }
+    float _509 = (_250 - ToneMapCBuffer_m0[5u].x) * ToneMapCBuffer_m0[2u].y;
+    float _510 = ToneMapCBuffer_m0[2u].z * (_252 - ToneMapCBuffer_m0[5u].y);
+    float _517 = max(sqrt(dot(float2(_509, _510), float2(_509, _510))) - ToneMapCBuffer_m0[2u].w, 0.0f);
+    float _520 = 1.0f / ((_517 * _517) + 1.0f);
+    float _521 = _520 * _520;
+    float _530 = (ToneMapCBuffer_m0[1u].z * 2.0f) + (-0.5f);
+    float _532 = ToneMapCBuffer_m0[1u].z * 6.283185482025146484375f;
+    float _534 = _234 - _530;
+    float _535 = (ToneMapCBuffer_m0[1u].w * _235) - _530;
+    float _536 = sin(_532);
+    float _537 = cos(_532);
+    float _554 = g_TmFilmGrainNoise.SampleLevel(g_LinearWrapSampler, float2(((_530 - (_535 * _536)) + (_534 * _537)) * ToneMapCBuffer_m0[1u].x, (((_534 * _536) + _530) + (_535 * _537)) * ToneMapCBuffer_m0[1u].x), 0.0f).x * 2.0f;
+    float _561 = ((((_554 >= 1.0f) ? _554 : (1.0f / (2.0f - _554))) + (-1.0f)) * ToneMapCBuffer_m0[1u].y) + 1.0f;
+    float _571 = ToneMapCBuffer_m0[2u].x * asfloat(g_TmAdaptedLumBuffer.Load(1u).x);
+    float4 _589 = g_TmToneMapLookup.SampleLevel(g_LinearClampSampler, float3((log2(((_521 * _498) * _561) * _571) * 0.060546875f) + 0.6513671875f, (log2(((_521 * _499) * _561) * _571) * 0.060546875f) + 0.6513671875f, (log2(((_521 * _500) * _561) * _571) * 0.060546875f) + 0.6513671875f), 0.0f);
+    float _597 = (ToneMapCBuffer_m0[7u].w != 0.0f) ? ToneMapCBuffer_m0[7u].z : 1.0f;
+    float _598 = _597 * _589.x;
+    float _599 = _597 * _589.y;
+    float _600 = _597 * _589.z;
+    float _601 = (-0.0f) - _379;
+    float _606 = (_598 * _601) + _375;
+    float _607 = (_599 * _601) + _376;
+    float _608 = (_600 * _601) + _377;
+    float _662;
+    float _663;
+    float _664;
+    float _665;
+    float _666;
+    float _667;
+    if (ToneMapCBuffer_m0[7u].x != 0.0f)
+    {
+        float _611 = max(_606, 1.0f);
+        float _612 = max(_607, 1.0f);
+        float _613 = max(_608, 1.0f);
+        float _614 = 1.0f / _611;
+        float _615 = 1.0f / _612;
+        float _616 = 1.0f / _613;
+        float _617 = _614 * _606;
+        float _618 = _615 * _607;
+        float _619 = _616 * _608;
+        float _620 = _614 * _598;
+        float _621 = _615 * _599;
+        float _622 = _616 * _600;
+        float4 _633 = g_TmColorFilterMap.SampleLevel(g_LinearClampSampler, float3((_617 * 0.96875f) + 0.015625f, (_618 * 0.96875f) + 0.015625f, (_619 * 0.96875f) + 0.015625f), 0.0f);
+        float _635 = _633.x;
+        float _636 = _633.y;
+        float _637 = _633.z;
+        _662 = ((ToneMapCBuffer_m0[7u].x * (_635 - _617)) + _617) * _611;
+        _663 = ((ToneMapCBuffer_m0[7u].x * (_636 - _618)) + _618) * _612;
+        _664 = ((ToneMapCBuffer_m0[7u].x * (_637 - _619)) + _619) * _613;
+        _665 = ((ToneMapCBuffer_m0[7u].x * (_635 - _620)) + _620) * _611;
+        _666 = ((ToneMapCBuffer_m0[7u].x * (_636 - _621)) + _621) * _612;
+        _667 = ((ToneMapCBuffer_m0[7u].x * (_637 - _622)) + _622) * _613;
+    }
+    else
+    {
+        _662 = _606;
+        _663 = _607;
+        _664 = _608;
+        _665 = _598;
+        _666 = _599;
+        _667 = _600;
+    }
+    float _798;
+    float _799;
+    float _800;
+    float _801;
+    float _802;
+    float _803;
+    float3 inputColor;
+
+    if (ToneMapCBuffer_m0[3u].w != 0.0f)
+    {
+        float m_HdrGamma;
+        if (RENODX_GAMMA_ADJUST_TYPE) {
+          m_HdrGamma = RENODX_GAMMA_ADJUST_VALUE;
+        } else {
+          m_HdrGamma = ToneMapCBuffer_m0[3u].w * RENODX_GAMMA_ADJUST_VALUE;
+        }
+        // scene gamma - 1.9 for some reason
+        float3 scene = float3(_662, _663, _664);
+        // float _680 = exp2(log2(_662) * m_HdrGamma);
+        // float _681 = exp2(log2(_663) * m_HdrGamma);
+        // float _682 = exp2(log2(_664) * m_HdrGamma);
+        scene = renodx::math::SignPow(scene, m_HdrGamma);
+        float _680 = scene.r;
+        float _681 = scene.g;
+        float _682 = scene.b;
+        
+        
+        // scene nits
+        float _683 = ToneMapCBuffer_m0[8u].x * 9.9999997473787516355514526367188e-05f;
+
+        // bt.2020
+        float _713 = exp2(log2(mad(0.0432999990880489349365234375f, _682, mad(0.329299986362457275390625f, _681, _680 * 0.627399981021881103515625f)) * _683) * 0.1593017578125f);
+        float _714 = exp2(log2(mad(0.011400000192224979400634765625f, _682, mad(0.91949999332427978515625f, _681, _680 * 0.069099999964237213134765625f)) * _683) * 0.1593017578125f);
+        float _715 = exp2(log2(mad(0.895600020885467529296875f, _682, mad(0.087999999523162841796875f, _681, _680 * 0.01640000008046627044677734375f)) * _683) * 0.1593017578125f);
+        
+        float _750 = exp2(log2(_665) * m_HdrGamma);
+        float _751 = exp2(log2(_666) * m_HdrGamma);
+        float _752 = exp2(log2(_667) * m_HdrGamma);
+
+        // inputColor = float3(_750, _751, _752);
+
+        float _771 = exp2(log2(mad(0.0432999990880489349365234375f, _752, mad(0.329299986362457275390625f, _751, _750 * 0.627399981021881103515625f)) * _683) * 0.1593017578125f);
+        float _772 = exp2(log2(mad(0.011400000192224979400634765625f, _752, mad(0.91949999332427978515625f, _751, _750 * 0.069099999964237213134765625f)) * _683) * 0.1593017578125f);
+        float _773 = exp2(log2(mad(0.895600020885467529296875f, _752, mad(0.087999999523162841796875f, _751, _750 * 0.01640000008046627044677734375f)) * _683) * 0.1593017578125f);
+        _798 = exp2(log2(((_713 * 18.8515625f) + 0.8359375f) / ((_713 * 18.6875f) + 1.0f)) * 78.84375f);
+        _799 = exp2(log2(((_714 * 18.8515625f) + 0.8359375f) / ((_714 * 18.6875f) + 1.0f)) * 78.84375f);
+        _800 = exp2(log2(((_715 * 18.8515625f) + 0.8359375f) / ((_715 * 18.6875f) + 1.0f)) * 78.84375f);
+        
+        _801 = exp2(log2(((_771 * 18.8515625f) + 0.8359375f) / ((_771 * 18.6875f) + 1.0f)) * 78.84375f);
+        _802 = exp2(log2(((_772 * 18.8515625f) + 0.8359375f) / ((_772 * 18.6875f) + 1.0f)) * 78.84375f);
+        _803 = exp2(log2(((_773 * 18.8515625f) + 0.8359375f) / ((_773 * 18.6875f) + 1.0f)) * 78.84375f);
+    }
+    else
+    {
+        _798 = _662;
+        _799 = _663;
+        _800 = _664;
+        _801 = _665;
+        _802 = _666;
+        _803 = _667;
+    }
+    g_TmOutput[uint2(gl_GlobalInvocationID.x, gl_GlobalInvocationID.y)] = float4(_798, _799, _800, 1.0f);
+    // g_TmOutput[uint2(gl_GlobalInvocationID.x, gl_GlobalInvocationID.y)] = float4(renodx::color::pq::EncodeSafe(renodx::color::bt2020::from::BT709(inputColor), 200.f), 1.0f);
+    if (ToneMapCBuffer_m0[9u].z != 0.0f)
+    {
+        g_TmOutputHudless[uint2(gl_GlobalInvocationID.x, gl_GlobalInvocationID.y)] = float4(_801, _802, _803, 1.0f);
+    }
+}
+
+[numthreads(8, 8, 1)]
+void main(SPIRV_Cross_Input stage_input)
+{
+    gl_GlobalInvocationID = stage_input.gl_GlobalInvocationID;
+    comp_main();
+}

--- a/src/games/spidermanmilesmorales/tonemap_0xB5DBD65C.cs_6_6.hlsl
+++ b/src/games/spidermanmilesmorales/tonemap_0xB5DBD65C.cs_6_6.hlsl
@@ -1,48 +1,4 @@
-#include "./shared.h"
-/*
-struct ToneMapCBuffer {
-  struct ToneMapCB {
-    float4 m_PixelScale;
-    float m_GrainUvScale;
-    float m_GrainStrength;
-    float m_GrainRandom;
-    float m_InvAspectRatio;
-    float m_AcesMiddleGray;
-    float m_VignetteHorzScale;
-    float m_VignetteVertScale;
-    float m_VignetteCenterClear;
-    float m_SharpenCenter;
-    float m_SharpenSide;
-    float m_SharpenCorner;
-    float m_HdrGamma;
-    float m_IsOffscreen;
-    float m_ChromAbUvScale;
-    float m_ChromAbRadScale;
-    float m_ChromAbRadBias;
-    float2 m_VignetteOffset;
-    float m_FrostedHudScale;
-    float m_FrostedHudBias;
-    float2 m_SrgbOverlayScale;
-    float2 m_SrgbOverlayBias;
-    float m_ColorFilterStrength;
-    float m_Contrast;
-    float m_ToneMappingScale;
-    float m_ApplyToneMappingScale;
-    float m_HdrWhitePoint;
-    float m_AspectBlurStart;
-    float m_AspectBlurEnd;
-    float m_AspectBlurRadius;
-    float m_AspectBlurTapScale;
-    float m_InvAdaptationLum;
-    float m_WriteHudless;
-    float m_Pad;
-  } g_TM;
-}
-*/
-cbuffer ToneMapCBufferUBO : register(b2, space0)
-{
-    float4 ToneMapCBuffer_m0[10] : packoffset(c0);
-};
+#include "./common.hlsl"
 
 Texture3D<float4> g_TmToneMapLookup : register(t5, space0);
 Texture2D<float4> g_TmRadianceMap : register(t6, space0);
@@ -69,6 +25,7 @@ groupshared float _40[128];
 
 void comp_main()
 {
+    // --- Thread-local Index Calculation ---
     uint _51 = gl_GlobalInvocationID.x & 7u;
     uint _53 = gl_GlobalInvocationID.y & 7u;
     uint _56 = (_53 << 3u) | _51;
@@ -77,15 +34,21 @@ void comp_main()
     float _79 = (float((gl_GlobalInvocationID.x - _51) + _66) + 0.5f) * ToneMapCBuffer_m0[0u].x;
     float _80 = (float((gl_GlobalInvocationID.y - _53) + _59) + 0.5f) * ToneMapCBuffer_m0[0u].y;
     uint _120 = _66 + (_59 * 10u);
+    
+    // --- Luminance Sampling --- 
     _40[_120] = log2(max(dot(float3(g_TmRadianceMap.SampleLevel(g_PointClampSampler, float2(_79, _80), 0.0f, int2(-1, -1)).xyz), float3(0.2125999927520751953125f, 0.715200006961822509765625f, 0.072200000286102294921875f)), 9.9999997473787516355514526367188e-06f));
     _40[_120 | 1u] = log2(max(dot(float3(g_TmRadianceMap.SampleLevel(g_PointClampSampler, float2(_79, _80), 0.0f, int2(0, -1)).xyz), float3(0.2125999927520751953125f, 0.715200006961822509765625f, 0.072200000286102294921875f)), 9.9999997473787516355514526367188e-06f));
     GroupMemoryBarrierWithGroupSync();
+    
+    // --- Local Adaptation Filtering ---
     uint _128 = (_53 * 10u) + _51;
     uint _129 = _128 + 11u;
     float _137 = _40[_129] + (-0.60000002384185791015625f);
     float _139 = _40[_129] + 0.60000002384185791015625f;
     float _223 = ((((((((ToneMapCBuffer_m0[3u].x * _40[_129]) - _40[_129]) + (ToneMapCBuffer_m0[3u].z * min(max(_40[_128], _137), _139))) + (ToneMapCBuffer_m0[3u].y * min(max(_40[_128 + 1u], _137), _139))) + (ToneMapCBuffer_m0[3u].z * min(max(_40[_128 + 2u], _137), _139))) + (ToneMapCBuffer_m0[3u].y * min(max(_40[_128 + 10u], _137), _139))) + (ToneMapCBuffer_m0[3u].y * min(max(_40[_128 + 12u], _137), _139))) + (ToneMapCBuffer_m0[3u].z * min(max(_40[_128 + 20u], _137), _139))) + (ToneMapCBuffer_m0[3u].y * min(max(_40[_128 + 21u], _137), _139));
     float _225 = exp2(_223 + (ToneMapCBuffer_m0[3u].z * min(max(_40[_128 + 22u], _137), _139)));
+    
+    // --- Main Texture ---
     float _234 = ToneMapCBuffer_m0[0u].x * (float(gl_GlobalInvocationID.x) + 0.5f);
     float _235 = ToneMapCBuffer_m0[0u].y * (float(gl_GlobalInvocationID.y) + 0.5f);
     float4 _239 = g_TmRadianceMap.SampleLevel(g_LinearClampSampler, float2(_234, _235), 0.0f);
@@ -93,6 +56,9 @@ void comp_main()
     float _245 = _239.y * _225;
     float _246 = _239.z * _225;
 
+    float3 inputColor = float3(_244, _245, _246);
+
+    // --- Chromatic Aberration and Bloom ---
     float _250 = _234 * 2.0f;
     float _252 = _235 * 2.0f;
     float _254 = _250 + (-1.0f);
@@ -100,17 +66,19 @@ void comp_main()
     float _268 = clamp((ToneMapCBuffer_m0[4u].z * dot(float2(_254, _256), float2(_254, _256))) - ToneMapCBuffer_m0[4u].w, 0.0f, 1.0f);
     float _270 = ToneMapCBuffer_m0[4u].y * _268;
     float _276 = _270 * 0.5f;
-    float _293 = clamp(_268 * 1.6665999889373779296875f, 0.0f, 1.0f);
+    float _293 = saturate(_268 * 1.6665999889373779296875f);
     float4 _305 = g_TmBloomMap.SampleLevel(g_LinearClampSampler, float2(_234, _235), 0.0f);
     float _310 = ((_293 * (g_TmChromaticAbMap.SampleLevel(g_LinearClampSampler, float2(_234, _235), 0.0f).x - _244)) + _244) + _305.x;
     float _311 = ((_293 * (g_TmChromaticAbMap.SampleLevel(g_LinearClampSampler, float2(_234 - (_276 * _254), _235 - (_276 * _256)), 0.0f).y - _245)) + _245) + _305.y;
     float _312 = (((g_TmChromaticAbMap.SampleLevel(g_LinearClampSampler, float2(_234 - (_270 * _254), _235 - (_270 * _256)), 0.0f).z - _246) * _293) + _246) + _305.z;
+    
+    // --- Contrast Slider ---
     float _342;
     float _343;
     float _344;
-    if (ToneMapCBuffer_m0[7u].y != 0.0f)
+    if (ToneMapCBuffer_m0[7u].y != 0.0f)    // if contrast slider is not 10
     {
-        float _323 = clamp(dot(float3(_310, _311, _312), float3(0.300000011920928955078125f, 0.5f, 0.20000000298023223876953125f)), 0.0f, 1.0f);
+        float _323 = saturate(dot(float3(_310, _311, _312), float3(0.3f, 0.5f, 0.2f)));
         float _338 = ((((((_323 * _323) * _323) * ((((_323 * 6.0f) + (-15.0f)) * _323) + 10.0f)) - _323) * ToneMapCBuffer_m0[7u].y) + _323) / max(_323, 9.9999997473787516355514526367188e-06f);
         _342 = _338 * _310;
         _343 = _338 * _311;
@@ -122,6 +90,8 @@ void comp_main()
         _343 = _311;
         _344 = _312;
     }
+    
+    // --- UI ---
     float _354 = (_234 * ToneMapCBuffer_m0[6u].x) + ToneMapCBuffer_m0[6u].z;
     float _355 = (_235 * ToneMapCBuffer_m0[6u].y) + ToneMapCBuffer_m0[6u].w;
     float _362 = clamp((1.0f - max(abs(_354), abs(_355))) * 4096.0f, 0.0f, 1.0f);
@@ -130,6 +100,8 @@ void comp_main()
     float _376 = _369.y * _362;
     float _377 = _369.z * _362;
     float _379 = (_369.w + (-1.0f)) * _362;
+
+    // --- Radial Blur? ---
     float _397 = min(clamp((ToneMapCBuffer_m0[5u].z * dot(float3(_375, _376, _377), float3(0.2125999927520751953125f, 0.715200006961822509765625f, 0.072200000286102294921875f))) - ToneMapCBuffer_m0[5u].w, 0.0f, 1.0f), clamp(19.5f - ((_379 + 1.0f) * 20.0f), 0.0f, 1.0f));
     float _498;
     float _499;
@@ -155,11 +127,15 @@ void comp_main()
         _499 = _343;
         _500 = _344;
     }
+
+    // --- ToneMap Setup ---
     float _509 = (_250 - ToneMapCBuffer_m0[5u].x) * ToneMapCBuffer_m0[2u].y;
     float _510 = ToneMapCBuffer_m0[2u].z * (_252 - ToneMapCBuffer_m0[5u].y);
     float _517 = max(sqrt(dot(float2(_509, _510), float2(_509, _510))) - ToneMapCBuffer_m0[2u].w, 0.0f);
     float _520 = 1.0f / ((_517 * _517) + 1.0f);
     float _521 = _520 * _520;
+
+    // --- Film Grain ---
     float _530 = (ToneMapCBuffer_m0[1u].z * 2.0f) + (-0.5f);
     float _532 = ToneMapCBuffer_m0[1u].z * 6.283185482025146484375f;
     float _534 = _234 - _530;
@@ -167,23 +143,46 @@ void comp_main()
     float _536 = sin(_532);
     float _537 = cos(_532);
     float _554 = g_TmFilmGrainNoise.SampleLevel(g_LinearWrapSampler, float2(((_530 - (_535 * _536)) + (_534 * _537)) * ToneMapCBuffer_m0[1u].x, (((_534 * _536) + _530) + (_535 * _537)) * ToneMapCBuffer_m0[1u].x), 0.0f).x * 2.0f;
-    float _561 = ((((_554 >= 1.0f) ? _554 : (1.0f / (2.0f - _554))) + (-1.0f)) * ToneMapCBuffer_m0[1u].y) + 1.0f;
+    float _561 = ((((_554 >= 1.0f) ? _554 : (1.0f / (2.0f - _554))) + (-1.0f)) * ToneMapCBuffer_m0[1u].y) + 1.0f;  // ToneMapCBuffer_m0[1u].y = film grain strength
+
+    // --- Auto Exposure ---
     float _571 = ToneMapCBuffer_m0[2u].x * asfloat(g_TmAdaptedLumBuffer.Load(1u).x);
-    float4 _589 = g_TmToneMapLookup.SampleLevel(g_LinearClampSampler, float3((log2(((_521 * _498) * _561) * _571) * 0.060546875f) + 0.6513671875f, (log2(((_521 * _499) * _561) * _571) * 0.060546875f) + 0.6513671875f, (log2(((_521 * _500) * _561) * _571) * 0.060546875f) + 0.6513671875f), 0.0f);
+
+    // --- Tone Mapping LUT Application ---
+    float3 lutInputColor = _521 * float3(_498, _499, _500) * _561 * _571;
+    const float lutScale = 31.f / 512.f, lutOffset = 333.5f / 512.f;
+    const float3 lutInputShaped = (log2(lutInputColor) * lutScale) + lutOffset;
+    float4 _589 = g_TmToneMapLookup.SampleLevel(g_LinearClampSampler, lutInputShaped, 0.0f);
     float _597 = (ToneMapCBuffer_m0[7u].w != 0.0f) ? ToneMapCBuffer_m0[7u].z : 1.0f;
     float _598 = _597 * _589.x;
     float _599 = _597 * _589.y;
     float _600 = _597 * _589.z;
+
+#if 0  // scale LUT Output
+    float3 lutInputColorTM = renodx::tonemap::dice::BT709(lutInputColor, 1500.f / 200.f, 1.f);
+    float3 lutOutputColor = renodx::math::SignPow(float3(_598, _599, _600), 2.2f);
+    float3 scaledLUTOutput = UpgradeToneMap(lutInputColor, lutInputColorTM, lutOutputColor, 1.f, 2u);
+    scaledLUTOutput = renodx::tonemap::dice::BT709(scaledLUTOutput, 1080.f / 200.f, 1.f);
+    scaledLUTOutput = renodx::math::SignPow(scaledLUTOutput, 1.f / 2.2f);
+
+    _598 = scaledLUTOutput.r, _599 = scaledLUTOutput.g, _600 = scaledLUTOutput.b;
+#endif
+
+    //  --- Blend UI and Game ---
     float _601 = (-0.0f) - _379;
     float _606 = (_598 * _601) + _375;
     float _607 = (_599 * _601) + _376;
     float _608 = (_600 * _601) + _377;
+
+    // inputColor = pow(float3(_606, _607, _608), 2.2f);
+
     float _662;
     float _663;
     float _664;
     float _665;
     float _666;
     float _667;
+    // LUT Application, tonemap, apply LUT, inverse tonemap
     if (ToneMapCBuffer_m0[7u].x != 0.0f)
     {
         float _611 = max(_606, 1.0f);
@@ -218,32 +217,20 @@ void comp_main()
         _666 = _599;
         _667 = _600;
     }
+    
     float _798;
     float _799;
     float _800;
     float _801;
     float _802;
     float _803;
-    float3 inputColor;
 
-    if (ToneMapCBuffer_m0[3u].w != 0.0f)
+    if (ToneMapCBuffer_m0[3u].w != 0.0f)    // BT.2020 + PQ
     {
-        float m_HdrGamma;
-        if (RENODX_GAMMA_ADJUST_TYPE) {
-          m_HdrGamma = RENODX_GAMMA_ADJUST_VALUE;
-        } else {
-          m_HdrGamma = ToneMapCBuffer_m0[3u].w * RENODX_GAMMA_ADJUST_VALUE;
-        }
         // scene gamma - 1.9 for some reason
         float3 scene = float3(_662, _663, _664);
-        // float _680 = exp2(log2(_662) * m_HdrGamma);
-        // float _681 = exp2(log2(_663) * m_HdrGamma);
-        // float _682 = exp2(log2(_664) * m_HdrGamma);
         scene = renodx::math::SignPow(scene, m_HdrGamma);
-        float _680 = scene.r;
-        float _681 = scene.g;
-        float _682 = scene.b;
-        
+        float _680 = scene.r, _681 = scene.g, _682 = scene.b;        
         
         // scene nits
         float _683 = ToneMapCBuffer_m0[8u].x * 9.9999997473787516355514526367188e-05f;
@@ -252,12 +239,10 @@ void comp_main()
         float _713 = exp2(log2(mad(0.0432999990880489349365234375f, _682, mad(0.329299986362457275390625f, _681, _680 * 0.627399981021881103515625f)) * _683) * 0.1593017578125f);
         float _714 = exp2(log2(mad(0.011400000192224979400634765625f, _682, mad(0.91949999332427978515625f, _681, _680 * 0.069099999964237213134765625f)) * _683) * 0.1593017578125f);
         float _715 = exp2(log2(mad(0.895600020885467529296875f, _682, mad(0.087999999523162841796875f, _681, _680 * 0.01640000008046627044677734375f)) * _683) * 0.1593017578125f);
-        
-        float _750 = exp2(log2(_665) * m_HdrGamma);
-        float _751 = exp2(log2(_666) * m_HdrGamma);
-        float _752 = exp2(log2(_667) * m_HdrGamma);
 
-        // inputColor = float3(_750, _751, _752);
+        float3 color = float3(_665, _666, _667);
+        color = renodx::math::SignPow(color, m_HdrGamma);
+        float _750 = color.r, _751 = color.g, _752 = color.b;
 
         float _771 = exp2(log2(mad(0.0432999990880489349365234375f, _752, mad(0.329299986362457275390625f, _751, _750 * 0.627399981021881103515625f)) * _683) * 0.1593017578125f);
         float _772 = exp2(log2(mad(0.011400000192224979400634765625f, _752, mad(0.91949999332427978515625f, _751, _750 * 0.069099999964237213134765625f)) * _683) * 0.1593017578125f);
@@ -279,6 +264,7 @@ void comp_main()
         _802 = _666;
         _803 = _667;
     }
+    // --- Write Final Outputs ---
     g_TmOutput[uint2(gl_GlobalInvocationID.x, gl_GlobalInvocationID.y)] = float4(_798, _799, _800, 1.0f);
     // g_TmOutput[uint2(gl_GlobalInvocationID.x, gl_GlobalInvocationID.y)] = float4(renodx::color::pq::EncodeSafe(renodx::color::bt2020::from::BT709(inputColor), 200.f), 1.0f);
     if (ToneMapCBuffer_m0[9u].z != 0.0f)

--- a/src/games/spidermanmilesmorales/tonemap_cAb_off_0xECBD5D23.cs_6_6.hlsl
+++ b/src/games/spidermanmilesmorales/tonemap_cAb_off_0xECBD5D23.cs_6_6.hlsl
@@ -1,0 +1,223 @@
+#include "./common.hlsl"
+
+Texture3D<float4> g_TmToneMapLookup : register(t5, space0);
+Texture2D<float4> g_TmRadianceMap : register(t6, space0);
+Texture2D<float4> g_TmBloomMap : register(t7, space0);
+Texture3D<float4> g_TmColorFilterMap : register(t9, space0);
+Texture2D<float4> g_TmFilmGrainNoise : register(t10, space0);
+Buffer<uint4> g_TmAdaptedLumBuffer : register(t11, space0);
+Texture2D<float4> g_TmSrgbOverlayMap : register(t12, space0);
+Texture2D<float4> g_TmRadianceBlurMap : register(t13, space0);
+RWTexture2D<float4> g_TmOutput : register(u0, space0);
+RWTexture2D<float4> g_TmOutputHudless : register(u1, space0);
+SamplerState g_PointClampSampler : register(s0, space0);
+SamplerState g_LinearClampSampler : register(s2, space0);
+SamplerState g_LinearWrapSampler : register(s3, space0);
+
+static uint3 gl_GlobalInvocationID;
+struct SPIRV_Cross_Input
+{
+    uint3 gl_GlobalInvocationID : SV_DispatchThreadID;
+};
+
+groupshared float _39[128];
+
+void comp_main()
+{
+    uint _50 = gl_GlobalInvocationID.x & 7u;
+    uint _52 = gl_GlobalInvocationID.y & 7u;
+    uint _55 = (_52 << 3u) | _50;
+    uint _58 = (_55 * 3277u) >> 14u;
+    uint _65 = ((_58 * 4294967291u) + _55) << 1u;
+    float _78 = (float((gl_GlobalInvocationID.x - _50) + _65) + 0.5f) * ToneMapCBuffer_m0[0u].x;
+    float _79 = (float((gl_GlobalInvocationID.y - _52) + _58) + 0.5f) * ToneMapCBuffer_m0[0u].y;
+    uint _119 = _65 + (_58 * 10u);
+    _39[_119] = log2(max(dot(float3(g_TmRadianceMap.SampleLevel(g_PointClampSampler, float2(_78, _79), 0.0f, int2(-1, -1)).xyz), float3(0.2125999927520751953125f, 0.715200006961822509765625f, 0.072200000286102294921875f)), 9.9999997473787516355514526367188e-06f));
+    _39[_119 | 1u] = log2(max(dot(float3(g_TmRadianceMap.SampleLevel(g_PointClampSampler, float2(_78, _79), 0.0f, int2(0, -1)).xyz), float3(0.2125999927520751953125f, 0.715200006961822509765625f, 0.072200000286102294921875f)), 9.9999997473787516355514526367188e-06f));
+    GroupMemoryBarrierWithGroupSync();
+    uint _127 = (_52 * 10u) + _50;
+    uint _128 = _127 + 11u;
+    float _136 = _39[_128] + (-0.60000002384185791015625f);
+    float _138 = _39[_128] + 0.60000002384185791015625f;
+    float _222 = ((((((((ToneMapCBuffer_m0[3u].x * _39[_128]) - _39[_128]) + (ToneMapCBuffer_m0[3u].z * min(max(_39[_127], _136), _138))) + (ToneMapCBuffer_m0[3u].y * min(max(_39[_127 + 1u], _136), _138))) + (ToneMapCBuffer_m0[3u].z * min(max(_39[_127 + 2u], _136), _138))) + (ToneMapCBuffer_m0[3u].y * min(max(_39[_127 + 10u], _136), _138))) + (ToneMapCBuffer_m0[3u].y * min(max(_39[_127 + 12u], _136), _138))) + (ToneMapCBuffer_m0[3u].z * min(max(_39[_127 + 20u], _136), _138))) + (ToneMapCBuffer_m0[3u].y * min(max(_39[_127 + 21u], _136), _138));
+    float _224 = exp2(_222 + (ToneMapCBuffer_m0[3u].z * min(max(_39[_127 + 22u], _136), _138)));
+    float _233 = ToneMapCBuffer_m0[0u].x * (float(gl_GlobalInvocationID.x) + 0.5f);
+    float _234 = ToneMapCBuffer_m0[0u].y * (float(gl_GlobalInvocationID.y) + 0.5f);
+    float4 _238 = g_TmRadianceMap.SampleLevel(g_LinearClampSampler, float2(_233, _234), 0.0f);
+    float4 _248 = g_TmBloomMap.SampleLevel(g_LinearClampSampler, float2(_233, _234), 0.0f);
+    float _253 = _248.x + (_238.x * _224);
+    float _254 = _248.y + (_238.y * _224);
+    float _255 = _248.z + (_238.z * _224);
+    float _286;
+    float _287;
+    float _288;
+    if (ToneMapCBuffer_m0[7u].y != 0.0f)
+    {
+        float _267 = clamp(dot(float3(_253, _254, _255), float3(0.300000011920928955078125f, 0.5f, 0.20000000298023223876953125f)), 0.0f, 1.0f);
+        float _282 = ((((((_267 * _267) * _267) * ((((_267 * 6.0f) + (-15.0f)) * _267) + 10.0f)) - _267) * ToneMapCBuffer_m0[7u].y) + _267) / max(_267, 9.9999997473787516355514526367188e-06f);
+        _286 = _282 * _253;
+        _287 = _282 * _254;
+        _288 = _282 * _255;
+    }
+    else
+    {
+        _286 = _253;
+        _287 = _254;
+        _288 = _255;
+    }
+    float _298 = (_233 * ToneMapCBuffer_m0[6u].x) + ToneMapCBuffer_m0[6u].z;
+    float _299 = (_234 * ToneMapCBuffer_m0[6u].y) + ToneMapCBuffer_m0[6u].w;
+    float _306 = clamp((1.0f - max(abs(_298), abs(_299))) * 4096.0f, 0.0f, 1.0f);
+    float4 _313 = g_TmSrgbOverlayMap.SampleLevel(g_LinearClampSampler, float2((_298 * 0.5f) + 0.5f, (_299 * 0.5f) + 0.5f), 0.0f);
+    float _319 = _313.x * _306;
+    float _320 = _313.y * _306;
+    float _321 = _313.z * _306;
+    float _324 = (_313.w + (-1.0f)) * _306;
+    float _342 = min(clamp((ToneMapCBuffer_m0[5u].z * dot(float3(_319, _320, _321), float3(0.2125999927520751953125f, 0.715200006961822509765625f, 0.072200000286102294921875f))) - ToneMapCBuffer_m0[5u].w, 0.0f, 1.0f), clamp(19.5f - ((_324 + 1.0f) * 20.0f), 0.0f, 1.0f));
+    float _443;
+    float _444;
+    float _445;
+    if (_342 > 0.0f)
+    {
+        float4 _346 = g_TmRadianceBlurMap.SampleLevel(g_LinearClampSampler, float2(_233, _234), 0.0f);
+        float4 _355 = g_TmRadianceBlurMap.SampleLevel(g_LinearClampSampler, float2(_233, _234), 0.0f, int2(-1, -1));
+        float4 _360 = g_TmRadianceBlurMap.SampleLevel(g_LinearClampSampler, float2(_233, _234), 0.0f, int2(0, -1));
+        float4 _366 = g_TmRadianceBlurMap.SampleLevel(g_LinearClampSampler, float2(_233, _234), 0.0f, int2(1, -1));
+        float4 _372 = g_TmRadianceBlurMap.SampleLevel(g_LinearClampSampler, float2(_233, _234), 0.0f, int2(-1, 0));
+        float4 _378 = g_TmRadianceBlurMap.SampleLevel(g_LinearClampSampler, float2(_233, _234), 0.0f, int2(1, 0));
+        float4 _384 = g_TmRadianceBlurMap.SampleLevel(g_LinearClampSampler, float2(_233, _234), 0.0f, int2(-1, 1));
+        float4 _390 = g_TmRadianceBlurMap.SampleLevel(g_LinearClampSampler, float2(_233, _234), 0.0f, int2(0, 1));
+        float4 _396 = g_TmRadianceBlurMap.SampleLevel(g_LinearClampSampler, float2(_233, _234), 0.0f, int2(1, 1));
+        _443 = (((((_346.x * 0.25f) - _286) + ((((_372.x + _360.x) + _378.x) + _390.x) * 0.125f)) + ((((_366.x + _355.x) + _384.x) + _396.x) * 0.0625f)) * _342) + _286;
+        _444 = (((((_346.y * 0.25f) - _287) + ((((_372.y + _360.y) + _378.y) + _390.y) * 0.125f)) + ((((_366.y + _355.y) + _384.y) + _396.y) * 0.0625f)) * _342) + _287;
+        _445 = (((((_346.z * 0.25f) - _288) + ((((_372.z + _360.z) + _378.z) + _390.z) * 0.125f)) + ((((_366.z + _355.z) + _384.z) + _396.z) * 0.0625f)) * _342) + _288;
+    }
+    else
+    {
+        _443 = _286;
+        _444 = _287;
+        _445 = _288;
+    }
+    float _457 = ((_233 * 2.0f) - ToneMapCBuffer_m0[5u].x) * ToneMapCBuffer_m0[2u].y;
+    float _458 = ToneMapCBuffer_m0[2u].z * ((_234 * 2.0f) - ToneMapCBuffer_m0[5u].y);
+    float _465 = max(sqrt(dot(float2(_457, _458), float2(_457, _458))) - ToneMapCBuffer_m0[2u].w, 0.0f);
+    float _468 = 1.0f / ((_465 * _465) + 1.0f);
+    float _469 = _468 * _468;
+    float _481 = (ToneMapCBuffer_m0[1u].z * 2.0f) + (-0.5f);
+    float _483 = ToneMapCBuffer_m0[1u].z * 6.283185482025146484375f;
+    float _485 = _233 - _481;
+    float _486 = (ToneMapCBuffer_m0[1u].w * _234) - _481;
+    float _487 = sin(_483);
+    float _488 = cos(_483);
+    float _505 = g_TmFilmGrainNoise.SampleLevel(g_LinearWrapSampler, float2(((_481 - (_486 * _487)) + (_485 * _488)) * ToneMapCBuffer_m0[1u].x, (((_485 * _487) + _481) + (_486 * _488)) * ToneMapCBuffer_m0[1u].x), 0.0f).x * 2.0f;
+    float _512 = ((((_505 >= 1.0f) ? _505 : (1.0f / (2.0f - _505))) + (-1.0f)) * ToneMapCBuffer_m0[1u].y) + 1.0f;
+    float _522 = ToneMapCBuffer_m0[2u].x * asfloat(g_TmAdaptedLumBuffer.Load(1u).x);
+    float4 _540 = g_TmToneMapLookup.SampleLevel(g_LinearClampSampler, float3((log2(((_469 * _443) * _512) * _522) * 0.060546875f) + 0.6513671875f, (log2(((_469 * _444) * _512) * _522) * 0.060546875f) + 0.6513671875f, (log2(((_469 * _445) * _512) * _522) * 0.060546875f) + 0.6513671875f), 0.0f);
+    float _548 = (ToneMapCBuffer_m0[7u].w != 0.0f) ? ToneMapCBuffer_m0[7u].z : 1.0f;
+    float _549 = _548 * _540.x;
+    float _550 = _548 * _540.y;
+    float _551 = _548 * _540.z;
+    float _552 = (-0.0f) - _324;
+    float _557 = (_549 * _552) + _319;
+    float _558 = (_550 * _552) + _320;
+    float _559 = (_551 * _552) + _321;
+    float _613;
+    float _614;
+    float _615;
+    float _616;
+    float _617;
+    float _618;
+    if (ToneMapCBuffer_m0[7u].x != 0.0f)
+    {
+        float _562 = max(_557, 1.0f);
+        float _563 = max(_558, 1.0f);
+        float _564 = max(_559, 1.0f);
+        float _565 = 1.0f / _562;
+        float _566 = 1.0f / _563;
+        float _567 = 1.0f / _564;
+        float _568 = _565 * _557;
+        float _569 = _566 * _558;
+        float _570 = _567 * _559;
+        float _571 = _565 * _549;
+        float _572 = _566 * _550;
+        float _573 = _567 * _551;
+        float4 _584 = g_TmColorFilterMap.SampleLevel(g_LinearClampSampler, float3((_568 * 0.96875f) + 0.015625f, (_569 * 0.96875f) + 0.015625f, (_570 * 0.96875f) + 0.015625f), 0.0f);
+        float _586 = _584.x;
+        float _587 = _584.y;
+        float _588 = _584.z;
+        _613 = ((ToneMapCBuffer_m0[7u].x * (_586 - _568)) + _568) * _562;
+        _614 = ((ToneMapCBuffer_m0[7u].x * (_587 - _569)) + _569) * _563;
+        _615 = ((ToneMapCBuffer_m0[7u].x * (_588 - _570)) + _570) * _564;
+        _616 = ((ToneMapCBuffer_m0[7u].x * (_586 - _571)) + _571) * _562;
+        _617 = ((ToneMapCBuffer_m0[7u].x * (_587 - _572)) + _572) * _563;
+        _618 = ((ToneMapCBuffer_m0[7u].x * (_588 - _573)) + _573) * _564;
+    }
+    else
+    {
+        _613 = _557;
+        _614 = _558;
+        _615 = _559;
+        _616 = _549;
+        _617 = _550;
+        _618 = _551;
+    }
+    float _749;
+    float _750;
+    float _751;
+    float _752;
+    float _753;
+    float _754;
+    if (ToneMapCBuffer_m0[3u].w != 0.0f)
+    {
+        float m_HdrGamma;
+        if (RENODX_GAMMA_ADJUST_TYPE) {
+            m_HdrGamma = RENODX_GAMMA_ADJUST_VALUE;
+        } else {
+            m_HdrGamma = ToneMapCBuffer_m0[3u].w * RENODX_GAMMA_ADJUST_VALUE;
+        }
+
+        float3 scene = float3(_613, _614, _615);
+        scene = renodx::math::SignPow(scene, m_HdrGamma);
+        float _631 = scene.r, _632 = scene.g, _633 = scene.b;
+
+        float _634 = ToneMapCBuffer_m0[8u].x * 9.9999997473787516355514526367188e-05f;
+        float _664 = exp2(log2(mad(0.0432999990880489349365234375f, _633, mad(0.329299986362457275390625f, _632, _631 * 0.627399981021881103515625f)) * _634) * 0.1593017578125f);
+        float _665 = exp2(log2(mad(0.011400000192224979400634765625f, _633, mad(0.91949999332427978515625f, _632, _631 * 0.069099999964237213134765625f)) * _634) * 0.1593017578125f);
+        float _666 = exp2(log2(mad(0.895600020885467529296875f, _633, mad(0.087999999523162841796875f, _632, _631 * 0.01640000008046627044677734375f)) * _634) * 0.1593017578125f);
+
+        float3 color = float3(_616, _617, _618);
+        color = renodx::math::SignPow(color, m_HdrGamma);
+        float _701 = color.r, _702 = color.g, _703 = color.b;
+
+        float _722 = exp2(log2(mad(0.0432999990880489349365234375f, _703, mad(0.329299986362457275390625f, _702, _701 * 0.627399981021881103515625f)) * _634) * 0.1593017578125f);
+        float _723 = exp2(log2(mad(0.011400000192224979400634765625f, _703, mad(0.91949999332427978515625f, _702, _701 * 0.069099999964237213134765625f)) * _634) * 0.1593017578125f);
+        float _724 = exp2(log2(mad(0.895600020885467529296875f, _703, mad(0.087999999523162841796875f, _702, _701 * 0.01640000008046627044677734375f)) * _634) * 0.1593017578125f);
+        _749 = exp2(log2(((_664 * 18.8515625f) + 0.8359375f) / ((_664 * 18.6875f) + 1.0f)) * 78.84375f);
+        _750 = exp2(log2(((_665 * 18.8515625f) + 0.8359375f) / ((_665 * 18.6875f) + 1.0f)) * 78.84375f);
+        _751 = exp2(log2(((_666 * 18.8515625f) + 0.8359375f) / ((_666 * 18.6875f) + 1.0f)) * 78.84375f);
+        _752 = exp2(log2(((_722 * 18.8515625f) + 0.8359375f) / ((_722 * 18.6875f) + 1.0f)) * 78.84375f);
+        _753 = exp2(log2(((_723 * 18.8515625f) + 0.8359375f) / ((_723 * 18.6875f) + 1.0f)) * 78.84375f);
+        _754 = exp2(log2(((_724 * 18.8515625f) + 0.8359375f) / ((_724 * 18.6875f) + 1.0f)) * 78.84375f);
+    }
+    else
+    {
+        _749 = _613;
+        _750 = _614;
+        _751 = _615;
+        _752 = _616;
+        _753 = _617;
+        _754 = _618;
+    }
+    g_TmOutput[uint2(gl_GlobalInvocationID.x, gl_GlobalInvocationID.y)] = float4(_749, _750, _751, 1.0f);
+    if (ToneMapCBuffer_m0[9u].z != 0.0f)
+    {
+        g_TmOutputHudless[uint2(gl_GlobalInvocationID.x, gl_GlobalInvocationID.y)] = float4(_752, _753, _754, 1.0f);
+    }
+}
+
+[numthreads(8, 8, 1)]
+void main(SPIRV_Cross_Input stage_input)
+{
+    gl_GlobalInvocationID = stage_input.gl_GlobalInvocationID;
+    comp_main();
+}


### PR DESCRIPTION
- Overrides the gamma value for Spider-Man: Miles Morales to 2.2 instead of the original ~1.9 value
- There are no sliders as they resulted in crashes when ray tracing is enabled
- The project folder has been set up in a way that allows for sliders to easily be added