### PR TITLE
feat(farycry5): use inverse midgray calculation for exposure matching

### DIFF
--- a/src/games/farcry5/addon.cpp
+++ b/src/games/farcry5/addon.cpp
@@ -32,11 +32,11 @@ renodx::utils::settings::Settings settings = {
         .key = "ToneMapType",
         .binding = &shader_injection.tone_map_type,
         .value_type = renodx::utils::settings::SettingValueType::INTEGER,
-        .default_value = 2.f,
+        .default_value = 3.f,
         .label = "Tone Mapper",
         .section = "Tone Mapping",
         .tooltip = "Sets the tone mapper type",
-        .labels = {"Vanilla", "None", "Vanilla+"},
+        .labels = {"Vanilla", "None", "Vanilla+", "ACES"},
     },
     new renodx::utils::settings::Setting{
         .key = "ToneMapPeakNits",
@@ -80,6 +80,7 @@ renodx::utils::settings::Settings settings = {
         .section = "Tone Mapping",
         .tooltip = "Overrides in-game contrast slider, emulates a 2.2 EOTF",
         .labels = {"Off", "2.2"},
+        .is_enabled = []() { return shader_injection.tone_map_type != 0; },
     },
     new renodx::utils::settings::Setting{
         .key = "ColorGradeExposure",
@@ -144,7 +145,7 @@ renodx::utils::settings::Settings settings = {
     new renodx::utils::settings::Setting{
         .key = "ColorGradeSceneScaling",
         .binding = &shader_injection.color_grade_scaling,
-        .default_value = 50.f,
+        .default_value = 75.f,
         .label = "Scene Grading Scaling",
         .section = "Color Grading",
         .tooltip = "Scales the scene grading to full range when size is clamped.",

--- a/src/games/farcry5/addon.cpp
+++ b/src/games/farcry5/addon.cpp
@@ -72,6 +72,18 @@ renodx::utils::settings::Settings settings = {
         .is_enabled = []() { return shader_injection.tone_map_type != 0; },
     },
     new renodx::utils::settings::Setting{
+        .key = "ToneMapHueCorrection",
+        .binding = &shader_injection.tone_map_hue_correction,
+        .default_value = 0.f,
+        .label = "Hue Correction",
+        .section = "Tone Mapping",
+        .tooltip = "Hue retention strength.",
+        .min = 0.f,
+        .max = 100.f,
+        .is_enabled = []() { return shader_injection.tone_map_type == 3.f; },
+        .parse = [](float value) { return value * 0.01f; },
+    },
+    new renodx::utils::settings::Setting{
         .key = "ToneMapGammaCorrection",
         .binding = &shader_injection.gamma_correction,
         .value_type = renodx::utils::settings::SettingValueType::BOOLEAN,

--- a/src/games/farcry5/shared.h
+++ b/src/games/farcry5/shared.h
@@ -22,6 +22,7 @@ struct ShaderInjectData {
   float peak_white_nits;
   float diffuse_white_nits;
   float graphics_white_nits;
+  float tone_map_hue_correction;
   float gamma_correction;
   float tone_map_exposure;
   float tone_map_highlights;
@@ -38,19 +39,20 @@ cbuffer cb13 : register(b13) {
   ShaderInjectData shader_injection : packoffset(c0);
 }
 
-#define RENODX_TONE_MAP_TYPE       shader_injection.tone_map_type
-#define RENODX_PEAK_WHITE_NITS     shader_injection.peak_white_nits
-#define RENODX_DIFFUSE_WHITE_NITS  shader_injection.diffuse_white_nits
-#define RENODX_GRAPHICS_WHITE_NITS shader_injection.graphics_white_nits
-#define RENODX_GAMMA_CORRECTION    shader_injection.gamma_correction
-#define RENODX_TONE_MAP_EXPOSURE   shader_injection.tone_map_exposure
-#define RENODX_TONE_MAP_HIGHLIGHTS shader_injection.tone_map_highlights
-#define RENODX_TONE_MAP_SHADOWS    shader_injection.tone_map_shadows
-#define RENODX_TONE_MAP_CONTRAST   shader_injection.tone_map_contrast
-#define RENODX_TONE_MAP_SATURATION shader_injection.tone_map_saturation
-#define RENODX_TONE_MAP_BLOWOUT    shader_injection.tone_map_blowout
-#define RENODX_COLOR_GRADE_SCALING shader_injection.color_grade_scaling
-#define CUSTOM_BLOOM               shader_injection.custom_bloom
+#define RENODX_TONE_MAP_TYPE           shader_injection.tone_map_type
+#define RENODX_PEAK_WHITE_NITS         shader_injection.peak_white_nits
+#define RENODX_DIFFUSE_WHITE_NITS      shader_injection.diffuse_white_nits
+#define RENODX_GRAPHICS_WHITE_NITS     shader_injection.graphics_white_nits
+#define RENODX_TONE_MAP_HUE_CORRECTION shader_injection.tone_map_hue_correction
+#define RENODX_GAMMA_CORRECTION        shader_injection.gamma_correction
+#define RENODX_TONE_MAP_EXPOSURE       shader_injection.tone_map_exposure
+#define RENODX_TONE_MAP_HIGHLIGHTS     shader_injection.tone_map_highlights
+#define RENODX_TONE_MAP_SHADOWS        shader_injection.tone_map_shadows
+#define RENODX_TONE_MAP_CONTRAST       shader_injection.tone_map_contrast
+#define RENODX_TONE_MAP_SATURATION     shader_injection.tone_map_saturation
+#define RENODX_TONE_MAP_BLOWOUT        shader_injection.tone_map_blowout
+#define RENODX_COLOR_GRADE_SCALING     shader_injection.color_grade_scaling
+#define CUSTOM_BLOOM                   shader_injection.custom_bloom
 
 #include "../../shaders/renodx.hlsl"
 


### PR DESCRIPTION
- fix midgray calculation when using `Vanilla+` tonemapper
- add `ACES` tonemapper
- disable gamma correction slider with `Vanilla` tonemapper
- set `scene grading scaling` default to 75