### PR TITLE
Baldur's Gate 3: Improved display mapping and hue correction 

### DIFF
--- a/src/games/baldursgate3/addon.cpp
+++ b/src/games/baldursgate3/addon.cpp
@@ -77,6 +77,17 @@ renodx::utils::settings::Settings settings = {
         .parse = [](float value) { return value * 0.01f; },
     },
     new renodx::utils::settings::Setting{
+        .key = "ToneMapShoulderStart",
+        .binding = &shader_injection.tone_map_shoulder_start,
+        .default_value = 0.375f,
+        .label = "Shoulder Start",
+        .section = "Tone Mapping",
+        .tooltip = "Sets the starting point for highlight rolloff.",
+        .min = 0.25f,
+        .max = 0.5f,
+        .format = "%.3f",
+    },
+    new renodx::utils::settings::Setting{
         .key = "ToneMapGammaCorrection",
         .binding = &shader_injection.gamma_correction,
         .value_type = renodx::utils::settings::SettingValueType::BOOLEAN,
@@ -214,6 +225,7 @@ void OnPresetOff() {
   renodx::utils::settings::UpdateSetting("ToneMapGameNits", 225.f);
   renodx::utils::settings::UpdateSetting("ToneMapUINits", 300.f);
   renodx::utils::settings::UpdateSetting("ToneMapHueCorrection", 0.f);
+  renodx::utils::settings::UpdateSetting("ToneMapShoulderStart", 0.5f);
   renodx::utils::settings::UpdateSetting("ToneMapGammaCorrection", 0.f);
   renodx::utils::settings::UpdateSetting("ColorGradeExposure", 1.f);
   renodx::utils::settings::UpdateSetting("ColorGradeHighlights", 50.f);

--- a/src/games/baldursgate3/addon.cpp
+++ b/src/games/baldursgate3/addon.cpp
@@ -66,6 +66,17 @@ renodx::utils::settings::Settings settings = {
         .max = 500.f,
     },
     new renodx::utils::settings::Setting{
+        .key = "ToneMapHueCorrection",
+        .binding = &shader_injection.tone_map_hue_correction,
+        .default_value = 0.f,
+        .label = "Hue Correction",
+        .section = "Tone Mapping",
+        .tooltip = "Hue retention strength.",
+        .min = 0.f,
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.01f; },
+    },
+    new renodx::utils::settings::Setting{
         .key = "ToneMapGammaCorrection",
         .binding = &shader_injection.gamma_correction,
         .value_type = renodx::utils::settings::SettingValueType::BOOLEAN,
@@ -202,6 +213,7 @@ void OnPresetOff() {
   renodx::utils::settings::UpdateSetting("ToneMapPeakNits", 1000.f);
   renodx::utils::settings::UpdateSetting("ToneMapGameNits", 225.f);
   renodx::utils::settings::UpdateSetting("ToneMapUINits", 300.f);
+  renodx::utils::settings::UpdateSetting("ToneMapHueCorrection", 0.f);
   renodx::utils::settings::UpdateSetting("ToneMapGammaCorrection", 0.f);
   renodx::utils::settings::UpdateSetting("ColorGradeExposure", 1.f);
   renodx::utils::settings::UpdateSetting("ColorGradeHighlights", 50.f);

--- a/src/games/baldursgate3/shared.h
+++ b/src/games/baldursgate3/shared.h
@@ -22,6 +22,7 @@ struct ShaderInjectData {
   float diffuse_white_nits;
   float graphics_white_nits;
   float tone_map_hue_correction;
+  float tone_map_shoulder_start;
   float gamma_correction;
   float tone_map_exposure;
   float tone_map_highlights;
@@ -41,6 +42,7 @@ cbuffer cb13 : register(b13) {
 #define RENODX_DIFFUSE_WHITE_NITS      shader_injection.diffuse_white_nits
 #define RENODX_GRAPHICS_WHITE_NITS     shader_injection.graphics_white_nits
 #define RENODX_TONE_MAP_HUE_CORRECTION shader_injection.tone_map_hue_correction
+#define RENODX_TONE_MAP_SHOULDER_START shader_injection.tone_map_shoulder_start
 #define RENODX_GAMMA_CORRECTION        shader_injection.gamma_correction
 #define RENODX_TONE_MAP_EXPOSURE       shader_injection.tone_map_exposure
 #define RENODX_TONE_MAP_HIGHLIGHTS     shader_injection.tone_map_highlights

--- a/src/games/baldursgate3/shared.h
+++ b/src/games/baldursgate3/shared.h
@@ -21,6 +21,7 @@ struct ShaderInjectData {
   float peak_white_nits;
   float diffuse_white_nits;
   float graphics_white_nits;
+  float tone_map_hue_correction;
   float gamma_correction;
   float tone_map_exposure;
   float tone_map_highlights;
@@ -36,17 +37,18 @@ cbuffer cb13 : register(b13) {
   ShaderInjectData shader_injection : packoffset(c0);
 }
 
-#define RENODX_PEAK_WHITE_NITS      shader_injection.peak_white_nits
-#define RENODX_DIFFUSE_WHITE_NITS   shader_injection.diffuse_white_nits
-#define RENODX_GRAPHICS_WHITE_NITS  shader_injection.graphics_white_nits
-#define RENODX_GAMMA_CORRECTION     shader_injection.gamma_correction
-#define RENODX_TONE_MAP_EXPOSURE    shader_injection.tone_map_exposure
-#define RENODX_TONE_MAP_HIGHLIGHTS  shader_injection.tone_map_highlights
-#define RENODX_TONE_MAP_SHADOWS     shader_injection.tone_map_shadows
-#define RENODX_TONE_MAP_CONTRAST    shader_injection.tone_map_contrast
-#define RENODX_TONE_MAP_SATURATION  shader_injection.tone_map_saturation
-#define RENODX_TONE_MAP_BLOWOUT     shader_injection.tone_map_blowout
-#define RENODX_COLOR_GRADE_STRENGTH shader_injection.color_grade_strength
+#define RENODX_PEAK_WHITE_NITS         shader_injection.peak_white_nits
+#define RENODX_DIFFUSE_WHITE_NITS      shader_injection.diffuse_white_nits
+#define RENODX_GRAPHICS_WHITE_NITS     shader_injection.graphics_white_nits
+#define RENODX_TONE_MAP_HUE_CORRECTION shader_injection.tone_map_hue_correction
+#define RENODX_GAMMA_CORRECTION        shader_injection.gamma_correction
+#define RENODX_TONE_MAP_EXPOSURE       shader_injection.tone_map_exposure
+#define RENODX_TONE_MAP_HIGHLIGHTS     shader_injection.tone_map_highlights
+#define RENODX_TONE_MAP_SHADOWS        shader_injection.tone_map_shadows
+#define RENODX_TONE_MAP_CONTRAST       shader_injection.tone_map_contrast
+#define RENODX_TONE_MAP_SATURATION     shader_injection.tone_map_saturation
+#define RENODX_TONE_MAP_BLOWOUT        shader_injection.tone_map_blowout
+#define RENODX_COLOR_GRADE_STRENGTH    shader_injection.color_grade_strength
 
 #include "../../shaders/renodx.hlsl"
 

--- a/src/games/baldursgate3/tonemap_sample_lut_0x11C53BBA.ps_5_0.hlsl
+++ b/src/games/baldursgate3/tonemap_sample_lut_0x11C53BBA.ps_5_0.hlsl
@@ -83,8 +83,9 @@ void main(
       RENODX_TONE_MAP_BLOWOUT,
       0.f);
   r0.rgb = renodx::color::bt2020::from::BT709(r0.rgb);
-  
-  r0.rgb = renodx::tonemap::ExponentialRollOff(r0.rgb, 0.18f, RENODX_PEAK_WHITE_NITS / RENODX_DIFFUSE_WHITE_NITS);
+
+  float shoulder_start = 0.5f;
+  r0.rgb = exp2(renodx::tonemap::ExponentialRollOff(log2(max(0, r0.rgb) * RENODX_DIFFUSE_WHITE_NITS), log2(RENODX_PEAK_WHITE_NITS * shoulder_start), log2(RENODX_PEAK_WHITE_NITS))) / RENODX_DIFFUSE_WHITE_NITS;
   r0.rgb = renodx::color::pq::EncodeSafe(r0.rgb, RENODX_DIFFUSE_WHITE_NITS);
 #endif
 

--- a/src/games/baldursgate3/tonemap_sample_lut_0x11C53BBA.ps_5_0.hlsl
+++ b/src/games/baldursgate3/tonemap_sample_lut_0x11C53BBA.ps_5_0.hlsl
@@ -85,7 +85,13 @@ void main(
   r0.rgb = renodx::color::bt2020::from::BT709(r0.rgb);
 
   float shoulder_start = 0.5f;
-  r0.rgb = exp2(renodx::tonemap::ExponentialRollOff(log2(max(0, r0.rgb) * RENODX_DIFFUSE_WHITE_NITS), log2(RENODX_PEAK_WHITE_NITS * shoulder_start), log2(RENODX_PEAK_WHITE_NITS))) / RENODX_DIFFUSE_WHITE_NITS;
+  float3 untonemapped = max(0, r0.rgb);
+  r0.rgb = exp2(renodx::tonemap::ExponentialRollOff(log2(untonemapped * RENODX_DIFFUSE_WHITE_NITS), log2(RENODX_PEAK_WHITE_NITS * shoulder_start), log2(RENODX_PEAK_WHITE_NITS))) / RENODX_DIFFUSE_WHITE_NITS;
+  if (RENODX_TONE_MAP_HUE_CORRECTION != 0.f) {
+    r0.rgb = renodx::color::bt709::from::BT2020(r0.rgb);
+    r0.rgb = renodx::color::correct::Hue(r0.rgb, renodx::color::bt709::from::BT2020(untonemapped), RENODX_TONE_MAP_HUE_CORRECTION);
+    r0.rgb = renodx::color::bt2020::from::BT709(r0.rgb);
+  }
   r0.rgb = renodx::color::pq::EncodeSafe(r0.rgb, RENODX_DIFFUSE_WHITE_NITS);
 #endif
 

--- a/src/games/baldursgate3/tonemap_sample_lut_0x11C53BBA.ps_5_0.hlsl
+++ b/src/games/baldursgate3/tonemap_sample_lut_0x11C53BBA.ps_5_0.hlsl
@@ -86,7 +86,7 @@ void main(
 
   float shoulder_start = 0.5f;
   float3 untonemapped = max(0, r0.rgb);
-  r0.rgb = exp2(renodx::tonemap::ExponentialRollOff(log2(untonemapped * RENODX_DIFFUSE_WHITE_NITS), log2(RENODX_PEAK_WHITE_NITS * shoulder_start), log2(RENODX_PEAK_WHITE_NITS))) / RENODX_DIFFUSE_WHITE_NITS;
+  r0.rgb = exp2(renodx::tonemap::ExponentialRollOff(log2(untonemapped * RENODX_DIFFUSE_WHITE_NITS), log2(RENODX_PEAK_WHITE_NITS * RENODX_TONE_MAP_SHOULDER_START), log2(RENODX_PEAK_WHITE_NITS))) / RENODX_DIFFUSE_WHITE_NITS;
   if (RENODX_TONE_MAP_HUE_CORRECTION != 0.f) {
     r0.rgb = renodx::color::bt709::from::BT2020(r0.rgb);
     r0.rgb = renodx::color::correct::Hue(r0.rgb, renodx::color::bt709::from::BT2020(untonemapped), RENODX_TONE_MAP_HUE_CORRECTION);


### PR DESCRIPTION
- Use `log2()` as shaper for `ExponentialRollOff()`
- Add hue correction slider
- Add shoulder start slider