### PR TITLE
fix(unrealengine): fix infinity nikki crashing on start up

### DIFF
--- a/src/games/unrealengine/addon.cpp
+++ b/src/games/unrealengine/addon.cpp
@@ -736,6 +736,7 @@ BOOL APIENTRY DllMain(HMODULE h_module, DWORD fdw_reason, LPVOID lpv_reserved) {
         if (params.size() >= 20) return false;
 
         if (product_name == "Jusant") return true;
+        if (product_name == "InfinityNikki") return true;
 
         // UE DX12 has a 4 param root sig that crashes if modified. Track for now
         return std::ranges::any_of(params, [](auto param) {


### PR DESCRIPTION
Infinity Nikki has issues with descriptor tables, causing the game to crash on start up, this makes the mod work again.