### PR TITLE
feat(roadhogengine): add Hard Reset Redux mod

### DIFF
--- a/src/games/roadhogengine/DICE.hlsl
+++ b/src/games/roadhogengine/DICE.hlsl
@@ -1,0 +1,252 @@
+#include "./shared.h"
+
+static const float HDR10_MaxWhiteNits = 10000.0f;
+static const float FLT_MAX = asfloat(0x7F7FFFFF);  // 3.402823466e+38f
+
+float max3(float a, float b, float c) {
+  return max(a, max(b, c));
+}
+
+float max3(float3 v) {
+  return max3(v.x, v.y, v.z);
+}
+
+static const float PQ_constant_M1 = 0.1593017578125f;
+static const float PQ_constant_M2 = 78.84375f;
+static const float PQ_constant_C1 = 0.8359375f;
+static const float PQ_constant_C2 = 18.8515625f;
+static const float PQ_constant_C3 = 18.6875f;
+
+// PQ (Perceptual Quantizer - ST.2084) encode/decode used for HDR10 BT.2100.
+// Clamp type:
+// 0 None
+// 1 Remove negative numbers
+// 2 Remove numbers beyond 0-1
+// 3 Mirror negative numbers
+float3 Linear_to_PQ(float3 LinearColor, int clampType = 0) {
+  float3 LinearColorSign = sign(LinearColor);
+  if (clampType == 1) {
+    LinearColor = max(LinearColor, 0.f);
+  } else if (clampType == 2) {
+    LinearColor = saturate(LinearColor);
+  } else if (clampType == 3) {
+    LinearColor = abs(LinearColor);
+  }
+  float3 colorPow = pow(LinearColor, PQ_constant_M1);
+  float3 numerator = PQ_constant_C1 + PQ_constant_C2 * colorPow;
+  float3 denominator = 1.f + PQ_constant_C3 * colorPow;
+  float3 pq = pow(numerator / denominator, PQ_constant_M2);
+  if (clampType == 3) {
+    return pq * LinearColorSign;
+  }
+  return pq;
+}
+
+float3 PQ_to_Linear(float3 ST2084Color, int clampType = 0) {
+  float3 ST2084ColorSign = sign(ST2084Color);
+  if (clampType == 1) {
+    ST2084Color = max(ST2084Color, 0.f);
+  } else if (clampType == 2) {
+    ST2084Color = saturate(ST2084Color);
+  } else if (clampType == 3) {
+    ST2084Color = abs(ST2084Color);
+  }
+  float3 colorPow = pow(ST2084Color, 1.f / PQ_constant_M2);
+  float3 numerator = max(colorPow - PQ_constant_C1, 0.f);
+  float3 denominator = PQ_constant_C2 - (PQ_constant_C3 * colorPow);
+  float3 linearColor = pow(numerator / denominator, 1.f / PQ_constant_M1);
+  if (clampType == 3) {
+    return linearColor * ST2084ColorSign;
+  }
+  return linearColor;
+}
+
+// Applies exponential ("Photographic") luminance/luma compression.
+// The pow can modulate the curve without changing the values around the edges.
+// The max is the max possible range to compress from, to not lose any output
+// range if the input range was limited.
+float rangeCompress(float X, float Max = asfloat(0x7F7FFFFF)) {
+  // Branches are for static parameters optimizations
+  if (Max == FLT_MAX) {
+    // This does e^X. We expect X to be between 0 and 1.
+    return 1.f - exp(-X);
+  }
+  const float lostRange = exp(-Max);
+  const float restoreRangeScale = 1.f / (1.f - lostRange);
+  return (1.f - exp(-X)) * restoreRangeScale;
+}
+
+// Refurbished DICE HDR tonemapper (per channel or luminance).
+// Expects "InValue" to be >= "ShoulderStart" and "OutMaxValue" to be >
+// "ShoulderStart".
+float luminanceCompress(float InValue, float OutMaxValue,
+                        float ShoulderStart = 0.f,
+                        bool ConsiderMaxValue = false,
+                        float InMaxValue = asfloat(0x7F7FFFFF)) {
+  const float compressableValue = InValue - ShoulderStart;
+  const float compressableRange = InMaxValue - ShoulderStart;
+  const float compressedRange = OutMaxValue - ShoulderStart;
+  const float possibleOutValue =
+      ShoulderStart + compressedRange * rangeCompress(compressableValue / compressedRange, ConsiderMaxValue ? (compressableRange / compressedRange) : FLT_MAX);
+#if 1
+  return possibleOutValue;
+#else  // Enable this branch if "InValue" can be smaller than "ShoulderStart"
+  return (InValue <= ShoulderStart) ? InValue : possibleOutValue;
+#endif
+}
+
+#define DICE_TYPE_BY_LUMINANCE_RGB 0
+// Doing the DICE compression in PQ (either on luminance or each color channel)
+// produces a curve that is closer to our "perception" and leaves more detail
+// highlights without overly compressing them
+#define DICE_TYPE_BY_LUMINANCE_PQ 1
+// Modern HDR displays clip individual rgb channels beyond their "white" peak
+// brightness, like, if the peak brightness is 700 nits, any r g b color beyond
+// a value of 700/80 will be clipped (not acknowledged, it won't make a
+// difference). Tonemapping by luminance, is generally more perception accurate
+// but can then generate rgb colors "out of range". This setting fixes them up,
+// though it's optional as it's working based on assumptions on how current
+// displays work, which might not be true anymore in the future. Note that this
+// can create some steep (rough, quickly changing) gradients on very bright
+// colors.
+#define DICE_TYPE_BY_LUMINANCE_PQ_CORRECT_CHANNELS_BEYOND_PEAK_WHITE 2
+// This might look more like classic SDR tonemappers and is closer to how modern
+// TVs and Monitors play back colors (usually they clip each individual channel
+// to the peak brightness value, though in their native panel color space, or
+// current SDR/HDR mode color space). Overall, this seems to handle bright
+// gradients more smoothly, even if it shifts hues more (and generally
+// desaturating).
+#define DICE_TYPE_BY_CHANNEL_PQ 3
+
+struct DICESettings {
+  uint Type;
+  // Determines where the highlights curve (shoulder) starts.
+  // Values between 0.25 and 0.5 are good with DICE by PQ (any type).
+  // With linear/rgb DICE this barely makes a difference, zero is a good default
+  // but (e.g.) 0.5 would also work. This should always be between 0 and 1.
+  float ShoulderStart;
+
+  // For "Type == DICE_TYPE_BY_LUMINANCE_PQ_CORRECT_CHANNELS_BEYOND_PEAK_WHITE"
+  // only: The sum of these needs to be <= 1, both within 0 and 1. The closer
+  // the sum is to 1, the more each color channel will be containted within its
+  // peak range.
+  float DesaturationAmount;
+  float DarkeningAmount;
+};
+
+DICESettings DefaultDICESettings() {
+  DICESettings Settings;
+  Settings.Type = DICE_TYPE_BY_CHANNEL_PQ;
+  Settings.ShoulderStart =
+      (Settings.Type > DICE_TYPE_BY_LUMINANCE_RGB)
+          ? (1.f / 3.f)
+          : 0.f;  // TODOFT3: increase value!!! (did I already?)
+  Settings.DesaturationAmount = 1.0 / 3.0;
+  Settings.DarkeningAmount = 1.0 / 3.0;
+  return Settings;
+}
+
+// Tonemapper inspired from DICE. Can work by luminance to maintain hue.
+// Takes scRGB colors with a white level (the value of 1 1 1) of 80 nits (sRGB)
+// (to not be confused with paper white). Paper white is expected to have
+// already been multiplied in.
+float3 DICETonemap(float3 Color, float PeakWhite,
+                   const DICESettings Settings /*= DefaultDICESettings()*/) {
+  const float sourceLuminance = renodx::color::y::from::BT709(Color);
+
+  if (Settings.Type != DICE_TYPE_BY_LUMINANCE_RGB) {
+    static const float HDR10_MaxWhite =
+        HDR10_MaxWhiteNits / renodx::color::srgb::REFERENCE_WHITE;
+
+    // We could first convert the peak white to PQ and then apply the "shoulder
+    // start" alpha to it (in PQ), but tests showed scaling it in linear
+    // actually produces a better curve and more consistently follows the peak
+    // across different values
+    const float shoulderStartPQ =
+        Linear_to_PQ((Settings.ShoulderStart * PeakWhite) / HDR10_MaxWhite).x;
+    if (Settings.Type == DICE_TYPE_BY_LUMINANCE_PQ || Settings.Type == DICE_TYPE_BY_LUMINANCE_PQ_CORRECT_CHANNELS_BEYOND_PEAK_WHITE) {
+      const float sourceLuminanceNormalized = sourceLuminance / HDR10_MaxWhite;
+      const float sourceLuminancePQ =
+          Linear_to_PQ(sourceLuminanceNormalized, 1).x;
+
+      if (sourceLuminancePQ > shoulderStartPQ)  // Luminance below the shoulder (or below zero) don't
+                                                // need to be adjusted
+      {
+        const float peakWhitePQ = Linear_to_PQ(PeakWhite / HDR10_MaxWhite).x;
+
+        const float compressedLuminancePQ =
+            luminanceCompress(sourceLuminancePQ, peakWhitePQ, shoulderStartPQ);
+        const float compressedLuminanceNormalized =
+            PQ_to_Linear(compressedLuminancePQ).x;
+        Color *= compressedLuminanceNormalized / sourceLuminanceNormalized;
+
+        if (Settings.Type == DICE_TYPE_BY_LUMINANCE_PQ_CORRECT_CHANNELS_BEYOND_PEAK_WHITE) {
+          float3 Color_BT2020 = renodx::color::bt2020::from::BT709(Color);
+          if (any(Color_BT2020 > PeakWhite))  // Optional "optimization" branch
+          {
+            float colorLuminance = renodx::color::y::from::BT2020(Color_BT2020);
+            float colorLuminanceInExcess = colorLuminance - PeakWhite;
+            float maxColorInExcess =
+                max3(Color_BT2020) - PeakWhite;  // This is guaranteed to be >=
+                                                 // "colorLuminanceInExcess"
+            float brightnessReduction = saturate(renodx::math::SafeDivision(
+                PeakWhite, max3(Color_BT2020),
+                1));  // Fall back to one in case of division by zero
+            float desaturateAlpha = saturate(renodx::math::SafeDivision(
+                maxColorInExcess, maxColorInExcess - colorLuminanceInExcess,
+                0));  // Fall back to zero in case of division by zero
+            Color_BT2020 = lerp(Color_BT2020, colorLuminance,
+                                desaturateAlpha * Settings.DesaturationAmount);
+            Color_BT2020 =
+                lerp(Color_BT2020, Color_BT2020 * brightnessReduction,
+                     Settings.DarkeningAmount);  // Also reduce the brightness to
+                                                 // partially maintain the hue,
+                                                 // at the cost of brightness
+            Color = renodx::color::bt709::from::BT2020(Color_BT2020);
+          }
+        }
+      }
+    } else  // DICE_TYPE_BY_CHANNEL_PQ
+    {
+      const float peakWhitePQ = Linear_to_PQ(PeakWhite / HDR10_MaxWhite).x;
+
+      // Tonemap in BT.2020 to more closely match the primaries of modern
+      // displays
+      const float3 sourceColorNormalized =
+          renodx::color::bt2020::from::BT709(Color) / HDR10_MaxWhite;
+      const float3 sourceColorPQ = Linear_to_PQ(sourceColorNormalized, 1);
+
+      [unroll]
+      for (uint i = 0; i < 3;
+           i++)  // TODO LUMA: optimize? will the shader compile already convert
+                 // this to float3? Or should we already make a version with no
+                 // branches that works in float3?
+      {
+        if (sourceColorPQ[i] > shoulderStartPQ)  // Colors below the shoulder (or below zero) don't
+                                                 // need to be adjusted
+        {
+          const float compressedColorPQ =
+              luminanceCompress(sourceColorPQ[i], peakWhitePQ, shoulderStartPQ);
+          const float compressedColorNormalized =
+              PQ_to_Linear(compressedColorPQ).x;
+          Color[i] = renodx::color::bt709::from::BT2020(
+                         Color[i] * (compressedColorNormalized / sourceColorNormalized[i]))
+                         .x;
+        }
+      }
+    }
+  } else  // DICE_TYPE_BY_LUMINANCE_RGB
+  {
+    const float shoulderStart =
+        PeakWhite * Settings.ShoulderStart;  // From alpha to linear range
+    if (sourceLuminance > shoulderStart)     // Luminances below the shoulder (or below zero) don't
+                                             // need to be adjusted
+    {
+      const float compressedLuminance =
+          luminanceCompress(sourceLuminance, PeakWhite, shoulderStart);
+      Color *= compressedLuminance / sourceLuminance;
+    }
+  }
+
+  return Color;
+}

--- a/src/games/roadhogengine/addon.cpp
+++ b/src/games/roadhogengine/addon.cpp
@@ -77,6 +77,20 @@ renodx::mods::shader::CustomShaders custom_shaders = {
     is_grain_used = false;
     return true;
     }),
+    CustomShaderEntryCallback(0x852CCF05, [](reshade::api::command_list* cmd_list) {  // tonemap
+    postprocessing_level = 2;
+    is_vignette_used = true;
+    is_sharpen_used = false;
+    is_grain_used = false;
+    return true;
+    }),
+    CustomShaderEntryCallback(0x4338D617, [](reshade::api::command_list* cmd_list) {  // tonemap
+    postprocessing_level = 2;
+    is_vignette_used = true;
+    is_sharpen_used = false;
+    is_grain_used = false;
+    return true;
+    }),
     CustomShaderEntryCallback(0xAD092DF9, [](reshade::api::command_list* cmd_list) {  // tonemap
     postprocessing_level = 1;
     is_vignette_used = true;
@@ -94,6 +108,13 @@ renodx::mods::shader::CustomShaders custom_shaders = {
     CustomShaderEntryCallback(0xE29A7A29, [](reshade::api::command_list* cmd_list) {  // tonemap
     postprocessing_level = 1;
     is_vignette_used = false;
+    is_sharpen_used = false;
+    is_grain_used = false;
+    return true;
+    }),
+    CustomShaderEntryCallback(0x6AEB4E45, [](reshade::api::command_list* cmd_list) {  // tonemap
+    postprocessing_level = 1;
+    is_vignette_used = true;
     is_sharpen_used = false;
     is_grain_used = false;
     return true;
@@ -116,7 +137,14 @@ renodx::mods::shader::CustomShaders custom_shaders = {
     is_grain_used = false;
     return true;
     }),
+    CustomShaderEntryCallback(0xE56AC1BF, [](reshade::api::command_list* cmd_list) {  // tonemap
+    postprocessing_level = 0;
+    is_vignette_used = true;
+    is_grain_used = false;
+    return true;
+    }),
     CustomShaderEntry(0x8FACEF64),  // videos
+    CustomShaderEntry(0x23F2025E),  // RIP (glitched death screen)
     // Shadow Warrior (2013)
     // Shadow Warrior 2, maybe
 };

--- a/src/games/roadhogengine/addon.cpp
+++ b/src/games/roadhogengine/addon.cpp
@@ -1,0 +1,515 @@
+/*
+ * Copyright (C) 2023 Carlos Lopez
+ * SPDX-License-Identifier: MIT
+ */
+
+#define ImTextureID ImU64
+
+#define DEBUG_LEVEL_0
+
+#include <embed/shaders.h>
+
+#include <deps/imgui/imgui.h>
+#include <include/reshade.hpp>
+
+#include "../../mods/shader.hpp"
+#include "../../mods/swapchain.hpp"
+#include "../../utils/date.hpp"
+#include "../../utils/settings.hpp"
+#include "./shared.h"
+
+namespace {
+
+int postprocessing_level;
+bool is_vignette_used;
+bool lens_effects_active;
+
+renodx::mods::shader::CustomShaders custom_shaders = {
+    // Hard Reset Redux
+    CustomShaderEntryCallback(0x2FF3AD78, [](reshade::api::command_list* cmd_list) {  // tonemap
+    postprocessing_level = 2;
+    is_vignette_used = true;
+    return true;
+    }),
+    CustomShaderEntryCallback(0xEF480D6C, [](reshade::api::command_list* cmd_list) {  // tonemap
+    postprocessing_level = 2;
+    is_vignette_used = true;
+    return true;
+    }),
+    CustomShaderEntryCallback(0xA8F9150B, [](reshade::api::command_list* cmd_list) {  // tonemap
+    postprocessing_level = 2;
+    is_vignette_used = false;
+    return true;
+    }),
+    CustomShaderEntryCallback(0x769FB187, [](reshade::api::command_list* cmd_list) {  // tonemap
+    postprocessing_level = 2;
+    is_vignette_used = false;
+    return true;
+    }),
+    CustomShaderEntryCallback(0xBA01D096, [](reshade::api::command_list* cmd_list) {  // tonemap
+    postprocessing_level = 2;
+    is_vignette_used = false;
+    return true;
+    }),
+    CustomShaderEntryCallback(0xAD092DF9, [](reshade::api::command_list* cmd_list) {  // tonemap
+    postprocessing_level = 1;
+    is_vignette_used = true;
+    return true;
+    }),
+    CustomShaderEntryCallback(0x38396D4E, [](reshade::api::command_list* cmd_list) {  // tonemap
+    postprocessing_level = 1;
+    is_vignette_used = false;
+    return true;
+    }),
+    CustomShaderEntryCallback(0x5D1BC502, [](reshade::api::command_list* cmd_list) {  // tonemap
+    postprocessing_level = 0;
+    is_vignette_used = true;
+    return true;
+    }),
+    CustomShaderEntryCallback(0x39A21265, [](reshade::api::command_list* cmd_list) {  // tonemap
+    postprocessing_level = 0;
+    is_vignette_used = false;
+    return true;
+    }),
+    CustomShaderEntry(0x8FACEF64),  // videos
+    // Shadow Warrior (2013)
+    // Shadow Warrior 2, maybe
+};
+
+ShaderInjectData shader_injection;
+float current_settings_mode = 0;
+renodx::utils::settings::Settings settings = {
+    new renodx::utils::settings::Setting{
+        .key = "SettingsMode",
+        .binding = &current_settings_mode,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 0.f,
+        .can_reset = false,
+        .label = "Settings Mode",
+        .labels = {"Simple", "Intermediate", "Advanced"},
+        .is_global = true,
+    },
+    new renodx::utils::settings::Setting{
+        .key = "toneMapType",
+        .binding = &shader_injection.toneMapType,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 3.f,
+        .can_reset = true,
+        .label = "Tone Mapper",
+        .section = "Tone Mapping",
+        .tooltip = "Sets the tone mapper type",
+        .labels = {"Vanilla", "None", "Frostbite", "RenoDRT", "DICE"},
+        .is_visible = []() { return settings[0]->GetValue() >= 1; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "toneMapPeakNits",
+        .binding = &shader_injection.toneMapPeakNits,
+        .default_value = 1000.f,
+        .can_reset = false,
+        .label = "Peak Brightness",
+        .section = "Tone Mapping",
+        .tooltip = "Sets the value of peak white in nits",
+        .min = 48.f,
+        .max = 4000.f,
+        .is_enabled = []() { return shader_injection.toneMapType >= 2.f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "toneMapGameNits",
+        .binding = &shader_injection.toneMapGameNits,
+        .default_value = 203.f,
+        .label = "Game Brightness",
+        .section = "Tone Mapping",
+        .tooltip = "Sets the value of 100% white in nits",
+        .min = 48.f,
+        .max = 500.f,
+    },
+    new renodx::utils::settings::Setting{
+        .key = "toneMapUINits",
+        .binding = &shader_injection.toneMapUINits,
+        .default_value = 203.f,
+        .label = "UI Brightness",
+        .section = "Tone Mapping",
+        .tooltip = "Sets the brightness of UI and HUD elements in nits",
+        .min = 48.f,
+        .max = 500.f,
+    },
+    new renodx::utils::settings::Setting{
+        .key = "toneMapGammaCorrection",
+        .binding = &shader_injection.toneMapGammaCorrection,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 1.f,
+        .label = "Gamma Correction",
+        .section = "Tone Mapping",
+        .tooltip = "Emulates a display EOTF.",
+        .labels = {"Off", "2.2", "BT.1886"},
+        .is_visible = []() { return current_settings_mode >= 1; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "toneMapPerChannel",
+        .binding = &shader_injection.toneMapPerChannel,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 0.f,
+        .label = "Scaling",
+        .section = "Tone Mapping",
+        .tooltip = "Luminance scales colors consistently while per-channel saturates and blows out sooner",
+        .labels = {"Luminance", "Per Channel"},
+        .is_enabled = []() { return shader_injection.toneMapType >= 3.f; },
+        .is_visible = []() { return current_settings_mode >= 2; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "toneMapHueProcessor",
+        .binding = &shader_injection.toneMapHueProcessor,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 1.f,
+        .label = "Hue Processor",
+        .section = "Tone Mapping",
+        .labels = {"OKLab", "ICtCp", "darktable UCS"},
+        .is_enabled = []() { return shader_injection.toneMapType >= 2.f; },
+        .is_visible = []() { return current_settings_mode >= 2; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "toneMapHueCorrection",
+        .binding = &shader_injection.toneMapHueCorrection,
+        .default_value = 100.f,
+        .label = "Hue Correction",
+        .section = "Tone Mapping",
+        .max = 100.f,
+        .is_enabled = []() { return shader_injection.toneMapType >= 2.f; },
+        .parse = [](float value) { return value * 0.01f; },
+        .is_visible = []() { return current_settings_mode >= 2; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "toneMapShoulderStart",
+        .binding = &shader_injection.toneMapShoulderStart,
+        .default_value = 0.25f,
+        .label = "Rolloff/Shoulder Start",
+        .section = "Tone Mapping",
+        .max = 0.99f,
+        .format = "%.2f",
+        .is_visible = []() { return shader_injection.toneMapType == 2.f || shader_injection.toneMapType == 4.f ; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "colorGradeExposure",
+        .binding = &shader_injection.colorGradeExposure,
+        .default_value = 1.f,
+        .label = "Exposure",
+        .section = "Color Grading",
+        .tint = 0xF6AC1C,
+        .max = 10.f,
+        .format = "%.2f",
+        .is_visible = []() { return current_settings_mode >= 1; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "colorGradeHighlights",
+        .binding = &shader_injection.colorGradeHighlights,
+        .default_value = 50.f,
+        .label = "Highlights",
+        .section = "Color Grading",
+        .tint = 0xF6AC1C,
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+        .is_visible = []() { return current_settings_mode >= 1; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "colorGradeShadows",
+        .binding = &shader_injection.colorGradeShadows,
+        .default_value = 50.f,
+        .label = "Shadows",
+        .section = "Color Grading",
+        .tint = 0xF6AC1C,
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+        .is_visible = []() { return current_settings_mode >= 1; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "colorGradeContrast",
+        .binding = &shader_injection.colorGradeContrast,
+        .default_value = 50.f,
+        .label = "Contrast",
+        .section = "Color Grading",
+        .tint = 0xF6AC1C,
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "colorGradeSaturation",
+        .binding = &shader_injection.colorGradeSaturation,
+        .default_value = 50.f,
+        .label = "Saturation",
+        .section = "Color Grading",
+        .tint = 0xF6AC1C,
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "colorGradeBlowout",
+        .binding = &shader_injection.colorGradeBlowout,
+        .default_value = 50.f,
+        .label = "Highlights Saturation",
+        .section = "Color Grading",
+        .tooltip = "Adds or removes highlights color.",
+        .tint = 0xF6AC1C,
+        .max = 100.f,
+        .is_enabled = []() { return shader_injection.toneMapType >= 3.f; },
+        .parse = [](float value) { return value * 0.02f; },
+        .is_visible = []() { return current_settings_mode >= 1; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "colorGradeDechroma",
+        .binding = &shader_injection.colorGradeDechroma,
+        .default_value = 50.f,
+        .label = "Blowout",
+        .section = "Color Grading",
+        .tooltip = "Controls highlight desaturation due to overexposure.",
+        .tint = 0xF6AC1C,
+        .max = 100.f,
+        .is_enabled = []() { return shader_injection.toneMapType >= 3.f; },
+        .parse = [](float value) { return value * 0.01f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "colorGradeFlare",
+        .binding = &shader_injection.colorGradeFlare,
+        .default_value = 25.f,
+        .label = "Flare",
+        .section = "Color Grading",
+        .tint = 0xF6AC1C,
+        .max = 100.f,
+        .is_enabled = []() { return shader_injection.toneMapType == 3.f; },
+        .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "fxBloom",
+        .binding = &shader_injection.fxBloom,
+        .default_value = 50.f,
+        .label = "Bloom",
+        .section = "Effects",
+        .tint = 0x01A8DF,
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+        .is_visible = []() { return postprocessing_level >= 1; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "fxLens",
+        .binding = &shader_injection.fxLens,
+        .default_value = 100.f,
+        .label = "Lens Flare/Dirt",
+        .section = "Effects",
+        .tint = 0x01A8DF,
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.01f; },
+        .is_visible = []() { return lens_effects_active; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "fxSharpen",
+        .binding = &shader_injection.fxSharpen,
+        .default_value = 50.f,
+        .label = "Sharpening",
+        .section = "Effects",
+        .tint = 0x01A8DF,
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+        .is_visible = []() { return postprocessing_level >= 1 && current_settings_mode >= 1; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "fxVignette",
+        .binding = &shader_injection.fxVignette,
+        .default_value = 100.f,
+        .label = "Vignette",
+        .section = "Effects",
+        .tint = 0x01A8DF,
+        .max = 100.f,
+        .is_enabled = []() { return is_vignette_used; },
+        .parse = [](float value) { return value * 0.01f; },
+        .is_visible = []() { return current_settings_mode >= 1; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "fxFilmGrain",
+        .binding = &shader_injection.fxFilmGrain,
+        .default_value = 50.f,
+        .label = "Film Grain",
+        .section = "Effects",
+        .tint = 0x01A8DF,
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "fxFilmGrainType",
+        .binding = &shader_injection.fxFilmGrainType,
+        .value_type = renodx::utils::settings::SettingValueType::BOOLEAN,
+        .default_value = 1.f,
+        .label = "Film Grain Type",
+        .section = "Effects",
+        .labels = {"Vanilla", "Perceptual"},
+        .tint = 0x01A8DF,
+        .is_visible = []() { return shader_injection.fxFilmGrain != 0.f; },
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::BUTTON,
+        .label = "Reset",
+        .section = "Color Grading Templates",
+        .group = "button-line-1",
+        .tint = 0xFE8F20,
+        .on_change = []() {
+          renodx::utils::settings::UpdateSetting("toneMapPerChannel", 0.f);
+          renodx::utils::settings::UpdateSetting("toneMapHueProcessor", 1.f);
+          renodx::utils::settings::UpdateSetting("toneMapHueCorrection", 100.f);
+          renodx::utils::settings::UpdateSetting("toneMapShoulderStart", 0.25f);
+          renodx::utils::settings::UpdateSetting("colorGradeExposure", 1.f);
+          renodx::utils::settings::UpdateSetting("colorGradeHighlights", 50.f);
+          renodx::utils::settings::UpdateSetting("colorGradeShadows", 50.f);
+          renodx::utils::settings::UpdateSetting("colorGradeContrast", 50.f);
+          renodx::utils::settings::UpdateSetting("colorGradeSaturation", 50.f);
+          renodx::utils::settings::UpdateSetting("colorGradeBlowout", 50.f);
+          renodx::utils::settings::UpdateSetting("colorGradeDechroma", 50.f);
+          renodx::utils::settings::UpdateSetting("colorGradeFlare", 25.f);
+        },
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::BUTTON,
+        .label = "HDR Look",
+        .section = "Color Grading Templates",
+        .group = "button-line-1",
+        .tint = 0x01A8DF,
+        .on_change = []() {
+          renodx::utils::settings::UpdateSetting("toneMapPerChannel", 0.f);
+          renodx::utils::settings::UpdateSetting("toneMapHueProcessor", 1.f);
+          renodx::utils::settings::UpdateSetting("toneMapHueCorrection", 100.f);
+          renodx::utils::settings::UpdateSetting("toneMapShoulderStart", 0.33f);
+          renodx::utils::settings::UpdateSetting("colorGradeExposure", 1.f);
+          renodx::utils::settings::UpdateSetting("colorGradeHighlights", 50.f);
+          renodx::utils::settings::UpdateSetting("colorGradeShadows", 50.f);
+          renodx::utils::settings::UpdateSetting("colorGradeContrast", 75.f);
+          renodx::utils::settings::UpdateSetting("colorGradeSaturation", 75.f);
+          renodx::utils::settings::UpdateSetting("colorGradeBlowout", 50.f);
+          renodx::utils::settings::UpdateSetting("colorGradeDechroma", 80.f);
+          renodx::utils::settings::UpdateSetting("colorGradeFlare", 20.f);
+        },
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::BUTTON,
+        .label = "HDR Den Discord",
+        .section = "About",
+        .group = "button-line-2",
+        .tint = 0x5865F2,
+        .on_change = []() {
+          renodx::utils::platform::Launch(
+            "https://discord.gg/XUhv"
+            "tR54yc");
+        },
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::BUTTON,
+        .label = "Github",
+        .section = "About",
+        .group = "button-line-2",
+        .on_change = []() {
+          ShellExecute(0, "open", "https://github.com/clshortfuse/renodx", 0, 0, SW_SHOW);
+        },
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::TEXT,
+        .label = "Version: " + std::string(renodx::utils::date::ISO_DATE),
+        .section = "About",
+        .tooltip = std::string(__DATE__),
+    },
+};
+
+void OnPresetOff() {
+  renodx::utils::settings::UpdateSetting("toneMapType", 0.f);
+  renodx::utils::settings::UpdateSetting("toneMapPeakNits", 203.f);
+  renodx::utils::settings::UpdateSetting("toneMapGameNits", 203.f);
+  renodx::utils::settings::UpdateSetting("toneMapUINits", 203.f);
+  renodx::utils::settings::UpdateSetting("toneMapGammaCorrection", 0.f);
+  renodx::utils::settings::UpdateSetting("colorGradeExposure", 1.f);
+  renodx::utils::settings::UpdateSetting("colorGradeHighlights", 50.f);
+  renodx::utils::settings::UpdateSetting("colorGradeShadows", 50.f);
+  renodx::utils::settings::UpdateSetting("colorGradeContrast", 50.f);
+  renodx::utils::settings::UpdateSetting("colorGradeSaturation", 50.f);
+  renodx::utils::settings::UpdateSetting("fxBloom", 50.f);
+  renodx::utils::settings::UpdateSetting("fxLens", 100.f);
+  renodx::utils::settings::UpdateSetting("fxSharpen", 50.f);
+  renodx::utils::settings::UpdateSetting("fxVignette", 100.f);
+  renodx::utils::settings::UpdateSetting("fxFilmGrain", 50.f);
+  renodx::utils::settings::UpdateSetting("fxFilmGrainType", 0.f);
+}
+
+auto start = std::chrono::steady_clock::now();
+bool fired_on_init_swapchain = false;
+
+void OnInitSwapchain(reshade::api::swapchain* swapchain) {
+  if (fired_on_init_swapchain) return;
+  fired_on_init_swapchain = true;
+  auto peak = renodx::utils::swapchain::GetPeakNits(swapchain);
+  if (peak.has_value()) {
+    settings[2]->default_value = peak.value();
+    settings[2]->can_reset = true;
+  }
+}
+
+void OnPresent(
+    reshade::api::command_queue* queue,
+    reshade::api::swapchain* swapchain,
+    const reshade::api::rect* source_rect,
+    const reshade::api::rect* dest_rect,
+    uint32_t dirty_rect_count,
+    const reshade::api::rect* dirty_rects) {
+  auto end = std::chrono::steady_clock::now();
+  shader_injection.elapsedTime = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+}
+
+}  // namespace
+
+// NOLINTBEGIN(readability-identifier-naming)
+
+extern "C" __declspec(dllexport) constexpr const char* NAME = "RenoDX";
+extern "C" __declspec(dllexport) constexpr const char* DESCRIPTION = "RenoDX for Hard Reset Redux";
+
+// NOLINTEND(readability-identifier-naming)
+
+BOOL APIENTRY DllMain(HMODULE h_module, DWORD fdw_reason, LPVOID lpv_reserved) {
+  switch (fdw_reason) {
+    case DLL_PROCESS_ATTACH:
+      if (!reshade::register_addon(h_module)) return FALSE;
+      renodx::mods::swapchain::force_borderless = false;
+      renodx::mods::swapchain::prevent_full_screen = true;
+      renodx::mods::swapchain::use_resource_cloning = true;
+      // renodx::mods::swapchain::swapchain_proxy_compatibility_mode = true;
+      renodx::mods::swapchain::swap_chain_proxy_vertex_shader = __swap_chain_proxy_vertex_shader;
+      renodx::mods::swapchain::swap_chain_proxy_pixel_shader = __swap_chain_proxy_pixel_shader;
+      
+      //  RGB10A2_unorm
+      renodx::mods::swapchain::swap_chain_upgrade_targets.push_back({
+          .old_format = reshade::api::format::r10g10b10a2_unorm,
+          .new_format = reshade::api::format::r16g16b16a16_float,
+          .ignore_size = true,
+      });
+      //  RGBA8_unorm
+      renodx::mods::swapchain::swap_chain_upgrade_targets.push_back({
+          .old_format = reshade::api::format::r8g8b8a8_unorm,
+          .new_format = reshade::api::format::r16g16b16a16_float,
+          .ignore_size = false,
+      });
+      //  RGBA8_unorm
+      renodx::mods::swapchain::swap_chain_upgrade_targets.push_back({
+          .old_format = reshade::api::format::r8g8b8a8_unorm,
+          .new_format = reshade::api::format::r16g16b16a16_float,
+          .ignore_size = true,
+          .usage_include = reshade::api::resource_usage::render_target,
+      });
+
+      reshade::register_event<reshade::addon_event::init_swapchain>(OnInitSwapchain);
+      reshade::register_event<reshade::addon_event::present>(OnPresent);
+      break;
+    case DLL_PROCESS_DETACH:
+      reshade::unregister_addon(h_module);
+      reshade::unregister_event<reshade::addon_event::init_swapchain>(OnInitSwapchain);
+      reshade::unregister_event<reshade::addon_event::present>(OnPresent);
+      break;
+  }
+
+  renodx::utils::settings::Use(fdw_reason, &settings, &OnPresetOff);
+  renodx::mods::swapchain::Use(fdw_reason, &shader_injection);
+  renodx::mods::shader::Use(fdw_reason, custom_shaders, &shader_injection);
+
+  return TRUE;
+}

--- a/src/games/roadhogengine/addon.cpp
+++ b/src/games/roadhogengine/addon.cpp
@@ -564,14 +564,7 @@ BOOL APIENTRY DllMain(HMODULE h_module, DWORD fdw_reason, LPVOID lpv_reserved) {
           .new_format = reshade::api::format::r16g16b16a16_float,
           .ignore_size = false,
       });
-      //  RGBA8_unorm
-      renodx::mods::swapchain::swap_chain_upgrade_targets.push_back({
-          .old_format = reshade::api::format::r8g8b8a8_unorm,
-          .new_format = reshade::api::format::r16g16b16a16_float,
-          .ignore_size = true,
-          .usage_include = reshade::api::resource_usage::render_target,
-      });
-
+      
       reshade::register_event<reshade::addon_event::init_swapchain>(OnInitSwapchain);
       reshade::register_event<reshade::addon_event::present>(OnPresent);
       break;

--- a/src/games/roadhogengine/addon.cpp
+++ b/src/games/roadhogengine/addon.cpp
@@ -51,6 +51,16 @@ renodx::mods::shader::CustomShaders custom_shaders = {
     is_vignette_used = false;
     return true;
     }),
+    CustomShaderEntryCallback(0xA6B01AE0, [](reshade::api::command_list* cmd_list) {  // tonemap
+    postprocessing_level = 2;
+    is_vignette_used = false;
+    return true;
+    }),
+    CustomShaderEntryCallback(0x45405040, [](reshade::api::command_list* cmd_list) {  // tonemap
+    postprocessing_level = 2;
+    is_vignette_used = false;
+    return true;
+    }),
     CustomShaderEntryCallback(0xAD092DF9, [](reshade::api::command_list* cmd_list) {  // tonemap
     postprocessing_level = 1;
     is_vignette_used = true;
@@ -61,12 +71,22 @@ renodx::mods::shader::CustomShaders custom_shaders = {
     is_vignette_used = false;
     return true;
     }),
+    CustomShaderEntryCallback(0xE29A7A29, [](reshade::api::command_list* cmd_list) {  // tonemap
+    postprocessing_level = 1;
+    is_vignette_used = false;
+    return true;
+    }),
     CustomShaderEntryCallback(0x5D1BC502, [](reshade::api::command_list* cmd_list) {  // tonemap
     postprocessing_level = 0;
     is_vignette_used = true;
     return true;
     }),
     CustomShaderEntryCallback(0x39A21265, [](reshade::api::command_list* cmd_list) {  // tonemap
+    postprocessing_level = 0;
+    is_vignette_used = false;
+    return true;
+    }),
+    CustomShaderEntryCallback(0x79D405C5, [](reshade::api::command_list* cmd_list) {  // tonemap
     postprocessing_level = 0;
     is_vignette_used = false;
     return true;

--- a/src/games/roadhogengine/addon.cpp
+++ b/src/games/roadhogengine/addon.cpp
@@ -21,6 +21,8 @@
 namespace {
 
 int postprocessing_level;
+bool is_grain_used;
+bool is_sharpen_used;
 bool is_vignette_used;
 bool lens_effects_active;
 
@@ -29,66 +31,89 @@ renodx::mods::shader::CustomShaders custom_shaders = {
     CustomShaderEntryCallback(0x2FF3AD78, [](reshade::api::command_list* cmd_list) {  // tonemap
     postprocessing_level = 2;
     is_vignette_used = true;
+    is_sharpen_used = true;
+    is_grain_used = true;
     return true;
     }),
     CustomShaderEntryCallback(0xEF480D6C, [](reshade::api::command_list* cmd_list) {  // tonemap
     postprocessing_level = 2;
     is_vignette_used = true;
+    is_sharpen_used = true;
+    is_grain_used = true;
     return true;
     }),
     CustomShaderEntryCallback(0xA8F9150B, [](reshade::api::command_list* cmd_list) {  // tonemap
     postprocessing_level = 2;
     is_vignette_used = false;
+    is_sharpen_used = true;
+    is_grain_used = true;
     return true;
     }),
     CustomShaderEntryCallback(0x769FB187, [](reshade::api::command_list* cmd_list) {  // tonemap
     postprocessing_level = 2;
     is_vignette_used = false;
+    is_sharpen_used = true;
+    is_grain_used = true;
     return true;
     }),
     CustomShaderEntryCallback(0xBA01D096, [](reshade::api::command_list* cmd_list) {  // tonemap
     postprocessing_level = 2;
     is_vignette_used = false;
+    is_sharpen_used = true;
+    is_grain_used = true;
     return true;
     }),
     CustomShaderEntryCallback(0xA6B01AE0, [](reshade::api::command_list* cmd_list) {  // tonemap
     postprocessing_level = 2;
     is_vignette_used = false;
+    is_sharpen_used = false;
+    is_grain_used = false;
     return true;
     }),
     CustomShaderEntryCallback(0x45405040, [](reshade::api::command_list* cmd_list) {  // tonemap
     postprocessing_level = 2;
     is_vignette_used = false;
+    is_sharpen_used = false;
+    is_grain_used = false;
     return true;
     }),
     CustomShaderEntryCallback(0xAD092DF9, [](reshade::api::command_list* cmd_list) {  // tonemap
     postprocessing_level = 1;
     is_vignette_used = true;
+    is_sharpen_used = true;
+    is_grain_used = true;
     return true;
     }),
     CustomShaderEntryCallback(0x38396D4E, [](reshade::api::command_list* cmd_list) {  // tonemap
     postprocessing_level = 1;
     is_vignette_used = false;
+    is_sharpen_used = true;
+    is_grain_used = true;
     return true;
     }),
     CustomShaderEntryCallback(0xE29A7A29, [](reshade::api::command_list* cmd_list) {  // tonemap
     postprocessing_level = 1;
     is_vignette_used = false;
+    is_sharpen_used = false;
+    is_grain_used = false;
     return true;
     }),
     CustomShaderEntryCallback(0x5D1BC502, [](reshade::api::command_list* cmd_list) {  // tonemap
     postprocessing_level = 0;
     is_vignette_used = true;
+    is_grain_used = true;
     return true;
     }),
     CustomShaderEntryCallback(0x39A21265, [](reshade::api::command_list* cmd_list) {  // tonemap
     postprocessing_level = 0;
     is_vignette_used = false;
+    is_grain_used = true;
     return true;
     }),
     CustomShaderEntryCallback(0x79D405C5, [](reshade::api::command_list* cmd_list) {  // tonemap
     postprocessing_level = 0;
     is_vignette_used = false;
+    is_grain_used = false;
     return true;
     }),
     CustomShaderEntry(0x8FACEF64),  // videos
@@ -327,6 +352,7 @@ renodx::utils::settings::Settings settings = {
         .section = "Effects",
         .tint = 0x01A8DF,
         .max = 100.f,
+        .is_enabled = []() { return is_sharpen_used; },
         .parse = [](float value) { return value * 0.02f; },
         .is_visible = []() { return postprocessing_level >= 1 && current_settings_mode >= 1; },
     },
@@ -350,6 +376,7 @@ renodx::utils::settings::Settings settings = {
         .section = "Effects",
         .tint = 0x01A8DF,
         .max = 100.f,
+        .is_enabled = []() { return is_grain_used; },
         .parse = [](float value) { return value * 0.02f; },
     },
     new renodx::utils::settings::Setting{
@@ -361,7 +388,7 @@ renodx::utils::settings::Settings settings = {
         .section = "Effects",
         .labels = {"Vanilla", "Perceptual"},
         .tint = 0x01A8DF,
-        .is_visible = []() { return shader_injection.fxFilmGrain != 0.f; },
+        .is_visible = []() { return shader_injection.fxFilmGrain != 0.f && is_grain_used; },
     },
     new renodx::utils::settings::Setting{
         .value_type = renodx::utils::settings::SettingValueType::BUTTON,

--- a/src/games/roadhogengine/common.hlsl
+++ b/src/games/roadhogengine/common.hlsl
@@ -40,13 +40,6 @@ float3 FinalizeOutput(float3 color) {
     color = renodx::color::srgb::DecodeSafe(color);
   }
   color *= injectedData.toneMapUINits;
-  /*if (injectedData.toneMapType != 1.f) {
-    float y_max = injectedData.toneMapPeakNits;
-    float y = renodx::color::y::from::BT709(abs(color));
-    if (y > y_max) {
-      color *= y_max / y;
-    }
-  }*/
   if (injectedData.toneMapType == 0.f) {
     color = renodx::color::bt709::clamp::BT709(color);
   } else {
@@ -177,7 +170,7 @@ float3 applyDICE(float3 input, renodx::tonemap::Config DiceConfig, bool sdr = fa
   return color;
 }
 
-float3 applyUserTonemap(float3 untonemapped, float2 screen) {
+float3 applyUserTonemap(float3 untonemapped, float2 screen, bool grain = true) {
   float3 outputColor = renodx::color::srgb::DecodeSafe(untonemapped);
   renodx::tonemap::Config config = renodx::tonemap::config::Create();
   config.type = injectedData.toneMapType;
@@ -212,7 +205,7 @@ float3 applyUserTonemap(float3 untonemapped, float2 screen) {
   } else {
     outputColor = renodx::tonemap::config::Apply(outputColor, config);
   }
-  if (injectedData.fxFilmGrainType == 1.f) {
+  if (grain && injectedData.fxFilmGrainType == 1.f) {
     outputColor = applyFilmGrain(outputColor, screen);
   }
   return outputColor;

--- a/src/games/roadhogengine/common.hlsl
+++ b/src/games/roadhogengine/common.hlsl
@@ -1,0 +1,219 @@
+#include "./shared.h"
+#include "./DICE.hlsl"
+
+//-----EFFECTS-----//
+float3 applyFilmGrain(float3 outputColor, float2 screen) {
+  float3 grainedColor = renodx::effects::ApplyFilmGrain(
+        outputColor,
+        screen,
+        frac(injectedData.elapsedTime / 1000.f),
+        injectedData.fxFilmGrain * 0.03f,
+        1.f);
+  return grainedColor;
+}
+
+//-----SCALING-----//
+float3 PostToneMapScale(float3 color) {
+  if (injectedData.toneMapGammaCorrection == 2.f) {
+    color = renodx::color::srgb::EncodeSafe(color);
+    color = renodx::color::gamma::DecodeSafe(color, 2.4f);
+    color *= injectedData.toneMapGameNits / injectedData.toneMapUINits;
+    color = renodx::color::gamma::EncodeSafe(color, 2.4f);
+  } else if (injectedData.toneMapGammaCorrection == 1.f) {
+    color = renodx::color::srgb::EncodeSafe(color);
+    color = renodx::color::gamma::DecodeSafe(color, 2.2f);
+    color *= injectedData.toneMapGameNits / injectedData.toneMapUINits;
+    color = renodx::color::gamma::EncodeSafe(color, 2.2f);
+  } else {
+    color *= injectedData.toneMapGameNits / injectedData.toneMapUINits;
+    color = renodx::color::srgb::EncodeSafe(color);
+  }
+  return color;
+}
+
+float3 FinalizeOutput(float3 color) {
+  if (injectedData.toneMapGammaCorrection == 2.f) {
+    color = renodx::color::gamma::DecodeSafe(color, 2.4f);
+  } else if (injectedData.toneMapGammaCorrection == 1.f) {
+    color = renodx::color::gamma::DecodeSafe(color, 2.2f);
+  } else {
+    color = renodx::color::srgb::DecodeSafe(color);
+  }
+  color *= injectedData.toneMapUINits;
+  /*if (injectedData.toneMapType != 1.f) {
+    float y_max = injectedData.toneMapPeakNits;
+    float y = renodx::color::y::from::BT709(abs(color));
+    if (y > y_max) {
+      color *= y_max / y;
+    }
+  }*/
+  if (injectedData.toneMapType == 0.f) {
+    color = renodx::color::bt709::clamp::BT709(color);
+  } else {
+    color = renodx::color::bt709::clamp::BT2020(color);
+  }
+  color /= 80.f;
+  return color;
+}
+
+//-----TONEMAP-----//
+float3 applyFrostbite(float3 input, renodx::tonemap::Config FbConfig, bool sdr = false) {
+  float3 color = input;
+  float FbPeak = sdr ? 1.f : FbConfig.peak_nits / FbConfig.game_nits;
+  if (FbConfig.gamma_correction != 0.f && sdr == false) {
+    FbPeak = renodx::color::correct::Gamma(FbPeak, FbConfig.gamma_correction > 0.f, abs(FbConfig.gamma_correction) == 1.f ? 2.2f : 2.4f);
+  }
+  float y = renodx::color::y::from::BT709(color * FbConfig.exposure);
+  color = renodx::color::grade::UserColorGrading(color, FbConfig.exposure, FbConfig.highlights, FbConfig.shadows, FbConfig.contrast);
+  color = renodx::tonemap::frostbite::BT709(color, FbPeak, injectedData.toneMapShoulderStart, injectedData.colorGradeBlowout, injectedData.toneMapHueCorrection);
+
+  if (FbConfig.saturation != 1.f || FbConfig.reno_drt_blowout != 0.f) {
+    float3 perceptual_new;
+
+    if (FbConfig.reno_drt_hue_correction_method == 0u) {
+      perceptual_new = renodx::color::oklab::from::BT709(color);
+    } else if (FbConfig.reno_drt_hue_correction_method == 1u) {
+      perceptual_new = renodx::color::ictcp::from::BT709(color);
+    } else if (FbConfig.reno_drt_hue_correction_method == 2u) {
+      perceptual_new = renodx::color::dtucs::uvY::from::BT709(color).zxy;
+    }
+
+    if (FbConfig.reno_drt_dechroma != 0.f) {
+      perceptual_new.yz *= lerp(1.f, 0.f, saturate(pow(y / (10000.f / 100.f), (1.f - FbConfig.reno_drt_dechroma))));
+    }
+
+    perceptual_new.yz *= FbConfig.saturation;
+
+    if (FbConfig.reno_drt_hue_correction_method == 0u) {
+      color = renodx::color::bt709::from::OkLab(perceptual_new);
+    } else if (FbConfig.reno_drt_hue_correction_method == 1u) {
+      color = renodx::color::bt709::from::ICtCp(perceptual_new);
+    } else if (FbConfig.reno_drt_hue_correction_method == 2u) {
+      color = renodx::color::bt709::from::dtucs::uvY(perceptual_new.yzx);
+    }
+  }
+  color = renodx::color::bt709::clamp::AP1(color);
+  return color;
+}
+
+float3 applyDICE(float3 input, renodx::tonemap::Config DiceConfig, bool sdr = false) {
+  float3 color = input;
+  DICESettings DICEconfig = DefaultDICESettings();
+  DICEconfig.Type = 2 + (uint)injectedData.toneMapPerChannel;
+  DICEconfig.ShoulderStart = injectedData.toneMapShoulderStart;
+  float DicePaperWhite = DiceConfig.game_nits / 80.f;
+  float DicePeak = sdr ? DicePaperWhite : DiceConfig.peak_nits / 80.f;
+  if (DiceConfig.gamma_correction != 0.f && sdr == false) {
+    DicePaperWhite = renodx::color::correct::Gamma(DicePaperWhite, DiceConfig.gamma_correction > 0.f, abs(DiceConfig.gamma_correction) == 1.f ? 2.2f : 2.4f);
+    DicePeak = renodx::color::correct::Gamma(DicePeak, DiceConfig.gamma_correction > 0.f, abs(DiceConfig.gamma_correction) == 1.f ? 2.2f : 2.4f);
+  }
+
+  float y = renodx::color::y::from::BT709(color * DiceConfig.exposure);
+  color = renodx::color::grade::UserColorGrading(color, DiceConfig.exposure, DiceConfig.highlights, DiceConfig.shadows, DiceConfig.contrast);
+  color = DICETonemap(color * DicePaperWhite, DicePeak, DICEconfig) / DicePaperWhite;
+
+  if (DiceConfig.saturation != 1.f || DiceConfig.hue_correction_strength != 0.f || DiceConfig.reno_drt_blowout != 0.f || DiceConfig.reno_drt_dechroma != 0.f) {
+    float3 perceptual_new;
+
+    if (DiceConfig.reno_drt_hue_correction_method == 0u) {
+      perceptual_new = renodx::color::oklab::from::BT709(color);
+    } else if (DiceConfig.reno_drt_hue_correction_method == 1u) {
+      perceptual_new = renodx::color::ictcp::from::BT709(color);
+    } else if (DiceConfig.reno_drt_hue_correction_method == 2u) {
+      perceptual_new = renodx::color::dtucs::uvY::from::BT709(color).zxy;
+    }
+
+    if (DiceConfig.hue_correction_strength != 0.f) {
+      float3 perceptual_old;
+      if (DiceConfig.hue_correction_type == renodx::tonemap::config::hue_correction_type::INPUT) {
+        DiceConfig.hue_correction_color = input;
+      }
+      if (DiceConfig.reno_drt_hue_correction_method == 0u) {
+        perceptual_old = renodx::color::oklab::from::BT709(DiceConfig.hue_correction_color);
+      } else if (DiceConfig.reno_drt_hue_correction_method == 1u) {
+        perceptual_old = renodx::color::ictcp::from::BT709(DiceConfig.hue_correction_color);
+      } else if (DiceConfig.reno_drt_hue_correction_method == 2u) {
+        perceptual_old = renodx::color::dtucs::uvY::from::BT709(DiceConfig.hue_correction_color).zxy;
+      }
+
+      // Save chrominance to apply black
+      float chrominance_pre_adjust = distance(perceptual_new.yz, 0);
+
+      perceptual_new.yz = lerp(perceptual_new.yz, perceptual_old.yz, DiceConfig.hue_correction_strength);
+
+      float chrominance_post_adjust = distance(perceptual_new.yz, 0);
+
+      // Apply back previous chrominance
+      perceptual_new.yz *= renodx::math::DivideSafe(chrominance_pre_adjust, chrominance_post_adjust, 1.f);
+    }
+
+    if (DiceConfig.reno_drt_dechroma != 0.f) {
+      perceptual_new.yz *= lerp(1.f, 0.f, saturate(pow(y / (10000.f / 100.f), (1.f - DiceConfig.reno_drt_dechroma))));
+    }
+
+    if (DiceConfig.reno_drt_blowout != 0.f) {
+      float percent_max = saturate(y * 100.f / 10000.f);
+      // positive = 1 to 0, negative = 1 to 2
+      float blowout_strength = 100.f;
+      float blowout_change = pow(1.f - percent_max, blowout_strength * abs(DiceConfig.reno_drt_blowout));
+      if (DiceConfig.reno_drt_blowout < 0) {
+        blowout_change = (2.f - blowout_change);
+      }
+
+      perceptual_new.yz *= blowout_change;
+    }
+
+    perceptual_new.yz *= DiceConfig.saturation;
+
+    if (DiceConfig.reno_drt_hue_correction_method == 0u) {
+      color = renodx::color::bt709::from::OkLab(perceptual_new);
+    } else if (DiceConfig.reno_drt_hue_correction_method == 1u) {
+      color = renodx::color::bt709::from::ICtCp(perceptual_new);
+    } else if (DiceConfig.reno_drt_hue_correction_method == 2u) {
+      color = renodx::color::bt709::from::dtucs::uvY(perceptual_new.yzx);
+    }
+  }
+  color = renodx::color::bt709::clamp::AP1(color);
+  return color;
+}
+
+float3 applyUserTonemap(float3 untonemapped, float2 screen) {
+  float3 outputColor = renodx::color::srgb::DecodeSafe(untonemapped);
+  renodx::tonemap::Config config = renodx::tonemap::config::Create();
+  config.type = injectedData.toneMapType;
+  config.peak_nits = injectedData.toneMapPeakNits;
+  config.game_nits = injectedData.toneMapGameNits;
+  config.gamma_correction = injectedData.toneMapGammaCorrection;
+  config.exposure = injectedData.colorGradeExposure;
+  config.highlights = injectedData.colorGradeHighlights;
+  config.shadows = injectedData.colorGradeShadows;
+  config.contrast = injectedData.colorGradeContrast;
+  config.saturation = injectedData.colorGradeSaturation;
+  config.mid_gray_nits = 19.f;
+  config.reno_drt_contrast = 1.04f;
+  config.reno_drt_saturation = 1.05f;
+  config.reno_drt_dechroma = injectedData.colorGradeDechroma;
+  config.reno_drt_flare = 0.01 * pow(injectedData.colorGradeFlare, 4.32192809489);
+  config.hue_correction_type = injectedData.toneMapPerChannel != 0.f
+                                   ? renodx::tonemap::config::hue_correction_type::INPUT
+                                   : renodx::tonemap::config::hue_correction_type::CUSTOM;
+  config.hue_correction_strength = injectedData.toneMapPerChannel != 0.f
+                                       ? (1.f - injectedData.toneMapHueCorrection)
+                                       : injectedData.toneMapHueCorrection;
+  config.hue_correction_color = renodx::tonemap::renodrt::NeutralSDR(outputColor);
+  config.reno_drt_tone_map_method = renodx::tonemap::renodrt::config::tone_map_method::DANIELE;
+  config.reno_drt_hue_correction_method = (uint)injectedData.toneMapHueProcessor;
+  config.reno_drt_blowout = 1.f - injectedData.colorGradeBlowout;
+  config.reno_drt_per_channel = injectedData.toneMapPerChannel != 0.f;
+  if (injectedData.toneMapType == 2.f) {  // Frostbite
+    outputColor = applyFrostbite(outputColor, config);
+  } else if (injectedData.toneMapType == 4.f) {  // DICE
+    outputColor = applyDICE(outputColor, config);
+  } else {
+    outputColor = renodx::tonemap::config::Apply(outputColor, config);
+  }
+  if (injectedData.fxFilmGrainType == 1.f) {
+    outputColor = applyFilmGrain(outputColor, screen);
+  }
+  return outputColor;
+}

--- a/src/games/roadhogengine/gamma_0xC567CE8A.ps_4_0.hlsl
+++ b/src/games/roadhogengine/gamma_0xC567CE8A.ps_4_0.hlsl
@@ -1,0 +1,24 @@
+Texture2D<float4> t0 : register(t0);
+SamplerState s4_s : register(s4);
+cbuffer cb0 : register(b0){
+  float4 cb0[38];
+}
+
+#define cmp -
+
+void main(
+  float4 v0 : SV_Position0,
+  float4 v1 : COLOR0,
+  float2 v2 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = t0.Sample(s4_s, v2.xy).xyzw;
+  r0.xyzw = v1.xyzw * r0.xyzw;
+  o0.w = r0.w;
+  o0.rgb = r0.rgb;
+  return;
+}

--- a/src/games/roadhogengine/hardresetredux/rip_0x23F2025E.ps_4_0.hlsl
+++ b/src/games/roadhogengine/hardresetredux/rip_0x23F2025E.ps_4_0.hlsl
@@ -1,0 +1,24 @@
+Texture2D<float4> t0 : register(t0);
+SamplerState s3_s : register(s3);
+
+#define cmp -
+
+void main(
+  float4 v0 : SV_Position0,
+  float4 v1 : COLOR0,
+  float4 v2 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = t0.Sample(s3_s, v2.xy).xyzw;
+  r1.x = r0.w * v1.w + -9.99999975e-05;
+  r0.xyzw = v1.xyzw * r0.xyzw;
+  o0.xyzw = r0.xyzw;
+  o0.a = saturate(o0.a);
+  r0.x = cmp(r1.x < 0);
+  if (r0.x != 0) discard;
+  return;
+}

--- a/src/games/roadhogengine/hardresetredux/tonemap_0x2FF3AD78.ps_4_0.hlsl
+++ b/src/games/roadhogengine/hardresetredux/tonemap_0x2FF3AD78.ps_4_0.hlsl
@@ -1,0 +1,78 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t15 : register(t15);
+Texture2D<float4> t14 : register(t14);
+Texture2D<float4> t13 : register(t13);
+Texture2D<float4> t12 : register(t12);
+SamplerState s8_s : register(s8);
+SamplerState s5_s : register(s5);
+SamplerState s4_s : register(s4);
+cbuffer cb1 : register(b1){
+  float4 cb1[13];
+}
+cbuffer cb0 : register(b0){
+  float4 cb0[19];
+}
+
+#define cmp -
+
+void main(
+  float4 v0 : SV_Position0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = v1.xy * cb1[1].xy + cb1[1].zw;
+  r0.xy = min(cb1[6].xy, r0.xy);
+  r0.xyzw = t13.SampleLevel(s5_s, r0.xy, 0).xyzw;
+  r0.xyz = -r0.xyz * cb1[7].xyz * injectedData.fxBloom + float3(1,1,1);
+  r1.xy = v1.xy * cb1[0].xy + cb1[0].zw;
+  r2.xyzw = t12.SampleLevel(s4_s, r1.xy, 0).xyzw;
+  r2.xyz = float3(4,4,4) * r2.xyz;
+  r1.zw = cb1[8].zw + r1.xy;
+  r3.xyzw = t15.SampleLevel(s8_s, r1.xy, 0).xyzw;
+  r0.w = r3.x * cb0[18].x + cb0[18].z;
+  r0.w = 1 / r0.w;
+  r1.xy = r0.ww * cb1[11].xz + cb1[11].yw;
+  o0.w = max(r1.x, r1.y);
+  o0.a = saturate(o0.a);
+  r1.xyzw = t12.SampleLevel(s4_s, r1.zw, 0).xyzw;
+  r2.xyz = -r1.xyz * float3(4,4,4) + r2.xyz;
+  r1.xyz = float3(4,4,4) * r1.xyz;
+  r1.xyz = cb1[7].www * r2.xyz * injectedData.fxSharpen + r1.xyz;
+  if (injectedData.toneMapType == 0.f) {
+    r1.rgb = saturate(r1.rgb);
+  }
+  r2.xyz = float3(1,1,1) + -r1.xyz;
+  r0.xyz = -r2.xyz * r0.xyz + float3(1,1,1);
+  r0.xyz = max(r1.xyz, r0.xyz);
+  //r0.xyz = r0.xyz + r0.xyz;
+  //r0.rgb = 0.53252053f * r0.rgb;
+  if (injectedData.toneMapType == 0.f) {
+    r0.rgb = saturate(r0.rgb);
+  }
+  r1.xy = v1.xy * cb1[2].xy + cb1[2].zw;
+  r0.w = dot(r1.xy, r1.xy);
+  r0.w = saturate(r0.w * cb1[8].x + cb1[8].y);
+  r0.w = r0.w * r0.w;
+  r0.xyz = r0.xyz * lerp(1.f, r0.www, injectedData.fxVignette);
+  if (injectedData.fxFilmGrainType == 0.f) {
+  r0.w = dot(r0.xyz, float3(0.212599993,0.715200007,0.0722000003));
+  r0.w = -r0.w * cb1[9].y + 1;
+  r1.xy = v1.xy * cb1[3].xy + cb1[3].zw;
+  r1.xyzw = t14.SampleLevel(s4_s, r1.xy, 0).xyzw;
+  r1.x = -0.5 + r1.x;
+  r1.x = cb1[9].x * r1.x;
+  r0.xyz = r1.xxx * r0.www * injectedData.fxFilmGrain + r0.xyz;
+  }
+  r0.w = dot(r0.xyz, float3(0.212599993,0.715200007,0.0722000003));
+  r0.xyz = -cb1[12].xyz * r0.www + r0.xyz;
+  r1.xyz = cb1[12].xyz * r0.www;
+  o0.xyz = cb1[9].zzz * r0.xyz + r1.xyz;
+  o0.rgb = applyUserTonemap(o0.rgb, v1);
+  o0.rgb = PostToneMapScale(o0.rgb);
+  return;
+}

--- a/src/games/roadhogengine/hardresetredux/tonemap_0x2FF3AD78.ps_4_0.hlsl
+++ b/src/games/roadhogengine/hardresetredux/tonemap_0x2FF3AD78.ps_4_0.hlsl
@@ -49,8 +49,7 @@ void main(
   r2.xyz = float3(1,1,1) + -r1.xyz;
   r0.xyz = -r2.xyz * r0.xyz + float3(1,1,1);
   r0.xyz = max(r1.xyz, r0.xyz);
-  //r0.xyz = r0.xyz + r0.xyz;
-  //r0.rgb = 0.53252053f * r0.rgb;
+  r0.rgb = 1.06504106f * r0.rgb;
   if (injectedData.toneMapType == 0.f) {
     r0.rgb = saturate(r0.rgb);
   }

--- a/src/games/roadhogengine/hardresetredux/tonemap_0x38396D4E.ps_4_0.hlsl
+++ b/src/games/roadhogengine/hardresetredux/tonemap_0x38396D4E.ps_4_0.hlsl
@@ -38,8 +38,7 @@ void main(
   r2.xyz = -r2.xyz * cb1[7].xyz * injectedData.fxBloom + float3(1,1,1);
   r1.xyz = -r1.xyz * r2.xyz + float3(1,1,1);
   r0.xyz = max(r1.xyz, r0.xyz);
-  //r0.xyz = r0.xyz + r0.xyz;
-  //r0.rgb = 0.53252053f * r0.rgb;
+  r0.rgb = 1.06504106f * r0.rgb;
   if (injectedData.toneMapType == 0.f) {
     r0.rgb = saturate(r0.rgb);
   }

--- a/src/games/roadhogengine/hardresetredux/tonemap_0x38396D4E.ps_4_0.hlsl
+++ b/src/games/roadhogengine/hardresetredux/tonemap_0x38396D4E.ps_4_0.hlsl
@@ -1,0 +1,64 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t14 : register(t14);
+Texture2D<float4> t13 : register(t13);
+Texture2D<float4> t12 : register(t12);
+SamplerState s5_s : register(s5);
+SamplerState s4_s : register(s4);
+cbuffer cb1 : register(b1){
+  float4 cb1[13];
+}
+
+#define cmp -
+
+void main(
+  float4 v0 : SV_Position0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = v1.xy * cb1[0].xy + cb1[0].zw;
+  r1.xyzw = t12.SampleLevel(s4_s, r0.xy, 0).xyzw;
+  r0.xy = cb1[8].zw + r0.xy;
+  r0.xyzw = t12.SampleLevel(s4_s, r0.xy, 0).xyzw;
+  r1.xyz = float3(4,4,4) * r1.xyz;
+  r1.xyz = -r0.xyz * float3(4,4,4) + r1.xyz;
+  r0.xyz = float3(4,4,4) * r0.xyz;
+  r0.xyz = cb1[7].www * r1.xyz * injectedData.fxSharpen + r0.xyz;
+  if (injectedData.toneMapType == 0.f) {
+    r0.rgb = saturate(r0.rgb);
+  }
+  r1.xyz = float3(1,1,1) + -r0.xyz;
+  r2.xy = v1.xy * cb1[1].xy + cb1[1].zw;
+  r2.xy = min(cb1[6].xy, r2.xy);
+  r2.xyzw = t13.SampleLevel(s5_s, r2.xy, 0).xyzw;
+  r2.xyz = -r2.xyz * cb1[7].xyz * injectedData.fxBloom + float3(1,1,1);
+  r1.xyz = -r1.xyz * r2.xyz + float3(1,1,1);
+  r0.xyz = max(r1.xyz, r0.xyz);
+  //r0.xyz = r0.xyz + r0.xyz;
+  //r0.rgb = 0.53252053f * r0.rgb;
+  if (injectedData.toneMapType == 0.f) {
+    r0.rgb = saturate(r0.rgb);
+  }
+  if (injectedData.fxFilmGrainType == 0.f) {
+  r0.a = renodx::color::y::from::BT709(r0.rgb);
+  r0.w = -r0.w * cb1[9].y + 1;
+  r1.xy = v1.xy * cb1[3].xy + cb1[3].zw;
+  r1.xyzw = t14.SampleLevel(s4_s, r1.xy, 0).xyzw;
+  r1.x = -0.5 + r1.x;
+  r1.x = cb1[9].x * r1.x;
+  r0.xyz = r1.xxx * r0.www * injectedData.fxFilmGrain + r0.xyz;
+  }
+  r0.a = renodx::color::y::from::BT709(r0.rgb);
+  r0.xyz = -cb1[12].xyz * r0.www + r0.xyz;
+  r1.xyz = cb1[12].xyz * r0.www;
+  r0.xyz = cb1[9].zzz * r0.xyz + r1.xyz;
+  o0.a = renodx::color::y::from::BT709(r0.rgb);
+  o0.xyz = r0.xyz;
+  o0.rgb = applyUserTonemap(o0.rgb, v1);
+  o0.rgb = PostToneMapScale(o0.rgb);
+  return;
+}

--- a/src/games/roadhogengine/hardresetredux/tonemap_0x39A21265.ps_4_0.hlsl
+++ b/src/games/roadhogengine/hardresetredux/tonemap_0x39A21265.ps_4_0.hlsl
@@ -1,0 +1,48 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t14 : register(t14);
+Texture2D<float4> t12 : register(t12);
+SamplerState s7_s : register(s7);
+SamplerState s4_s : register(s4);
+cbuffer cb1 : register(b1){
+  float4 cb1[13];
+}
+
+#define cmp -
+
+void main(
+  float4 v0 : SV_Position0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = v1.xy * cb1[0].xy + cb1[0].zw;
+  r0.xyzw = t12.SampleLevel(s7_s, r0.xy, 0).xyzw;
+  r0.xyz = float3(4,4,4) * r0.xyz;
+  //r0.xyz = r0.xyz + r0.xyz;
+  //r0.rgb = 0.53252053f * r0.rgb;
+  if (injectedData.toneMapType == 0.f) {
+    r0.rgb = saturate(r0.rgb);
+  }
+  if (injectedData.fxFilmGrainType == 0.f) {
+  r0.a = renodx::color::y::from::BT709(r0.rgb);
+  r0.w = -r0.w * cb1[9].y + 1;
+  r1.xy = v1.xy * cb1[3].xy + cb1[3].zw;
+  r1.xyzw = t14.SampleLevel(s4_s, r1.xy, 0).xyzw;
+  r1.x = -0.5 + r1.x;
+  r1.x = cb1[9].x * r1.x;
+  r0.xyz = r1.xxx * r0.www * injectedData.fxFilmGrain + r0.xyz;
+  }
+  r0.a = renodx::color::y::from::BT709(r0.rgb);
+  r0.xyz = -cb1[12].xyz * r0.www + r0.xyz;
+  r1.xyz = cb1[12].xyz * r0.www;
+  r0.xyz = cb1[9].zzz * r0.xyz + r1.xyz;
+  o0.a = renodx::color::y::from::BT709(r0.rgb);
+  o0.xyz = r0.xyz;
+  o0.rgb = applyUserTonemap(o0.rgb, v1);
+  o0.rgb = PostToneMapScale(o0.rgb);
+  return;
+}

--- a/src/games/roadhogengine/hardresetredux/tonemap_0x39A21265.ps_4_0.hlsl
+++ b/src/games/roadhogengine/hardresetredux/tonemap_0x39A21265.ps_4_0.hlsl
@@ -22,8 +22,7 @@ void main(
   r0.xy = v1.xy * cb1[0].xy + cb1[0].zw;
   r0.xyzw = t12.SampleLevel(s7_s, r0.xy, 0).xyzw;
   r0.xyz = float3(4,4,4) * r0.xyz;
-  //r0.xyz = r0.xyz + r0.xyz;
-  //r0.rgb = 0.53252053f * r0.rgb;
+  r0.rgb = 1.06504106f * r0.rgb;
   if (injectedData.toneMapType == 0.f) {
     r0.rgb = saturate(r0.rgb);
   }

--- a/src/games/roadhogengine/hardresetredux/tonemap_0x4338D617.ps_4_0.hlsl
+++ b/src/games/roadhogengine/hardresetredux/tonemap_0x4338D617.ps_4_0.hlsl
@@ -1,0 +1,64 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t15 : register(t15);
+Texture2D<float4> t13 : register(t13);
+Texture2D<float4> t12 : register(t12);
+Texture2D<float4> t11 : register(t11);
+SamplerState s8_s : register(s8);
+SamplerState s7_s : register(s7);
+SamplerState s5_s : register(s5);
+cbuffer cb1 : register(b1){
+  float4 cb1[13];
+}
+cbuffer cb0 : register(b0){
+  float4 cb0[19];
+}
+
+#define cmp -
+
+void main(
+  float4 v0 : SV_Position0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = v1.xy * cb1[1].xy + cb1[1].zw;
+  r0.xy = min(cb1[6].xy, r0.xy);
+  r0.xyzw = t13.SampleLevel(s5_s, r0.xy, 0).xyzw;
+  r1.xy = v1.xy * cb1[4].xy + cb1[4].zw;
+  r1.xy = min(cb1[6].zw, r1.xy);
+  r1.xyzw = t11.SampleLevel(s5_s, r1.xy, 0).xyzw;
+  r0.xyz = r0.xyz * cb1[7].xyz * injectedData.fxBloom + r1.xyz;
+  r0.xyz = float3(1,1,1) + -r0.xyz;
+  r1.xy = v1.xy * cb1[0].xy + cb1[0].zw;
+  r2.xyzw = t12.SampleLevel(s7_s, r1.xy, 0).xyzw;
+  r1.xyzw = t15.SampleLevel(s8_s, r1.xy, 0).xyzw;
+  r0.w = r1.x * cb0[18].x + cb0[18].z;
+  r0.w = 1 / r0.w;
+  r1.xy = r0.ww * cb1[11].xz + cb1[11].yw;
+  o0.w = max(r1.x, r1.y);
+  o0.a = saturate(o0.a);
+  r1.xyz = float3(4,4,4) * r2.xyz;
+  r2.xyz = float3(1,1,1) + -r1.xyz;
+  r0.xyz = -r2.xyz * r0.xyz + float3(1,1,1);
+  r0.xyz = max(r1.xyz, r0.xyz);
+  r0.rgb = 1.06504106f * r0.rgb;
+  if (injectedData.toneMapType == 0.f) {
+    r0.rgb = saturate(r0.rgb);
+  }
+  r1.xy = v1.xy * cb1[2].xy + cb1[2].zw;
+  r0.w = dot(r1.xy, r1.xy);
+  r0.w = saturate(r0.w * cb1[8].x + cb1[8].y);
+  r0.w = r0.w * r0.w;
+  r1.xyz = r0.xyz * lerp(1.f, r0.www, injectedData.fxVignette);
+  r1.x = renodx::color::y::from::BT709(r1.rgb);
+  r1.xyz = cb1[12].xyz * r1.xxx;
+  r0.xyz = r0.xyz * r0.www + -r1.xyz;
+  o0.xyz = cb1[9].zzz * r0.xyz + r1.xyz;
+  o0.rgb = applyUserTonemap(o0.rgb, v1, false);
+  o0.rgb = PostToneMapScale(o0.rgb);
+  return;
+}

--- a/src/games/roadhogengine/hardresetredux/tonemap_0x45405040.ps_4_0.hlsl
+++ b/src/games/roadhogengine/hardresetredux/tonemap_0x45405040.ps_4_0.hlsl
@@ -1,0 +1,59 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t15 : register(t15);
+Texture2D<float4> t13 : register(t13);
+Texture2D<float4> t12 : register(t12);
+Texture2D<float4> t11 : register(t11);
+SamplerState s8_s : register(s8);
+SamplerState s7_s : register(s7);
+SamplerState s5_s : register(s5);
+cbuffer cb1 : register(b1){
+  float4 cb1[13];
+}
+cbuffer cb0 : register(b0){
+  float4 cb0[19];
+}
+
+#define cmp -
+
+void main(
+  float4 v0 : SV_Position0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = v1.xy * cb1[1].xy + cb1[1].zw;
+  r0.xy = min(cb1[6].xy, r0.xy);
+  r0.xyzw = t13.SampleLevel(s5_s, r0.xy, 0).xyzw;
+  r1.xy = v1.xy * cb1[4].xy + cb1[4].zw;
+  r1.xy = min(cb1[6].zw, r1.xy);
+  r1.xyzw = t11.SampleLevel(s5_s, r1.xy, 0).xyzw;
+  r0.xyz = r0.xyz * cb1[7].xyz * injectedData.fxBloom + r1.xyz;
+  r0.xyz = float3(1,1,1) + -r0.xyz;
+  r1.xy = v1.xy * cb1[0].xy + cb1[0].zw;
+  r2.xyzw = t12.SampleLevel(s7_s, r1.xy, 0).xyzw;
+  r1.xyzw = t15.SampleLevel(s8_s, r1.xy, 0).xyzw;
+  r0.w = r1.x * cb0[18].x + cb0[18].z;
+  r0.w = 1 / r0.w;
+  r1.xy = r0.ww * cb1[11].xz + cb1[11].yw;
+  o0.w = max(r1.x, r1.y);
+  o0.a = saturate(o0.a);
+  r1.xyz = float3(4,4,4) * r2.xyz;
+  r2.xyz = float3(1,1,1) + -r1.xyz;
+  r0.xyz = -r2.xyz * r0.xyz + float3(1,1,1);
+  r0.xyz = max(r1.xyz, r0.xyz);
+  r0.rgb = 1.06504106f * r0.rgb;
+  if (injectedData.toneMapType == 0.f) {
+    r0.rgb = saturate(r0.rgb);
+  }
+  r0.a = renodx::color::y::from::BT709(r0.rgb);
+  r0.xyz = -cb1[12].xyz * r0.www + r0.xyz;
+  r1.xyz = cb1[12].xyz * r0.www;
+  o0.xyz = cb1[9].zzz * r0.xyz + r1.xyz;
+  o0.rgb = applyUserTonemap(o0.rgb, v1, false);
+  o0.rgb = PostToneMapScale(o0.rgb);
+  return;
+}

--- a/src/games/roadhogengine/hardresetredux/tonemap_0x5D1BC502.ps_4_0.hlsl
+++ b/src/games/roadhogengine/hardresetredux/tonemap_0x5D1BC502.ps_4_0.hlsl
@@ -22,8 +22,7 @@ void main(
   r0.xy = v1.xy * cb1[0].xy + cb1[0].zw;
   r0.xyzw = t12.SampleLevel(s7_s, r0.xy, 0).xyzw;
   r0.xyz = float3(4,4,4) * r0.xyz;
-  //r0.xyz = r0.xyz + r0.xyz;
-  //r0.rgb = 0.53252053f * r0.rgb;
+  r0.rgb = 1.06504106f * r0.rgb;
   if (injectedData.toneMapType == 0.f) {
     r0.rgb = saturate(r0.rgb);
   }

--- a/src/games/roadhogengine/hardresetredux/tonemap_0x5D1BC502.ps_4_0.hlsl
+++ b/src/games/roadhogengine/hardresetredux/tonemap_0x5D1BC502.ps_4_0.hlsl
@@ -1,0 +1,53 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t14 : register(t14);
+Texture2D<float4> t12 : register(t12);
+SamplerState s7_s : register(s7);
+SamplerState s4_s : register(s4);
+cbuffer cb1 : register(b1){
+  float4 cb1[13];
+}
+
+#define cmp -
+
+void main(
+  float4 v0 : SV_Position0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = v1.xy * cb1[0].xy + cb1[0].zw;
+  r0.xyzw = t12.SampleLevel(s7_s, r0.xy, 0).xyzw;
+  r0.xyz = float3(4,4,4) * r0.xyz;
+  //r0.xyz = r0.xyz + r0.xyz;
+  //r0.rgb = 0.53252053f * r0.rgb;
+  if (injectedData.toneMapType == 0.f) {
+    r0.rgb = saturate(r0.rgb);
+  }
+  r1.xy = v1.xy * cb1[2].xy + cb1[2].zw;
+  r0.w = dot(r1.xy, r1.xy);
+  r0.w = saturate(r0.w * cb1[8].x + cb1[8].y);
+  r0.w = r0.w * r0.w;
+  r0.xyz = r0.xyz * lerp(1.f, r0.www, injectedData.fxVignette);
+  if (injectedData.fxFilmGrainType == 0.f) {
+  r0.a = renodx::color::y::from::BT709(r0.rgb);
+  r0.w = -r0.w * cb1[9].y + 1;
+  r1.xy = v1.xy * cb1[3].xy + cb1[3].zw;
+  r1.xyzw = t14.SampleLevel(s4_s, r1.xy, 0).xyzw;
+  r1.x = -0.5 + r1.x;
+  r1.x = cb1[9].x * r1.x;
+  r0.xyz = r1.xxx * r0.www * injectedData.fxFilmGrain + r0.xyz;
+  }
+  r0.a = renodx::color::y::from::BT709(r0.rgb);
+  r0.xyz = -cb1[12].xyz * r0.www + r0.xyz;
+  r1.xyz = cb1[12].xyz * r0.www;
+  r0.xyz = cb1[9].zzz * r0.xyz + r1.xyz;
+  o0.a = renodx::color::y::from::BT709(r0.rgb);
+  o0.xyz = r0.xyz;
+  o0.rgb = applyUserTonemap(o0.rgb, v1);
+  o0.rgb = PostToneMapScale(o0.rgb);
+  return;
+}

--- a/src/games/roadhogengine/hardresetredux/tonemap_0x6AEB4E45.ps_4_0.hlsl
+++ b/src/games/roadhogengine/hardresetredux/tonemap_0x6AEB4E45.ps_4_0.hlsl
@@ -1,0 +1,50 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t13 : register(t13);
+Texture2D<float4> t12 : register(t12);
+SamplerState s7_s : register(s7);
+SamplerState s5_s : register(s5);
+cbuffer cb1 : register(b1){
+  float4 cb1[13];
+}
+
+#define cmp -
+
+void main(
+  float4 v0 : SV_Position0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = v1.xy * cb1[1].xy + cb1[1].zw;
+  r0.xy = min(cb1[6].xy, r0.xy);
+  r0.xyzw = t13.SampleLevel(s5_s, r0.xy, 0).xyzw;
+  r0.xyz = -r0.xyz * cb1[7].xyz * injectedData.fxBloom + float3(1,1,1);
+  r1.xy = v1.xy * cb1[0].xy + cb1[0].zw;
+  r1.xyzw = t12.SampleLevel(s7_s, r1.xy, 0).xyzw;
+  r1.xyz = float3(4,4,4) * r1.xyz;
+  r2.xyz = float3(1,1,1) + -r1.xyz;
+  r0.xyz = -r2.xyz * r0.xyz + float3(1,1,1);
+  r0.xyz = max(r1.xyz, r0.xyz);
+  r0.rgb = 1.06504106f * r0.rgb;
+  if (injectedData.toneMapType == 0.f) {
+    r0.rgb = saturate(r0.rgb);
+  }
+  r1.xy = v1.xy * cb1[2].xy + cb1[2].zw;
+  r0.w = dot(r1.xy, r1.xy);
+  r0.w = saturate(r0.w * cb1[8].x + cb1[8].y);
+  r0.w = r0.w * r0.w;
+  r1.xyz = r0.xyz * lerp(1.f, r0.www, injectedData.fxVignette);
+  r1.x = renodx::color::y::from::BT709(r1.rgb);
+  r1.xyz = cb1[12].xyz * r1.xxx;
+  r0.xyz = r0.xyz * r0.www + -r1.xyz;
+  r0.xyz = cb1[9].zzz * r0.xyz + r1.xyz;
+  o0.a = renodx::color::y::from::BT709(r0.rgb);
+  o0.xyz = r0.xyz;
+  o0.rgb = applyUserTonemap(o0.rgb, v1, false);
+  o0.rgb = PostToneMapScale(o0.rgb);
+  return;
+}

--- a/src/games/roadhogengine/hardresetredux/tonemap_0x769FB187.ps_4_0.hlsl
+++ b/src/games/roadhogengine/hardresetredux/tonemap_0x769FB187.ps_4_0.hlsl
@@ -1,0 +1,78 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t15 : register(t15);
+Texture2D<float4> t14 : register(t14);
+Texture2D<float4> t13 : register(t13);
+Texture2D<float4> t12 : register(t12);
+Texture2D<float4> t11 : register(t11);
+SamplerState s8_s : register(s8);
+SamplerState s5_s : register(s5);
+SamplerState s4_s : register(s4);
+cbuffer cb1 : register(b1){
+  float4 cb1[13];
+}
+cbuffer cb0 : register(b0){
+  float4 cb0[19];
+}
+
+#define cmp -
+
+void main(
+  float4 v0 : SV_Position0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = v1.xy * cb1[1].xy + cb1[1].zw;
+  r0.xy = min(cb1[6].xy, r0.xy);
+  r0.xyzw = t13.SampleLevel(s5_s, r0.xy, 0).xyzw;
+  r1.xy = v1.xy * cb1[4].xy + cb1[4].zw;
+  r1.xy = min(cb1[6].zw, r1.xy);
+  r1.xyzw = t11.SampleLevel(s5_s, r1.xy, 0).xyzw;
+  r0.xyz = r0.xyz * cb1[7].xyz * injectedData.fxBloom + r1.xyz;
+  r0.xyz = float3(1,1,1) + -r0.xyz;
+  r1.xy = v1.xy * cb1[0].xy + cb1[0].zw;
+  r2.xyzw = t12.SampleLevel(s4_s, r1.xy, 0).xyzw;
+  r2.xyz = float3(4,4,4) * r2.xyz;
+  r1.zw = cb1[8].zw + r1.xy;
+  r3.xyzw = t15.SampleLevel(s8_s, r1.xy, 0).xyzw;
+  r0.w = r3.x * cb0[18].x + cb0[18].z;
+  r0.w = 1 / r0.w;
+  r1.xy = r0.ww * cb1[11].xz + cb1[11].yw;
+  o0.w = max(r1.x, r1.y);
+  o0.a = saturate(o0.a);
+  r1.xyzw = t12.SampleLevel(s4_s, r1.zw, 0).xyzw;
+  r2.xyz = -r1.xyz * float3(4,4,4) + r2.xyz;
+  r1.xyz = float3(4,4,4) * r1.xyz;
+  r1.xyz = cb1[7].www * r2.xyz * injectedData.fxSharpen + r1.xyz;
+  if (injectedData.toneMapType == 0.f) {
+    r1.rgb = saturate(r1.rgb);
+  }
+  r2.xyz = float3(1,1,1) + -r1.xyz;
+  r0.xyz = -r2.xyz * r0.xyz + float3(1,1,1);
+  r0.xyz = max(r1.xyz, r0.xyz);
+  //r0.xyz = r0.xyz + r0.xyz;
+  //r0.rgb = 0.53252053f * r0.rgb;
+  if (injectedData.toneMapType == 0.f) {
+    r0.rgb = saturate(r0.rgb);
+  }
+  if (injectedData.fxFilmGrainType == 0.f) {
+  r0.a = renodx::color::y::from::BT709(r0.rgb);
+  r0.w = -r0.w * cb1[9].y + 1;
+  r1.xy = v1.xy * cb1[3].xy + cb1[3].zw;
+  r1.xyzw = t14.SampleLevel(s4_s, r1.xy, 0).xyzw;
+  r1.x = -0.5 + r1.x;
+  r1.x = cb1[9].x * r1.x;
+  r0.xyz = r1.xxx * r0.www * injectedData.fxFilmGrain + r0.xyz;
+  }
+  r0.a = renodx::color::y::from::BT709(r0.rgb);
+  r0.xyz = -cb1[12].xyz * r0.www + r0.xyz;
+  r1.xyz = cb1[12].xyz * r0.www;
+  o0.xyz = cb1[9].zzz * r0.xyz + r1.xyz;
+  o0.rgb = applyUserTonemap(o0.rgb, v1);
+  o0.rgb = PostToneMapScale(o0.rgb);
+  return;
+}

--- a/src/games/roadhogengine/hardresetredux/tonemap_0x769FB187.ps_4_0.hlsl
+++ b/src/games/roadhogengine/hardresetredux/tonemap_0x769FB187.ps_4_0.hlsl
@@ -54,8 +54,7 @@ void main(
   r2.xyz = float3(1,1,1) + -r1.xyz;
   r0.xyz = -r2.xyz * r0.xyz + float3(1,1,1);
   r0.xyz = max(r1.xyz, r0.xyz);
-  //r0.xyz = r0.xyz + r0.xyz;
-  //r0.rgb = 0.53252053f * r0.rgb;
+  r0.rgb = 1.06504106f * r0.rgb;
   if (injectedData.toneMapType == 0.f) {
     r0.rgb = saturate(r0.rgb);
   }

--- a/src/games/roadhogengine/hardresetredux/tonemap_0x79D405C5.ps_4_0.hlsl
+++ b/src/games/roadhogengine/hardresetredux/tonemap_0x79D405C5.ps_4_0.hlsl
@@ -1,0 +1,36 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t12 : register(t12);
+SamplerState s7_s : register(s7);
+cbuffer cb1 : register(b1){
+  float4 cb1[13];
+}
+
+#define cmp -
+
+void main(
+  float4 v0 : SV_Position0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = v1.xy * cb1[0].xy + cb1[0].zw;
+  r0.xyzw = t12.SampleLevel(s7_s, r0.xy, 0).xyzw;
+  r0.xyz = float3(4,4,4) * r0.xyz;
+  r0.rgb = 1.06504106f * r0.rgb;
+  if (injectedData.toneMapType == 0.f) {
+    r0.rgb = saturate(r0.rgb);
+  }
+  r0.a = renodx::color::y::from::BT709(r0.rgb);
+  r0.xyz = -cb1[12].xyz * r0.www + r0.xyz;
+  r1.xyz = cb1[12].xyz * r0.www;
+  r0.xyz = cb1[9].zzz * r0.xyz + r1.xyz;
+  o0.a = renodx::color::y::from::BT709(r0.rgb);
+  o0.xyz = r0.xyz;
+  o0.rgb = applyUserTonemap(o0.rgb, v1, false);
+  o0.rgb = PostToneMapScale(o0.rgb);
+  return;
+}

--- a/src/games/roadhogengine/hardresetredux/tonemap_0x852CCF05.ps_4_0.hlsl
+++ b/src/games/roadhogengine/hardresetredux/tonemap_0x852CCF05.ps_4_0.hlsl
@@ -1,0 +1,59 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t15 : register(t15);
+Texture2D<float4> t13 : register(t13);
+Texture2D<float4> t12 : register(t12);
+SamplerState s8_s : register(s8);
+SamplerState s7_s : register(s7);
+SamplerState s5_s : register(s5);
+cbuffer cb1 : register(b1){
+  float4 cb1[13];
+}
+cbuffer cb0 : register(b0){
+  float4 cb0[19];
+}
+
+#define cmp -
+
+void main(
+  float4 v0 : SV_Position0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = v1.xy * cb1[1].xy + cb1[1].zw;
+  r0.xy = min(cb1[6].xy, r0.xy);
+  r0.xyzw = t13.SampleLevel(s5_s, r0.xy, 0).xyzw;
+  r0.xyz = -r0.xyz * cb1[7].xyz * injectedData.fxBloom + float3(1,1,1);
+  r1.xy = v1.xy * cb1[0].xy + cb1[0].zw;
+  r2.xyzw = t12.SampleLevel(s7_s, r1.xy, 0).xyzw;
+  r1.xyzw = t15.SampleLevel(s8_s, r1.xy, 0).xyzw;
+  r0.w = r1.x * cb0[18].x + cb0[18].z;
+  r0.w = 1 / r0.w;
+  r1.xy = r0.ww * cb1[11].xz + cb1[11].yw;
+  o0.w = max(r1.x, r1.y);
+  o0.a = saturate(o0.a);
+  r1.xyz = float3(4,4,4) * r2.xyz;
+  r2.xyz = float3(1,1,1) + -r1.xyz;
+  r0.xyz = -r2.xyz * r0.xyz + float3(1,1,1);
+  r0.xyz = max(r1.xyz, r0.xyz);
+  r0.rgb = 1.06504106f * r0.rgb;
+  if (injectedData.toneMapType == 0.f) {
+    r0.rgb = saturate(r0.rgb);
+  }
+  r1.xy = v1.xy * cb1[2].xy + cb1[2].zw;
+  r0.w = dot(r1.xy, r1.xy);
+  r0.w = saturate(r0.w * cb1[8].x + cb1[8].y);
+  r0.w = r0.w * r0.w;
+  r1.xyz = r0.xyz * lerp(1.f, r0.www, injectedData.fxVignette);
+  r1.x = renodx::color::y::from::BT709(r1.rgb);
+  r1.xyz = cb1[12].xyz * r1.xxx;
+  r0.xyz = r0.xyz * r0.www + -r1.xyz;
+  o0.xyz = cb1[9].zzz * r0.xyz + r1.xyz;
+  o0.rgb = applyUserTonemap(o0.rgb, v1, false);
+  o0.rgb = PostToneMapScale(o0.rgb);
+  return;
+}

--- a/src/games/roadhogengine/hardresetredux/tonemap_0xA6B01AE0.ps_4_0.hlsl
+++ b/src/games/roadhogengine/hardresetredux/tonemap_0xA6B01AE0.ps_4_0.hlsl
@@ -1,0 +1,54 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t15 : register(t15);
+Texture2D<float4> t13 : register(t13);
+Texture2D<float4> t12 : register(t12);
+SamplerState s8_s : register(s8);
+SamplerState s7_s : register(s7);
+SamplerState s5_s : register(s5);
+cbuffer cb1 : register(b1){
+  float4 cb1[13];
+}
+cbuffer cb0 : register(b0){
+  float4 cb0[19];
+}
+
+#define cmp -
+
+void main(
+  float4 v0 : SV_Position0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = v1.xy * cb1[1].xy + cb1[1].zw;
+  r0.xy = min(cb1[6].xy, r0.xy);
+  r0.xyzw = t13.SampleLevel(s5_s, r0.xy, 0).xyzw;
+  r0.xyz = -r0.xyz * cb1[7].xyz * injectedData.fxBloom + float3(1,1,1);
+  r1.xy = v1.xy * cb1[0].xy + cb1[0].zw;
+  r2.xyzw = t12.SampleLevel(s7_s, r1.xy, 0).xyzw;
+  r1.xyzw = t15.SampleLevel(s8_s, r1.xy, 0).xyzw;
+  r0.w = r1.x * cb0[18].x + cb0[18].z;
+  r0.w = 1 / r0.w;
+  r1.xy = r0.ww * cb1[11].xz + cb1[11].yw;
+  o0.w = max(r1.x, r1.y);
+  o0.a = saturate(o0.a);
+  r1.xyz = float3(4,4,4) * r2.xyz;
+  r2.xyz = float3(1,1,1) + -r1.xyz;
+  r0.xyz = -r2.xyz * r0.xyz + float3(1,1,1);
+  r0.xyz = max(r1.xyz, r0.xyz);
+  r0.rgb = 1.06504106f * r0.rgb;
+  if (injectedData.toneMapType == 0.f) {
+    r0.rgb = saturate(r0.rgb);
+  }
+  r0.a = renodx::color::y::from::BT709(r0.rgb);
+  r0.xyz = -cb1[12].xyz * r0.www + r0.xyz;
+  r1.xyz = cb1[12].xyz * r0.www;
+  o0.xyz = cb1[9].zzz * r0.xyz + r1.xyz;
+  o0.rgb = applyUserTonemap(o0.rgb, v1, false);
+  o0.rgb = PostToneMapScale(o0.rgb);
+  return;
+}

--- a/src/games/roadhogengine/hardresetredux/tonemap_0xA8F9150B.ps_4_0.hlsl
+++ b/src/games/roadhogengine/hardresetredux/tonemap_0xA8F9150B.ps_4_0.hlsl
@@ -1,0 +1,73 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t15 : register(t15);
+Texture2D<float4> t14 : register(t14);
+Texture2D<float4> t13 : register(t13);
+Texture2D<float4> t12 : register(t12);
+SamplerState s8_s : register(s8);
+SamplerState s5_s : register(s5);
+SamplerState s4_s : register(s4);
+cbuffer cb1 : register(b1){
+  float4 cb1[13];
+}
+cbuffer cb0 : register(b0){
+  float4 cb0[19];
+}
+
+#define cmp -
+
+void main(
+  float4 v0 : SV_Position0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = v1.xy * cb1[1].xy + cb1[1].zw;
+  r0.xy = min(cb1[6].xy, r0.xy);
+  r0.xyzw = t13.SampleLevel(s5_s, r0.xy, 0).xyzw;
+  r0.xyz = -r0.xyz * cb1[7].xyz * injectedData.fxBloom + float3(1,1,1);
+  r1.xy = v1.xy * cb1[0].xy + cb1[0].zw;
+  r2.xyzw = t12.SampleLevel(s4_s, r1.xy, 0).xyzw;
+  r2.xyz = float3(4,4,4) * r2.xyz;
+  r1.zw = cb1[8].zw + r1.xy;
+  r3.xyzw = t15.SampleLevel(s8_s, r1.xy, 0).xyzw;
+  r0.w = r3.x * cb0[18].x + cb0[18].z;
+  r0.w = 1 / r0.w;
+  r1.xy = r0.ww * cb1[11].xz + cb1[11].yw;
+  o0.w = max(r1.x, r1.y);
+  o0.a = saturate(o0.a);
+  r1.xyzw = t12.SampleLevel(s4_s, r1.zw, 0).xyzw;
+  r2.xyz = -r1.xyz * float3(4,4,4) + r2.xyz;
+  r1.xyz = float3(4,4,4) * r1.xyz;
+  r1.xyz = cb1[7].www * r2.xyz * injectedData.fxSharpen + r1.xyz;
+  if (injectedData.toneMapType == 0.f) {
+    r1.rgb = saturate(r1.rgb);
+  }
+  r2.xyz = float3(1,1,1) + -r1.xyz;
+  r0.xyz = -r2.xyz * r0.xyz + float3(1,1,1);
+  r0.xyz = max(r1.xyz, r0.xyz);
+  //r0.xyz = r0.xyz + r0.xyz;
+  //r0.rgb = 0.53252053f * r0.rgb;
+  if (injectedData.toneMapType == 0.f) {
+    r0.rgb = saturate(r0.rgb);
+  }
+  if (injectedData.fxFilmGrainType == 0.f) {
+  r0.a = renodx::color::y::from::BT709(r0.rgb);
+  r0.w = -r0.w * cb1[9].y + 1;
+  r1.xy = v1.xy * cb1[3].xy + cb1[3].zw;
+  r1.xyzw = t14.SampleLevel(s4_s, r1.xy, 0).xyzw;
+  r1.x = -0.5 + r1.x;
+  r1.x = cb1[9].x * r1.x;
+  r0.xyz = r1.xxx * r0.www * injectedData.fxFilmGrain + r0.xyz;
+  }
+  r0.a = renodx::color::y::from::BT709(r0.rgb);
+  r0.xyz = -cb1[12].xyz * r0.www + r0.xyz;
+  r1.xyz = cb1[12].xyz * r0.www;
+  o0.xyz = cb1[9].zzz * r0.xyz + r1.xyz;
+  o0.rgb = applyUserTonemap(o0.rgb, v1);
+  o0.rgb = PostToneMapScale(o0.rgb);
+  return;
+}

--- a/src/games/roadhogengine/hardresetredux/tonemap_0xA8F9150B.ps_4_0.hlsl
+++ b/src/games/roadhogengine/hardresetredux/tonemap_0xA8F9150B.ps_4_0.hlsl
@@ -49,8 +49,7 @@ void main(
   r2.xyz = float3(1,1,1) + -r1.xyz;
   r0.xyz = -r2.xyz * r0.xyz + float3(1,1,1);
   r0.xyz = max(r1.xyz, r0.xyz);
-  //r0.xyz = r0.xyz + r0.xyz;
-  //r0.rgb = 0.53252053f * r0.rgb;
+  r0.rgb = 1.06504106f * r0.rgb;
   if (injectedData.toneMapType == 0.f) {
     r0.rgb = saturate(r0.rgb);
   }

--- a/src/games/roadhogengine/hardresetredux/tonemap_0xAD092DF9.ps_4_0.hlsl
+++ b/src/games/roadhogengine/hardresetredux/tonemap_0xAD092DF9.ps_4_0.hlsl
@@ -1,0 +1,69 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t14 : register(t14);
+Texture2D<float4> t13 : register(t13);
+Texture2D<float4> t12 : register(t12);
+SamplerState s5_s : register(s5);
+SamplerState s4_s : register(s4);
+cbuffer cb1 : register(b1){
+  float4 cb1[13];
+}
+
+#define cmp -
+
+void main(
+  float4 v0 : SV_Position0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = v1.xy * cb1[0].xy + cb1[0].zw;
+  r1.xyzw = t12.SampleLevel(s4_s, r0.xy, 0).xyzw;
+  r0.xy = cb1[8].zw + r0.xy;
+  r0.xyzw = t12.SampleLevel(s4_s, r0.xy, 0).xyzw;
+  r1.xyz = float3(4,4,4) * r1.xyz;
+  r1.xyz = -r0.xyz * float3(4,4,4) + r1.xyz;
+  r0.xyz = float3(4,4,4) * r0.xyz;
+  r0.xyz = cb1[7].www * r1.xyz * injectedData.fxSharpen + r0.xyz;
+  if (injectedData.toneMapType == 0.f) {
+    r0.rgb = saturate(r0.rgb);
+  }
+  r1.xyz = float3(1,1,1) + -r0.xyz;
+  r2.xy = v1.xy * cb1[1].xy + cb1[1].zw;
+  r2.xy = min(cb1[6].xy, r2.xy);
+  r2.xyzw = t13.SampleLevel(s5_s, r2.xy, 0).xyzw;
+  r2.xyz = -r2.xyz * cb1[7].xyz * injectedData.fxBloom + float3(1,1,1);
+  r1.xyz = -r1.xyz * r2.xyz + float3(1,1,1);
+  r0.xyz = max(r1.xyz, r0.xyz);
+  //r0.xyz = r0.xyz + r0.xyz;
+  //r0.rgb = 0.53252053f * r0.rgb;
+  if (injectedData.toneMapType == 0.f) {
+    r0.rgb = saturate(r0.rgb);
+  }
+  r1.xy = v1.xy * cb1[2].xy + cb1[2].zw;
+  r0.w = dot(r1.xy, r1.xy);
+  r0.w = saturate(r0.w * cb1[8].x + cb1[8].y);
+  r0.w = r0.w * r0.w;
+  r0.xyz = r0.xyz * lerp(1.f, r0.www, injectedData.fxVignette);
+  if (injectedData.fxFilmGrainType == 0.f) {
+  r0.a = renodx::color::y::from::BT709(r0.rgb);
+  r0.w = -r0.w * cb1[9].y + 1;
+  r1.xy = v1.xy * cb1[3].xy + cb1[3].zw;
+  r1.xyzw = t14.SampleLevel(s4_s, r1.xy, 0).xyzw;
+  r1.x = -0.5 + r1.x;
+  r1.x = cb1[9].x * r1.x;
+  r0.xyz = r1.xxx * r0.www * injectedData.fxFilmGrain + r0.xyz;
+  }
+  r0.a = renodx::color::y::from::BT709(r0.rgb);
+  r0.xyz = -cb1[12].xyz * r0.www + r0.xyz;
+  r1.xyz = cb1[12].xyz * r0.www;
+  r0.xyz = cb1[9].zzz * r0.xyz + r1.xyz;
+  o0.a = renodx::color::y::from::BT709(r0.rgb);
+  o0.xyz = r0.xyz;
+  o0.rgb = applyUserTonemap(o0.rgb, v1);
+  o0.rgb = PostToneMapScale(o0.rgb);
+  return;
+}

--- a/src/games/roadhogengine/hardresetredux/tonemap_0xAD092DF9.ps_4_0.hlsl
+++ b/src/games/roadhogengine/hardresetredux/tonemap_0xAD092DF9.ps_4_0.hlsl
@@ -38,8 +38,7 @@ void main(
   r2.xyz = -r2.xyz * cb1[7].xyz * injectedData.fxBloom + float3(1,1,1);
   r1.xyz = -r1.xyz * r2.xyz + float3(1,1,1);
   r0.xyz = max(r1.xyz, r0.xyz);
-  //r0.xyz = r0.xyz + r0.xyz;
-  //r0.rgb = 0.53252053f * r0.rgb;
+  r0.rgb = 1.06504106f * r0.rgb;
   if (injectedData.toneMapType == 0.f) {
     r0.rgb = saturate(r0.rgb);
   }

--- a/src/games/roadhogengine/hardresetredux/tonemap_0xBA01D096.ps_4_0.hlsl
+++ b/src/games/roadhogengine/hardresetredux/tonemap_0xBA01D096.ps_4_0.hlsl
@@ -43,8 +43,7 @@ void main(
   r2.xyz = float3(1,1,1) + -r1.xyz;
   r0.xyz = -r2.xyz * r0.xyz + float3(1,1,1);
   r0.xyz = max(r1.xyz, r0.xyz);
-  //r0.xyz = r0.xyz + r0.xyz;
-  //r0.rgb = 0.53252053f * r0.rgb;
+  r0.rgb = 1.06504106f * r0.rgb;
   if (injectedData.toneMapType == 0.f) {
     r0.rgb = saturate(r0.rgb);
   }

--- a/src/games/roadhogengine/hardresetredux/tonemap_0xBA01D096.ps_4_0.hlsl
+++ b/src/games/roadhogengine/hardresetredux/tonemap_0xBA01D096.ps_4_0.hlsl
@@ -1,0 +1,69 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t14 : register(t14);
+Texture2D<float4> t13 : register(t13);
+Texture2D<float4> t12 : register(t12);
+Texture2D<float4> t11 : register(t11);
+SamplerState s5_s : register(s5);
+SamplerState s4_s : register(s4);
+cbuffer cb1 : register(b1){
+  float4 cb1[13];
+}
+
+#define cmp -
+
+void main(
+  float4 v0 : SV_Position0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = v1.xy * cb1[1].xy + cb1[1].zw;
+  r0.xy = min(cb1[6].xy, r0.xy);
+  r0.xyzw = t13.SampleLevel(s5_s, r0.xy, 0).xyzw;
+  r1.xy = v1.xy * cb1[4].xy + cb1[4].zw;
+  r1.xy = min(cb1[6].zw, r1.xy);
+  r1.xyzw = t11.SampleLevel(s5_s, r1.xy, 0).xyzw;
+  r0.xyz = r0.xyz * cb1[7].xyz * injectedData.fxBloom + r1.xyz;
+  r0.xyz = float3(1,1,1) + -r0.xyz;
+  r1.xy = v1.xy * cb1[0].xy + cb1[0].zw;
+  r2.xyzw = t12.SampleLevel(s4_s, r1.xy, 0).xyzw;
+  r1.xy = cb1[8].zw + r1.xy;
+  r1.xyzw = t12.SampleLevel(s4_s, r1.xy, 0).xyzw;
+  r2.xyz = float3(4,4,4) * r2.xyz;
+  r2.xyz = -r1.xyz * float3(4,4,4) + r2.xyz;
+  r1.xyz = float3(4,4,4) * r1.xyz;
+  r1.xyz = cb1[7].www * r2.xyz * injectedData.fxSharpen + r1.xyz;
+  if (injectedData.toneMapType == 0.f) {
+    r1.rgb = saturate(r1.rgb);
+  }
+  r2.xyz = float3(1,1,1) + -r1.xyz;
+  r0.xyz = -r2.xyz * r0.xyz + float3(1,1,1);
+  r0.xyz = max(r1.xyz, r0.xyz);
+  //r0.xyz = r0.xyz + r0.xyz;
+  //r0.rgb = 0.53252053f * r0.rgb;
+  if (injectedData.toneMapType == 0.f) {
+    r0.rgb = saturate(r0.rgb);
+  }
+  if (injectedData.fxFilmGrainType == 0.f) {
+  r0.a = renodx::color::y::from::BT709(r0.rgb);
+  r0.w = -r0.w * cb1[9].y + 1;
+  r1.xy = v1.xy * cb1[3].xy + cb1[3].zw;
+  r1.xyzw = t14.SampleLevel(s4_s, r1.xy, 0).xyzw;
+  r1.x = -0.5 + r1.x;
+  r1.x = cb1[9].x * r1.x;
+  r0.xyz = r1.xxx * r0.www * injectedData.fxFilmGrain + r0.xyz;
+  }
+  r0.a = renodx::color::y::from::BT709(r0.rgb);
+  r0.xyz = -cb1[12].xyz * r0.www + r0.xyz;
+  r1.xyz = cb1[12].xyz * r0.www;
+  r0.xyz = cb1[9].zzz * r0.xyz + r1.xyz;
+  o0.a = renodx::color::y::from::BT709(r0.rgb);
+  o0.xyz = r0.xyz;
+  o0.rgb = applyUserTonemap(o0.rgb, v1);
+  o0.rgb = PostToneMapScale(o0.rgb);
+  return;
+}

--- a/src/games/roadhogengine/hardresetredux/tonemap_0xE29A7A29.ps_4_0.hlsl
+++ b/src/games/roadhogengine/hardresetredux/tonemap_0xE29A7A29.ps_4_0.hlsl
@@ -1,0 +1,44 @@
+#include "../common.hlsl"
+Texture2D<float4> t13 : register(t13);
+Texture2D<float4> t12 : register(t12);
+SamplerState s7_s : register(s7);
+SamplerState s5_s : register(s5);
+cbuffer cb1 : register(b1){
+  float4 cb1[13];
+}
+
+#define cmp -
+
+void main(
+  float4 v0 : SV_Position0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = v1.xy * cb1[1].xy + cb1[1].zw;
+  r0.xy = min(cb1[6].xy, r0.xy);
+  r0.xyzw = t13.SampleLevel(s5_s, r0.xy, 0).xyzw;
+  r0.xyz = -r0.xyz * cb1[7].xyz * injectedData.fxBloom + float3(1,1,1);
+  r1.xy = v1.xy * cb1[0].xy + cb1[0].zw;
+  r1.xyzw = t12.SampleLevel(s7_s, r1.xy, 0).xyzw;
+  r1.xyz = float3(4,4,4) * r1.xyz;
+  r2.xyz = float3(1,1,1) + -r1.xyz;
+  r0.xyz = -r2.xyz * r0.xyz + float3(1,1,1);
+  r0.xyz = max(r1.xyz, r0.xyz);
+  r0.rgb = 1.06504106f * r0.rgb;
+  if (injectedData.toneMapType == 0.f) {
+    r0.rgb = saturate(r0.rgb);
+  }
+  r0.a = renodx::color::y::from::BT709(r0.rgb);
+  r0.xyz = -cb1[12].xyz * r0.www + r0.xyz;
+  r1.xyz = cb1[12].xyz * r0.www;
+  r0.xyz = cb1[9].zzz * r0.xyz + r1.xyz;
+  o0.a = renodx::color::y::from::BT709(r0.rgb);
+  o0.xyz = r0.xyz;
+  o0.rgb = applyUserTonemap(o0.rgb, v1, false);
+  o0.rgb = PostToneMapScale(o0.rgb);
+  return;
+}

--- a/src/games/roadhogengine/hardresetredux/tonemap_0xE56AC1BF.ps_4_0.hlsl
+++ b/src/games/roadhogengine/hardresetredux/tonemap_0xE56AC1BF.ps_4_0.hlsl
@@ -1,0 +1,41 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t12 : register(t12);
+SamplerState s7_s : register(s7);
+cbuffer cb1 : register(b1){
+  float4 cb1[13];
+}
+
+#define cmp -
+
+void main(
+  float4 v0 : SV_Position0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = v1.xy * cb1[0].xy + cb1[0].zw;
+  r0.xyzw = t12.SampleLevel(s7_s, r0.xy, 0).xyzw;
+  r0.xyz = float3(4,4,4) * r0.xyz;
+  r0.rgb = 1.06504106f * r0.rgb;
+  if (injectedData.toneMapType == 0.f) {
+    r0.rgb = saturate(r0.rgb);
+  }
+  r1.xy = v1.xy * cb1[2].xy + cb1[2].zw;
+  r0.w = dot(r1.xy, r1.xy);
+  r0.w = saturate(r0.w * cb1[8].x + cb1[8].y);
+  r0.w = r0.w * r0.w;
+  r1.xyz = r0.xyz * lerp(1.f, r0.www, injectedData.fxVignette);
+  r1.x = renodx::color::y::from::BT709(r1.rgb);
+  r1.xyz = cb1[12].xyz * r1.xxx;
+  r0.xyz = r0.xyz * r0.www + -r1.xyz;
+  r0.xyz = cb1[9].zzz * r0.xyz + r1.xyz;
+  o0.a = renodx::color::y::from::BT709(r0.rgb);
+  o0.xyz = r0.xyz;
+  o0.rgb = applyUserTonemap(o0.rgb, v1, false);
+  o0.rgb = PostToneMapScale(o0.rgb);
+  return;
+}

--- a/src/games/roadhogengine/hardresetredux/tonemap_0xEF480D6C.ps_4_0.hlsl
+++ b/src/games/roadhogengine/hardresetredux/tonemap_0xEF480D6C.ps_4_0.hlsl
@@ -54,8 +54,7 @@ void main(
   r2.xyz = float3(1,1,1) + -r1.xyz;
   r0.xyz = -r2.xyz * r0.xyz + float3(1,1,1);
   r0.xyz = max(r1.xyz, r0.xyz);
-  //r0.xyz = r0.xyz + r0.xyz;
-  //r0.rgb = 0.53252053f * r0.rgb;
+  r0.rgb = 1.06504106f * r0.rgb;
   if (injectedData.toneMapType == 0.f) {
     r0.rgb = saturate(r0.rgb);
   }

--- a/src/games/roadhogengine/hardresetredux/tonemap_0xEF480D6C.ps_4_0.hlsl
+++ b/src/games/roadhogengine/hardresetredux/tonemap_0xEF480D6C.ps_4_0.hlsl
@@ -1,0 +1,83 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t15 : register(t15);
+Texture2D<float4> t14 : register(t14);
+Texture2D<float4> t13 : register(t13);
+Texture2D<float4> t12 : register(t12);
+Texture2D<float4> t11 : register(t11);
+SamplerState s8_s : register(s8);
+SamplerState s5_s : register(s5);
+SamplerState s4_s : register(s4);
+cbuffer cb1 : register(b1){
+  float4 cb1[13];
+}
+cbuffer cb0 : register(b0){
+  float4 cb0[19];
+}
+
+#define cmp -
+
+void main(
+  float4 v0 : SV_Position0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = v1.xy * cb1[1].xy + cb1[1].zw;
+  r0.xy = min(cb1[6].xy, r0.xy);
+  r0.xyzw = t13.SampleLevel(s5_s, r0.xy, 0).xyzw;
+  r1.xy = v1.xy * cb1[4].xy + cb1[4].zw;
+  r1.xy = min(cb1[6].zw, r1.xy);
+  r1.xyzw = t11.SampleLevel(s5_s, r1.xy, 0).xyzw;
+  r0.xyz = r0.xyz * cb1[7].xyz * injectedData.fxBloom + r1.xyz;
+  r0.xyz = float3(1,1,1) + -r0.xyz;
+  r1.xy = v1.xy * cb1[0].xy + cb1[0].zw;
+  r2.xyzw = t12.SampleLevel(s4_s, r1.xy, 0).xyzw;
+  r2.xyz = float3(4,4,4) * r2.xyz;
+  r1.zw = cb1[8].zw + r1.xy;
+  r3.xyzw = t15.SampleLevel(s8_s, r1.xy, 0).xyzw;
+  r0.w = r3.x * cb0[18].x + cb0[18].z;
+  r0.w = 1 / r0.w;
+  r1.xy = r0.ww * cb1[11].xz + cb1[11].yw;
+  o0.w = max(r1.x, r1.y);
+  o0.a = saturate(o0.a);
+  r1.xyzw = t12.SampleLevel(s4_s, r1.zw, 0).xyzw;
+  r2.xyz = -r1.xyz * float3(4,4,4) + r2.xyz;
+  r1.xyz = float3(4,4,4) * r1.xyz;
+  r1.xyz = cb1[7].www * r2.xyz * injectedData.fxSharpen + r1.xyz;
+  if (injectedData.toneMapType == 0.f) {
+    r1.rgb = saturate(r1.rgb);
+  }
+  r2.xyz = float3(1,1,1) + -r1.xyz;
+  r0.xyz = -r2.xyz * r0.xyz + float3(1,1,1);
+  r0.xyz = max(r1.xyz, r0.xyz);
+  //r0.xyz = r0.xyz + r0.xyz;
+  //r0.rgb = 0.53252053f * r0.rgb;
+  if (injectedData.toneMapType == 0.f) {
+    r0.rgb = saturate(r0.rgb);
+  }
+  r1.xy = v1.xy * cb1[2].xy + cb1[2].zw;
+  r0.w = dot(r1.xy, r1.xy);
+  r0.w = saturate(r0.w * cb1[8].x + cb1[8].y);
+  r0.w = r0.w * r0.w;
+  r0.xyz = r0.xyz * lerp(1.f, r0.www, injectedData.fxVignette);
+  if (injectedData.fxFilmGrainType == 0.f) {
+  r0.a = renodx::color::y::from::BT709(r0.rgb);
+  r0.w = -r0.w * cb1[9].y + 1;
+  r1.xy = v1.xy * cb1[3].xy + cb1[3].zw;
+  r1.xyzw = t14.SampleLevel(s4_s, r1.xy, 0).xyzw;
+  r1.x = -0.5 + r1.x;
+  r1.x = cb1[9].x * r1.x;
+  r0.xyz = r1.xxx * r0.www * injectedData.fxFilmGrain + r0.xyz;
+  }
+  r0.a = renodx::color::y::from::BT709(r0.rgb);
+  r0.xyz = -cb1[12].xyz * r0.www + r0.xyz;
+  r1.xyz = cb1[12].xyz * r0.www;
+  o0.xyz = cb1[9].zzz * r0.xyz + r1.xyz;
+  o0.rgb = applyUserTonemap(o0.rgb, v1);
+  o0.rgb = PostToneMapScale(o0.rgb);
+  return;
+}

--- a/src/games/roadhogengine/hardresetredux/videos_0x8FACEF64.ps_4_0.hlsl
+++ b/src/games/roadhogengine/hardresetredux/videos_0x8FACEF64.ps_4_0.hlsl
@@ -1,0 +1,50 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t2 : register(t2);
+Texture2D<float4> t1 : register(t1);
+Texture2D<float4> t0 : register(t0);
+SamplerState s5_s : register(s5);
+cbuffer cb1 : register(b1){
+  float4 cb1[4];
+}
+
+#define cmp -
+
+void main(
+  float4 v0 : SV_Position0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = cmp(v1.xy < cb1[3].xy);
+  r0.xy = r0.xy ? float2(1,1) : 0;
+  r0.x = dot(r0.xy, float2(1,1));
+  r0.yz = cmp(cb1[3].zw < v1.xy);
+  r0.yz = r0.yz ? float2(1,1) : 0;
+  r0.y = dot(r0.yz, float2(1,1));
+  r0.x = r0.x + r0.y;
+  r0.x = min(1, r0.x);
+  r1.xyzw = t2.Sample(s5_s, v1.xy).xyzw;
+  r0.y = -0.5 + r1.x;
+  r1.xyzw = t1.Sample(s5_s, v1.xy).xyzw;
+  r0.z = -0.5 + r1.x;
+  r1.xyzw = t0.Sample(s5_s, v1.xy).xyzw;
+  r0.w = -0.0627449974 + r1.x;
+  r1.x = 1.16400003 * r0.w;
+  r1.yz = r0.zz * float2(-0.213,2.11500001) + r1.xx;
+  r1.xy = r0.yy * float2(1.79299998,-0.533999979) + r1.xy;
+  r0.yzw = cb1[2].xyz * r1.xyz;
+  r1.xyz = cb1[2].www * r0.yzw;
+  r2.x = 0;
+  r2.w = cb1[2].w;
+  r1.w = cb1[2].w;
+  r2.xyzw = r2.xxxw + -r1.xyzw;
+  o0.xyzw = r0.xxxx * r2.xyzw + r1.xyzw;
+  //o0 = saturate(o0);
+  o0.rgb = renodx::color::srgb::DecodeSafe(o0.rgb);
+  o0.rgb = PostToneMapScale(o0.rgb);
+  return;
+}

--- a/src/games/roadhogengine/shared.h
+++ b/src/games/roadhogengine/shared.h
@@ -1,0 +1,45 @@
+#ifndef SRC_ROADHOGENGINE_SHARED_H_
+#define SRC_ROADHOGENGINE_SHARED_H_
+
+#ifndef __cplusplus
+#include "../../shaders/renodx.hlsl"
+#endif
+
+// Must be 32bit aligned
+// Should be 4x32
+struct ShaderInjectData {
+  float toneMapType;
+  float toneMapPeakNits;
+  float toneMapGameNits;
+  float toneMapUINits;
+  float toneMapGammaCorrection;
+  float toneMapPerChannel;
+  float toneMapHueProcessor;
+  float toneMapHueCorrection;
+  float toneMapShoulderStart;
+  float colorGradeExposure;
+  float colorGradeHighlights;
+  float colorGradeShadows;
+  float colorGradeContrast;
+  float colorGradeSaturation;
+  float colorGradeBlowout;
+  float colorGradeDechroma;
+  float colorGradeFlare;
+  float fxAutoExposure;
+  float fxBloom;
+  float fxLens;
+  float fxSharpen;
+  float fxVignette;
+  float fxFilmGrain;
+  float fxFilmGrainType;
+
+  float elapsedTime;
+};
+
+#ifndef __cplusplus
+cbuffer cb13 : register(b13) {
+  ShaderInjectData injectedData : packoffset(c0);
+}
+#endif
+
+#endif  // SRC_ROADHOGENGINE_SHARED_H_

--- a/src/games/roadhogengine/swap_chain_proxy_pixel_shader.ps_5_0.hlsl
+++ b/src/games/roadhogengine/swap_chain_proxy_pixel_shader.ps_5_0.hlsl
@@ -1,0 +1,13 @@
+#include "./common.hlsl"
+
+SamplerState sourceSampler_s : register(s0);
+Texture2D<float4> sourceTexture : register(t0);
+
+void main(
+    float4 vpos: SV_Position,
+    float2 texcoord: TEXCOORD,
+    out float4 output: SV_Target0) {
+  float4 color = sourceTexture.Sample(sourceSampler_s, texcoord.xy);
+  color.rgb = FinalizeOutput(color.rgb);
+  output.rgba = color;
+}

--- a/src/games/roadhogengine/swap_chain_proxy_vertex_shader.vs_5_0.hlsl
+++ b/src/games/roadhogengine/swap_chain_proxy_vertex_shader.vs_5_0.hlsl
@@ -1,0 +1,5 @@
+void main(uint id: SV_VERTEXID, out float4 pos: SV_POSITION, out float2 uv: TEXCOORD0) {
+  uv.x = (id == 1) ? 2.0 : 0.0;
+  uv.y = (id == 2) ? 2.0 : 0.0;
+  pos = float4(uv * float2(2.0, -2.0) + float2(-1.0, 1.0), 0.0, 1.0);
+}


### PR DESCRIPTION
Adds native HDR support to Hard Reset Redux.

Note: addon may be updated in the future to support Shadow Warrior (2013), and eventually fix Shadow Warrior 2 existing HDR implementation, hence the name.