### PR TITLE
fix(unrealengine): Fix resource upgrades on Infinity Nikki v1.5

### DIFF
--- a/src/games/unrealengine/addon.cpp
+++ b/src/games/unrealengine/addon.cpp
@@ -445,6 +445,11 @@ void AddGamePatches() {
     AddAvowedUpgrades();
     reshade::log::message(reshade::log::level::info, std::format("Applied patches for {} ({}).", filename, product_name).c_str());
   }
+
+  if (product_name == "InfinityNikki") {
+    renodx::mods::swapchain::ignored_window_class_names.emplace("bridge");  // Dummy window created by PerfSight.dll
+    reshade::log::message(reshade::log::level::info, std::format("Applied patches for {} ({}).", filename, product_name).c_str());
+  }
 }
 
 const auto UPGRADE_TYPE_NONE = 0.f;
@@ -492,6 +497,12 @@ const std::unordered_map<
         },
         {
             "Avowed",
+            {
+                {"Upgrade_R10G10B10A2_UNORM", UPGRADE_TYPE_OUTPUT_SIZE},
+            },
+        },
+        {
+            "InfinityNikki",
             {
                 {"Upgrade_R10G10B10A2_UNORM", UPGRADE_TYPE_OUTPUT_SIZE},
             },

--- a/src/mods/swapchain.hpp
+++ b/src/mods/swapchain.hpp
@@ -124,6 +124,7 @@ static bool is_vulkan = false;
 static bool swapchain_proxy_compatibility_mode = true;
 static bool swapchain_proxy_revert_state = false;
 static bool bypass_dummy_windows = true;
+static std::unordered_set<std::string> ignored_window_class_names = {};
 static reshade::api::format swap_chain_proxy_format = reshade::api::format::r16g16b16a16_float;
 static std::vector<std::uint8_t> swap_chain_proxy_vertex_shader = {};
 static std::vector<std::uint8_t> swap_chain_proxy_pixel_shader = {};
@@ -1017,6 +1018,42 @@ static void OnDestroyCommandList(reshade::api::command_list* cmd_list) {
   renodx::utils::data::Delete<CommandListData>(cmd_list);
 }
 
+static bool ShouldModifySwapchainHwnd(HWND hwnd) {
+  if (renodx::utils::platform::IsToolWindow(hwnd)) {
+    std::stringstream s;
+    s << "mods::swapchain::ShouldModifySwapchainHwnd(Tool Window: ";
+    s << PRINT_PTR(reinterpret_cast<uintptr_t>(hwnd));
+    s << ")";
+    reshade::log::message(reshade::log::level::info, s.str().c_str());
+    return false;
+  }
+
+  if (bypass_dummy_windows && renodx::utils::platform::IsDummyWindow(hwnd)) {
+    std::stringstream s;
+    s << "mods::swapchain::ShouldModifySwapchainHwnd(Dummy window: ";
+    s << PRINT_PTR(reinterpret_cast<uintptr_t>(hwnd));
+    s << ")";
+    reshade::log::message(reshade::log::level::info, s.str().c_str());
+    return false;
+  }
+
+  if (!ignored_window_class_names.empty()) {
+    auto class_name = renodx::utils::platform::GetWindowClassName(hwnd);
+    if (!class_name.empty()) {
+      if (ignored_window_class_names.contains(class_name)) {
+        std::stringstream s;
+        s << "mods::swapchain::ShouldModifySwapchainHwnd(Ignored class name: ";
+        s << PRINT_PTR(reinterpret_cast<uintptr_t>(hwnd));
+        s << ")";
+        reshade::log::message(reshade::log::level::info, s.str().c_str());
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
 // Before CreatePipelineState
 static bool OnCreateSwapchain(reshade::api::swapchain_desc& desc, void* hwnd) {
   auto abort_modification = [=]() {
@@ -1026,25 +1063,12 @@ static bool OnCreateSwapchain(reshade::api::swapchain_desc& desc, void* hwnd) {
 
   if (!renodx::utils::bitwise::HasFlag(desc.back_buffer.usage, reshade::api::resource_usage::render_target)) {
     std::stringstream s;
-    s << "mods::swapchain::OnCreateSwapchain(Abort from not used for rendering: ";
-    s << PRINT_PTR(reinterpret_cast<uintptr_t>(hwnd));
-    s << ")";
-    reshade::log::message(reshade::log::level::info, s.str().c_str());
     return abort_modification();
   }
 
-  if (renodx::utils::platform::IsToolWindow(static_cast<HWND>(hwnd))) {
+  if (!ShouldModifySwapchainHwnd(static_cast<HWND>(hwnd))) {
     std::stringstream s;
-    s << "mods::swapchain::OnCreateSwapchain(Abort from tool window: ";
-    s << PRINT_PTR(reinterpret_cast<uintptr_t>(hwnd));
-    s << ")";
-    reshade::log::message(reshade::log::level::info, s.str().c_str());
-    return abort_modification();
-  }
-
-  if (bypass_dummy_windows && renodx::utils::platform::IsDummyWindow(static_cast<HWND>(hwnd))) {
-    std::stringstream s;
-    s << "mods::swapchain::OnCreateSwapchain(Abort from dummy window: ";
+    s << "mods::swapchain::OnCreateSwapchain(Abort from ShouldModifySwapchainHwnd: ";
     s << PRINT_PTR(reinterpret_cast<uintptr_t>(hwnd));
     s << ")";
     reshade::log::message(reshade::log::level::info, s.str().c_str());
@@ -1145,19 +1169,10 @@ static void OnInitSwapchain(reshade::api::swapchain* swapchain, bool resize) {
   };
 
   HWND hwnd = static_cast<HWND>(swapchain->get_hwnd());
-  if (renodx::utils::platform::IsToolWindow(hwnd)) {
-    std::stringstream s;
-    s << "mods::swapchain::OnInitSwapchain(Abort from tool window: ";
-    s << PRINT_PTR(reinterpret_cast<uintptr_t>(hwnd));
-    s << ")";
-    reshade::log::message(reshade::log::level::info, s.str().c_str());
-    abort_modification();
-    return;
-  }
 
-  if (bypass_dummy_windows && renodx::utils::platform::IsDummyWindow(hwnd)) {
+  if (!ShouldModifySwapchainHwnd(hwnd)) {
     std::stringstream s;
-    s << "mods::swapchain::OnInitSwapchain(Abort from dummy window: ";
+    s << "mods::swapchain::OnInitSwapchain(Abort from ShouldModifySwapchainHwnd: ";
     s << PRINT_PTR(reinterpret_cast<uintptr_t>(hwnd));
     s << ")";
     reshade::log::message(reshade::log::level::info, s.str().c_str());

--- a/src/utils/platform.hpp
+++ b/src/utils/platform.hpp
@@ -209,14 +209,17 @@ static bool IsToolWindow(HWND hwnd) {
   return (ex_style & WS_EX_TOOLWINDOW) != 0;
 }
 
-static bool IsDummyWindow(HWND hwnd) {
+static std::string GetWindowClassName(HWND hwnd) {
   char class_name[256];
   if (GetClassName(hwnd, class_name, sizeof(class_name))) {
-    auto lower_case_view = std::string(class_name) | std::views::transform([](auto c) { return std::tolower(c); });
-    if (!std::ranges::search(lower_case_view, std::string("dummy")).empty()) return true;
+    return std::string(class_name);
   }
+  return "";
+}
 
-  return false;
+static bool IsDummyWindow(HWND hwnd) {
+  auto lower_case_view = GetWindowClassName(hwnd) | std::views::transform([](auto c) { return std::tolower(c); });
+  return !std::ranges::search(lower_case_view, std::string("dummy")).empty();
 }
 
 static std::string GetFileVersion(const std::filesystem::path& path) {


### PR DESCRIPTION
Post patch 1.5, Infinity Nikki uses a middleware solution called PerfSight (https://perfsight.wetest.net/) for performance telemetry, this introduced a problem with RenoDX, where the PerfSight DLL would hook into the Direct3D device of the game and create a dummy swapchain (100x100) for a "bridge" window with the game's Direct3D device, causing RenoDX to think the game's backbuffer is 100x100, breaking resolution-based resource upgrades. 

This PR addresses this issue by allowing addons to ignore windows from swapchain upgrades. 