### PR TITLE
implement a global more accurate reference white calculation + replace it where it was used before

### DIFF
--- a/src/games/cp2077/addon.cpp
+++ b/src/games/cp2077/addon.cpp
@@ -58,10 +58,6 @@ ShaderInjectData shader_injection;
 
 auto last_is_hdr = false;
 
-float ComputeReferenceWhite(float peak_nits) {
-  return std::clamp(roundf(powf(10.f, 0.03460730900256f + (0.757737096673107f * log10f(peak_nits)))), 100.f, 300.f);
-}
-
 renodx::utils::settings::Settings settings = {
     new renodx::utils::settings::Setting{
         .key = "toneMapType",
@@ -447,7 +443,7 @@ void OnInitSwapchain(reshade::api::swapchain* swapchain, bool resize) {
     settings[1]->default_value = 1000.f;
   }
 
-  settings[2]->default_value = ComputeReferenceWhite(settings[1]->default_value);
+  settings[2]->default_value = renodx::utils::swapchain::ComputeReferenceWhite(settings[1]->default_value);
 }
 
 }  // namespace

--- a/src/games/risetombraider/addon.cpp
+++ b/src/games/risetombraider/addon.cpp
@@ -475,7 +475,7 @@ void OnInitSwapchain(reshade::api::swapchain* swapchain, bool resize) {
     peak = 1000.f;
   }
   settings[2]->default_value = peak.value();
-  settings[3]->default_value = std::clamp(roundf(powf(10.f, 0.03460730900256f + (0.757737096673107f * log10f(peak.value())))), 100.f, 300.f);
+  settings[3]->default_value = renodx::utils::swapchain::ComputeReferenceWhite(peak.value());
 }
 
 std::mt19937 random_generator(std::chrono::system_clock::now().time_since_epoch().count());

--- a/src/games/seaofstars/addon.cpp
+++ b/src/games/seaofstars/addon.cpp
@@ -249,10 +249,6 @@ void OnPresetOff() {
 
 auto last_is_hdr = false;
 
-float ComputeReferenceWhite(float peak_nits) {
-  return std::clamp(roundf(powf(10.f, 0.03460730900256f + (0.757737096673107f * log10f(peak_nits)))), 100.f, 300.f);
-}
-
 void OnInitSwapchain(reshade::api::swapchain* swapchain, bool resize) {
   last_is_hdr = renodx::utils::swapchain::IsHDRColorSpace(swapchain);
   if (!last_is_hdr) {
@@ -270,7 +266,7 @@ void OnInitSwapchain(reshade::api::swapchain* swapchain, bool resize) {
     settings[1]->default_value = 1000.f;
   }
 
-  settings[2]->default_value = ComputeReferenceWhite(settings[1]->default_value);
+  settings[2]->default_value = renodx::utils::swapchain::ComputeReferenceWhite(settings[1]->default_value);
 
   auto white_level = renodx::utils::swapchain::GetSDRWhiteNits(swapchain);
   if (white_level.has_value()) {

--- a/src/games/tombraider2013/addon.cpp
+++ b/src/games/tombraider2013/addon.cpp
@@ -508,7 +508,7 @@ void OnInitSwapchain(reshade::api::swapchain* swapchain, bool resize) {
     peak = 1000.f;
   }
   settings[2]->default_value = peak.value();
-  settings[3]->default_value = std::clamp(roundf(powf(10.f, 0.03460730900256f + (0.757737096673107f * log10f(peak.value())))), 100.f, 300.f);
+  settings[3]->default_value = renodx::utils::swapchain::ComputeReferenceWhite(peak.value());
 }
 
 std::mt19937 random_generator(std::chrono::system_clock::now().time_since_epoch().count());

--- a/src/games/tombraider2013de/addon.cpp
+++ b/src/games/tombraider2013de/addon.cpp
@@ -502,7 +502,7 @@ void OnInitSwapchain(reshade::api::swapchain* swapchain, bool resize) {
     peak = 1000.f;
   }
   settings[2]->default_value = peak.value();
-  settings[3]->default_value = std::clamp(roundf(powf(10.f, 0.03460730900256f + (0.757737096673107f * log10f(peak.value())))), 100.f, 300.f);
+  settings[3]->default_value = renodx::utils::swapchain::ComputeReferenceWhite(peak.value());
 }
 
 std::mt19937 random_generator(std::chrono::system_clock::now().time_since_epoch().count());


### PR DESCRIPTION
- Implements a reference white calculation based off of calculating the HLG inverse OETF at 75% input and deriving the reference white nits of that value with the HLG OOTF. This is the most accurate way to do it.
- Replace the old reference white calculations in all addons with this new one.