### PR TITLE
Added bloom and fog controls to bioshock 1 version of RenoDX

### DIFF
--- a/src/games/bioshock/Bloom_Tonemap_0x6457104F.ps_4_0.hlsl
+++ b/src/games/bioshock/Bloom_Tonemap_0x6457104F.ps_4_0.hlsl
@@ -35,7 +35,7 @@ void main(
 {
   float3 bloomColor = s_bloom.Sample(s_bloom_s, w1.xy).rgb;
   float4 sceneColor = s_framebuffer.Sample(s_framebuffer_s, v1.xy).rgba;
-  bloomColor *= bloomAlpha; // Scale down (or up) the bloom intensity
+  bloomColor *= bloomAlpha * injectedData.BloomAmount; // Scale down (or up) the bloom intensity
   sceneColor.rgb += bloomColor; // Bloom is 100% additive here
   sceneColor.rgb *= sceneBias; // Exposure?
   

--- a/src/games/bioshock/Fog2_0x0C454543.ps_4_0.hlsl
+++ b/src/games/bioshock/Fog2_0x0C454543.ps_4_0.hlsl
@@ -1,0 +1,218 @@
+#include "./shared.h"
+
+cbuffer _Globals : register(b0)
+{
+  float LayerLighting_hlsl_PSMain015108167936257073_54bits : packoffset(c0) = {0};
+  float4 fogColor : packoffset(c1);
+  float3 fogTransform : packoffset(c2);
+  float4x3 screenDataToCamera : packoffset(c3);
+  float globalScale : packoffset(c6);
+  float sceneDepthAlphaMask : packoffset(c6.y);
+  float globalOpacity : packoffset(c6.z);
+  float distortionBufferScale : packoffset(c6.w);
+  float2 wToZScaleAndBias : packoffset(c7);
+  float4 screenTransform[2] : packoffset(c8);
+  float4x4 worldViewProj : packoffset(c10);
+  float3 localEyePos : packoffset(c14);
+  float4 vertexClipPlane : packoffset(c15);
+  float specularPower : packoffset(c16);
+  float distortionStrength : packoffset(c16.y);
+  float3 specularColor : packoffset(c17);
+  float environmentMapLevel : packoffset(c17.w);
+  float3 selfIlluminationColor : packoffset(c18);
+  float3 subsurfaceColor : packoffset(c19);
+  float3 diffuseColor : packoffset(c20);
+  float specularCubeMapBrightness : packoffset(c20.w);
+  float minAlphaClipValue : packoffset(c21);
+  float maxAlphaClipValue : packoffset(c21.y);
+  float2 heightMapScaleAndBias : packoffset(c21.z);
+  float4x2 diffuseTexTransform : packoffset(c22);
+  float4x2 opacityTexTransform : packoffset(c24);
+  float4x2 selfIllumTexTransform : packoffset(c26);
+
+  struct
+  {
+    float4 ambientVector;
+    float4 ambientColorLow;
+    float4 ambientControls;
+  } Ambient : packoffset(c28);
+
+  float4 luminanceMapUVPacking : packoffset(c31);
+
+  struct
+  {
+    float4 worldVector;
+    float4 color;
+    float4 channelMask;
+  } lights[6] : packoffset(c32);
+
+  row_major float4x4 localToWorld : packoffset(c50);
+  row_major float4x4 screenToWorld : packoffset(c54);
+  float3 worldEyePos : packoffset(c58);
+}
+
+SamplerState mtbSampleSlot1_s : register(s0);
+SamplerState mtbSampleSlot2_s : register(s1);
+SamplerState GaussianLookup_s : register(s2);
+SamplerState s_luminanceMap1_s : register(s3);
+SamplerState s_luminanceMap2_s : register(s4);
+SamplerState s_shadowMask_s : register(s5);
+Texture2D<float4> mtbSampleSlot2 : register(t0);
+Texture2D<float4> s_luminanceMap1 : register(t1);
+Texture2D<float4> s_luminanceMap2 : register(t2);
+Texture2D<float4> mtbSampleSlot1 : register(t3);
+Texture2D<float4> s_shadowMask : register(t4);
+Texture2D<float4> GaussianLookup : register(t5);
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : TEXCOORD0,
+  float4 v1 : TEXCOORD1,
+  float4 v2 : TEXCOORD6,
+  float4 v3 : TEXCOORD7,
+  float4 v4 : TEXCOORD3,
+  float4 v5 : TEXCOORD4,
+  float4 v6 : TEXCOORD5,
+  float3 v7 : COLOR0,
+  float4 v8 : TEXCOORD9,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8,r9;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyz = worldEyePos.xyz + -v8.xyz;
+  r0.w = dot(r0.xyz, r0.xyz);
+  r0.w = rsqrt(r0.w);
+  r0.xyz = r0.xyz * r0.www;
+  r1.xyz = -v8.xyz * lights[1].worldVector + lights[1].worldVector;
+  r0.w = dot(r1.xyz, r1.xyz);
+  r0.w = rsqrt(r0.w);
+  r2.xyz = r1.xyz * r0.www + r0.xyz;
+  r1.xyz = r1.xyz * r0.www;
+  r0.w = dot(r2.xyz, r2.xyz);
+  r0.w = rsqrt(r0.w);
+  r2.xyz = r2.xyz * r0.www;
+  r3.xyzw = mtbSampleSlot2.Sample(mtbSampleSlot2_s, v0.xy).xyzw;
+  r3.xyz = r3.xyz * float3(2,2,2) + float3(-1,-1,-1);
+  r4.xyz = v5.xyz * r3.yyy;
+  r3.xyw = r3.xxx * v4.xyz + r4.xyz;
+  r3.xyz = r3.zzz * v6.xyz + r3.xyw;
+  r0.w = dot(r3.xyz, r3.xyz);
+  r0.w = rsqrt(r0.w);
+  r3.xyz = r3.xyz * r0.www;
+  r0.w = saturate(dot(r3.xyz, r2.xyz));
+  r0.w = log2(r0.w);
+  r2.y = 0.001953125 * specularPower;
+  r2.x = dot(r3.xyz, r3.xyz);
+  r2.xyzw = GaussianLookup.Sample(GaussianLookup_s, r2.xy).xyzw;
+  r2.xy = saturate(r2.xy);
+  r1.w = 0.00100000005 + r2.x;
+  r1.w = r1.w * specularPower + 1.00000001e-007;
+  r0.w = r1.w * r0.w;
+  r0.w = exp2(r0.w);
+  r2.xzw = -v8.xyz * lights[2].worldVector + lights[2].worldVector;
+  r3.w = dot(r2.xzw, r2.xzw);
+  r3.w = rsqrt(r3.w);
+  r4.xyz = r2.xzw * r3.www + r0.xyz;
+  r2.xzw = r3.www * r2.xzw;
+  r2.x = saturate(dot(r2.xzw, r3.xyz));
+  r2.z = dot(r4.xyz, r4.xyz);
+  r2.z = rsqrt(r2.z);
+  r4.xyz = r4.xyz * r2.zzz;
+  r2.z = saturate(dot(r3.xyz, r4.xyz));
+  r2.z = log2(r2.z);
+  r2.z = r2.z * r1.w;
+  r2.z = exp2(r2.z);
+  r4.x = v4.w;
+  r4.y = v5.w;
+  r4.xyzw = s_luminanceMap1.Sample(s_luminanceMap1_s, r4.xy).xyzw;
+  r5.xy = v2.xy / v2.ww;
+  r5.xyzw = s_shadowMask.Sample(s_shadowMask_s, r5.xy).xyzw;
+  r2.w = saturate(dot(r5.xyzw, lights[2].channelMask));
+  r2.w = 1 + -r2.w;
+  r2.w = saturate(r4.z * r2.w);
+  r6.xyz = lights[2].color * r2.www;
+  r7.xyz = r6.xyz * r2.zzz;
+  r2.xzw = r6.xyz * r2.xxx;
+  r3.w = saturate(dot(r5.xyzw, lights[1].channelMask));
+  r3.w = 1 + -r3.w;
+  r3.w = saturate(r4.y * r3.w);
+  r4.yzw = lights[1].color * r3.www;
+  r6.xyz = r0.www * r4.yzw + r7.xyz;
+  r7.xyz = -v8.xyz * lights[3].worldVector + lights[3].worldVector;
+  r0.w = dot(r7.xyz, r7.xyz);
+  r0.w = rsqrt(r0.w);
+  r8.xyz = r7.xyz * r0.www + r0.xyz;
+  r7.xyz = r7.xyz * r0.www;
+  r0.w = saturate(dot(r7.xyz, r3.xyz));
+  r3.w = dot(r8.xyz, r8.xyz);
+  r3.w = rsqrt(r3.w);
+  r7.xyz = r8.xyz * r3.www;
+  r3.w = saturate(dot(r3.xyz, r7.xyz));
+  r3.w = log2(r3.w);
+  r3.w = r3.w * r1.w;
+  r3.w = exp2(r3.w);
+  r6.w = saturate(dot(r5.xyzw, lights[3].channelMask));
+  r6.w = 1 + -r6.w;
+  r4.x = saturate(r6.w * r4.x);
+  r7.xyz = lights[3].color * r4.xxx;
+  r6.xyz = r3.www * r7.xyz + r6.xyz;
+  r8.xyz = -v8.xyz * lights[4].worldVector + lights[4].worldVector;
+  r3.w = dot(r8.xyz, r8.xyz);
+  r3.w = rsqrt(r3.w);
+  r9.xyz = r8.xyz * r3.www + r0.xyz;
+  r8.xyz = r8.xyz * r3.www;
+  r3.w = saturate(dot(r8.xyz, r3.xyz));
+  r4.x = dot(r9.xyz, r9.xyz);
+  r4.x = rsqrt(r4.x);
+  r8.xyz = r9.xyz * r4.xxx;
+  r4.x = saturate(dot(r3.xyz, r8.xyz));
+  r4.x = log2(r4.x);
+  r4.x = r4.x * r1.w;
+  r4.x = exp2(r4.x);
+  r6.w = saturate(dot(r5.xyzw, lights[4].channelMask));
+  r5.x = saturate(dot(r5.xyzw, lights[5].channelMask));
+  r5.x = 1 + -r5.x;
+  r5.y = 1 + -r6.w;
+  r8.xyzw = s_luminanceMap2.Sample(s_luminanceMap2_s, v7.xy).xyzw;
+  r5.xy = saturate(r8.zy * r5.xy);
+  r5.xzw = lights[5].color * r5.xxx;
+  r8.xyz = lights[4].color * r5.yyy;
+  r6.xyz = r4.xxx * r8.xyz + r6.xyz;
+  r9.xyz = -v8.xyz * lights[5].worldVector + lights[5].worldVector;
+  r4.x = dot(r9.xyz, r9.xyz);
+  r4.x = rsqrt(r4.x);
+  r0.xyz = r9.xyz * r4.xxx + r0.xyz;
+  r9.xyz = r9.xyz * r4.xxx;
+  r4.x = saturate(dot(r9.xyz, r3.xyz));
+  r5.y = dot(r0.xyz, r0.xyz);
+  r5.y = rsqrt(r5.y);
+  r0.xyz = r5.yyy * r0.xyz;
+  r0.x = saturate(dot(r3.xyz, r0.xyz));
+  r0.y = saturate(dot(r1.xyz, r3.xyz));
+  r1.xyz = r0.yyy * r4.yzw + r2.xzw;
+  r0.yzw = r0.www * r7.xyz + r1.xyz;
+  r0.yzw = r3.www * r8.xyz + r0.yzw;
+  r0.yzw = r4.xxx * r5.xzw + r0.yzw;
+  r0.x = log2(r0.x);
+  r0.x = r1.w * r0.x;
+  r0.x = exp2(r0.x);
+  r1.xyz = r0.xxx * r5.xzw + r6.xyz;
+  r3.xyzw = mtbSampleSlot1.Sample(mtbSampleSlot1_s, v0.xy).xyzw;
+  r2.xzw = diffuseColor.xyz * r3.xyz;
+  r0.xyz = r2.xzw * r0.yzw;
+  r2.xzw = specularColor.xyz * r3.www;
+  r2.xzw = r2.xzw * r3.xyz;
+  r2.xyz = r2.yyy * r2.xzw;
+  r0.xyz = r2.xyz * r1.xyz + r0.xyz;
+  r1.xyz = fogColor.xyz + -r0.xyz;
+  r0.xyz = v2.zzz * r1.xyz + r0.xyz;
+  o0.xyz = globalScale * injectedData.FogAmount * r0.xyz;
+  o0.w = globalOpacity * v3.w;
+  return;
+}

--- a/src/games/bioshock/Fog3_0x3F8A5A79.ps_4_0.hlsl
+++ b/src/games/bioshock/Fog3_0x3F8A5A79.ps_4_0.hlsl
@@ -1,0 +1,202 @@
+#include "./shared.h"
+
+cbuffer _Globals : register(b0)
+{
+  float LayerLighting_hlsl_PSMain010323094607244337_54bits : packoffset(c0) = {0};
+  float4 fogColor : packoffset(c1);
+  float3 fogTransform : packoffset(c2);
+  float4x3 screenDataToCamera : packoffset(c3);
+  float globalScale : packoffset(c6);
+  float sceneDepthAlphaMask : packoffset(c6.y);
+  float globalOpacity : packoffset(c6.z);
+  float distortionBufferScale : packoffset(c6.w);
+  float2 wToZScaleAndBias : packoffset(c7);
+  float4 screenTransform[2] : packoffset(c8);
+  float4x4 worldViewProj : packoffset(c10);
+  float3 localEyePos : packoffset(c14);
+  float4 vertexClipPlane : packoffset(c15);
+  float specularPower : packoffset(c16);
+  float distortionStrength : packoffset(c16.y);
+  float3 specularColor : packoffset(c17);
+  float environmentMapLevel : packoffset(c17.w);
+  float3 selfIlluminationColor : packoffset(c18);
+  float3 subsurfaceColor : packoffset(c19);
+  float3 diffuseColor : packoffset(c20);
+  float specularCubeMapBrightness : packoffset(c20.w);
+  float minAlphaClipValue : packoffset(c21);
+  float maxAlphaClipValue : packoffset(c21.y);
+  float2 heightMapScaleAndBias : packoffset(c21.z);
+  float4x2 diffuseTexTransform : packoffset(c22);
+  float4x2 opacityTexTransform : packoffset(c24);
+  float4x2 selfIllumTexTransform : packoffset(c26);
+
+  struct
+  {
+    float4 ambientVector;
+    float4 ambientColorLow;
+    float4 ambientControls;
+  } Ambient : packoffset(c28);
+
+  float4 luminanceMapUVPacking : packoffset(c31);
+
+  struct
+  {
+    float4 worldVector;
+    float4 color;
+    float4 channelMask;
+  } lights[5] : packoffset(c32);
+
+  row_major float4x4 localToWorld : packoffset(c47);
+  row_major float4x4 screenToWorld : packoffset(c51);
+  float3 worldEyePos : packoffset(c55);
+}
+
+SamplerState mtbSampleSlot1_s : register(s0);
+SamplerState mtbSampleSlot2_s : register(s1);
+SamplerState mtbSampleSlot3_s : register(s2);
+SamplerState GaussianLookup_s : register(s3);
+SamplerState s_luminanceMap1_s : register(s4);
+SamplerState s_luminanceMap2_s : register(s5);
+SamplerState s_shadowMask_s : register(s6);
+Texture2D<float4> mtbSampleSlot2 : register(t0);
+Texture2D<float4> s_luminanceMap1 : register(t1);
+Texture2D<float4> s_luminanceMap2 : register(t2);
+Texture2D<float4> mtbSampleSlot1 : register(t3);
+Texture2D<float4> s_shadowMask : register(t4);
+Texture2D<float4> mtbSampleSlot3 : register(t5);
+Texture2D<float4> GaussianLookup : register(t6);
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : TEXCOORD0,
+  float4 v1 : TEXCOORD1,
+  float4 v2 : TEXCOORD6,
+  float4 v3 : TEXCOORD7,
+  float4 v4 : TEXCOORD3,
+  float4 v5 : TEXCOORD4,
+  float4 v6 : TEXCOORD5,
+  float3 v7 : COLOR0,
+  float4 v8 : TEXCOORD9,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyz = worldEyePos.xyz + -v8.xyz;
+  r0.w = dot(r0.xyz, r0.xyz);
+  r0.w = rsqrt(r0.w);
+  r0.xyz = r0.xyz * r0.www;
+  r1.xyz = -v8.xyz * lights[1].worldVector + lights[1].worldVector;
+  r0.w = dot(r1.xyz, r1.xyz);
+  r0.w = rsqrt(r0.w);
+  r2.xyz = r1.xyz * r0.www + r0.xyz;
+  r1.xyz = r1.xyz * r0.www;
+  r0.w = dot(r2.xyz, r2.xyz);
+  r0.w = rsqrt(r0.w);
+  r2.xyz = r2.xyz * r0.www;
+  r3.xyzw = mtbSampleSlot2.Sample(mtbSampleSlot2_s, v0.xy).xyzw;
+  r3.xyz = r3.xyz * float3(2,2,2) + float3(-1,-1,-1);
+  r4.xyz = v5.xyz * r3.yyy;
+  r3.xyw = r3.xxx * v4.xyz + r4.xyz;
+  r3.xyz = r3.zzz * v6.xyz + r3.xyw;
+  r0.w = dot(r3.xyz, r3.xyz);
+  r0.w = rsqrt(r0.w);
+  r3.xyz = r3.xyz * r0.www;
+  r0.w = saturate(dot(r3.xyz, r2.xyz));
+  r0.w = log2(r0.w);
+  r2.y = 0.001953125 * specularPower;
+  r2.x = dot(r3.xyz, r3.xyz);
+  r2.xyzw = GaussianLookup.Sample(GaussianLookup_s, r2.xy).xyzw;
+  r2.xy = saturate(r2.xy);
+  r1.w = 0.00100000005 + r2.x;
+  r1.w = r1.w * specularPower + 1.00000001e-007;
+  r0.w = r1.w * r0.w;
+  r0.w = exp2(r0.w);
+  r2.xzw = -v8.xyz * lights[2].worldVector + lights[2].worldVector;
+  r3.w = dot(r2.xzw, r2.xzw);
+  r3.w = rsqrt(r3.w);
+  r4.xyz = r2.xzw * r3.www + r0.xyz;
+  r2.xzw = r3.www * r2.xzw;
+  r2.x = saturate(dot(r2.xzw, r3.xyz));
+  r2.z = dot(r4.xyz, r4.xyz);
+  r2.z = rsqrt(r2.z);
+  r4.xyz = r4.xyz * r2.zzz;
+  r2.z = saturate(dot(r3.xyz, r4.xyz));
+  r2.z = log2(r2.z);
+  r2.z = r2.z * r1.w;
+  r2.z = exp2(r2.z);
+  r4.x = v4.w;
+  r4.y = v5.w;
+  r4.xyzw = s_luminanceMap1.Sample(s_luminanceMap1_s, r4.xy).xyzw;
+  r5.xy = v2.xy / v2.ww;
+  r5.xyzw = s_shadowMask.Sample(s_shadowMask_s, r5.xy).xyzw;
+  r2.w = saturate(dot(r5.xyzw, lights[2].channelMask));
+  r2.w = 1 + -r2.w;
+  r2.w = saturate(r4.z * r2.w);
+  r6.xyz = lights[2].color * r2.www;
+  r7.xyz = r6.xyz * r2.zzz;
+  r2.xzw = r6.xyz * r2.xxx;
+  r3.w = saturate(dot(r5.xyzw, lights[1].channelMask));
+  r3.w = 1 + -r3.w;
+  r3.w = saturate(r4.y * r3.w);
+  r4.yzw = lights[1].color * r3.www;
+  r6.xyz = r0.www * r4.yzw + r7.xyz;
+  r7.xyz = -v8.xyz * lights[3].worldVector + lights[3].worldVector;
+  r0.w = dot(r7.xyz, r7.xyz);
+  r0.w = rsqrt(r0.w);
+  r8.xyz = r7.xyz * r0.www + r0.xyz;
+  r7.xyz = r7.xyz * r0.www;
+  r0.w = saturate(dot(r7.xyz, r3.xyz));
+  r3.w = dot(r8.xyz, r8.xyz);
+  r3.w = rsqrt(r3.w);
+  r7.xyz = r8.xyz * r3.www;
+  r3.w = saturate(dot(r3.xyz, r7.xyz));
+  r3.w = log2(r3.w);
+  r3.w = r3.w * r1.w;
+  r3.w = exp2(r3.w);
+  r6.w = saturate(dot(r5.xyzw, lights[3].channelMask));
+  r5.x = saturate(dot(r5.xyzw, lights[4].channelMask));
+  r5.x = 1 + -r5.x;
+  r5.y = 1 + -r6.w;
+  r4.x = saturate(r5.y * r4.x);
+  r5.yzw = lights[3].color * r4.xxx;
+  r6.xyz = r3.www * r5.yzw + r6.xyz;
+  r7.xyz = -v8.xyz * lights[4].worldVector + lights[4].worldVector;
+  r3.w = dot(r7.xyz, r7.xyz);
+  r3.w = rsqrt(r3.w);
+  r0.xyz = r7.xyz * r3.www + r0.xyz;
+  r7.xyz = r7.xyz * r3.www;
+  r3.w = saturate(dot(r7.xyz, r3.xyz));
+  r4.x = dot(r0.xyz, r0.xyz);
+  r4.x = rsqrt(r4.x);
+  r0.xyz = r4.xxx * r0.xyz;
+  r0.x = saturate(dot(r3.xyz, r0.xyz));
+  r0.y = saturate(dot(r1.xyz, r3.xyz));
+  r1.xyz = r0.yyy * r4.yzw + r2.xzw;
+  r0.yzw = r0.www * r5.yzw + r1.xyz;
+  r0.x = log2(r0.x);
+  r0.x = r1.w * r0.x;
+  r0.x = exp2(r0.x);
+  r1.xyzw = s_luminanceMap2.Sample(s_luminanceMap2_s, v7.xy).xyzw;
+  r1.x = saturate(r1.y * r5.x);
+  r1.xyz = lights[4].color * r1.xxx;
+  r2.xzw = r0.xxx * r1.xyz + r6.xyz;
+  r0.xyz = r3.www * r1.xyz + r0.yzw;
+  r1.xyzw = mtbSampleSlot1.Sample(mtbSampleSlot1_s, v0.xy).xyzw;
+  r1.xyz = diffuseColor.xyz * r1.xyz;
+  r0.xyz = r1.xyz * r0.xyz;
+  r1.xyzw = mtbSampleSlot3.Sample(mtbSampleSlot3_s, v0.xy).xyzw;
+  r1.xyz = specularColor.xyz * r1.xyz;
+  r1.xyz = r2.yyy * r1.xyz;
+  r0.xyz = r1.xyz * r2.xzw + r0.xyz;
+  r1.xyz = fogColor.xyz + -r0.xyz;
+  r0.xyz = v2.zzz * r1.xyz + r0.xyz;
+  o0.xyz = globalScale * injectedData.FogAmount * r0.xyz;
+  o0.w = globalOpacity * v3.w;
+  return;
+}

--- a/src/games/bioshock/Fog4_0x64B4F8D8.ps_4_0.hlsl
+++ b/src/games/bioshock/Fog4_0x64B4F8D8.ps_4_0.hlsl
@@ -1,0 +1,220 @@
+#include "./shared.h"
+
+cbuffer _Globals : register(b0)
+{
+  float LayerLighting_hlsl_PSMain010604569583954993_54bits : packoffset(c0) = {0};
+  float4 fogColor : packoffset(c1);
+  float3 fogTransform : packoffset(c2);
+  float4x3 screenDataToCamera : packoffset(c3);
+  float globalScale : packoffset(c6);
+  float sceneDepthAlphaMask : packoffset(c6.y);
+  float globalOpacity : packoffset(c6.z);
+  float distortionBufferScale : packoffset(c6.w);
+  float2 wToZScaleAndBias : packoffset(c7);
+  float4 screenTransform[2] : packoffset(c8);
+  float4x4 worldViewProj : packoffset(c10);
+  float3 localEyePos : packoffset(c14);
+  float4 vertexClipPlane : packoffset(c15);
+  float specularPower : packoffset(c16);
+  float distortionStrength : packoffset(c16.y);
+  float3 specularColor : packoffset(c17);
+  float environmentMapLevel : packoffset(c17.w);
+  float3 selfIlluminationColor : packoffset(c18);
+  float3 subsurfaceColor : packoffset(c19);
+  float3 diffuseColor : packoffset(c20);
+  float specularCubeMapBrightness : packoffset(c20.w);
+  float minAlphaClipValue : packoffset(c21);
+  float maxAlphaClipValue : packoffset(c21.y);
+  float2 heightMapScaleAndBias : packoffset(c21.z);
+  float4x2 diffuseTexTransform : packoffset(c22);
+  float4x2 opacityTexTransform : packoffset(c24);
+  float4x2 selfIllumTexTransform : packoffset(c26);
+
+  struct
+  {
+    float4 ambientVector;
+    float4 ambientColorLow;
+    float4 ambientControls;
+  } Ambient : packoffset(c28);
+
+  float4 luminanceMapUVPacking : packoffset(c31);
+
+  struct
+  {
+    float4 worldVector;
+    float4 color;
+    float4 channelMask;
+  } lights[6] : packoffset(c32);
+
+  row_major float4x4 localToWorld : packoffset(c50);
+  row_major float4x4 screenToWorld : packoffset(c54);
+  float3 worldEyePos : packoffset(c58);
+}
+
+SamplerState mtbSampleSlot1_s : register(s0);
+SamplerState mtbSampleSlot2_s : register(s1);
+SamplerState mtbSampleSlot3_s : register(s2);
+SamplerState GaussianLookup_s : register(s3);
+SamplerState s_luminanceMap1_s : register(s4);
+SamplerState s_luminanceMap2_s : register(s5);
+SamplerState s_shadowMask_s : register(s6);
+Texture2D<float4> mtbSampleSlot2 : register(t0);
+Texture2D<float4> s_luminanceMap1 : register(t1);
+Texture2D<float4> s_luminanceMap2 : register(t2);
+Texture2D<float4> mtbSampleSlot1 : register(t3);
+Texture2D<float4> s_shadowMask : register(t4);
+Texture2D<float4> mtbSampleSlot3 : register(t5);
+Texture2D<float4> GaussianLookup : register(t6);
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : TEXCOORD0,
+  float4 v1 : TEXCOORD1,
+  float4 v2 : TEXCOORD6,
+  float4 v3 : TEXCOORD7,
+  float4 v4 : TEXCOORD3,
+  float4 v5 : TEXCOORD4,
+  float4 v6 : TEXCOORD5,
+  float3 v7 : COLOR0,
+  float4 v8 : TEXCOORD9,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8,r9;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyz = worldEyePos.xyz + -v8.xyz;
+  r0.w = dot(r0.xyz, r0.xyz);
+  r0.w = rsqrt(r0.w);
+  r0.xyz = r0.xyz * r0.www;
+  r1.xyz = -v8.xyz * lights[1].worldVector + lights[1].worldVector;
+  r0.w = dot(r1.xyz, r1.xyz);
+  r0.w = rsqrt(r0.w);
+  r2.xyz = r1.xyz * r0.www + r0.xyz;
+  r1.xyz = r1.xyz * r0.www;
+  r0.w = dot(r2.xyz, r2.xyz);
+  r0.w = rsqrt(r0.w);
+  r2.xyz = r2.xyz * r0.www;
+  r3.xyzw = mtbSampleSlot2.Sample(mtbSampleSlot2_s, v0.xy).xyzw;
+  r3.xyz = r3.xyz * float3(2,2,2) + float3(-1,-1,-1);
+  r4.xyz = v5.xyz * r3.yyy;
+  r3.xyw = r3.xxx * v4.xyz + r4.xyz;
+  r3.xyz = r3.zzz * v6.xyz + r3.xyw;
+  r0.w = dot(r3.xyz, r3.xyz);
+  r0.w = rsqrt(r0.w);
+  r3.xyz = r3.xyz * r0.www;
+  r0.w = saturate(dot(r3.xyz, r2.xyz));
+  r0.w = log2(r0.w);
+  r2.y = 0.001953125 * specularPower;
+  r2.x = dot(r3.xyz, r3.xyz);
+  r2.xyzw = GaussianLookup.Sample(GaussianLookup_s, r2.xy).xyzw;
+  r2.xy = saturate(r2.xy);
+  r1.w = 0.00100000005 + r2.x;
+  r1.w = r1.w * specularPower + 1.00000001e-007;
+  r0.w = r1.w * r0.w;
+  r0.w = exp2(r0.w);
+  r2.xzw = -v8.xyz * lights[2].worldVector + lights[2].worldVector;
+  r3.w = dot(r2.xzw, r2.xzw);
+  r3.w = rsqrt(r3.w);
+  r4.xyz = r2.xzw * r3.www + r0.xyz;
+  r2.xzw = r3.www * r2.xzw;
+  r2.x = saturate(dot(r2.xzw, r3.xyz));
+  r2.z = dot(r4.xyz, r4.xyz);
+  r2.z = rsqrt(r2.z);
+  r4.xyz = r4.xyz * r2.zzz;
+  r2.z = saturate(dot(r3.xyz, r4.xyz));
+  r2.z = log2(r2.z);
+  r2.z = r2.z * r1.w;
+  r2.z = exp2(r2.z);
+  r4.x = v4.w;
+  r4.y = v5.w;
+  r4.xyzw = s_luminanceMap1.Sample(s_luminanceMap1_s, r4.xy).xyzw;
+  r5.xy = v2.xy / v2.ww;
+  r5.xyzw = s_shadowMask.Sample(s_shadowMask_s, r5.xy).xyzw;
+  r2.w = saturate(dot(r5.xyzw, lights[2].channelMask));
+  r2.w = 1 + -r2.w;
+  r2.w = saturate(r4.z * r2.w);
+  r6.xyz = lights[2].color * r2.www;
+  r7.xyz = r6.xyz * r2.zzz;
+  r2.xzw = r6.xyz * r2.xxx;
+  r3.w = saturate(dot(r5.xyzw, lights[1].channelMask));
+  r3.w = 1 + -r3.w;
+  r3.w = saturate(r4.y * r3.w);
+  r4.yzw = lights[1].color * r3.www;
+  r6.xyz = r0.www * r4.yzw + r7.xyz;
+  r7.xyz = -v8.xyz * lights[3].worldVector + lights[3].worldVector;
+  r0.w = dot(r7.xyz, r7.xyz);
+  r0.w = rsqrt(r0.w);
+  r8.xyz = r7.xyz * r0.www + r0.xyz;
+  r7.xyz = r7.xyz * r0.www;
+  r0.w = saturate(dot(r7.xyz, r3.xyz));
+  r3.w = dot(r8.xyz, r8.xyz);
+  r3.w = rsqrt(r3.w);
+  r7.xyz = r8.xyz * r3.www;
+  r3.w = saturate(dot(r3.xyz, r7.xyz));
+  r3.w = log2(r3.w);
+  r3.w = r3.w * r1.w;
+  r3.w = exp2(r3.w);
+  r6.w = saturate(dot(r5.xyzw, lights[3].channelMask));
+  r6.w = 1 + -r6.w;
+  r4.x = saturate(r6.w * r4.x);
+  r7.xyz = lights[3].color * r4.xxx;
+  r6.xyz = r3.www * r7.xyz + r6.xyz;
+  r8.xyz = -v8.xyz * lights[4].worldVector + lights[4].worldVector;
+  r3.w = dot(r8.xyz, r8.xyz);
+  r3.w = rsqrt(r3.w);
+  r9.xyz = r8.xyz * r3.www + r0.xyz;
+  r8.xyz = r8.xyz * r3.www;
+  r3.w = saturate(dot(r8.xyz, r3.xyz));
+  r4.x = dot(r9.xyz, r9.xyz);
+  r4.x = rsqrt(r4.x);
+  r8.xyz = r9.xyz * r4.xxx;
+  r4.x = saturate(dot(r3.xyz, r8.xyz));
+  r4.x = log2(r4.x);
+  r4.x = r4.x * r1.w;
+  r4.x = exp2(r4.x);
+  r6.w = saturate(dot(r5.xyzw, lights[4].channelMask));
+  r5.x = saturate(dot(r5.xyzw, lights[5].channelMask));
+  r5.x = 1 + -r5.x;
+  r5.y = 1 + -r6.w;
+  r8.xyzw = s_luminanceMap2.Sample(s_luminanceMap2_s, v7.xy).xyzw;
+  r5.xy = saturate(r8.zy * r5.xy);
+  r5.xzw = lights[5].color * r5.xxx;
+  r8.xyz = lights[4].color * r5.yyy;
+  r6.xyz = r4.xxx * r8.xyz + r6.xyz;
+  r9.xyz = -v8.xyz * lights[5].worldVector + lights[5].worldVector;
+  r4.x = dot(r9.xyz, r9.xyz);
+  r4.x = rsqrt(r4.x);
+  r0.xyz = r9.xyz * r4.xxx + r0.xyz;
+  r9.xyz = r9.xyz * r4.xxx;
+  r4.x = saturate(dot(r9.xyz, r3.xyz));
+  r5.y = dot(r0.xyz, r0.xyz);
+  r5.y = rsqrt(r5.y);
+  r0.xyz = r5.yyy * r0.xyz;
+  r0.x = saturate(dot(r3.xyz, r0.xyz));
+  r0.y = saturate(dot(r1.xyz, r3.xyz));
+  r1.xyz = r0.yyy * r4.yzw + r2.xzw;
+  r0.yzw = r0.www * r7.xyz + r1.xyz;
+  r0.yzw = r3.www * r8.xyz + r0.yzw;
+  r0.yzw = r4.xxx * r5.xzw + r0.yzw;
+  r0.x = log2(r0.x);
+  r0.x = r1.w * r0.x;
+  r0.x = exp2(r0.x);
+  r1.xyz = r0.xxx * r5.xzw + r6.xyz;
+  r3.xyzw = mtbSampleSlot1.Sample(mtbSampleSlot1_s, v0.xy).xyzw;
+  r2.xzw = diffuseColor.xyz * r3.xyz;
+  r0.xyz = r2.xzw * r0.yzw;
+  r3.xyzw = mtbSampleSlot3.Sample(mtbSampleSlot3_s, v0.xy).xyzw;
+  r2.xzw = specularColor.xyz * r3.xyz;
+  r2.xyz = r2.yyy * r2.xzw;
+  r0.xyz = r2.xyz * r1.xyz + r0.xyz;
+  r1.xyz = fogColor.xyz + -r0.xyz;
+  r0.xyz = v2.zzz * r1.xyz + r0.xyz;
+  o0.xyz = globalScale * injectedData.FogAmount * r0.xyz;
+  o0.w = globalOpacity * v3.w;
+  return;
+}

--- a/src/games/bioshock/Fog5_0x21303C74.ps_4_0.hlsl
+++ b/src/games/bioshock/Fog5_0x21303C74.ps_4_0.hlsl
@@ -1,0 +1,200 @@
+#include "./shared.h"
+
+cbuffer _Globals : register(b0)
+{
+  float LayerLighting_hlsl_PSMain014826692959546417_54bits : packoffset(c0) = {0};
+  float4 fogColor : packoffset(c1);
+  float3 fogTransform : packoffset(c2);
+  float4x3 screenDataToCamera : packoffset(c3);
+  float globalScale : packoffset(c6);
+  float sceneDepthAlphaMask : packoffset(c6.y);
+  float globalOpacity : packoffset(c6.z);
+  float distortionBufferScale : packoffset(c6.w);
+  float2 wToZScaleAndBias : packoffset(c7);
+  float4 screenTransform[2] : packoffset(c8);
+  float4x4 worldViewProj : packoffset(c10);
+  float3 localEyePos : packoffset(c14);
+  float4 vertexClipPlane : packoffset(c15);
+  float specularPower : packoffset(c16);
+  float distortionStrength : packoffset(c16.y);
+  float3 specularColor : packoffset(c17);
+  float environmentMapLevel : packoffset(c17.w);
+  float3 selfIlluminationColor : packoffset(c18);
+  float3 subsurfaceColor : packoffset(c19);
+  float3 diffuseColor : packoffset(c20);
+  float specularCubeMapBrightness : packoffset(c20.w);
+  float minAlphaClipValue : packoffset(c21);
+  float maxAlphaClipValue : packoffset(c21.y);
+  float2 heightMapScaleAndBias : packoffset(c21.z);
+  float4x2 diffuseTexTransform : packoffset(c22);
+  float4x2 opacityTexTransform : packoffset(c24);
+  float4x2 selfIllumTexTransform : packoffset(c26);
+
+  struct
+  {
+    float4 ambientVector;
+    float4 ambientColorLow;
+    float4 ambientControls;
+  } Ambient : packoffset(c28);
+
+  float4 luminanceMapUVPacking : packoffset(c31);
+
+  struct
+  {
+    float4 worldVector;
+    float4 color;
+    float4 channelMask;
+  } lights[5] : packoffset(c32);
+
+  row_major float4x4 localToWorld : packoffset(c47);
+  row_major float4x4 screenToWorld : packoffset(c51);
+  float3 worldEyePos : packoffset(c55);
+}
+
+SamplerState mtbSampleSlot1_s : register(s0);
+SamplerState mtbSampleSlot2_s : register(s1);
+SamplerState GaussianLookup_s : register(s2);
+SamplerState s_luminanceMap1_s : register(s3);
+SamplerState s_luminanceMap2_s : register(s4);
+SamplerState s_shadowMask_s : register(s5);
+Texture2D<float4> mtbSampleSlot2 : register(t0);
+Texture2D<float4> s_luminanceMap1 : register(t1);
+Texture2D<float4> s_luminanceMap2 : register(t2);
+Texture2D<float4> mtbSampleSlot1 : register(t3);
+Texture2D<float4> s_shadowMask : register(t4);
+Texture2D<float4> GaussianLookup : register(t5);
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : TEXCOORD0,
+  float4 v1 : TEXCOORD1,
+  float4 v2 : TEXCOORD6,
+  float4 v3 : TEXCOORD7,
+  float4 v4 : TEXCOORD3,
+  float4 v5 : TEXCOORD4,
+  float4 v6 : TEXCOORD5,
+  float3 v7 : COLOR0,
+  float4 v8 : TEXCOORD9,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyz = worldEyePos.xyz + -v8.xyz;
+  r0.w = dot(r0.xyz, r0.xyz);
+  r0.w = rsqrt(r0.w);
+  r0.xyz = r0.xyz * r0.www;
+  r1.xyz = -v8.xyz * lights[1].worldVector + lights[1].worldVector;
+  r0.w = dot(r1.xyz, r1.xyz);
+  r0.w = rsqrt(r0.w);
+  r2.xyz = r1.xyz * r0.www + r0.xyz;
+  r1.xyz = r1.xyz * r0.www;
+  r0.w = dot(r2.xyz, r2.xyz);
+  r0.w = rsqrt(r0.w);
+  r2.xyz = r2.xyz * r0.www;
+  r3.xyzw = mtbSampleSlot2.Sample(mtbSampleSlot2_s, v0.xy).xyzw;
+  r3.xyz = r3.xyz * float3(2,2,2) + float3(-1,-1,-1);
+  r4.xyz = v5.xyz * r3.yyy;
+  r3.xyw = r3.xxx * v4.xyz + r4.xyz;
+  r3.xyz = r3.zzz * v6.xyz + r3.xyw;
+  r0.w = dot(r3.xyz, r3.xyz);
+  r0.w = rsqrt(r0.w);
+  r3.xyz = r3.xyz * r0.www;
+  r0.w = saturate(dot(r3.xyz, r2.xyz));
+  r0.w = log2(r0.w);
+  r2.y = 0.001953125 * specularPower;
+  r2.x = dot(r3.xyz, r3.xyz);
+  r2.xyzw = GaussianLookup.Sample(GaussianLookup_s, r2.xy).xyzw;
+  r2.xy = saturate(r2.xy);
+  r1.w = 0.00100000005 + r2.x;
+  r1.w = r1.w * specularPower + 1.00000001e-007;
+  r0.w = r1.w * r0.w;
+  r0.w = exp2(r0.w);
+  r2.xzw = -v8.xyz * lights[2].worldVector + lights[2].worldVector;
+  r3.w = dot(r2.xzw, r2.xzw);
+  r3.w = rsqrt(r3.w);
+  r4.xyz = r2.xzw * r3.www + r0.xyz;
+  r2.xzw = r3.www * r2.xzw;
+  r2.x = saturate(dot(r2.xzw, r3.xyz));
+  r2.z = dot(r4.xyz, r4.xyz);
+  r2.z = rsqrt(r2.z);
+  r4.xyz = r4.xyz * r2.zzz;
+  r2.z = saturate(dot(r3.xyz, r4.xyz));
+  r2.z = log2(r2.z);
+  r2.z = r2.z * r1.w;
+  r2.z = exp2(r2.z);
+  r4.x = v4.w;
+  r4.y = v5.w;
+  r4.xyzw = s_luminanceMap1.Sample(s_luminanceMap1_s, r4.xy).xyzw;
+  r5.xy = v2.xy / v2.ww;
+  r5.xyzw = s_shadowMask.Sample(s_shadowMask_s, r5.xy).xyzw;
+  r2.w = saturate(dot(r5.xyzw, lights[2].channelMask));
+  r2.w = 1 + -r2.w;
+  r2.w = saturate(r4.z * r2.w);
+  r6.xyz = lights[2].color * r2.www;
+  r7.xyz = r6.xyz * r2.zzz;
+  r2.xzw = r6.xyz * r2.xxx;
+  r3.w = saturate(dot(r5.xyzw, lights[1].channelMask));
+  r3.w = 1 + -r3.w;
+  r3.w = saturate(r4.y * r3.w);
+  r4.yzw = lights[1].color * r3.www;
+  r6.xyz = r0.www * r4.yzw + r7.xyz;
+  r7.xyz = -v8.xyz * lights[3].worldVector + lights[3].worldVector;
+  r0.w = dot(r7.xyz, r7.xyz);
+  r0.w = rsqrt(r0.w);
+  r8.xyz = r7.xyz * r0.www + r0.xyz;
+  r7.xyz = r7.xyz * r0.www;
+  r0.w = saturate(dot(r7.xyz, r3.xyz));
+  r3.w = dot(r8.xyz, r8.xyz);
+  r3.w = rsqrt(r3.w);
+  r7.xyz = r8.xyz * r3.www;
+  r3.w = saturate(dot(r3.xyz, r7.xyz));
+  r3.w = log2(r3.w);
+  r3.w = r3.w * r1.w;
+  r3.w = exp2(r3.w);
+  r6.w = saturate(dot(r5.xyzw, lights[3].channelMask));
+  r5.x = saturate(dot(r5.xyzw, lights[4].channelMask));
+  r5.x = 1 + -r5.x;
+  r5.y = 1 + -r6.w;
+  r4.x = saturate(r5.y * r4.x);
+  r5.yzw = lights[3].color * r4.xxx;
+  r6.xyz = r3.www * r5.yzw + r6.xyz;
+  r7.xyz = -v8.xyz * lights[4].worldVector + lights[4].worldVector;
+  r3.w = dot(r7.xyz, r7.xyz);
+  r3.w = rsqrt(r3.w);
+  r0.xyz = r7.xyz * r3.www + r0.xyz;
+  r7.xyz = r7.xyz * r3.www;
+  r3.w = saturate(dot(r7.xyz, r3.xyz));
+  r4.x = dot(r0.xyz, r0.xyz);
+  r4.x = rsqrt(r4.x);
+  r0.xyz = r4.xxx * r0.xyz;
+  r0.x = saturate(dot(r3.xyz, r0.xyz));
+  r0.y = saturate(dot(r1.xyz, r3.xyz));
+  r1.xyz = r0.yyy * r4.yzw + r2.xzw;
+  r0.yzw = r0.www * r5.yzw + r1.xyz;
+  r0.x = log2(r0.x);
+  r0.x = r1.w * r0.x;
+  r0.x = exp2(r0.x);
+  r1.xyzw = s_luminanceMap2.Sample(s_luminanceMap2_s, v7.xy).xyzw;
+  r1.x = saturate(r1.y * r5.x);
+  r1.xyz = lights[4].color * r1.xxx;
+  r2.xzw = r0.xxx * r1.xyz + r6.xyz;
+  r0.xyz = r3.www * r1.xyz + r0.yzw;
+  r1.xyzw = mtbSampleSlot1.Sample(mtbSampleSlot1_s, v0.xy).xyzw;
+  r3.xyz = diffuseColor.xyz * r1.xyz;
+  r0.xyz = r3.xyz * r0.xyz;
+  r3.xyz = specularColor.xyz * r1.www;
+  r1.xyz = r3.xyz * r1.xyz;
+  r1.xyz = r2.yyy * r1.xyz;
+  r0.xyz = r1.xyz * r2.xzw + r0.xyz;
+  r1.xyz = fogColor.xyz + -r0.xyz;
+  r0.xyz = v2.zzz * r1.xyz + r0.xyz;
+  o0.xyz = globalScale * injectedData.FogAmount * r0.xyz;
+  o0.w = globalOpacity * v3.w;
+  return;
+}

--- a/src/games/bioshock/Fog6_0x63693A7F.ps_4_0.hlsl
+++ b/src/games/bioshock/Fog6_0x63693A7F.ps_4_0.hlsl
@@ -1,0 +1,205 @@
+#include "./shared.h"
+
+cbuffer _Globals : register(b0)
+{
+  float LayerLighting_hlsl_PSMain010323095345441841_54bits : packoffset(c0) = {0};
+  float4 fogColor : packoffset(c1);
+  float3 fogTransform : packoffset(c2);
+  float4x3 screenDataToCamera : packoffset(c3);
+  float globalScale : packoffset(c6);
+  float sceneDepthAlphaMask : packoffset(c6.y);
+  float globalOpacity : packoffset(c6.z);
+  float distortionBufferScale : packoffset(c6.w);
+  float2 wToZScaleAndBias : packoffset(c7);
+  float4 screenTransform[2] : packoffset(c8);
+  float4x4 worldViewProj : packoffset(c10);
+  float3 localEyePos : packoffset(c14);
+  float4 vertexClipPlane : packoffset(c15);
+  float specularPower : packoffset(c16);
+  float distortionStrength : packoffset(c16.y);
+  float3 specularColor : packoffset(c17);
+  float environmentMapLevel : packoffset(c17.w);
+  float3 selfIlluminationColor : packoffset(c18);
+  float3 subsurfaceColor : packoffset(c19);
+  float3 diffuseColor : packoffset(c20);
+  float specularCubeMapBrightness : packoffset(c20.w);
+  float minAlphaClipValue : packoffset(c21);
+  float maxAlphaClipValue : packoffset(c21.y);
+  float2 heightMapScaleAndBias : packoffset(c21.z);
+  float4x2 diffuseTexTransform : packoffset(c22);
+  float4x2 opacityTexTransform : packoffset(c24);
+  float4x2 selfIllumTexTransform : packoffset(c26);
+
+  struct
+  {
+    float4 ambientVector;
+    float4 ambientColorLow;
+    float4 ambientControls;
+  } Ambient : packoffset(c28);
+
+  float4 luminanceMapUVPacking : packoffset(c31);
+
+  struct
+  {
+    float4 worldVector;
+    float4 color;
+    float4 channelMask;
+  } lights[5] : packoffset(c32);
+
+  row_major float4x4 localToWorld : packoffset(c47);
+  row_major float4x4 screenToWorld : packoffset(c51);
+  float3 worldEyePos : packoffset(c55);
+}
+
+SamplerState mtbSampleSlot1_s : register(s0);
+SamplerState mtbSampleSlot2_s : register(s1);
+SamplerState mtbSampleSlot3_s : register(s2);
+SamplerState GaussianLookup_s : register(s3);
+SamplerState s_luminanceMap1_s : register(s4);
+SamplerState s_luminanceMap2_s : register(s5);
+SamplerState s_shadowMask_s : register(s6);
+Texture2D<float4> mtbSampleSlot2 : register(t0);
+Texture2D<float4> s_luminanceMap1 : register(t1);
+Texture2D<float4> s_luminanceMap2 : register(t2);
+Texture2D<float4> mtbSampleSlot1 : register(t3);
+Texture2D<float4> s_shadowMask : register(t4);
+Texture2D<float4> mtbSampleSlot3 : register(t5);
+Texture2D<float4> GaussianLookup : register(t6);
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : TEXCOORD0,
+  float4 v1 : TEXCOORD1,
+  float4 v2 : TEXCOORD6,
+  float4 v3 : TEXCOORD7,
+  float4 v4 : TEXCOORD3,
+  float4 v5 : TEXCOORD4,
+  float4 v6 : TEXCOORD5,
+  float3 v7 : COLOR0,
+  float4 v8 : TEXCOORD9,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5,r6,r7,r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyz = worldEyePos.xyz + -v8.xyz;
+  r0.w = dot(r0.xyz, r0.xyz);
+  r0.w = rsqrt(r0.w);
+  r0.xyz = r0.xyz * r0.www;
+  r1.xyz = -v8.xyz * lights[1].worldVector + lights[1].worldVector;
+  r0.w = dot(r1.xyz, r1.xyz);
+  r0.w = rsqrt(r0.w);
+  r2.xyz = r1.xyz * r0.www + r0.xyz;
+  r1.xyz = r1.xyz * r0.www;
+  r0.w = dot(r2.xyz, r2.xyz);
+  r0.w = rsqrt(r0.w);
+  r2.xyz = r2.xyz * r0.www;
+  r3.xyzw = mtbSampleSlot2.Sample(mtbSampleSlot2_s, v0.xy).xyzw;
+  r3.xyz = r3.xyz * float3(2,2,2) + float3(-1,-1,-1);
+  r4.xyz = v5.xyz * r3.yyy;
+  r3.xyw = r3.xxx * v4.xyz + r4.xyz;
+  r3.xyz = r3.zzz * v6.xyz + r3.xyw;
+  r0.w = dot(r3.xyz, r3.xyz);
+  r0.w = rsqrt(r0.w);
+  r3.xyz = r3.xyz * r0.www;
+  r0.w = saturate(dot(r3.xyz, r2.xyz));
+  r0.w = log2(r0.w);
+  r2.y = 0.001953125 * specularPower;
+  r2.x = dot(r3.xyz, r3.xyz);
+  r2.xyzw = GaussianLookup.Sample(GaussianLookup_s, r2.xy).xyzw;
+  r2.xy = saturate(r2.xy);
+  r1.w = 0.00100000005 + r2.x;
+  r1.w = r1.w * specularPower + 1.00000001e-007;
+  r0.w = r1.w * r0.w;
+  r0.w = exp2(r0.w);
+  r2.xzw = -v8.xyz * lights[2].worldVector + lights[2].worldVector;
+  r3.w = dot(r2.xzw, r2.xzw);
+  r3.w = rsqrt(r3.w);
+  r4.xyz = r2.xzw * r3.www + r0.xyz;
+  r2.xzw = r3.www * r2.xzw;
+  r2.x = saturate(dot(r2.xzw, r3.xyz));
+  r2.z = dot(r4.xyz, r4.xyz);
+  r2.z = rsqrt(r2.z);
+  r4.xyz = r4.xyz * r2.zzz;
+  r2.z = saturate(dot(r3.xyz, r4.xyz));
+  r2.z = log2(r2.z);
+  r2.z = r2.z * r1.w;
+  r2.z = exp2(r2.z);
+  r4.x = v4.w;
+  r4.y = v5.w;
+  r4.xyzw = s_luminanceMap1.Sample(s_luminanceMap1_s, r4.xy).xyzw;
+  r5.xy = v2.xy / v2.ww;
+  r5.xyzw = s_shadowMask.Sample(s_shadowMask_s, r5.xy).xyzw;
+  r2.w = saturate(dot(r5.xyzw, lights[2].channelMask));
+  r2.w = 1 + -r2.w;
+  r2.w = saturate(r4.z * r2.w);
+  r6.xyz = lights[2].color * r2.www;
+  r7.xyz = r6.xyz * r2.zzz;
+  r2.xzw = r6.xyz * r2.xxx;
+  r3.w = saturate(dot(r5.xyzw, lights[1].channelMask));
+  r3.w = 1 + -r3.w;
+  r3.w = saturate(r4.y * r3.w);
+  r4.yzw = lights[1].color * r3.www;
+  r6.xyz = r0.www * r4.yzw + r7.xyz;
+  r7.xyz = -v8.xyz * lights[3].worldVector + lights[3].worldVector;
+  r0.w = dot(r7.xyz, r7.xyz);
+  r0.w = rsqrt(r0.w);
+  r8.xyz = r7.xyz * r0.www + r0.xyz;
+  r7.xyz = r7.xyz * r0.www;
+  r0.w = saturate(dot(r7.xyz, r3.xyz));
+  r3.w = dot(r8.xyz, r8.xyz);
+  r3.w = rsqrt(r3.w);
+  r7.xyz = r8.xyz * r3.www;
+  r3.w = saturate(dot(r3.xyz, r7.xyz));
+  r3.w = log2(r3.w);
+  r3.w = r3.w * r1.w;
+  r3.w = exp2(r3.w);
+  r6.w = saturate(dot(r5.xyzw, lights[3].channelMask));
+  r5.x = saturate(dot(r5.xyzw, lights[4].channelMask));
+  r5.x = 1 + -r5.x;
+  r5.y = 1 + -r6.w;
+  r4.x = saturate(r5.y * r4.x);
+  r5.yzw = lights[3].color * r4.xxx;
+  r6.xyz = r3.www * r5.yzw + r6.xyz;
+  r7.xyz = -v8.xyz * lights[4].worldVector + lights[4].worldVector;
+  r3.w = dot(r7.xyz, r7.xyz);
+  r3.w = rsqrt(r3.w);
+  r0.xyz = r7.xyz * r3.www + r0.xyz;
+  r7.xyz = r7.xyz * r3.www;
+  r3.w = saturate(dot(r7.xyz, r3.xyz));
+  r4.x = dot(r0.xyz, r0.xyz);
+  r4.x = rsqrt(r4.x);
+  r0.xyz = r4.xxx * r0.xyz;
+  r0.x = saturate(dot(r3.xyz, r0.xyz));
+  r0.y = saturate(dot(r1.xyz, r3.xyz));
+  r1.xyz = r0.yyy * r4.yzw + r2.xzw;
+  r0.yzw = r0.www * r5.yzw + r1.xyz;
+  r0.x = log2(r0.x);
+  r0.x = r1.w * r0.x;
+  r0.x = exp2(r0.x);
+  r1.xyzw = s_luminanceMap2.Sample(s_luminanceMap2_s, v7.xy).xyzw;
+  r1.x = saturate(r1.y * r5.x);
+  r1.xyz = lights[4].color * r1.xxx;
+  r2.xzw = r0.xxx * r1.xyz + r6.xyz;
+  r0.xyz = r3.www * r1.xyz + r0.yzw;
+  r1.xyzw = mtbSampleSlot1.Sample(mtbSampleSlot1_s, v0.xy).xyzw;
+  r1.xyz = diffuseColor.xyz * r1.xyz;
+  r0.xyz = r1.xyz * r0.xyz;
+  r1.xyzw = mtbSampleSlot3.Sample(mtbSampleSlot3_s, v0.xy).xyzw;
+  r3.xy = specularColor.xy * r1.zz;
+  r3.xy = r3.xy * r1.xy;
+  r0.w = r1.z * r1.z;
+  r3.z = specularColor.z * r0.w;
+  r1.xyz = r3.xyz * r2.yyy;
+  r0.xyz = r1.xyz * r2.xzw + r0.xyz;
+  r1.xyz = fogColor.xyz + -r0.xyz;
+  r0.xyz = v2.zzz * r1.xyz + r0.xyz;
+  o0.xyz = globalScale * injectedData.FogAmount * r0.xyz;
+  o0.w = globalOpacity * v3.w;
+  return;
+}

--- a/src/games/bioshock/Fog_0xDAA8E1E9.ps_4_0.hlsl
+++ b/src/games/bioshock/Fog_0xDAA8E1E9.ps_4_0.hlsl
@@ -1,0 +1,85 @@
+#include "./shared.h"
+
+cbuffer _Globals : register(b0)
+{
+  float Base_hlsl_PSMain09_4bits : packoffset(c0) = {0};
+  float4 fogColor : packoffset(c1);
+  float3 fogTransform : packoffset(c2);
+  float4x3 screenDataToCamera : packoffset(c3);
+  float globalScale : packoffset(c6);
+  float sceneDepthAlphaMask : packoffset(c6.y);
+  float globalOpacity : packoffset(c6.z);
+  float distortionBufferScale : packoffset(c6.w);
+  float2 wToZScaleAndBias : packoffset(c7);
+  float4 screenTransform[2] : packoffset(c8);
+  float4x4 worldViewProj : packoffset(c10);
+  float3 localEyePos : packoffset(c14);
+  float4 vertexClipPlane : packoffset(c15);
+  float3 beamColor : packoffset(c16);
+  float beamBrightness : packoffset(c16.w);
+  float backFadeDistance : packoffset(c17);
+  float nearClipFadeDistance : packoffset(c17.y);
+  float nearClipPlane : packoffset(c17.z);
+  float4x2 dustTexTransform : packoffset(c18);
+  float4 unlitColor : packoffset(c20);
+  row_major float4x3 localToWorld : packoffset(c21);
+}
+
+SamplerState s_sceneDepth_s : register(s0);
+SamplerState mtbSampleSlot1_s : register(s1);
+SamplerState mtbSampleSlot2_s : register(s2);
+Texture2D<float4> s_sceneDepth : register(t0);
+Texture2D<float4> mtbSampleSlot1 : register(t1);
+Texture2D<float4> mtbSampleSlot2 : register(t2);
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : TEXCOORD6,
+  float4 v1 : TEXCOORD7,
+  float4 v2 : TEXCOORD0,
+  float4 v3 : TEXCOORD3,
+  float4 v4 : TEXCOORD4,
+  float3 v5 : TEXCOORD5,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = v0.xy / v0.ww;
+  r0.xyzw = s_sceneDepth.Sample(s_sceneDepth_s, r0.xy).xyzw;
+  r0.x = -wToZScaleAndBias.x + r0.x;
+  r0.x = wToZScaleAndBias.y / r0.x;
+  r0.x = -v0.w + r0.x;
+  r0.x = saturate(r0.x / backFadeDistance);
+  r0.y = dot(v1.xyz, v1.xyz);
+  r0.y = rsqrt(r0.y);
+  r0.yz = v1.xz * r0.yy;
+  r0.z = 0.699999988 * abs(r0.z);
+  r1.x = r0.y * -0.5 + 0.5;
+  r0.y = r0.z * r0.z;
+  r0.y = min(1, r0.y);
+  r0.y = 1.42857146 * r0.y;
+  r1.yw = v2.yz;
+  r2.xyzw = mtbSampleSlot1.Sample(mtbSampleSlot1_s, r1.xy).xyzw;
+  r1.z = v2.w + r1.x;
+  r1.xyzw = mtbSampleSlot2.Sample(mtbSampleSlot2_s, r1.zw).xyzw;
+  r2.xyz = beamColor.xyz * r2.xyz;
+  r2.xyz = beamBrightness * r2.xyz;
+  r0.yzw = r2.xyz * r0.yyy;
+  r0.xyz = r0.yzw * r0.xxx;
+  r0.w = -nearClipPlane + v0.w;
+  r0.w = saturate(r0.w / nearClipFadeDistance);
+  r0.xyz = r0.xyz * r0.www;
+  r0.xyz = r0.xyz * r1.xyz;
+  r1.xyz = unlitColor.xyz * r0.xyz;
+  r0.xyz = -r0.xyz * unlitColor.xyz + fogColor.xyz;
+  r0.xyz = v0.zzz * r0.xyz + r1.xyz;
+  o0.xyz = globalScale * injectedData.FogAmount * r0.xyz;
+  o0.w = globalOpacity * v1.w;
+  return;
+}

--- a/src/games/bioshock/addon.cpp
+++ b/src/games/bioshock/addon.cpp
@@ -9,6 +9,7 @@
 
 #include <embed/0xEC834D82.h>
 #include <embed/0x6457104F.h>
+#include <embed/0xDAA8E1E9.h>
 
 #include <embed/0xFFFFFFFD.h>  // Custom final VS
 #include <embed/0xFFFFFFFE.h>  // Custom final PS
@@ -26,6 +27,7 @@ namespace {
 renodx::mods::shader::CustomShaders custom_shaders = {
     CustomShaderEntry(0xEC834D82),
     CustomShaderEntry(0x6457104F),
+    CustomShaderEntry(0xDAA8E1E9),
 };
 
 ShaderInjectData shader_injection;
@@ -52,6 +54,30 @@ renodx::utils::settings::Settings settings = {
         .tooltip = "Sets the value of paper white in nits",
         .min = 80.f,
         .max = 500.f,
+    },
+    new renodx::utils::settings::Setting{
+        .key = "BloomAmount",
+        .binding = &shader_injection.BloomAmount,
+        .default_value = 1.f,
+        .can_reset = true,
+        .label = "Bloom Amount",
+        .section = "FX",
+        .tooltip = "Game's default bloom shader amount",
+        .min = 0.f,
+        .max = 2.f,
+        .format = "%.2f",
+    },
+    new renodx::utils::settings::Setting{
+        .key = "FogAmount",
+        .binding = &shader_injection.FogAmount,
+        .default_value = 1.f,
+        .can_reset = true,
+        .label = "Fog Amount",
+        .section = "FX",
+        .tooltip = "Game's default fog shader amount",
+        .min = 0.f,
+        .max = 2.f,
+        .format = "%.2f",
     },
     new renodx::utils::settings::Setting{
         .value_type = renodx::utils::settings::SettingValueType::BUTTON,

--- a/src/games/bioshock/addon.cpp
+++ b/src/games/bioshock/addon.cpp
@@ -10,6 +10,11 @@
 #include <embed/0xEC834D82.h>
 #include <embed/0x6457104F.h>
 #include <embed/0xDAA8E1E9.h>
+#include <embed/0x0C454543.h>
+#include <embed/0x3F8A5A79.h>
+#include <embed/0x64B4F8D8.h>
+#include <embed/0x21303C74.h>
+#include <embed/0x63693A7F.h>
 
 #include <embed/0xFFFFFFFD.h>  // Custom final VS
 #include <embed/0xFFFFFFFE.h>  // Custom final PS
@@ -28,6 +33,11 @@ renodx::mods::shader::CustomShaders custom_shaders = {
     CustomShaderEntry(0xEC834D82),
     CustomShaderEntry(0x6457104F),
     CustomShaderEntry(0xDAA8E1E9),
+    CustomShaderEntry(0x0C454543),
+    CustomShaderEntry(0x3F8A5A79),
+    CustomShaderEntry(0x64B4F8D8),
+    CustomShaderEntry(0x21303C74),
+    CustomShaderEntry(0x63693A7F),
 };
 
 ShaderInjectData shader_injection;

--- a/src/games/bioshock/shared.h
+++ b/src/games/bioshock/shared.h
@@ -9,6 +9,8 @@
 struct ShaderInjectData {
   float peakWhiteNits;
   float paperWhiteNits;
+  float BloomAmount;
+  float FogAmount;
 };
 
 #ifndef __cplusplus


### PR DESCRIPTION
- Bloom controls default game's bloom amount. Scales from 0.0 (disabled) to 2.0 (double of the vanilla amount)
- Fog appears to control both shader based fog and "fake" mesh based fog, so it's a global scalar. Similarly to bloom, it scale from 0.0 to 2.0

Context: https://github.com/clshortfuse/renodx/pull/84