### PR TITLE
God of War: Ragnarok – HDR Tonemapping Fix & Improvements

### DIFF
--- a/src/games/gowragnarok/addon.cpp
+++ b/src/games/gowragnarok/addon.cpp
@@ -1,0 +1,222 @@
+/*
+ * Copyright (C) 2025 Musa Haji
+ * Copyright (C) 2025 Carlos Lopez
+ * SPDX-License-Identifier: MIT
+ */
+
+#define ImTextureID ImU64
+
+#define DEBUG_LEVEL_0
+#define DEBUG_SLIDERS_OFF
+
+#include <deps/imgui/imgui.h>
+#include <include/reshade.hpp>
+
+#include <embed/shaders.h>
+
+#include "../../mods/shader.hpp"
+#include "../../utils/date.hpp"
+#include "../../utils/settings.hpp"
+#include "./shared.h"
+
+namespace {
+
+ShaderInjectData shader_injection;
+
+renodx::mods::shader::CustomShaders custom_shaders = {
+    CustomShaderEntry(0xC66F9B98),  // Bloom
+
+    CustomShaderEntry(0x4BB65477),  // HDR Calibration Menu
+
+    // CustomShaderEntry(0x4B89087D),  // LUT?
+    CustomShaderEntry(0x4D780747),  // ToneMap
+    CustomShaderEntry(0x903B49C1),  // BT.2020 + PQ Encode
+                                    // CustomShaderEntry(0x64DB1117),  // Gamma Adjust (only relevant in SDR)
+};
+
+renodx::utils::settings::Settings settings = {
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapType",
+        .binding = &shader_injection.tone_map_type,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 1.f,
+        .label = "Tone Mapper",
+        .section = "Tone Mapping",
+        .tooltip = "Sets the tone mapper type",
+        .labels = {"Vanilla", "Vanilla+"},
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapOverridePeakBrightness",
+        .binding = &shader_injection.tone_map_override_peak_nits,
+        .value_type = renodx::utils::settings::SettingValueType::BOOLEAN,
+        .default_value = 0.f,
+        .label = "Override Peak Brightness",
+        .section = "Tone Mapping",
+        .tooltip = "Overrides the peak brightness auto-detected by the game",
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapPeakNits",
+        .binding = &shader_injection.peak_white_nits,
+        .default_value = 1000.f,
+        .label = "Peak Brightness",
+        .section = "Tone Mapping",
+        .tooltip = "Sets the value of peak white in nits",
+        .min = 48.f,
+        .max = 4000.f,
+        .is_enabled = []() { return shader_injection.tone_map_override_peak_nits != 0; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapGameNits",
+        .binding = &shader_injection.diffuse_white_nits,
+        .default_value = 203.f,
+        .label = "Game Brightness",
+        .section = "Tone Mapping",
+        .tooltip = "Sets the value of 100% white in nits",
+        .min = 48.f,
+        .max = 500.f,
+        .is_enabled = []() { return shader_injection.tone_map_type != 0; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeExposure",
+        .binding = &shader_injection.tone_map_exposure,
+        .default_value = 1.f,
+        .label = "Exposure",
+        .section = "Color Grading",
+        .max = 2.f,
+        .format = "%.2f",
+    },
+    new renodx::utils::settings::Setting{
+        .key = "FxBloom",
+        .binding = &shader_injection.custom_bloom,
+        .default_value = 100.f,
+        .label = "Bloom",
+        .section = "Effects",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.01f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "HDR10Encoding",
+        .binding = &shader_injection.custom_hdr10_encoding,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 1.f,
+        .label = "HDR10 Encoding",
+        .section = "Advanced",
+        .tooltip = "Sets the HDR10 Encoding format",
+        .labels = {"Vanilla (PQ Approximation)", "PQ"},
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::BUTTON,
+        .label = "Reset All",
+        .section = "Options",
+        .group = "button-line-1",
+        .on_change = []() {
+          for (auto* setting : settings) {
+            if (setting->key.empty()) continue;
+            if (!setting->can_reset) continue;
+            renodx::utils::settings::UpdateSetting(setting->key, setting->default_value);
+          }
+        },
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::BUTTON,
+        .label = "Discord",
+        .section = "Links",
+        .group = "button-line-2",
+        .tint = 0x5865F2,
+        .on_change = []() {
+          renodx::utils::platform::LaunchURL("https://discord.gg/", "5WZXDpmbpP");
+        },
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::BUTTON,
+        .label = "More Mods",
+        .section = "Links",
+        .group = "button-line-2",
+        .tint = 0x2B3137,
+        .on_change = []() {
+          renodx::utils::platform::LaunchURL("https://github.com/clshortfuse/renodx/wiki/Mods");
+        },
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::BUTTON,
+        .label = "Github",
+        .section = "Links",
+        .group = "button-line-2",
+        .tint = 0x2B3137,
+        .on_change = []() {
+          renodx::utils::platform::LaunchURL("https://github.com/clshortfuse/renodx");
+        },
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::BUTTON,
+        .label = "Musa's Ko-Fi",
+        .section = "Links",
+        .group = "button-line-3",
+        .tint = 0xFF5A16,
+        .on_change = []() { renodx::utils::platform::LaunchURL("https://ko-fi.com/musaqh"); },
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::TEXT,
+        .label = std::string("Build: ") + renodx::utils::date::ISO_DATE_TIME,
+        .section = "About",
+    },
+};
+
+void OnPresetOff() {
+  renodx::utils::settings::UpdateSettings({
+      {"ToneMapType", 0.f},
+      {"ToneMapOverridePeakBrightness", 0.f},
+      {"ToneMapGameNits", 100.f},
+      {"ColorGradeExposure", 1.f},
+      {"FxBloom", 100.f},
+      {"HDR10Encoding", 0.f},
+  });
+}
+
+bool fired_on_init_swapchain = false;
+
+void OnInitSwapchain(reshade::api::swapchain* swapchain, bool resize) {
+  if (fired_on_init_swapchain) return;
+  fired_on_init_swapchain = true;
+
+  auto peak = renodx::utils::swapchain::GetPeakNits(swapchain);
+  if (!peak.has_value()) {
+    peak = 1000.f;
+  }
+  settings[2]->default_value = peak.value();
+}
+bool initialized = false;
+
+}  // namespace
+
+extern "C" __declspec(dllexport) constexpr const char* NAME = "RenoDX";
+extern "C" __declspec(dllexport) constexpr const char* DESCRIPTION = "RenoDX God of War: Ragnarok";
+
+BOOL APIENTRY DllMain(HMODULE h_module, DWORD fdw_reason, LPVOID lpv_reserved) {
+  switch (fdw_reason) {
+    case DLL_PROCESS_ATTACH:
+      if (!reshade::register_addon(h_module)) return FALSE;
+
+      if (!initialized) {
+        renodx::mods::shader::force_pipeline_cloning = true;
+        renodx::mods::shader::expected_constant_buffer_space = 50;
+        renodx::mods::shader::expected_constant_buffer_index = 13;
+        // renodx::mods::shader::manual_shader_scheduling = true;
+        renodx::mods::shader::allow_multiple_push_constants = true;
+
+        initialized = true;
+      }
+
+      reshade::register_event<reshade::addon_event::init_swapchain>(OnInitSwapchain);  // peak nits detection
+      break;
+    case DLL_PROCESS_DETACH:
+      reshade::unregister_addon(h_module);
+      reshade::unregister_event<reshade::addon_event::init_swapchain>(OnInitSwapchain);  // peak nits detection
+      break;
+  }
+
+  renodx::utils::settings::Use(fdw_reason, &settings, &OnPresetOff);
+  renodx::mods::shader::Use(fdw_reason, custom_shaders, &shader_injection);
+
+  return TRUE;
+}

--- a/src/games/gowragnarok/bloom_0xF1E4F5FE.cs_6_6.hlsl
+++ b/src/games/gowragnarok/bloom_0xF1E4F5FE.cs_6_6.hlsl
@@ -1,0 +1,52 @@
+cbuffer ConstBuf_constantsUBO : register(b0, space0) {
+  float4 ConstBuf_constants_m0[15] : packoffset(c0);
+};
+
+// Don't declare _9, _13, _17
+
+static uint3 gl_GlobalInvocationID;
+struct SPIRV_Cross_Input {
+  uint3 gl_GlobalInvocationID : SV_DispatchThreadID;
+};
+
+void comp_main() {
+  float _46 = ConstBuf_constants_m0[14u].y * (float(gl_GlobalInvocationID.x) + 0.5f);
+  float _47 = (float(gl_GlobalInvocationID.y) + 0.5f) * ConstBuf_constants_m0[14u].z;
+  uint4 _52 = asuint(ConstBuf_constants_m0[13u]);
+  uint _53 = _52.y;
+  uint _57 = _52.x;
+  uint _outIndex = _52.w;
+
+  Texture2D<float4> tex = ResourceDescriptorHeap[_53];
+  SamplerState sampler = ResourceDescriptorHeap[_57];
+  RWTexture2D<float4> outTex = ResourceDescriptorHeap[_outIndex];
+
+  float2 uv = float2(_46, _47);
+  float4 _66 = tex.SampleLevel(sampler, uv, 0.0f, int2(-2, -2));
+  float4 _76 = tex.SampleLevel(sampler, uv, 0.0f, int2(-2, 0));
+  float4 _84 = tex.SampleLevel(sampler, uv, 0.0f, int2(-2, 2));
+  float4 _91 = tex.SampleLevel(sampler, uv, 0.0f, int2(0, -2));
+  float4 _98 = tex.SampleLevel(sampler, uv, 0.0f);
+  float4 _104 = tex.SampleLevel(sampler, uv, 0.0f, int2(0, 2));
+  float4 _111 = tex.SampleLevel(sampler, uv, 0.0f, int2(2, -2));
+  float4 _118 = tex.SampleLevel(sampler, uv, 0.0f, int2(2, 0));
+  float4 _125 = tex.SampleLevel(sampler, uv, 0.0f, int2(2, 2));
+  float4 _133 = tex.SampleLevel(sampler, uv, 0.0f, int2(-1, -1));
+  float4 _141 = tex.SampleLevel(sampler, uv, 0.0f, int2(-1, 1));
+  float4 _148 = tex.SampleLevel(sampler, uv, 0.0f, int2(1, -1));
+  float4 _155 = tex.SampleLevel(sampler, uv, 0.0f, int2(1, 1));
+
+  float4 result;
+  result.r = (((((_91.x + _76.x) + _104.x) + _118.x) * 0.0625f) + (((((_133.x + _98.x) + _141.x) + _148.x) + _155.x) * 0.125f)) + ((((_84.x + _66.x) + _111.x) + _125.x) * 0.03125f);
+  result.g = (((((_91.y + _76.y) + _104.y) + _118.y) * 0.0625f) + (((((_133.y + _98.y) + _141.y) + _148.y) + _155.y) * 0.125f)) + ((((_84.y + _66.y) + _111.y) + _125.y) * 0.03125f);
+  result.b = (((((_91.z + _76.z) + _104.z) + _118.z) * 0.0625f) + (((((_133.z + _98.z) + _141.z) + _148.z) + _155.z) * 0.125f)) + ((((_84.z + _66.z) + _111.z) + _125.z) * 0.03125f);
+  result.a = (((((_91.w + _76.w) + _104.w) + _118.w) * 0.0625f) + (((((_133.w + _98.w) + _141.w) + _148.w) + _155.w) * 0.125f)) + ((((_84.w + _66.w) + _111.w) + _125.w) * 0.03125f);
+
+  outTex[gl_GlobalInvocationID.xy] = result;
+}
+
+[numthreads(8, 8, 1)]
+void main(SPIRV_Cross_Input stage_input) {
+  gl_GlobalInvocationID = stage_input.gl_GlobalInvocationID;
+  comp_main();
+}

--- a/src/games/gowragnarok/calibration_0x4BB65477.ps_6_6.hlsl
+++ b/src/games/gowragnarok/calibration_0x4BB65477.ps_6_6.hlsl
@@ -1,0 +1,405 @@
+#include "./shared.h"
+
+cbuffer ConstBuf_passDataUBO : register(b0, space0) {
+  float4 ConstBuf_passData_m0[2288] : packoffset(c0);
+};
+
+cbuffer ConstBuf_modelDataUBO : register(b1, space0) {
+  float4 ConstBuf_modelData_m0[11] : packoffset(c0);
+};
+
+cbuffer ConstBuf_viewDataUBO : register(b3, space0) {
+  float4 ConstBuf_viewData_m0[81] : packoffset(c0);
+};
+
+cbuffer ConstBuf_materialDataUBO : register(b4, space0) {
+  float4 ConstBuf_materialData_m0[1] : packoffset(c0);
+};
+
+// ResourceDescriptorHeap
+// Texture2D<float4> _9[] : register(t0, space0);
+// SamplerState _13[] : register(s0, space0);
+
+static float4 gl_FragCoord;
+static float2 TEXCOORD;
+static float3 NORMAL;
+static float4 TANGENT;
+static float3 PREV_POSITION_PS;
+static uint VERTEX_ID;
+static float4 SV_Target;
+
+struct SPIRV_Cross_Input {
+  float4 gl_FragCoord : SV_Position;           // Register 0
+  float2 TEXCOORD : TEXCOORD0;                 // Register 1
+  float3 NORMAL : NORMAL;                      // Register 2
+  float4 TANGENT : TANGENT;                    // Register 3
+  float3 PREV_POSITION_PS : PREV_POSITION_PS;  // Register 4
+  nointerpolation uint VERTEX_ID : VERTEX_ID;  // Register 5
+};
+
+struct SPIRV_Cross_Output {
+  float4 SV_Target : SV_Target0;
+};
+
+static bool discard_state;
+
+void discard_exit() {
+  if (discard_state) {
+    discard;
+  }
+}
+
+void frag_main() {
+  discard_state = false;
+  float _77 = ConstBuf_viewData_m0[48u].w * gl_FragCoord.y;
+
+  uint texIndex = asuint(ConstBuf_materialData_m0[0u]).x + asuint(ConstBuf_viewData_m0[47u]).w;
+  uint samplerIndex = asuint(ConstBuf_viewData_m0[78u]).w;
+  Texture2D<float4> tex = ResourceDescriptorHeap[texIndex];
+  SamplerState samp = ResourceDescriptorHeap[samplerIndex];
+  float4 _97 = tex.Sample(samp, TEXCOORD);
+  // float4 _97 = _9[asuint(ConstBuf_materialData_m0[0u]).x + asuint(ConstBuf_viewData_m0[47u]).w].Sample(_13[asuint(ConstBuf_viewData_m0[78u]).w], float2(TEXCOORD.x, TEXCOORD.y));
+
+  float _106 = ConstBuf_modelData_m0[2u].y * _97.x;
+  float _107 = ConstBuf_modelData_m0[2u].y * _97.y;
+  float _108 = ConstBuf_modelData_m0[2u].y * _97.z;
+  float _117;
+
+  float peak_nits = min(4000.0f, ConstBuf_passData_m0[2271u].z);
+  float min_nits = max(9.9999997473787516355514526367188e-05f, ConstBuf_passData_m0[2270u].w);
+  float exposure = ConstBuf_passData_m0[2271u].x;  // brightness slider
+
+  if (RENODX_OVERRIDE_PEAK_NITS) {
+    peak_nits = RENODX_PEAK_WHITE_NITS;
+  }
+  if (RENODX_TONE_MAP_TYPE) {
+    min_nits = 0.0001f;
+    exposure = 8.f * RENODX_TONE_MAP_EXPOSURE;
+    float scale = 100.f / RENODX_DIFFUSE_WHITE_NITS;
+    peak_nits *= scale;
+    min_nits *= scale;
+
+    float invDiffuseWhite = 1.0f / RENODX_DIFFUSE_WHITE_NITS;
+    peak_nits = renodx::color::correct::Gamma(peak_nits * invDiffuseWhite, true) * RENODX_DIFFUSE_WHITE_NITS;
+    min_nits = renodx::color::correct::Gamma(min_nits * invDiffuseWhite, true) * RENODX_DIFFUSE_WHITE_NITS;
+  }
+
+  if ((asuint(ConstBuf_modelData_m0[0u]).x & 512u) == 0u) {
+    _117 = 1.0f;
+  } else {
+    float frontier_phi_1_2_ladder;
+    if ((ConstBuf_modelData_m0[7u].w > 0.0f) || ((ConstBuf_modelData_m0[7u].z > 0.0f) || ((ConstBuf_modelData_m0[7u].x > 0.0f) || (ConstBuf_modelData_m0[7u].y > 0.0f)))) {
+      float _153 = ConstBuf_viewData_m0[48u].z * gl_FragCoord.x;
+      float _175 = ((clamp((_77 - ConstBuf_modelData_m0[6u].y) / ConstBuf_modelData_m0[7u].y, 0.0f, 1.0f) * clamp((_153 - ConstBuf_modelData_m0[6u].x) / ConstBuf_modelData_m0[7u].x, 0.0f, 1.0f)) * clamp((ConstBuf_modelData_m0[6u].z - _153) / ConstBuf_modelData_m0[7u].z, 0.0f, 1.0f)) * clamp((ConstBuf_modelData_m0[6u].w - _77) / ConstBuf_modelData_m0[7u].w, 0.0f, 1.0f);
+      float _119 = clamp((asuint(ConstBuf_modelData_m0[8u]).x == 0u) ? _175 : (_175 * _175), 0.0f, 1.0f);
+      float frontier_phi_1_2_ladder_5_ladder;
+      if (_119 > 0.0f) {
+        frontier_phi_1_2_ladder_5_ladder = _119;
+      } else {
+        discard_state = true;
+        frontier_phi_1_2_ladder_5_ladder = _119;
+      }
+      frontier_phi_1_2_ladder = frontier_phi_1_2_ladder_5_ladder;
+    } else {
+      frontier_phi_1_2_ladder = 1.0f;
+    }
+    _117 = frontier_phi_1_2_ladder;
+  }
+  if (_117 < 9.9999997473787516355514526367188e-05f) {
+    discard_state = true;
+  }
+  uint _143 = asuint(ConstBuf_modelData_m0[0u]).x >> 28u;
+  float _185;
+  float _187;
+  float _189;
+  if (((1u << _143) & asuint(ConstBuf_viewData_m0[60u]).x) == 0u) {
+    _185 = _106;
+    _187 = _107;
+    _189 = _108;
+  } else {
+    uint _308 = _143 + 61u;
+    float _315 = dot(float3(0.2125999927520751953125f, 0.715200006961822509765625f, 0.072200000286102294921875f), float3(_106, _107, _108));
+    _185 = _315 * ConstBuf_viewData_m0[_308].x;
+    _187 = _315 * ConstBuf_viewData_m0[_308].y;
+    _189 = _315 * ConstBuf_viewData_m0[_308].z;
+  }
+  float _208 = log2(max(9.9999997473787516355514526367188e-05f, ConstBuf_passData_m0[2270u].w));  //   float _208 = log2(max(9.9999997473787516355514526367188e-05f, ConstBuf_passData_m0[2270u].w));
+  float _213 = clamp((_208 * 0.13082401454448699951171875f) + 1.7383518218994140625f, 0.0f, 1.0f);
+  float _220 = exp2((_213 * (-6.5f)) - ((1.0f - _213) * 15.0f));
+  float _223 = log2(peak_nits);  //   float _223 = log2(min(4000.0f, ConstBuf_passData_m0[2271u].z));
+  float _228 = clamp((_223 * 0.1298237740993499755859375f) + (-0.725060939788818359375f), 0.0f, 1.0f);
+  float _235 = exp2(((1.0f - _228) * 6.5f) + (_228 * 18.0f));
+  float _237 = log2(_220 * 0.180000007152557373046875f);
+  float _238 = _208 * 0.3010300099849700927734375f;
+  float _240 = _237 * 0.077766083180904388427734375f;
+  float _242 = _240 + 0.873629271984100341796875f;
+  float _244 = 0.48885345458984375f - _240;
+  float _250 = clamp((log2(_220) + 15.0f) * 0.117647059261798858642578125f, 0.0f, 1.0f);
+  float _259 = ((0.681241333484649658203125f - _238) * (((1.0f - _250) * 0.180000007152557373046875f) + (_250 * 0.3499999940395355224609375f))) + _238;
+  float _260 = log2(_235 * 0.180000007152557373046875f);
+  float _261 = _260 * 0.077766083180904388427734375f;
+  float _262 = 0.48885345458984375f - _261;
+  float _263 = _261 + 0.873629271984100341796875f;
+  float _264 = _223 * 0.3010300099849700927734375f;
+  float _269 = clamp((log2(_235) + (-6.5f)) * 0.086956523358821868896484375f, 0.0f, 1.0f);
+  float _279 = ((((1.0f - _269) * 0.88999998569488525390625f) + (_269 * 0.89999997615814208984375f)) * (_264 + (-0.681241333484649658203125f))) + 0.681241333484649658203125f;
+  float _282 = log2(exp2(_237));
+  float _287 = log2(exp2(_260));
+  float _295 = (_259 + _238) * 0.5f;
+  float _300 = (_279 + _263) * 0.5f;
+  float _306 = log2(max(exposure, 1.0000000133514319600180897396058e-10f)) * 0.3010300099849700927734375f;  // exposure
+  float _331;
+  if (_306 > _238) {
+    float frontier_phi_13_9_ladder;
+    if ((_306 <= 0.681241333484649658203125f) && (_306 > _238)) {
+      float _389;
+      float _391;
+      float _393;
+      float _395;
+      if ((_306 > ((_208 + _208) * 0.15051500499248504638671875f)) && (_306 <= _295)) {
+        _389 = 0.0f;
+        _391 = _238;
+        _393 = _238;
+        _395 = _259;
+      } else {
+        bool _421 = (_306 > _295) && (_306 <= ((_259 + _242) * 0.5f));
+        _389 = _421 ? 1.0f : 2.0f;
+        _391 = _421 ? _238 : _259;
+        _393 = _421 ? _259 : _242;
+        _395 = _421 ? _242 : _244;
+      }
+      float _397 = _391 * 0.5f;
+      float _401 = _393 - _391;
+      float _403 = mad(_393, 0.5f, _397) - _306;
+      frontier_phi_13_9_ladder = (_282 * 0.3010300099849700927734375f) + ((((_403 * 2.0f) / (((-0.0f) - _401) - sqrt((_401 * _401) - ((mad(_395, 0.5f, mad(_393, -1.0f, _397)) * 4.0f) * _403)))) + _389) * ((-0.24824249744415283203125f) - (_282 * 0.100343339145183563232421875f)));
+    } else {
+      float frontier_phi_13_9_ladder_12_ladder;
+      if ((_306 > 0.681241333484649658203125f) && (_306 < _264)) {
+        float _440;
+        float _442;
+        float _444;
+        float _446;
+        if ((_306 >= 0.68124139308929443359375f) && (_306 <= _300)) {
+          _440 = 0.0f;
+          _442 = _262;
+          _444 = _263;
+          _446 = _279;
+        } else {
+          bool _467 = (_306 > _300) && (_306 <= ((_279 + _264) * 0.5f));
+          _440 = _467 ? 1.0f : 2.0f;
+          _442 = _467 ? _263 : _279;
+          _444 = _467 ? _279 : _264;
+          _446 = _264;
+        }
+        float _447 = _442 * 0.5f;
+        float _450 = _444 - _442;
+        float _452 = mad(_444, 0.5f, _447) - _306;
+        frontier_phi_13_9_ladder_12_ladder = ((((_452 * 2.0f) / (((-0.0f) - _450) - sqrt((_450 * _450) - ((mad(_446, 0.5f, mad(_444, -1.0f, _447)) * 4.0f) * _452)))) + _440) * ((_287 * 0.100343339145183563232421875f) + 0.24824249744415283203125f)) + (-0.74472749233245849609375f);
+      } else {
+        frontier_phi_13_9_ladder_12_ladder = _287 * 0.3010300099849700927734375f;
+      }
+      frontier_phi_13_9_ladder = frontier_phi_13_9_ladder_12_ladder;
+    }
+    _331 = frontier_phi_13_9_ladder;
+  } else {
+    _331 = _282 * 0.3010300099849700927734375f;
+  }
+  float _338 = log2(exp2(_331 * 3.3219280242919921875f));
+  float _339 = _338 + 2.4739310741424560546875f;
+  float _345 = exp2((-4.947862148284912109375f) - _338);
+  float _347 = exp2(_260 - _339);
+  float _59[6];
+  _59[0u] = _238;
+  _59[1u] = _238;
+  _59[2u] = _259;
+  _59[3u] = _242;
+  _59[4u] = _244;
+  _59[5u] = _244;
+  float _60[6];
+  _60[0u] = _262;
+  _60[1u] = _263;
+  _60[2u] = _279;
+  _60[3u] = _264;
+  _60[4u] = _264;
+  _60[5u] = _264;
+  float _384 = log2(max(mad(0.04823090136051177978515625f, _189, mad(0.3545829951763153076171875f, _187, _185 * 0.597186982631683349609375f)), 5.9604644775390625e-08f));
+  float _385 = _384 * 0.3010300099849700927734375f;
+  float _386 = log2(exp2(_237 - _339));
+  float _387 = _386 * 0.3010300099849700927734375f;
+  float _431;
+  if (_385 > _387) {
+    float _427 = log2(_345);
+    float _428 = _427 * 0.3010300099849700927734375f;
+    float frontier_phi_19_18_ladder;
+    if ((_385 > _387) && (_385 < _428)) {
+      float _473 = ((_384 - _386) * 0.903090000152587890625f) / ((_427 - _386) * 0.3010300099849700927734375f);
+      uint _474 = uint(int(_473));
+      float _476 = _473 - float(int(_474));
+      uint _479 = _474 + 1u;
+      float _486 = _59[_474] * 0.5f;
+      frontier_phi_19_18_ladder = dot(float3(_476 * _476, _476, 1.0f), float3(mad(_59[_474 + 2u], 0.5f, mad(_59[_479], -1.0f, _486)), _59[_479] - _59[_474], mad(_59[_479], 0.5f, _486)));
+    } else {
+      float _494 = log2(_347);
+      float frontier_phi_19_18_ladder_23_ladder;
+      if ((_385 >= _428) && (_385 < (_494 * 0.3010300099849700927734375f))) {
+        float _516 = ((_384 - _427) * 0.903090000152587890625f) / ((_494 - _427) * 0.3010300099849700927734375f);
+        uint _517 = uint(int(_516));
+        float _519 = _516 - float(int(_517));
+        uint _522 = _517 + 1u;
+        float _529 = _60[_517] * 0.5f;
+        frontier_phi_19_18_ladder_23_ladder = dot(float3(_519 * _519, _519, 1.0f), float3(mad(_60[_517 + 2u], 0.5f, mad(_60[_522], -1.0f, _529)), _60[_522] - _60[_517], mad(_60[_522], 0.5f, _529)));
+      } else {
+        frontier_phi_19_18_ladder_23_ladder = _264;
+      }
+      frontier_phi_19_18_ladder = frontier_phi_19_18_ladder_23_ladder;
+    }
+    _431 = frontier_phi_19_18_ladder;
+  } else {
+    _431 = _238;
+  }
+  float _435 = exp2(_431 * 3.3219280242919921875f);
+  float _437 = log2(max(mad(0.0156609006226062774658203125f, _189, mad(0.908339977264404296875f, _187, _185 * 0.075998999178409576416015625f)), 5.9604644775390625e-08f));
+  float _438 = _437 * 0.3010300099849700927734375f;
+  float _503;
+  if (_438 > _387) {
+    float _499 = log2(_345);
+    float _500 = _499 * 0.3010300099849700927734375f;
+    float frontier_phi_25_24_ladder;
+    if ((_438 > _387) && (_438 < _500)) {
+      float _540 = ((_437 - _386) * 0.903090000152587890625f) / ((_499 - _386) * 0.3010300099849700927734375f);
+      uint _541 = uint(int(_540));
+      float _543 = _540 - float(int(_541));
+      uint _546 = _541 + 1u;
+      float _553 = _59[_541] * 0.5f;
+      frontier_phi_25_24_ladder = dot(float3(_543 * _543, _543, 1.0f), float3(mad(_59[_541 + 2u], 0.5f, mad(_59[_546], -1.0f, _553)), _59[_546] - _59[_541], mad(_59[_546], 0.5f, _553)));
+    } else {
+      float _561 = log2(_347);
+      float frontier_phi_25_24_ladder_28_ladder;
+      if ((_438 >= _500) && (_438 < (_561 * 0.3010300099849700927734375f))) {
+        float _605 = ((_437 - _499) * 0.903090000152587890625f) / ((_561 - _499) * 0.3010300099849700927734375f);
+        uint _606 = uint(int(_605));
+        float _608 = _605 - float(int(_606));
+        uint _611 = _606 + 1u;
+        float _618 = _60[_606] * 0.5f;
+        frontier_phi_25_24_ladder_28_ladder = dot(float3(_608 * _608, _608, 1.0f), float3(mad(_60[_606 + 2u], 0.5f, mad(_60[_611], -1.0f, _618)), _60[_611] - _60[_606], mad(_60[_611], 0.5f, _618)));
+      } else {
+        frontier_phi_25_24_ladder_28_ladder = _264;
+      }
+      frontier_phi_25_24_ladder = frontier_phi_25_24_ladder_28_ladder;
+    }
+    _503 = frontier_phi_25_24_ladder;
+  } else {
+    _503 = _238;
+  }
+  float _507 = exp2(_503 * 3.3219280242919921875f);
+  float _509 = log2(max(mad(0.837768971920013427734375f, _189, mad(0.1338270008563995361328125f, _187, _185 * 0.02840399928390979766845703125f)), 5.9604644775390625e-08f));
+  float _510 = _509 * 0.3010300099849700927734375f;
+  float _570;
+  if (_510 > _387) {
+    float _566 = log2(_345);
+    float _567 = _566 * 0.3010300099849700927734375f;
+    float frontier_phi_30_29_ladder;
+    if ((_510 > _387) && (_510 < _567)) {
+      float _629 = ((_509 - _386) * 0.903090000152587890625f) / ((_566 - _386) * 0.3010300099849700927734375f);
+      uint _630 = uint(int(_629));
+      float _632 = _629 - float(int(_630));
+      uint _635 = _630 + 1u;
+      float _642 = _59[_630] * 0.5f;
+      frontier_phi_30_29_ladder = dot(float3(_632 * _632, _632, 1.0f), float3(mad(_59[_630 + 2u], 0.5f, mad(_59[_635], -1.0f, _642)), _59[_635] - _59[_630], mad(_59[_635], 0.5f, _642)));
+    } else {
+      float _650 = log2(_347);
+      float frontier_phi_30_29_ladder_33_ladder;
+      if ((_510 >= _567) && (_510 < (_650 * 0.3010300099849700927734375f))) {
+        float _825 = ((_509 - _566) * 0.903090000152587890625f) / ((_650 - _566) * 0.3010300099849700927734375f);
+        uint _826 = uint(int(_825));
+        float _828 = _825 - float(int(_826));
+        uint _831 = _826 + 1u;
+        float _838 = _60[_826] * 0.5f;
+        frontier_phi_30_29_ladder_33_ladder = dot(float3(_828 * _828, _828, 1.0f), float3(mad(_60[_826 + 2u], 0.5f, mad(_60[_831], -1.0f, _838)), _60[_831] - _60[_826], mad(_60[_831], 0.5f, _838)));
+      } else {
+        frontier_phi_30_29_ladder_33_ladder = _264;
+      }
+      frontier_phi_30_29_ladder = frontier_phi_30_29_ladder_33_ladder;
+    }
+    _570 = frontier_phi_30_29_ladder;
+  } else {
+    _570 = _238;
+  }
+  float _574 = exp2(_570 * 3.3219280242919921875f);
+
+  // AP1 -> BT.709
+  float _579 = mad(-0.0832588970661163330078125f, _574, mad(-0.621792018413543701171875f, _507, _435 * 1.705049991607666015625f));
+  float _585 = mad(-0.010548300109803676605224609375f, _574, mad(1.140799999237060546875f, _507, _435 * (-0.130255997180938720703125f)));
+  float _591 = mad(1.15296995639801025390625f, _574, mad(-0.12896899878978729248046875f, _507, _435 * (-0.02400339953601360321044921875f)));
+  float _593 = _579 * 0.00999999977648258209228515625f;
+  float _595 = _585 * 0.00999999977648258209228515625f;
+  float _596 = _591 * 0.00999999977648258209228515625f;
+  float _598 = log2(_593);
+  float _599 = log2(_595);
+  float _600 = log2(_596);
+  float _845;
+  float _846;
+  float _847;
+  if (ConstBuf_passData_m0[2270u].z != 0.0f) {
+    float _695, _701, _707;
+    if (!RENODX_TONE_MAP_TYPE) {
+      float _683 = exp2(log2(0.0f) * 0.4166666567325592041015625f);
+      float _684 = 1.0f - _683;
+      float _688 = exp2(log2(_684) * 2.400000095367431640625f);
+      float _689 = _683 / _684;
+      _695 = exp2(log2(max(_689 + ((_593 < 0.017999999225139617919921875f) ? (_579 * 0.0449999980628490447998046875f) : ((exp2(_598 * 0.449999988079071044921875f) * 1.09899997711181640625f) + (-0.098999999463558197021484375f))), 0.0f)) * 2.400000095367431640625f) * _688;
+      _701 = exp2(log2(max(_689 + ((_595 < 0.017999999225139617919921875f) ? (_585 * 0.0449999980628490447998046875f) : ((exp2(_599 * 0.449999988079071044921875f) * 1.09899997711181640625f) + (-0.098999999463558197021484375f))), 0.0f)) * 2.400000095367431640625f) * _688;
+      _707 = exp2(log2(max(_689 + ((_596 < 0.017999999225139617919921875f) ? (_591 * 0.0449999980628490447998046875f) : ((exp2(_600 * 0.449999988079071044921875f) * 1.09899997711181640625f) + (-0.098999999463558197021484375f))), 0.0f)) * 2.400000095367431640625f) * _688;
+    } else {
+      float3 corrected = renodx::color::correct::GammaSafe(float3(_593, _595, _596));
+      _695 = corrected.r, _701 = corrected.g, _707 = corrected.b;
+    }
+
+    float _726 = mad(0.0433130674064159393310546875f, _707, mad(0.3292830288410186767578125f, _701, _695 * 0.627403914928436279296875f));
+    float _727 = mad(0.01136231608688831329345703125f, _707, mad(0.9195404052734375f, _701, _695 * 0.069097287952899932861328125f));
+    float _728 = mad(0.895595252513885498046875f, _707, mad(0.08801330626010894775390625f, _701, _695 * 0.01639143936336040496826171875f));
+
+    float scalar;
+    if (!RENODX_TONE_MAP_TYPE) {
+      scalar = ConstBuf_passData_m0[2269u].y;
+    } else {
+      scalar = RENODX_DIFFUSE_WHITE_NITS / 100.f;
+    }
+    _726 *= scalar, _727 *= scalar, _728 *= scalar;  // 1.f at slider = 50
+
+    if (!RENODX_USE_PQ_ENCODING) {
+      _845 = ((((((((((_726 * 533095.75f) + 47438308.0f) * _726) + 29063622.0f) * _726) + 575216.75f) * _726) + 383.091033935546875f) * _726) + 0.000487781013362109661102294921875f) / ((((((((_726 * 66391356.0f) + 81884528.0f) * _726) + 4182885.0f) * _726) + 10668.404296875f) * _726) + 1.0f);
+      _846 = ((((((((((_727 * 533095.75f) + 47438308.0f) * _727) + 29063622.0f) * _727) + 575216.75f) * _727) + 383.091033935546875f) * _727) + 0.000487781013362109661102294921875f) / ((((((((_727 * 66391356.0f) + 81884528.0f) * _727) + 4182885.0f) * _727) + 10668.404296875f) * _727) + 1.0f);
+      _847 = ((((((((((_728 * 533095.75f) + 47438308.0f) * _728) + 29063622.0f) * _728) + 575216.75f) * _728) + 383.091033935546875f) * _728) + 0.000487781013362109661102294921875f) / ((((((((_728 * 66391356.0f) + 81884528.0f) * _728) + 4182885.0f) * _728) + 10668.404296875f) * _728) + 1.0f);
+    } else {
+      float3 pq_color = renodx::color::pq::EncodeSafe(float3(_726, _727, _728), 100.f);
+      _845 = pq_color.r, _846 = pq_color.g, _847 = pq_color.b;
+    }
+  } else {
+    _845 = (_593 < 0.003130800090730190277099609375f) ? (_579 * 0.12919999659061431884765625f) : ((exp2(_598 * 0.4166666567325592041015625f) * 1.05499994754791259765625f) + (-0.054999999701976776123046875f));
+    _846 = (_595 < 0.003130800090730190277099609375f) ? (_585 * 0.12919999659061431884765625f) : ((exp2(_599 * 0.4166666567325592041015625f) * 1.05499994754791259765625f) + (-0.054999999701976776123046875f));
+    _847 = (_596 < 0.003130800090730190277099609375f) ? (_591 * 0.12919999659061431884765625f) : ((exp2(_600 * 0.4166666567325592041015625f) * 1.05499994754791259765625f) + (-0.054999999701976776123046875f));
+  }
+  float _857 = dot(float3(0.300000011920928955078125f, 0.60000002384185791015625f, 0.114000000059604644775390625f), float3(_845, _846, _847)) * 0.300000011920928955078125f;
+  SV_Target.x = (((_857 - _845) * ConstBuf_modelData_m0[2u].z) + _845) * ConstBuf_modelData_m0[2u].x;
+  SV_Target.y = (((_857 - _846) * ConstBuf_modelData_m0[2u].z) + _846) * ConstBuf_modelData_m0[2u].x;
+  SV_Target.z = (((_857 - _847) * ConstBuf_modelData_m0[2u].z) + _847) * ConstBuf_modelData_m0[2u].x;
+
+  SV_Target.w = ConstBuf_modelData_m0[2u].x;
+
+  discard_exit();
+}
+
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input) {
+  gl_FragCoord = stage_input.gl_FragCoord;
+  gl_FragCoord.w = 1.0 / gl_FragCoord.w;
+  TEXCOORD = stage_input.TEXCOORD;
+  NORMAL = stage_input.NORMAL;
+  TANGENT = stage_input.TANGENT;
+  PREV_POSITION_PS = stage_input.PREV_POSITION_PS;
+  VERTEX_ID = stage_input.VERTEX_ID;
+  frag_main();
+  SPIRV_Cross_Output stage_output;
+  stage_output.SV_Target = SV_Target;
+  return stage_output;
+}

--- a/src/games/gowragnarok/compute_bloom_0xC66F9B98.cs_6_6.hlsl
+++ b/src/games/gowragnarok/compute_bloom_0xC66F9B98.cs_6_6.hlsl
@@ -1,0 +1,169 @@
+#include "./shared.h"
+
+cbuffer ConstBuf_constantsUBO : register(b0, space0) {
+  float4 ConstBuf_constants_m0[15] : packoffset(c0);
+};
+
+// Texture2D<float4> _9[] : register(t0, space0);
+// SamplerState _13[] : register(s0, space0);
+// Texture3D<float4> _17[] : register(t0, space0);
+// RWTexture2D<float4> _21[] : register(u0, space0);
+
+static uint3 gl_GlobalInvocationID;
+struct SPIRV_Cross_Input {
+  uint3 gl_GlobalInvocationID : SV_DispatchThreadID;
+};
+
+void comp_main() {
+  float _39 = float(gl_GlobalInvocationID.x);
+  float _40 = float(gl_GlobalInvocationID.y);
+  float _50 = ConstBuf_constants_m0[14u].y * (_39 + 0.5f);
+  float _51 = (_40 + 0.5f) * ConstBuf_constants_m0[14u].z;
+  uint4 _59 = asuint(ConstBuf_constants_m0[13u]);
+  uint texIndex = _59.y;  // uint _60 = _59.y;
+  float _64 = ConstBuf_constants_m0[14u].y * _39;
+  float _67 = ConstBuf_constants_m0[14u].z * (_40 + 1.0f);
+  uint samplerIndex = _59.x;  // uint _68 = _59.x;
+
+  Texture2D<float4> tex = ResourceDescriptorHeap[texIndex];    // _9[_60]
+  SamplerState samp = ResourceDescriptorHeap[samplerIndex];    // _13[_68]
+  float4 _75 = tex.SampleLevel(samp, float2(_64, _67), 0.0f);  // float4 _75 = _9[_60].SampleLevel(_13[_68], float2(_64, _67), 0.0f);
+
+  uint lutIndex = asuint(ConstBuf_constants_m0[14u].x);
+  Texture3D<float4> lut = ResourceDescriptorHeap[lutIndex];  // _17[asuint(ConstBuf_constants_m0[14u]).x]
+
+  uint outputIndex = _59.w;
+  RWTexture2D<float4> outTex = ResourceDescriptorHeap[outputIndex];
+
+  float _78 = _75.x;
+  float _97 = 1.0f / max(9.9999997473787516355514526367188e-06f, 4.0f - dot(float3(0.2125999927520751953125f, 0.715200006961822509765625f, 0.072200000286102294921875f), float3(_78, _75.yz)));
+  float _98 = (_78 * 4.0f) * _97;
+  float _99 = (_75.y * 4.0f) * _97;
+  float _100 = (_75.z * 4.0f) * _97;
+  bool _106 = ConstBuf_constants_m0[2u].x != 0.0f;
+  float _163;
+  float _164;
+  float _165;
+  if (_106) {
+    float _115 = 1.0f / ConstBuf_constants_m0[2u].y;
+    float _116 = _115 * _98;
+    float _117 = _115 * _99;
+    float _118 = _115 * _100;
+    float4 _136 = lut.SampleLevel(samp, float3(_50, _51, (ConstBuf_constants_m0[12u].x * log2(max(9.9999999747524270787835121154785e-07f, dot(float3(0.2125999927520751953125f, 0.715200006961822509765625f, 0.072200000286102294921875f), float3(_116, _117, _118))) * 8.0f)) + ConstBuf_constants_m0[12u].y), 0.0f);
+    float _146 = ((_136.x / max(9.9999997473787516355514526367188e-05f, _136.y)) + 2.4739310741424560546875f) - ConstBuf_constants_m0[2u].z;
+    float _159 = exp2((-0.0f) - (ConstBuf_constants_m0[2u].z + (((_146 < 0.0f) ? ConstBuf_constants_m0[2u].w : ConstBuf_constants_m0[3u].x) * _146))) * 8.0f;
+    _163 = _159 * _116;
+    _164 = _159 * _117;
+    _165 = _159 * _118;
+  } else {
+    _163 = _98;
+    _164 = _99;
+    _165 = _100;
+  }
+  float _166 = dot(float3(0.2125999927520751953125f, 0.715200006961822509765625f, 0.072200000286102294921875f), float3(_163, _164, _165));
+  float _170 = max(0.0f, _166 - ConstBuf_constants_m0[1u].x);
+  float _174 = max(_166, 9.9999997473787516355514526367188e-06f);
+  float _182 = ConstBuf_constants_m0[14u].y * (_39 + 1.0f);
+  float _183 = ConstBuf_constants_m0[14u].z * _40;
+  float4 _185 = tex.SampleLevel(samp, float2(_182, _183), 0.0f);
+  float _187 = _185.x;
+  float _199 = 1.0f / max(9.9999997473787516355514526367188e-06f, 4.0f - dot(float3(0.2125999927520751953125f, 0.715200006961822509765625f, 0.072200000286102294921875f), float3(_187, _185.yz)));
+  float _200 = (_187 * 4.0f) * _199;
+  float _201 = (_185.y * 4.0f) * _199;
+  float _202 = (_185.z * 4.0f) * _199;
+  float _250;
+  float _251;
+  float _252;
+  if (_106) {
+    float _210 = 1.0f / ConstBuf_constants_m0[2u].y;
+    float _211 = _210 * _200;
+    float _212 = _210 * _201;
+    float _213 = _210 * _202;
+    float4 _227 = lut.SampleLevel(samp, float3(_50, _51, (ConstBuf_constants_m0[12u].x * log2(max(9.9999999747524270787835121154785e-07f, dot(float3(0.2125999927520751953125f, 0.715200006961822509765625f, 0.072200000286102294921875f), float3(_211, _212, _213))) * 8.0f)) + ConstBuf_constants_m0[12u].y), 0.0f);
+    float _235 = ((_227.x / max(9.9999997473787516355514526367188e-05f, _227.y)) + 2.4739310741424560546875f) - ConstBuf_constants_m0[2u].z;
+    float _246 = exp2((-0.0f) - (ConstBuf_constants_m0[2u].z + (((_235 < 0.0f) ? ConstBuf_constants_m0[2u].w : ConstBuf_constants_m0[3u].x) * _235))) * 8.0f;
+    _250 = _246 * _211;
+    _251 = _246 * _212;
+    _252 = _246 * _213;
+  } else {
+    _250 = _200;
+    _251 = _201;
+    _252 = _202;
+  }
+  float _253 = dot(float3(0.2125999927520751953125f, 0.715200006961822509765625f, 0.072200000286102294921875f), float3(_250, _251, _252));
+  float _257 = max(0.0f, _253 - ConstBuf_constants_m0[1u].x);
+  float _261 = max(_253, 9.9999997473787516355514526367188e-06f);
+  float4 _273 = tex.SampleLevel(samp, float2(_182, _67), 0.0f);
+  float _275 = _273.x;
+  float _287 = 1.0f / max(9.9999997473787516355514526367188e-06f, 4.0f - dot(float3(0.2125999927520751953125f, 0.715200006961822509765625f, 0.072200000286102294921875f), float3(_275, _273.yz)));
+  float _288 = (_275 * 4.0f) * _287;
+  float _289 = (_273.y * 4.0f) * _287;
+  float _290 = (_273.z * 4.0f) * _287;
+  float _338;
+  float _339;
+  float _340;
+  if (_106) {
+    float _298 = 1.0f / ConstBuf_constants_m0[2u].y;
+    float _299 = _298 * _288;
+    float _300 = _298 * _289;
+    float _301 = _298 * _290;
+    float4 _315 = lut.SampleLevel(samp, float3(_50, _51, (ConstBuf_constants_m0[12u].x * log2(max(9.9999999747524270787835121154785e-07f, dot(float3(0.2125999927520751953125f, 0.715200006961822509765625f, 0.072200000286102294921875f), float3(_299, _300, _301))) * 8.0f)) + ConstBuf_constants_m0[12u].y), 0.0f);
+    float _323 = ((_315.x / max(9.9999997473787516355514526367188e-05f, _315.y)) + 2.4739310741424560546875f) - ConstBuf_constants_m0[2u].z;
+    float _334 = exp2((-0.0f) - (ConstBuf_constants_m0[2u].z + (((_323 < 0.0f) ? ConstBuf_constants_m0[2u].w : ConstBuf_constants_m0[3u].x) * _323))) * 8.0f;
+    _338 = _334 * _299;
+    _339 = _334 * _300;
+    _340 = _334 * _301;
+  } else {
+    _338 = _288;
+    _339 = _289;
+    _340 = _290;
+  }
+  float _341 = dot(float3(0.2125999927520751953125f, 0.715200006961822509765625f, 0.072200000286102294921875f), float3(_338, _339, _340));
+  float _345 = max(0.0f, _341 - ConstBuf_constants_m0[1u].x);
+  float _349 = max(_341, 9.9999997473787516355514526367188e-06f);
+  float4 _361 = tex.SampleLevel(samp, float2(_64, _183), 0.0f);
+  float _363 = _361.x;
+  float _375 = 1.0f / max(9.9999997473787516355514526367188e-06f, 4.0f - dot(float3(0.2125999927520751953125f, 0.715200006961822509765625f, 0.072200000286102294921875f), float3(_363, _361.yz)));
+  float _376 = (_363 * 4.0f) * _375;
+  float _377 = (_361.y * 4.0f) * _375;
+  float _378 = (_361.z * 4.0f) * _375;
+  float _426;
+  float _427;
+  float _428;
+  if (_106) {
+    float _386 = 1.0f / ConstBuf_constants_m0[2u].y;
+    float _387 = _386 * _376;
+    float _388 = _386 * _377;
+    float _389 = _386 * _378;
+    float4 _403 = lut.SampleLevel(samp, float3(_50, _51, (ConstBuf_constants_m0[12u].x * log2(max(9.9999999747524270787835121154785e-07f, dot(float3(0.2125999927520751953125f, 0.715200006961822509765625f, 0.072200000286102294921875f), float3(_387, _388, _389))) * 8.0f)) + ConstBuf_constants_m0[12u].y), 0.0f);
+    float _411 = ((_403.x / max(9.9999997473787516355514526367188e-05f, _403.y)) + 2.4739310741424560546875f) - ConstBuf_constants_m0[2u].z;
+    float _422 = exp2((-0.0f) - (ConstBuf_constants_m0[2u].z + (((_411 < 0.0f) ? ConstBuf_constants_m0[2u].w : ConstBuf_constants_m0[3u].x) * _411))) * 8.0f;
+    _426 = _422 * _387;
+    _427 = _422 * _388;
+    _428 = _422 * _389;
+  } else {
+    _426 = _376;
+    _427 = _377;
+    _428 = _378;
+  }
+  float _429 = dot(float3(0.2125999927520751953125f, 0.715200006961822509765625f, 0.072200000286102294921875f), float3(_426, _427, _428));
+  float _433 = max(0.0f, _429 - ConstBuf_constants_m0[1u].x);
+  float _437 = max(_429, 9.9999997473787516355514526367188e-06f);
+
+  float4 final_color = float4(
+      (((max(0.0f, (_257 * _250) / _261) + max(0.0f, (_170 * _163) / _174)) + max(0.0f, (_345 * _338) / _349)) + max(0.0f, (_433 * _426) / _437)) * 0.25f,
+      (((max(0.0f, (_257 * _251) / _261) + max(0.0f, (_170 * _164) / _174)) + max(0.0f, (_345 * _339) / _349)) + max(0.0f, (_433 * _427) / _437)) * 0.25f,
+      (((max(0.0f, (_257 * _252) / _261) + max(0.0f, (_170 * _165) / _174)) + max(0.0f, (_345 * _340) / _349)) + max(0.0f, (_433 * _428) / _437)) * 0.25f,
+      (((_185.w + _75.w) + _273.w) + _361.w) * 0.25f);
+
+  final_color.rgb *= CUSTOM_BLOOM;
+
+  outTex[uint2(gl_GlobalInvocationID.x, gl_GlobalInvocationID.y)] = final_color;
+  //   outTex[uint2(gl_GlobalInvocationID.x, gl_GlobalInvocationID.y)] = float4((((max(0.0f, (_257 * _250) / _261) + max(0.0f, (_170 * _163) / _174)) + max(0.0f, (_345 * _338) / _349)) + max(0.0f, (_433 * _426) / _437)) * 0.25f, (((max(0.0f, (_257 * _251) / _261) + max(0.0f, (_170 * _164) / _174)) + max(0.0f, (_345 * _339) / _349)) + max(0.0f, (_433 * _427) / _437)) * 0.25f, (((max(0.0f, (_257 * _252) / _261) + max(0.0f, (_170 * _165) / _174)) + max(0.0f, (_345 * _340) / _349)) + max(0.0f, (_433 * _428) / _437)) * 0.25f, (((_185.w + _75.w) + _273.w) + _361.w) * 0.25f);
+}
+
+[numthreads(8, 8, 1)]
+void main(SPIRV_Cross_Input stage_input) {
+  gl_GlobalInvocationID = stage_input.gl_GlobalInvocationID;
+  comp_main();
+}

--- a/src/games/gowragnarok/final_0x903B49C1.ps_6_6.hlsl
+++ b/src/games/gowragnarok/final_0x903B49C1.ps_6_6.hlsl
@@ -1,0 +1,174 @@
+#include "./shared.h"
+
+cbuffer ConstBuf_passDataUBO : register(b0, space0) {
+  float4 ConstBuf_passData_m0[39] : packoffset(c0);
+};
+
+// Don't declare _9[] or _13[] — use ResourceDescriptorHeap directly
+// Texture2D<float4> _9[] : register(t0, space0);
+// SamplerState _13[] : register(s0, space0);
+
+static float4 gl_FragCoord;
+static float2 TEXCOORD;
+static float2 TEXCOORD_1;
+static float4 SV_Target;
+
+struct SPIRV_Cross_Input {
+  float4 gl_FragCoord : SV_Position;
+  float2 TEXCOORD : TEXCOORD0;
+  float2 TEXCOORD_1 : TEXCOORD1;
+};
+
+struct SPIRV_Cross_Output {
+  float4 SV_Target : SV_Target0;
+};
+
+namespace rec709 {
+static const float REFERENCE_WHITE = 100.f;
+
+float3 OETF(float3 channel) {
+  const float3 linearPart = channel * 4.5f;
+  const float3 nonLinearPart = 1.099f * pow(channel, 0.45f) - 0.099f;
+  return select(nonLinearPart, linearPart, channel < 0.018f);
+}
+
+float3 InverseOETF(float3 channel) {
+  const float3 linearPart = channel / 4.5f;
+  const float3 nonLinearPart = pow((channel + 0.099f) / 1.099f, 1.0f / 0.45f);
+  return select(nonLinearPart, linearPart, channel < 0.081f);  // 0.081 = 0.018 * 4.5
+}
+
+}  // namespace rec709
+
+void frag_main() {
+  uint _56 = uint(int((ConstBuf_passData_m0[10u].x - ConstBuf_passData_m0[9u].z) * 0.5f));
+  uint _57 = uint(int((ConstBuf_passData_m0[10u].y - ConstBuf_passData_m0[9u].w) * 0.5f));
+  uint _64 = uint(int(gl_FragCoord.x));
+  uint _65 = uint(int(gl_FragCoord.y));
+  if ((int(_65) > int(uint(int(float(int(_57)) + ConstBuf_passData_m0[9u].w)))) || (((int(_64) < int(_56)) || (int(_65) < int(_57))) || (int(_64) > int(uint(int(float(int(_56)) + ConstBuf_passData_m0[9u].z)))))) {
+    SV_Target.x = 0.0f;
+    SV_Target.y = 0.0f;
+    SV_Target.z = 0.0f;
+    SV_Target.w = 1.0f;
+  } else {
+    uint _83 = _64 - _56;
+    uint _84 = _65 - _57;
+    uint4 _89 = asuint(ConstBuf_passData_m0[38u]);
+
+    uint texIndex = _89.x;  // uint _90 = _89.x;
+    Texture2D<float4> tex = ResourceDescriptorHeap[texIndex];
+
+    float4 _94 = tex.Load(int3(uint2(_83, _84), 0u));  // float4 _94 = _9[_90].Load(int3(uint2(_83, _84), 0u));
+    float _97 = _94.x;
+    float _98 = _94.y;
+    float _99 = _94.z;
+    float _193;
+    float _194;
+    float _195;
+    if (ConstBuf_passData_m0[18u].w != 0.0f) {
+      float4 _107 = tex.Load(int3(uint2(_83 + 4294967295u, _84), 0u));
+      float _109 = _107.x;
+      float _110 = _107.y;
+      float _111 = _107.z;
+      float4 _113 = tex.Load(int3(uint2(_83 + 1u, _84), 0u));
+      float _115 = _113.x;
+      float _116 = _113.y;
+      float _117 = _113.z;
+      float4 _119 = tex.Load(int3(uint2(_83, _84 + 1u), 0u));
+      float _121 = _119.x;
+      float _122 = _119.y;
+      float _123 = _119.z;
+      float4 _125 = tex.Load(int3(uint2(_83, _84 + 4294967295u), 0u));
+      float _127 = _125.x;
+      float _128 = _125.y;
+      float _129 = _125.z;
+      float _138 = min(min(_97, min(_109, _115)), min(_121, _127));
+      float _140 = min(min(_98, min(_110, _116)), min(_122, _128));
+      float _142 = min(min(_99, min(_111, _117)), min(_123, _129));
+      float _164 = (((_115 + _109) + _121) + _127) * 0.25f;
+      float _166 = (((_116 + _110) + _122) + _128) * 0.25f;
+      float _167 = (((_117 + _111) + _123) + _129) * 0.25f;
+      float _178 = (ConstBuf_passData_m0[19u].x * (_97 - _164)) + _164;
+      float _179 = (ConstBuf_passData_m0[19u].x * (_98 - _166)) + _166;
+      float _180 = (ConstBuf_passData_m0[19u].x * (_99 - _167)) + _167;
+      _193 = max(min(_178, _138), min(max(_178, _138), max(max(_97, max(_109, _115)), max(_121, _127))));
+      _194 = max(min(_179, _140), min(max(_179, _140), max(max(_98, max(_110, _116)), max(_122, _128))));
+      _195 = max(min(_180, _142), min(max(_180, _142), max(max(_99, max(_111, _117)), max(_123, _129))));
+    } else {
+      _193 = _97;
+      _194 = _98;
+      _195 = _99;
+    }
+    float _199 = dot(float3(clamp(_193, 0.0f, 1.0f), clamp(_194, 0.0f, 1.0f), clamp(_195, 0.0f, 1.0f)), float3(0.2989999949932098388671875f, 0.58700001239776611328125f, 0.114000000059604644775390625f));
+    float _209 = clamp(1.0f - (_199 * 4.0f), 0.0f, 1.0f);
+    float _214 = clamp((_199 * 8.0f) + (-1.0f), 0.0f, 1.0f);
+
+    Texture2D<float4> texInput = ResourceDescriptorHeap[_89.y];
+    SamplerState samp = ResourceDescriptorHeap[asuint(ConstBuf_passData_m0[37u]).z];
+
+    float4 sample = texInput.SampleLevel(
+        samp,
+        float2((ConstBuf_passData_m0[17u].x * TEXCOORD.x) + ConstBuf_passData_m0[17u].z,
+               (ConstBuf_passData_m0[17u].y * TEXCOORD.y) + ConstBuf_passData_m0[17u].w),
+        0.0f);
+
+    float _256 = ((sample.x * 2.0f) - 1.0f) * (((ConstBuf_passData_m0[18u].z * _214) + (ConstBuf_passData_m0[18u].x * _209)) + (ConstBuf_passData_m0[18u].y * clamp((1.0f - _209) - _214, 0.0f, 1.0f)));
+
+    float _260 = max(_256 + _193, 0.0f);
+    float _261 = max(_256 + _194, 0.0f);
+    float _262 = max(_256 + _195, 0.0f);
+
+    float _309, _310, _311;
+    float3 x = float3(_260, _261, _262);
+    float3 corrected;
+    if (RENODX_TONE_MAP_TYPE == 0.f) {
+      const float a = 0.89722502231597900390625f;
+      const float b = -0.001492740004323422908782958984375f;
+      //   const float b = 0.005;
+      const float c = 0.01871629990637302398681640625f;
+      const float d = 0.686428010463714599609375f;
+      const float e = 1.11840999126434326171875f;
+      const float f = 0.072178699076175689697265625f;
+
+      corrected = (x * x * (x + a) + x * b) / (((((x * c) + d) * x + e) * x) + f);
+
+      _309 = corrected.r, _310 = corrected.g, _311 = corrected.b;
+    } else {
+      x = renodx::color::correct::GammaSafe(x);
+      _309 = x.r, _310 = x.g, _311 = x.b;
+    }
+
+    float _330 = mad(0.0433130674064159393310546875f, _311, mad(0.3292830288410186767578125f, _310, _309 * 0.627403914928436279296875f));
+    float _331 = mad(0.01136231608688831329345703125f, _311, mad(0.9195404052734375f, _310, _309 * 0.069097287952899932861328125f));
+    float _332 = mad(0.895595252513885498046875f, _311, mad(0.08801330626010894775390625f, _310, _309 * 0.01639143936336040496826171875f));
+    float3 bt2020_color = float3(_330, _331, _332);
+
+    float scalar;
+    if (RENODX_TONE_MAP_TYPE == 0.f) {
+      scalar = ConstBuf_passData_m0[29u].y;
+    } else {
+      scalar = RENODX_DIFFUSE_WHITE_NITS / 100.f;
+    }
+    _330 *= scalar, _331 *= scalar, _332 *= scalar;  // 1.f at slider = 50
+
+    if (RENODX_USE_PQ_ENCODING == 0.f) {
+      SV_Target.x = ((((((((((_330 * 533095.75f) + 47438308.0f) * _330) + 29063622.0f) * _330) + 575216.75f) * _330) + 383.091033935546875f) * _330) + 0.000487781013362109661102294921875f) / ((((((((_330 * 66391356.0f) + 81884528.0f) * _330) + 4182885.0f) * _330) + 10668.404296875f) * _330) + 1.0f);
+      SV_Target.y = ((((((((((_331 * 533095.75f) + 47438308.0f) * _331) + 29063622.0f) * _331) + 575216.75f) * _331) + 383.091033935546875f) * _331) + 0.000487781013362109661102294921875f) / ((((((((_331 * 66391356.0f) + 81884528.0f) * _331) + 4182885.0f) * _331) + 10668.404296875f) * _331) + 1.0f);
+      SV_Target.z = ((((((((((_332 * 533095.75f) + 47438308.0f) * _332) + 29063622.0f) * _332) + 575216.75f) * _332) + 383.091033935546875f) * _332) + 0.000487781013362109661102294921875f) / ((((((((_332 * 66391356.0f) + 81884528.0f) * _332) + 4182885.0f) * _332) + 10668.404296875f) * _332) + 1.0f);
+    } else {
+      SV_Target.rgb = renodx::color::pq::EncodeSafe(float3(_330, _331, _332), 100.f);
+    }
+    SV_Target.w = 1.0f;
+  }
+}
+
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input) {
+  gl_FragCoord = stage_input.gl_FragCoord;
+  gl_FragCoord.w = 1.0 / gl_FragCoord.w;
+  TEXCOORD = stage_input.TEXCOORD;
+  TEXCOORD_1 = stage_input.TEXCOORD_1;
+  frag_main();
+  SPIRV_Cross_Output stage_output;
+  stage_output.SV_Target = SV_Target;
+  return stage_output;
+}

--- a/src/games/gowragnarok/shared.h
+++ b/src/games/gowragnarok/shared.h
@@ -1,0 +1,41 @@
+#ifndef SRC_GOWRAGNAROK_SHARED_H
+#define SRC_GOWRAGNAROK_SHARED_H
+
+// #define RENODX_PEAK_WHITE_NITS      1000.f
+// #define RENODX_DIFFUSE_WHITE_NITS   203.f
+// #define RENODX_OVERRIDE_PEAK_NITS   1u
+// #define RENODX_TONE_MAP_TYPE        1u
+// #define RENODX_TONE_MAP_EXPOSURE    1.f
+// #define CUSTOM_BLOOM                1.f
+// #define RENODX_USE_PQ_ENCODING      1u
+
+// Must be 32bit aligned
+// Should be 4x32
+struct ShaderInjectData {
+  float tone_map_type;
+  float tone_map_override_peak_nits;
+  float peak_white_nits;
+  float diffuse_white_nits;
+  float tone_map_exposure;
+  float custom_bloom;
+  float custom_hdr10_encoding;
+};
+
+#ifndef __cplusplus
+cbuffer shader_injection : register(b13, space50) {
+  ShaderInjectData shader_injection : packoffset(c0);
+}
+
+#define RENODX_TONE_MAP_TYPE      shader_injection.tone_map_type
+#define RENODX_OVERRIDE_PEAK_NITS shader_injection.tone_map_override_peak_nits
+#define RENODX_PEAK_WHITE_NITS    shader_injection.peak_white_nits
+#define RENODX_DIFFUSE_WHITE_NITS shader_injection.diffuse_white_nits
+#define RENODX_TONE_MAP_EXPOSURE  shader_injection.tone_map_exposure
+#define CUSTOM_BLOOM              shader_injection.custom_bloom
+#define RENODX_USE_PQ_ENCODING    shader_injection.custom_hdr10_encoding
+
+#include "../../shaders/renodx.hlsl"
+
+#endif
+
+#endif  // SRC_GOWRAGNAROK_SHARED_H

--- a/src/games/gowragnarok/tonemap_0x4D780747.cs_6_6.hlsl
+++ b/src/games/gowragnarok/tonemap_0x4D780747.cs_6_6.hlsl
@@ -1,0 +1,175 @@
+#include "./shared.h"
+cbuffer ConstBuf_constantsUBO : register(b0, space0) {
+  float4 ConstBuf_constants_m0[11] : packoffset(c0);
+};
+
+// ResourceDescriptorHeap
+// RWTexture1D<float4> _9[] : register(u0, space0);
+
+static uint3 gl_GlobalInvocationID;
+struct SPIRV_Cross_Input {
+  uint3 gl_GlobalInvocationID : SV_DispatchThreadID;
+};
+
+void comp_main() {
+  RWTexture1D<float4> outputTexture = ResourceDescriptorHeap[asuint(ConstBuf_constants_m0[10u].x)];
+
+  float peak_nits = min(4000.0f, ConstBuf_constants_m0[4u].z);
+  float min_nits = max(9.9999997473787516355514526367188e-05f, ConstBuf_constants_m0[3u].w);
+  float exposure = ConstBuf_constants_m0[4u].x;  // brightness slider
+
+  if (RENODX_OVERRIDE_PEAK_NITS) {
+    peak_nits = RENODX_PEAK_WHITE_NITS;
+  }
+  if (RENODX_TONE_MAP_TYPE) {
+    min_nits = 0.0001f;
+    exposure = 8.f * RENODX_TONE_MAP_EXPOSURE;
+    float scale = 100.f / RENODX_DIFFUSE_WHITE_NITS;
+    peak_nits *= scale;
+    min_nits *= scale;
+
+    float invDiffuseWhite = 1.0f / RENODX_DIFFUSE_WHITE_NITS;
+    peak_nits = renodx::color::correct::Gamma(peak_nits * invDiffuseWhite, true) * RENODX_DIFFUSE_WHITE_NITS;
+    min_nits = renodx::color::correct::Gamma(min_nits * invDiffuseWhite, true) * RENODX_DIFFUSE_WHITE_NITS;
+  }
+
+  float _44 = log2(min_nits);  // float _44 = log2(max(9.9999997473787516355514526367188e-05f, ConstBuf_constants_m0[3u].w));
+  float _51 = clamp((_44 * 0.13082401454448699951171875f) + 1.7383518218994140625f, 0.0f, 1.0f);
+  float _58 = exp2((_51 * (-6.5f)) - ((1.0f - _51) * 15.0f));
+  float _61 = log2(peak_nits);  // float _61 = log2(max(9.9999997473787516355514526367188e-05f, ConstBuf_constants_m0[3u].w));
+  float _66 = clamp((_61 * 0.1298237740993499755859375f) + (-0.725060939788818359375f), 0.0f, 1.0f);
+  float _73 = exp2(((1.0f - _66) * 6.5f) + (_66 * 18.0f));
+  float _75 = log2(_58 * 0.180000007152557373046875f);
+  float _76 = _44 * 0.3010300099849700927734375f;
+  float _78 = _75 * 0.077766083180904388427734375f;
+  float _80 = _78 + 0.873629271984100341796875f;
+  float _82 = 0.48885345458984375f - _78;
+  float _88 = clamp((log2(_58) + 15.0f) * 0.117647059261798858642578125f, 0.0f, 1.0f);
+  float _97 = ((0.681241333484649658203125f - _76) * (((1.0f - _88) * 0.180000007152557373046875f) + (_88 * 0.3499999940395355224609375f))) + _76;
+  float _98 = log2(_73 * 0.180000007152557373046875f);
+  float _99 = _98 * 0.077766083180904388427734375f;
+  float _100 = 0.48885345458984375f - _99;
+  float _101 = _99 + 0.873629271984100341796875f;
+  float _102 = _61 * 0.3010300099849700927734375f;
+  float _107 = clamp((log2(_73) + (-6.5f)) * 0.086956523358821868896484375f, 0.0f, 1.0f);
+  float _117 = ((((1.0f - _107) * 0.88999998569488525390625f) + (_107 * 0.89999997615814208984375f)) * (_102 + (-0.681241333484649658203125f))) + 0.681241333484649658203125f;
+  float _120 = log2(exp2(_75));
+  float _125 = log2(exp2(_98));
+  float _133 = (_97 + _76) * 0.5f;
+  float _138 = (_117 + _101) * 0.5f;
+  float _144 = log2(max(exposure, 1.0000000133514319600180897396058e-10f)) * 0.3010300099849700927734375f;
+  float _157;
+  if (_144 > _76) {
+    float frontier_phi_5_1_ladder;
+    if ((_144 <= 0.681241333484649658203125f) && (_144 > _76)) {
+      float _206;
+      float _208;
+      float _210;
+      float _212;
+      if ((_144 > ((_44 + _44) * 0.15051500499248504638671875f)) && (_144 <= _133)) {
+        _206 = 0.0f;
+        _208 = _76;
+        _210 = _76;
+        _212 = _97;
+      } else {
+        bool _238 = (_144 > _133) && (_144 <= ((_97 + _80) * 0.5f));
+        _206 = _238 ? 1.0f : 2.0f;
+        _208 = _238 ? _76 : _97;
+        _210 = _238 ? _97 : _80;
+        _212 = _238 ? _80 : _82;
+      }
+      float _214 = _208 * 0.5f;
+      float _218 = _210 - _208;
+      float _220 = mad(_210, 0.5f, _214) - _144;
+      frontier_phi_5_1_ladder = (_120 * 0.3010300099849700927734375f) + ((((_220 * 2.0f) / (((-0.0f) - _218) - sqrt((_218 * _218) - ((mad(_212, 0.5f, mad(_210, -1.0f, _214)) * 4.0f) * _220)))) + _206) * ((-0.24824249744415283203125f) - (_120 * 0.100343339145183563232421875f)));
+    } else {
+      float frontier_phi_5_1_ladder_4_ladder;
+      if ((_144 > 0.681241333484649658203125f) && (_144 < _102)) {
+        float _267;
+        float _269;
+        float _271;
+        float _273;
+        if ((_144 >= 0.68124139308929443359375f) && (_144 <= _138)) {
+          _267 = 0.0f;
+          _269 = _100;
+          _271 = _101;
+          _273 = _117;
+        } else {
+          bool _294 = (_144 > _138) && (_144 <= ((_117 + _102) * 0.5f));
+          _267 = _294 ? 1.0f : 2.0f;
+          _269 = _294 ? _101 : _117;
+          _271 = _294 ? _117 : _102;
+          _273 = _102;
+        }
+        float _274 = _269 * 0.5f;
+        float _277 = _271 - _269;
+        float _279 = mad(_271, 0.5f, _274) - _144;
+        frontier_phi_5_1_ladder_4_ladder = ((((_279 * 2.0f) / (((-0.0f) - _277) - sqrt((_277 * _277) - ((mad(_273, 0.5f, mad(_271, -1.0f, _274)) * 4.0f) * _279)))) + _267) * ((_125 * 0.100343339145183563232421875f) + 0.24824249744415283203125f)) + (-0.74472749233245849609375f);
+      } else {
+        frontier_phi_5_1_ladder_4_ladder = _125 * 0.3010300099849700927734375f;
+      }
+      frontier_phi_5_1_ladder = frontier_phi_5_1_ladder_4_ladder;
+    }
+    _157 = frontier_phi_5_1_ladder;
+  } else {
+    _157 = _120 * 0.3010300099849700927734375f;
+  }
+  float _164 = log2(exp2(_157 * 3.3219280242919921875f));
+  float _165 = _164 + 2.4739310741424560546875f;
+  float _27[6];
+  _27[0u] = _76;
+  _27[1u] = _76;
+  _27[2u] = _97;
+  _27[3u] = _80;
+  _27[4u] = _82;
+  _27[5u] = _82;
+  float _28[6];
+  _28[0u] = _100;
+  _28[1u] = _101;
+  _28[2u] = _117;
+  _28[3u] = _102;
+  _28[4u] = _102;
+  _28[5u] = _102;
+  float _201 = log2(max(exp2(((float(gl_GlobalInvocationID.x) * 33.0f) * ConstBuf_constants_m0[10u].y) + (-15.0f)) * 0.180000007152557373046875f, 5.9604644775390625e-08f));  // not brightness slider
+  float _202 = _201 * 0.3010300099849700927734375f;
+  float _203 = log2(exp2(_75 - _165));
+  float _204 = _203 * 0.3010300099849700927734375f;
+  float _251;
+  if (_202 > _204) {
+    float _247 = log2(exp2((-4.947862148284912109375f) - _164));
+    float _248 = _247 * 0.3010300099849700927734375f;
+    float frontier_phi_11_10_ladder;
+    if ((_202 > _204) && (_202 < _248)) {
+      float _300 = ((_201 - _203) * 0.903090000152587890625f) / ((_247 - _203) * 0.3010300099849700927734375f);
+      uint _301 = uint(int(_300));
+      float _303 = _300 - float(int(_301));
+      uint _306 = _301 + 1u;
+      float _313 = _27[_301] * 0.5f;
+      frontier_phi_11_10_ladder = dot(float3(_303 * _303, _303, 1.0f), float3(mad(_27[_301 + 2u], 0.5f, mad(_27[_306], -1.0f, _313)), _27[_306] - _27[_301], mad(_27[_306], 0.5f, _313)));
+    } else {
+      float _322 = log2(exp2(_98 - _165));
+      float frontier_phi_11_10_ladder_15_ladder;
+      if ((_202 >= _248) && (_202 < (_322 * 0.3010300099849700927734375f))) {
+        float _330 = ((_201 - _247) * 0.903090000152587890625f) / ((_322 - _247) * 0.3010300099849700927734375f);
+        uint _331 = uint(int(_330));
+        float _333 = _330 - float(int(_331));
+        uint _336 = _331 + 1u;
+        float _343 = _28[_331] * 0.5f;
+        frontier_phi_11_10_ladder_15_ladder = dot(float3(_333 * _333, _333, 1.0f), float3(mad(_28[_331 + 2u], 0.5f, mad(_28[_336], -1.0f, _343)), _28[_336] - _28[_331], mad(_28[_336], 0.5f, _343)));
+      } else {
+        frontier_phi_11_10_ladder_15_ladder = _102;
+      }
+      frontier_phi_11_10_ladder = frontier_phi_11_10_ladder_15_ladder;
+    }
+    _251 = frontier_phi_11_10_ladder;
+  } else {
+    _251 = _76;
+  }
+  outputTexture[gl_GlobalInvocationID.x] = (exp2(_251 * 3.3219280242919921875f) * 0.00999999977648258209228515625f).xxxx;  // _9[asuint(ConstBuf_constants_m0[10u]).x][gl_GlobalInvocationID.x] = (exp2(_251 * 3.3219280242919921875f) * 0.00999999977648258209228515625f).xxxx;
+}
+
+[numthreads(64, 1, 1)]
+void main(SPIRV_Cross_Input stage_input) {
+  gl_GlobalInvocationID = stage_input.gl_GlobalInvocationID;
+  comp_main();
+}


### PR DESCRIPTION
## God of War: Ragnarok – HDR Tonemapping Fix & Improvements

### Summary  
Fixes and improves the game's HDR rendering pipeline by correcting PQ encoding, replacing broken exposure logic, and enabling accurate brightness scaling. Preserves the original tonemapper with optional `Vanilla+` enhancements, and adds configurable controls for exposure and bloom. Also bypasses the game’s flawed gamma correction logic for accurate contrast and black levels.

### Key Changes

#### Tone Mapping Shader (`0x4D780747`)
- Preserves the game's **vanilla tonemapper**.
- Adds `Vanilla+` mode:
  - Disables the game’s built-in exposure logic.
  - Adds a **new exposure slider** (`ColorGradeExposure`) for adjusting exposure cleanly when `Vanilla+` is enabled.
  - Applies brightness scaling **after** tonemapping using `ToneMapGameNits` to preserve hue, contrast, and saturation.
  - Dynamically recalculates `peak_nits` and `min_nits` based on gamma correction and game brightness for accurate tonemapping.

#### Final Output Shader (`0x903B49C1`)
- Applies proper **sRGB → 2.2 gamma correction** at the **end of the pipeline**, just before BT.2020 → PQ encoding.
  - This bypasses the game’s flawed gamma correction, which appears to be an incorrect curve fit attempting to correct sRGB to 2.2 gamma.
  - The original logic likely stemmed from developing on 2.2 gamma displays while encoding in sRGB in SDR.
  - Applies when `Vanilla+` is enabled.
- Converts BT.709 → BT.2020 → PQ.
- Supports both the game's approximation curve and proper HDR10 (ST2084) encoding.
- Does **not** affect UI or the HDR calibration image.

#### HDR Calibration Menu Shader (`0x4BB65477`)
- Updated to reflect the same logic as the main scene:
  - Includes brightness scaling and peak/min nits adjustments.

#### Bloom Shader (`0xC66F9B98`)
- Adds a **bloom strength slider** (`FxBloom`) for controlling bloom intensity independently in HDR.

#### Shader Injection
- Uses `CustomShaderEntry()` to patch the following shaders:
  - `0x4D780747` – Tonemap
  - `0x903B49C1` – Final scene output (BT.2020 + PQ)
  - `0x4BB65477` – HDR calibration menu
  - `0xC66F9B98` – Bloom

---

**Tested and verified across multiple scenes with consistent tone mapping, accurate PQ output, and fully adjustable bloom and exposure.**  
**Ready for review.**
