### PR TITLE
Add Support for Ori and the Blind Forest: Definitive Edition

### DIFF
--- a/src/games/ori1definitive/addon.cpp
+++ b/src/games/ori1definitive/addon.cpp
@@ -278,6 +278,16 @@ renodx::utils::settings::Settings settings = {
     },
     new renodx::utils::settings::Setting{
         .value_type = renodx::utils::settings::SettingValueType::BUTTON,
+        .label = "Github Discussions",
+        .section = "Links",
+        .group = "button-line-2",
+        .tint = 0x2B3137,
+        .on_change = []() {
+          renodx::utils::platform::Launch("https://github.com/clshortfuse/renodx/discussions/223");
+        },
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::BUTTON,
         .label = "Musa's Ko-Fi",
         .section = "Links",
         .group = "button-line-3",

--- a/src/games/ori1definitive/addon.cpp
+++ b/src/games/ori1definitive/addon.cpp
@@ -46,6 +46,18 @@ renodx::mods::shader::CustomShaders custom_shaders = {
     CustomShaderEntry(0xE020E0E3),
     // even more artifact fixes
     CustomShaderEntry(0xF2280F92),
+    CustomShaderEntry(0x7EA3E0B2),
+    CustomShaderEntry(0x92EF8684),
+    CustomShaderEntry(0x95E462F3),
+    CustomShaderEntry(0x0422C69E),
+    CustomShaderEntry(0xE311E5C3),
+    CustomShaderEntry(0x89FC4143),
+    CustomShaderEntry(0xB932F19B),
+    CustomShaderEntry(0x11507068),
+    CustomShaderEntry(0xB8F1C5BC),
+    CustomShaderEntry(0x61EDCA76),
+    CustomShaderEntry(0x3D449D34),
+    CustomShaderEntry(0x1612A2ED),
 
     CustomShaderEntry(0x470BECFA),  // post processing ubershader
     CustomShaderEntry(0x52BC2F1B),  // final

--- a/src/games/ori1definitive/addon.cpp
+++ b/src/games/ori1definitive/addon.cpp
@@ -1,0 +1,386 @@
+/*
+ * Copyright (C) 2024 Carlos Lopez
+ * SPDX-License-Identifier: MIT
+ */
+
+#define ImTextureID ImU64
+
+#define DEBUG_LEVEL_0
+
+#include <deps/imgui/imgui.h>
+#include <include/reshade.hpp>
+
+#include <embed/shaders.h>
+
+#include "../../mods/shader.hpp"
+#include "../../mods/swapchain.hpp"
+#include "../../utils/date.hpp"
+#include "../../utils/settings.hpp"
+#include "./shared.h"
+
+namespace {
+
+renodx::mods::shader::CustomShaders custom_shaders = {
+
+    // Manually clamp shaders to fix artifacts
+    CustomShaderEntry(0x74F1A9BF),
+    CustomShaderEntry(0xA5B9F647),
+    CustomShaderEntry(0xBC4BB886),
+    CustomShaderEntry(0xC997373E),
+    CustomShaderEntry(0xEDD7A595),
+    CustomShaderEntry(0xFD5E9187),
+    CustomShaderEntry(0x0F10CE07),
+    CustomShaderEntry(0xD327EDF9),
+    CustomShaderEntry(0xEF83C032),
+    // more artifact fixes
+    CustomShaderEntry(0xCC3D6FF7),
+    CustomShaderEntry(0xD6DBC682),
+    CustomShaderEntry(0x9A326CB2),
+    CustomShaderEntry(0xA0679E6A),
+    CustomShaderEntry(0x69935E20),
+    CustomShaderEntry(0xDBE2402A),
+    CustomShaderEntry(0x08EC9524),
+    CustomShaderEntry(0x791C6897),
+    CustomShaderEntry(0x1018F519),
+    CustomShaderEntry(0x6743CB50),
+    CustomShaderEntry(0xE020E0E3),
+    // even more artifact fixes
+    CustomShaderEntry(0xF2280F92),
+
+    CustomShaderEntry(0x470BECFA),  // post processing ubershader
+    CustomShaderEntry(0x52BC2F1B),  // final
+    CustomShaderEntry(0x591107A5),  // video final
+
+    // UI
+    CustomShaderEntry(0x0B9EF709),
+    CustomShaderEntry(0x0CBCCA15),
+    CustomShaderEntry(0x3EE35D33),
+    CustomShaderEntry(0x06E0FF55),
+    CustomShaderEntry(0x32BBB6EC),
+    CustomShaderEntry(0x405A953B),
+    CustomShaderEntry(0x2776C84A),
+    CustomShaderEntry(0xA3665A61),
+    CustomShaderEntry(0xE63F1AA1),
+    CustomShaderEntry(0xE534D964),
+    CustomShaderEntry(0xEEDE4B16),
+    CustomShaderEntry(0xF5017B78),
+    CustomShaderEntry(0x57172B6F),
+    CustomShaderEntry(0x0BC8B7AD),
+    CustomShaderEntry(0x89FB32DC),
+    CustomShaderEntry(0xF1446A0F),
+    // more UI
+    CustomShaderEntry(0x0BF7ABF5),
+    CustomShaderEntry(0x7E661BCB),
+    CustomShaderEntry(0x9EF7455E),
+    CustomShaderEntry(0x844C51B1),
+    CustomShaderEntry(0x4185B9AB),
+    CustomShaderEntry(0x93682B5C),
+    CustomShaderEntry(0xB39B9252),
+    CustomShaderEntry(0xB56D6357),
+    CustomShaderEntry(0xB68ED355),
+    CustomShaderEntry(0xCA28B653),
+    CustomShaderEntry(0xCCC2E9D3),
+    CustomShaderEntry(0xD6874AF6),
+    CustomShaderEntry(0xDDCCAB25),
+    CustomShaderEntry(0xE6C66A25),
+    CustomShaderEntry(0xF976A2A9),
+    CustomShaderEntry(0xFE58A410),
+    // even more UI
+    CustomShaderEntry(0x110CBF45),
+    CustomShaderEntry(0x3610A504),
+
+};
+
+ShaderInjectData shader_injection;
+
+renodx::utils::settings::Settings settings = {
+
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapType",
+        .binding = &shader_injection.tone_map_type,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 2.f,
+        .can_reset = true,
+        .label = "Tone Mapper",
+        .section = "Tone Mapping",
+        .tooltip = "Sets the tone mapper type",
+        .labels = {"Vanilla", "None", "Exponential Rolloff"},
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapPeakNits",
+        .binding = &shader_injection.peak_white_nits,
+        .default_value = 1000.f,
+        .can_reset = false,
+        .label = "Peak Brightness",
+        .section = "Tone Mapping",
+        .tooltip = "Sets the value of peak white in nits",
+        .min = 48.f,
+        .max = 4000.f,
+        .is_enabled = []() { return shader_injection.tone_map_type >= 2; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapGameNits",
+        .binding = &shader_injection.diffuse_white_nits,
+        .default_value = 203.f,
+        .label = "Game Brightness",
+        .section = "Tone Mapping",
+        .tooltip = "Sets the value of 100% white in nits",
+        .min = 48.f,
+        .max = 500.f,
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapUINits",
+        .binding = &shader_injection.graphics_white_nits,
+        .default_value = 203.f,
+        .label = "UI Brightness",
+        .section = "Tone Mapping",
+        .tooltip = "Sets the brightness of UI and HUD elements in nits",
+        .min = 48.f,
+        .max = 500.f,
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeExposure",
+        .binding = &shader_injection.tone_map_exposure,
+        .default_value = 1.f,
+        .label = "Exposure",
+        .section = "Color Grading",
+        .max = 2.f,
+        .format = "%.2f",
+        .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeHighlights",
+        .binding = &shader_injection.tone_map_highlights,
+        .default_value = 50.f,
+        .label = "Highlights",
+        .section = "Color Grading",
+        .max = 100.f,
+        .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+        .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeShadows",
+        .binding = &shader_injection.tone_map_shadows,
+        .default_value = 50.f,
+        .label = "Shadows",
+        .section = "Color Grading",
+        .max = 100.f,
+        .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+        .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeContrast",
+        .binding = &shader_injection.tone_map_contrast,
+        .default_value = 50.f,
+        .label = "Contrast",
+        .section = "Color Grading",
+        .max = 100.f,
+        .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+        .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeSaturation",
+        .binding = &shader_injection.tone_map_saturation,
+        .default_value = 50.f,
+        .label = "Saturation",
+        .section = "Color Grading",
+        .max = 100.f,
+        .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+        .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeBlowout",
+        .binding = &shader_injection.tone_map_blowout,
+        .default_value = 0.f,
+        .label = "Blowout",
+        .section = "Color Grading",
+        .tooltip = "Controls highlight desaturation due to overexposure.",
+        .max = 100.f,
+        .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+        .parse = [](float value) { return value * 0.01f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeStrength",
+        .binding = &shader_injection.color_grade_strength,
+        .default_value = 100.f,
+        .label = "Color Grade Strength",
+        .section = "Color Grading",
+        .max = 100.f,
+        .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+        .parse = [](float value) { return value * 0.01f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeScaling",
+        .binding = &shader_injection.color_grade_scaling,
+        .default_value = 100.f,
+        .label = "Color Grade Scaling",
+        .section = "Color Grading",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.01f; },
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::BUTTON,
+        .label = "Reset All",
+        .section = "Options",
+        .group = "button-line-1",
+        .on_change = []() {
+          for (auto* setting : settings) {
+            if (setting->key.empty()) continue;
+            if (!setting->can_reset) continue;
+            renodx::utils::settings::UpdateSetting(setting->key, setting->default_value);
+          }
+        },
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::BUTTON,
+        .label = "Discord",
+        .section = "Links",
+        .group = "button-line-2",
+        .tint = 0x5865F2,
+        .on_change = []() {
+          renodx::utils::platform::Launch(
+              "https://discord.gg/"
+              "5WZXDpmbpP");
+        },
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::BUTTON,
+        .label = "More Mods",
+        .section = "Links",
+        .group = "button-line-2",
+        .tint = 0x2B3137,
+        .on_change = []() {
+          renodx::utils::platform::Launch("https://github.com/clshortfuse/renodx/wiki/Mods");
+        },
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::BUTTON,
+        .label = "Github",
+        .section = "Links",
+        .group = "button-line-2",
+        .tint = 0x2B3137,
+        .on_change = []() {
+          renodx::utils::platform::Launch("https://github.com/clshortfuse/renodx");
+        },
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::BUTTON,
+        .label = "Musa's Ko-Fi",
+        .section = "Links",
+        .group = "button-line-3",
+        .tint = 0xFF5A16,
+        .on_change = []() { renodx::utils::platform::Launch("https://ko-fi.com/musaqh"); },
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::TEXT,
+        .label = std::string("Build: ") + renodx::utils::date::ISO_DATE_TIME,
+        .section = "About",
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::TEXT,
+        .label = std::string("- Game might occasionally have some rendering artifacts"),
+        .section = "About",
+    },
+};
+
+void OnPresetOff() {
+  renodx::utils::settings::UpdateSettings({
+      {"ToneMapType", 0.f},
+      {"ToneMapPeakNits", 203.f},
+      {"ToneMapGameNits", 203.f},
+      {"ToneMapUINits", 203.f},
+      {"ColorGradeExposure", 1.f},
+      {"ColorGradeHighlights", 50.f},
+      {"ColorGradeShadows", 50.f},
+      {"ColorGradeContrast", 50.f},
+      {"ColorGradeSaturation", 50.f},
+      {"ColorGradeBlowout", 0.f},
+      {"ColorGradeStrength", 100.f},
+      {"ColorGradeScaling", 0.f},
+  });
+}
+
+void OnInitDevice(reshade::api::device* device) {
+  if (device->get_api() == reshade::api::device_api::d3d11) {
+    renodx::mods::shader::expected_constant_buffer_space = 0;
+    renodx::mods::swapchain::expected_constant_buffer_space = 0;
+
+    return;
+  }
+
+  if (device->get_api() == reshade::api::device_api::d3d12) {
+    // Switch over to DX12
+    renodx::mods::shader::expected_constant_buffer_space = 50;
+    renodx::mods::swapchain::expected_constant_buffer_space = 50;
+  }
+}
+
+bool fired_on_init_swapchain = false;
+
+void OnInitSwapchain(reshade::api::swapchain* swapchain, bool resize) {
+  if (fired_on_init_swapchain) return;
+  fired_on_init_swapchain = true;
+  auto peak = renodx::utils::swapchain::GetPeakNits(swapchain);
+  if (peak.has_value()) {
+    settings[1]->default_value = peak.value();
+    settings[1]->can_reset = true;
+  }
+}
+
+bool initialized = false;
+
+}  // namespace
+
+extern "C" __declspec(dllexport) constexpr const char* NAME = "RenoDX";
+extern "C" __declspec(dllexport) constexpr const char* DESCRIPTION = "RenoDX for Ori and the Blind Forest: Definitive Edition";
+
+BOOL APIENTRY DllMain(HMODULE h_module, DWORD fdw_reason, LPVOID lpv_reserved) {
+  switch (fdw_reason) {
+    case DLL_PROCESS_ATTACH:
+      if (!reshade::register_addon(h_module)) return FALSE;
+
+      if (!initialized) {
+        renodx::mods::shader::force_pipeline_cloning = true;
+        renodx::mods::shader::expected_constant_buffer_space = 50;
+        renodx::mods::shader::expected_constant_buffer_index = 13;
+
+        // // TODO: find upgrades needed to unclamp crossfade transitions
+        // for (auto index : {
+        //          0,  // unclamps some stuff
+        //          5,  // post processing ubershader
+        //      }) {
+        //   renodx::mods::swapchain::swap_chain_upgrade_targets.push_back({
+        //       .old_format = reshade::api::format::r8g8b8a8_typeless,
+        //       .new_format = reshade::api::format::r16g16b16a16_float,
+        //       .index = index,
+        //       .aspect_ratio = renodx::mods::swapchain::SwapChainUpgradeTarget::BACK_BUFFER,
+        //       .usage_include = reshade::api::resource_usage::render_target,  // shader_resource and unodered_access are also flags
+        //   });
+        // }
+
+        renodx::mods::swapchain::swap_chain_upgrade_targets.push_back({
+            .old_format = reshade::api::format::r8g8b8a8_typeless,
+            .new_format = reshade::api::format::r16g16b16a16_float,
+            .aspect_ratio = renodx::mods::swapchain::SwapChainUpgradeTarget::BACK_BUFFER,
+            .usage_include = reshade::api::resource_usage::render_target,  // shader_resource and unodered_access are also flags
+        });
+
+        initialized = true;
+      }
+
+      reshade::register_event<reshade::addon_event::init_device>(OnInitDevice);
+      reshade::register_event<reshade::addon_event::init_swapchain>(OnInitSwapchain);
+      break;
+    case DLL_PROCESS_DETACH:
+      reshade::unregister_addon(h_module);
+      reshade::unregister_event<reshade::addon_event::init_swapchain>(OnInitSwapchain);
+      reshade::unregister_event<reshade::addon_event::init_device>(OnInitDevice);
+      break;
+  }
+
+  renodx::utils::settings::Use(fdw_reason, &settings, &OnPresetOff);
+  renodx::mods::swapchain::Use(fdw_reason, &shader_injection);
+  renodx::mods::shader::Use(fdw_reason, custom_shaders, &shader_injection);
+
+  return TRUE;
+}

--- a/src/games/ori1definitive/addon.cpp
+++ b/src/games/ori1definitive/addon.cpp
@@ -61,6 +61,7 @@ renodx::mods::shader::CustomShaders custom_shaders = {
 
     CustomShaderEntry(0x470BECFA),  // post processing ubershader
     CustomShaderEntry(0x52BC2F1B),  // final
+    CustomShaderEntry(0xB31E6B7C),  // final - no motion blur
     CustomShaderEntry(0x591107A5),  // video final
 
     // UI

--- a/src/games/ori1definitive/artifacts/artifact_0x0422C69E.ps_4_0.hlsl
+++ b/src/games/ori1definitive/artifacts/artifact_0x0422C69E.ps_4_0.hlsl
@@ -1,0 +1,102 @@
+// ---- Created with 3Dmigoto v1.4.1 on Sat Apr  5 00:32:21 2025
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[54];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = saturate(v1.yx);
+  r0.xy = -cb0[20].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[20].wz);
+  r0.zw = cb0[7].yy * r0.xy;
+  r1.x = 1 + -cb0[7].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[19].zw + cb0[19].xy;
+  r0.xyzw = t0.Sample(s0_s, r0.xy).xyzw;
+  r1.x = saturate(dot(r0.xyzw, cb0[8].xyzw));
+  r0.xyzw = r1.xxxx * cb0[9].xyzw + r0.xyzw;
+  r0.xyz = r0.xyz / r0.www;
+  r0.xyzw = cb0[21].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.x = cmp(r0.y < r0.z);
+  r2.xy = r0.zy;
+  r3.xy = r2.yx;
+  r2.zw = float2(-1,0.666666687);
+  r3.zw = float2(0,-0.333333343);
+  r1.xyzw = r1.xxxx ? r2.xywz : r3.xywz;
+  r0.y = cmp(r0.x < r1.x);
+  r2.z = r1.w;
+  r1.w = r0.x;
+  o0.w = r0.w;
+  r2.xyw = r1.wyx;
+  r0.xyzw = r0.yyyy ? r1.xyzw : r2.xyzw;
+  r1.x = min(r0.w, r0.y);
+  r1.x = -r1.x + r0.x;
+  r1.y = r1.x * 6 + cb0[53].x;
+  r0.y = r0.w + -r0.y;
+  r0.y = r0.y / r1.y;
+  r0.y = r0.y + r0.z;
+  r0.y = cb0[42].x + abs(r0.y);
+  r0.y = frac(r0.y);
+  r0.yzw = r0.yyy * float3(6,6,6) + float3(-3,-2,-4);
+  r0.yzw = saturate(abs(r0.yzw) * float3(1,-1,-1) + float3(-1,2,2));
+  r0.yzw = float3(-1,-1,-1) + r0.yzw;
+  r1.y = cb0[53].x + r0.x;
+  r1.x = r1.x / r1.y;
+  r0.yzw = r0.yzw * r1.xxx + float3(1,1,1);
+  r0.xyz = r0.yzw * r0.xxx;
+  r1.xyzw = t1.Sample(s1_s, v2.xy).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[47].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t2.Sample(s2_s, v2.zw).xyzw;
+  r0.w = cb0[47].w * r2.w;
+  r0.xyz = r0.www * r1.xyz + r0.xyz;
+  r1.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[52].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t4.Sample(s4_s, v3.zw).xyzw;
+  r0.w = cb0[52].w * r2.w;
+  o0.xyz = r0.www * r1.xyz + r0.xyz;
+
+  o0 = saturate(o0);
+  return;
+}

--- a/src/games/ori1definitive/artifacts/artifact_0x11507068.ps_4_0.hlsl
+++ b/src/games/ori1definitive/artifacts/artifact_0x11507068.ps_4_0.hlsl
@@ -1,0 +1,92 @@
+// ---- Created with 3Dmigoto v1.4.1 on Sat Apr  5 00:32:24 2025
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[41];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  float4 v4 : TEXCOORD3,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = saturate(v1.yx);
+  r0.xy = -cb0[21].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[21].wz);
+  r0.zw = cb0[8].yy * r0.xy;
+  r1.x = 1 + -cb0[8].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[20].zw + cb0[20].xy;
+  r0.xyzw = t0.Sample(s0_s, r0.xy).xyzw;
+  r1.x = saturate(dot(r0.xyzw, cb0[9].xyzw));
+  r0.xyzw = r1.xxxx * cb0[10].xyzw + r0.xyzw;
+  r0.xyz = r0.xyz / r0.www;
+  r0.xyzw = cb0[22].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.x = cmp(r0.y < r0.z);
+  r2.xy = r0.zy;
+  r3.xy = r2.yx;
+  r2.zw = float2(-1,0.666666687);
+  r3.zw = float2(0,-0.333333343);
+  r1.xyzw = r1.xxxx ? r2.xywz : r3.xywz;
+  r0.y = cmp(r0.x < r1.x);
+  r2.z = r1.w;
+  r1.w = r0.x;
+  o0.w = r0.w;
+  r2.xyw = r1.wyx;
+  r0.xyzw = r0.yyyy ? r1.xyzw : r2.xyzw;
+  r1.x = min(r0.w, r0.y);
+  r1.x = -r1.x + r0.x;
+  r1.y = r1.x * 6 + cb0[40].x;
+  r0.y = r0.w + -r0.y;
+  r0.y = r0.y / r1.y;
+  r0.y = r0.y + r0.z;
+  r0.y = cb0[34].x + abs(r0.y);
+  r0.y = frac(r0.y);
+  r0.yzw = r0.yyy * float3(6,6,6) + float3(-3,-2,-4);
+  r0.yzw = saturate(abs(r0.yzw) * float3(1,-1,-1) + float3(-1,2,2));
+  r0.yzw = float3(-1,-1,-1) + r0.yzw;
+  r1.y = cb0[40].x + r0.x;
+  r1.x = r1.x / r1.y;
+  r0.yzw = r0.yzw * r1.xxx + float3(1,1,1);
+  r0.xyz = r0.yzw * r0.xxx;
+  r1.xyzw = t1.Sample(s1_s, v2.xy).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[39].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t2.Sample(s2_s, v2.zw).xyzw;
+  r0.w = cb0[39].w * r2.w;
+  r0.xyz = r0.www * r1.xyz + r0.xyz;
+  r1.xyz = v4.xyz + -r0.xyz;
+  r0.xyz = v4.www * r1.xyz + r0.xyz;
+  r1.xyz = v3.xyz + -r0.xyz;
+  o0.xyz = v3.www * r1.xyz + r0.xyz;
+
+  o0 = saturate(o0);
+  return;
+}

--- a/src/games/ori1definitive/artifacts/artifact_0x1612A2ED.ps_4_0.hlsl
+++ b/src/games/ori1definitive/artifacts/artifact_0x1612A2ED.ps_4_0.hlsl
@@ -1,0 +1,70 @@
+// ---- Created with 3Dmigoto v1.4.1 on Sat Apr  5 00:32:25 2025
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[43];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = saturate(v1.yx);
+  r0.xy = -cb0[20].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[20].wz);
+  r0.zw = cb0[7].yy * r0.xy;
+  r1.x = 1 + -cb0[7].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[19].zw + cb0[19].xy;
+  r0.xyzw = t0.Sample(s0_s, r0.xy).xyzw;
+  r1.x = saturate(dot(r0.xyzw, cb0[8].xyzw));
+  r0.xyzw = r1.xxxx * cb0[9].xyzw + r0.xyzw;
+  r0.xyz = r0.xyz / r0.www;
+  r0.xyzw = cb0[21].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.x = cmp(r0.y < r0.z);
+  r2.xy = r0.zy;
+  r3.xy = r2.yx;
+  r2.zw = float2(-1,0.666666687);
+  r3.zw = float2(0,-0.333333343);
+  r1.xyzw = r1.xxxx ? r2.xywz : r3.xywz;
+  r0.y = cmp(r0.x < r1.x);
+  r2.z = r1.w;
+  r1.w = r0.x;
+  o0.w = r0.w;
+  r2.xyw = r1.wyx;
+  r0.xyzw = r0.yyyy ? r1.xyzw : r2.xyzw;
+  r1.x = min(r0.w, r0.y);
+  r1.x = -r1.x + r0.x;
+  r1.y = r1.x * 6 + cb0[42].y;
+  r0.y = r0.w + -r0.y;
+  r0.y = r0.y / r1.y;
+  r0.y = r0.y + r0.z;
+  r0.y = cb0[42].x + abs(r0.y);
+  r0.y = frac(r0.y);
+  r0.yzw = r0.yyy * float3(6,6,6) + float3(-3,-2,-4);
+  r0.yzw = saturate(abs(r0.yzw) * float3(1,-1,-1) + float3(-1,2,2));
+  r0.yzw = float3(-1,-1,-1) + r0.yzw;
+  r1.y = cb0[42].y + r0.x;
+  r1.x = r1.x / r1.y;
+  r0.yzw = r0.yzw * r1.xxx + float3(1,1,1);
+  o0.xyz = r0.yzw * r0.xxx;
+
+  o0 = saturate(o0);
+  return;
+}

--- a/src/games/ori1definitive/artifacts/artifact_0x3D449D34.ps_4_0.hlsl
+++ b/src/games/ori1definitive/artifacts/artifact_0x3D449D34.ps_4_0.hlsl
@@ -1,0 +1,101 @@
+// ---- Created with 3Dmigoto v1.4.1 on Sat Apr  5 00:32:35 2025
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[52];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  float4 v4 : TEXCOORD3,
+  float4 v5 : TEXCOORD4,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = saturate(v1.yx);
+  r0.xy = -cb0[21].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[21].wz);
+  r0.zw = cb0[8].yy * r0.xy;
+  r1.x = 1 + -cb0[8].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[20].zw + cb0[20].xy;
+  r0.xyzw = t0.Sample(s0_s, r0.xy).xyzw;
+  r1.x = saturate(dot(r0.xyzw, cb0[9].xyzw));
+  r0.xyzw = r1.xxxx * cb0[10].xyzw + r0.xyzw;
+  r0.xyz = r0.xyz / r0.www;
+  r0.xyzw = cb0[22].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.x = cmp(r0.y < r0.z);
+  r2.xy = r0.zy;
+  r3.xy = r2.yx;
+  r2.zw = float2(-1,0.666666687);
+  r3.zw = float2(0,-0.333333343);
+  r1.xyzw = r1.xxxx ? r2.xywz : r3.xywz;
+  r0.y = cmp(r0.x < r1.x);
+  r2.z = r1.w;
+  r1.w = r0.x;
+  r2.xyw = r1.wyx;
+  r1.xyzw = r0.yyyy ? r1.xyzw : r2.xyzw;
+  r0.x = min(r1.w, r1.y);
+  r0.x = r1.x + -r0.x;
+  r0.y = r0.x * 6 + cb0[51].x;
+  r0.z = r1.w + -r1.y;
+  r0.y = r0.z / r0.y;
+  r0.y = r0.y + r1.z;
+  r0.y = cb0[45].y + abs(r0.y);
+  r0.y = frac(r0.y);
+  r1.yzw = r0.yyy * float3(6,6,6) + float3(-3,-2,-4);
+  r1.yzw = saturate(abs(r1.yzw) * float3(1,-1,-1) + float3(-1,2,2));
+  r1.yzw = float3(-1,-1,-1) + r1.yzw;
+  r0.y = cb0[51].x + r1.x;
+  r0.x = r0.x / r0.y;
+  r0.xyz = r1.yzw * r0.xxx + float3(1,1,1);
+  r0.xyz = r0.xyz * r1.xxx;
+  r1.xyzw = t2.Sample(s2_s, v2.zw).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[50].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r1.w = cb0[50].w * r2.w;
+  r0.xyz = r1.www * r1.xyz + r0.xyz;
+  r1.xyz = v5.xyz + -r0.xyz;
+  r0.xyz = v5.www * r1.xyz + r0.xyz;
+  r1.xyz = v4.xyz + -r0.xyz;
+  o0.xyz = v4.www * r1.xyz + r0.xyz;
+  r1.xyzw = t1.Sample(s1_s, v2.xy).xyzw;
+  r0.x = -1 + r1.w;
+  r0.x = cb0[45].x * r0.x + 1;
+  o0.w = r0.w * r0.x;
+
+  o0 = saturate(o0);
+  
+  return;
+}

--- a/src/games/ori1definitive/artifacts/artifact_0x61EDCA76.ps_4_0.hlsl
+++ b/src/games/ori1definitive/artifacts/artifact_0x61EDCA76.ps_4_0.hlsl
@@ -1,0 +1,117 @@
+// ---- Created with 3Dmigoto v1.4.1 on Sat Apr  5 00:32:44 2025
+Texture2D<float4> t5 : register(t5);
+
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s5_s : register(s5);
+
+SamplerState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[57];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  float4 v4 : TEXCOORD3,
+  float4 v5 : TEXCOORD4,
+  float4 v6 : TEXCOORD5,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = saturate(v1.yx);
+  r0.xy = -cb0[21].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[21].wz);
+  r0.zw = cb0[8].yy * r0.xy;
+  r1.x = 1 + -cb0[8].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[20].zw + cb0[20].xy;
+  r0.xyzw = t0.Sample(s0_s, r0.xy).xyzw;
+  r1.x = saturate(dot(r0.xyzw, cb0[9].xyzw));
+  r0.xyzw = r1.xxxx * cb0[10].xyzw + r0.xyzw;
+  r0.xyz = r0.xyz / r0.www;
+  r0.xyzw = cb0[22].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.x = cmp(r0.y < r0.z);
+  r2.xy = r0.zy;
+  r3.xy = r2.yx;
+  r2.zw = float2(-1,0.666666687);
+  r3.zw = float2(0,-0.333333343);
+  r1.xyzw = r1.xxxx ? r2.xywz : r3.xywz;
+  r0.y = cmp(r0.x < r1.x);
+  r2.z = r1.w;
+  r1.w = r0.x;
+  r2.xyw = r1.wyx;
+  r1.xyzw = r0.yyyy ? r1.xyzw : r2.xyzw;
+  r0.x = min(r1.w, r1.y);
+  r0.x = r1.x + -r0.x;
+  r0.y = r0.x * 6 + cb0[56].x;
+  r0.z = r1.w + -r1.y;
+  r0.y = r0.z / r0.y;
+  r0.y = r0.y + r1.z;
+  r0.y = cb0[45].y + abs(r0.y);
+  r0.y = frac(r0.y);
+  r1.yzw = r0.yyy * float3(6,6,6) + float3(-3,-2,-4);
+  r1.yzw = saturate(abs(r1.yzw) * float3(1,-1,-1) + float3(-1,2,2));
+  r1.yzw = float3(-1,-1,-1) + r1.yzw;
+  r0.y = cb0[56].x + r1.x;
+  r0.x = r0.x / r0.y;
+  r0.xyz = r1.yzw * r0.xxx + float3(1,1,1);
+  r0.xyz = r0.xyz * r1.xxx;
+  r1.xyzw = t2.Sample(s2_s, v2.zw).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[50].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r1.w = cb0[50].w * r2.w;
+  r0.xyz = r1.www * r1.xyz + r0.xyz;
+  r1.xyzw = t4.Sample(s4_s, v3.zw).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[55].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t5.Sample(s5_s, v4.xy).xyzw;
+  r1.w = cb0[55].w * r2.w;
+  r0.xyz = r1.www * r1.xyz + r0.xyz;
+  r1.xyz = v6.xyz + -r0.xyz;
+  r0.xyz = v6.www * r1.xyz + r0.xyz;
+  r1.xyz = v5.xyz + -r0.xyz;
+  o0.xyz = v5.www * r1.xyz + r0.xyz;
+  r1.xyzw = t1.Sample(s1_s, v2.xy).xyzw;
+  r0.x = -1 + r1.w;
+  r0.x = cb0[45].x * r0.x + 1;
+  o0.w = r0.w * r0.x;
+
+  o0 = saturate(o0);
+  
+  return;
+}

--- a/src/games/ori1definitive/artifacts/artifact_0x74F1A9BF.ps_4_0.hlsl
+++ b/src/games/ori1definitive/artifacts/artifact_0x74F1A9BF.ps_4_0.hlsl
@@ -1,0 +1,81 @@
+// ---- Created with 3Dmigoto v1.4.1 on Sat Apr  5 00:32:49 2025
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[33];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  float4 v4 : TEXCOORD3,
+  float4 v5 : TEXCOORD4,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = saturate(v1.yx);
+  r0.xy = -cb0[21].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[21].wz);
+  r0.zw = cb0[8].yy * r0.xy;
+  r1.x = 1 + -cb0[8].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[20].zw + cb0[20].xy;
+  r0.xyzw = t0.Sample(s0_s, r0.xy).xyzw;
+  r1.x = saturate(dot(r0.xyzw, cb0[9].xyzw));
+  r0.xyzw = r1.xxxx * cb0[10].xyzw + r0.xyzw;
+  r0.xyz = r0.xyz / r0.www;
+  r0.xyzw = cb0[22].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.xyzw = t1.Sample(s1_s, v2.xy).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[27].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t2.Sample(s2_s, v2.zw).xyzw;
+  r1.w = cb0[27].w * r2.w;
+  r0.xyz = r1.www * r1.xyz + r0.xyz;
+  o0.w = r0.w;
+  r1.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r1.xyz = cb0[32].xyz * r1.xyz;
+  r2.xyzw = t4.Sample(s4_s, v3.zw).xyzw;
+  r1.xyz = r2.www * r1.xyz;
+  r1.xyz = cb0[32].www * r1.xyz;
+  r0.xyz = r1.xyz * float3(2,2,2) + r0.xyz;
+  r1.xyz = v5.xyz + -r0.xyz;
+  r0.xyz = v5.www * r1.xyz + r0.xyz;
+  r1.xyz = v4.xyz + -r0.xyz;
+  o0.xyz = v4.www * r1.xyz + r0.xyz;
+
+  o0 = saturate(o0);
+  return;
+}

--- a/src/games/ori1definitive/artifacts/artifact_0x7EA3E0B2.ps_4_0.hlsl
+++ b/src/games/ori1definitive/artifacts/artifact_0x7EA3E0B2.ps_4_0.hlsl
@@ -1,0 +1,109 @@
+// ---- Created with 3Dmigoto v1.4.1 on Sat Apr  5 00:32:51 2025
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[55];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  float4 v4 : TEXCOORD3,
+  float4 v5 : TEXCOORD4,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = saturate(v1.yx);
+  r0.xy = -cb0[21].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[21].wz);
+  r0.zw = cb0[8].yy * r0.xy;
+  r1.x = 1 + -cb0[8].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[20].zw + cb0[20].xy;
+  r0.xyzw = t0.Sample(s0_s, r0.xy).xyzw;
+  r1.x = saturate(dot(r0.xyzw, cb0[9].xyzw));
+  r0.xyzw = r1.xxxx * cb0[10].xyzw + r0.xyzw;
+  r0.xyz = r0.xyz / r0.www;
+  r0.xyzw = cb0[22].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.x = cmp(r0.y < r0.z);
+  r2.xy = r0.zy;
+  r3.xy = r2.yx;
+  r2.zw = float2(-1,0.666666687);
+  r3.zw = float2(0,-0.333333343);
+  r1.xyzw = r1.xxxx ? r2.xywz : r3.xywz;
+  r0.y = cmp(r0.x < r1.x);
+  r2.z = r1.w;
+  r1.w = r0.x;
+  o0.w = r0.w;
+  r2.xyw = r1.wyx;
+  r0.xyzw = r0.yyyy ? r1.xyzw : r2.xyzw;
+  r1.x = min(r0.w, r0.y);
+  r1.x = -r1.x + r0.x;
+  r1.y = r1.x * 6 + cb0[54].x;
+  r0.y = r0.w + -r0.y;
+  r0.y = r0.y / r1.y;
+  r0.y = r0.y + r0.z;
+  r0.y = cb0[43].x + abs(r0.y);
+  r0.y = frac(r0.y);
+  r0.yzw = r0.yyy * float3(6,6,6) + float3(-3,-2,-4);
+  r0.yzw = saturate(abs(r0.yzw) * float3(1,-1,-1) + float3(-1,2,2));
+  r0.yzw = float3(-1,-1,-1) + r0.yzw;
+  r1.y = cb0[54].x + r0.x;
+  r1.x = r1.x / r1.y;
+  r0.yzw = r0.yzw * r1.xxx + float3(1,1,1);
+  r0.xyz = r0.yzw * r0.xxx;
+  r1.xyzw = t1.Sample(s1_s, v2.xy).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[48].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t2.Sample(s2_s, v2.zw).xyzw;
+  r0.w = cb0[48].w * r2.w;
+  r0.xyz = r0.www * r1.xyz + r0.xyz;
+  r1.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[53].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t4.Sample(s4_s, v3.zw).xyzw;
+  r0.w = cb0[53].w * r2.w;
+  r0.xyz = r0.www * r1.xyz + r0.xyz;
+  r1.xyz = v5.xyz + -r0.xyz;
+  r0.xyz = v5.www * r1.xyz + r0.xyz;
+  r1.xyz = v4.xyz + -r0.xyz;
+  o0.xyz = v4.www * r1.xyz + r0.xyz;
+
+o0 = saturate(o0);
+
+  return;
+}

--- a/src/games/ori1definitive/artifacts/artifact_0x89FC4143.ps_4_0.hlsl
+++ b/src/games/ori1definitive/artifacts/artifact_0x89FC4143.ps_4_0.hlsl
@@ -1,0 +1,93 @@
+// ---- Created with 3Dmigoto v1.4.1 on Sat Apr  5 00:32:55 2025
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[50];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  float4 v4 : TEXCOORD3,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = saturate(v1.yx);
+  r0.xy = -cb0[21].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[21].wz);
+  r0.zw = cb0[8].yy * r0.xy;
+  r1.x = 1 + -cb0[8].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[20].zw + cb0[20].xy;
+  r0.xyzw = t0.Sample(s0_s, r0.xy).xyzw;
+  r1.x = saturate(dot(r0.xyzw, cb0[9].xyzw));
+  r0.xyzw = r1.xxxx * cb0[10].xyzw + r0.xyzw;
+  r0.xyz = r0.xyz / r0.www;
+  r0.xyzw = cb0[22].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.x = cmp(r0.y < r0.z);
+  r2.xy = r0.zy;
+  r3.xy = r2.yx;
+  r2.zw = float2(-1,0.666666687);
+  r3.zw = float2(0,-0.333333343);
+  r1.xyzw = r1.xxxx ? r2.xywz : r3.xywz;
+  r0.y = cmp(r0.x < r1.x);
+  r2.z = r1.w;
+  r1.w = r0.x;
+  o0.w = r0.w;
+  r2.xyw = r1.wyx;
+  r0.xyzw = r0.yyyy ? r1.xyzw : r2.xyzw;
+  r1.x = min(r0.w, r0.y);
+  r1.x = -r1.x + r0.x;
+  r1.y = r1.x * 6 + cb0[49].x;
+  r0.y = r0.w + -r0.y;
+  r0.y = r0.y / r1.y;
+  r0.y = r0.y + r0.z;
+  r0.y = cb0[43].x + abs(r0.y);
+  r0.y = frac(r0.y);
+  r0.yzw = r0.yyy * float3(6,6,6) + float3(-3,-2,-4);
+  r0.yzw = saturate(abs(r0.yzw) * float3(1,-1,-1) + float3(-1,2,2));
+  r0.yzw = float3(-1,-1,-1) + r0.yzw;
+  r1.y = cb0[49].x + r0.x;
+  r1.x = r1.x / r1.y;
+  r0.yzw = r0.yzw * r1.xxx + float3(1,1,1);
+  r0.xyz = r0.yzw * r0.xxx;
+  r1.xyzw = t1.Sample(s1_s, v2.xy).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[48].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t2.Sample(s2_s, v2.zw).xyzw;
+  r0.w = cb0[48].w * r2.w;
+  r0.xyz = r0.www * r1.xyz + r0.xyz;
+  r1.xyz = v4.xyz + -r0.xyz;
+  r0.xyz = v4.www * r1.xyz + r0.xyz;
+  r1.xyz = v3.xyz + -r0.xyz;
+  o0.xyz = v3.www * r1.xyz + r0.xyz;
+
+  o0 = saturate(o0);
+
+  return;
+}

--- a/src/games/ori1definitive/artifacts/artifact_0x92EF8684.ps_4_0.hlsl
+++ b/src/games/ori1definitive/artifacts/artifact_0x92EF8684.ps_4_0.hlsl
@@ -1,0 +1,120 @@
+// ---- Created with 3Dmigoto v1.4.1 on Sat Apr  5 00:32:56 2025
+Texture2D<float4> t6 : register(t6);
+
+Texture2D<float4> t5 : register(t5);
+
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s6_s : register(s6);
+
+SamplerState s5_s : register(s5);
+
+SamplerState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[78];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  float4 v4 : TEXCOORD3,
+  float4 v5 : TEXCOORD4,
+  float4 v6 : COLOR0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = cb0[40].xy + -v4.xy;
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = sqrt(r0.x);
+  r0.y = cb0[69].y * cb0[40].z;
+  r0.x = saturate(r0.x / r0.y);
+  r0.x = -1 + r0.x;
+  r0.x = cb0[40].w * r0.x;
+  r0.x = cb0[69].x * r0.x + 1;
+  r0.y = 0;
+  r0.xyzw = t4.Sample(s4_s, r0.xy).xyzw;
+  r0.y = r0.x * -2 + 1;
+  r0.x = cb0[69].w * r0.y + r0.x;
+  r0.y = cb0[70].w + -r0.x;
+  r0.x = cb0[71].x * r0.y + r0.x;
+  r0.x = -1 + r0.x;
+  r0.xy = cb0[70].yx * r0.xx + float2(1,1);
+  r0.z = cb0[76].w * r0.x + -1;
+  r0.z = saturate(-6.66666794 * r0.z);
+  r0.w = r0.z * -2 + 3;
+  r0.z = r0.z * r0.z;
+  r0.z = r0.w * r0.z;
+  r0.x = -cb0[76].w * r0.x + 1;
+  r1.xyzw = t5.Sample(s6_s, v5.xy).xyzw;
+  r1.xy = r1.zw * float2(2,2) + float2(-1,-1);
+  r1.xy = r1.xy * cb0[77].xy + v3.zw;
+  r1.xyzw = t6.Sample(s5_s, r1.xy).xyzw;
+  r0.x = saturate(-r1.w * 0.930000007 + r0.x);
+  r0.w = 1 + -r1.w;
+  r0.w = r0.w * 0.930000007 + 0.0700000003;
+  r0.w = cb0[77].z * r0.w;
+  r0.w = 0.5 * r0.w;
+  r0.x = r0.x / r0.w;
+  r0.z = r0.x * r0.z;
+  r0.x = 1 + -r0.x;
+  r0.z = log2(r0.z);
+  r0.w = 1 / cb0[77].w;
+  r0.z = r0.w * r0.z;
+  r0.z = exp2(r0.z);
+  r1.xyzw = t0.Sample(s1_s, v2.xy).xyzw;
+  r1.xy = r1.wz * float2(2,2) + float2(-1,-1);
+  r1.xy = cb0[32].yx * r1.xy;
+  r2.xyzw = t1.Sample(s2_s, v2.zw).xyzw;
+  r1.xy = r1.xy * r2.ww + v1.yx;
+  r1.xy = frac(r1.xy);
+  r1.xy = -cb0[20].yx + r1.xy;
+  r1.xy = saturate(r1.xy / cb0[20].wz);
+  r1.zw = cb0[7].yy * r1.xy;
+  r0.w = 1 + -cb0[7].y;
+  r1.xy = r1.yx * r0.ww + r1.zw;
+  r1.xy = r1.xy * cb0[19].zw + cb0[19].xy;
+  r1.xyzw = t2.Sample(s0_s, r1.xy).xyzw;
+  r1.xyzw = cb0[21].xyzw * r1.xyzw;
+  r1.xyzw = r1.xyzw + r1.xyzw;
+  o0.xyz = cb0[76].xyz * r0.zzz + r1.xyz;
+  r2.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r0.z = -1 + r2.w;
+  r0.z = cb0[39].x * r0.z + 1;
+  r0.z = r1.w * r0.z;
+  r0.y = r0.z * r0.y;
+  o0.w = r0.y * r0.x;
+
+  o0 = saturate(o0);
+
+  return;
+}

--- a/src/games/ori1definitive/artifacts/artifact_0x95E462F3.ps_4_0.hlsl
+++ b/src/games/ori1definitive/artifacts/artifact_0x95E462F3.ps_4_0.hlsl
@@ -1,0 +1,124 @@
+// ---- Created with 3Dmigoto v1.4.1 on Sat Apr  5 00:32:57 2025
+Texture2D<float4> t6 : register(t6);
+
+Texture2D<float4> t5 : register(t5);
+
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s6_s : register(s6);
+
+SamplerState s5_s : register(s5);
+
+SamplerState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[78];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  float4 v4 : TEXCOORD3,
+  float4 v5 : TEXCOORD4,
+  float4 v6 : COLOR0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = cb0[40].xy + -v4.xy;
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = sqrt(r0.x);
+  r0.y = cb0[69].y * cb0[40].z;
+  r0.x = saturate(r0.x / r0.y);
+  r0.x = -1 + r0.x;
+  r0.x = cb0[40].w * r0.x;
+  r0.x = cb0[69].x * r0.x + 1;
+  r0.y = 0;
+  r0.xyzw = t4.Sample(s4_s, r0.xy).xyzw;
+  r0.y = 1 + -r0.x;
+  r0.y = r0.y + -r0.x;
+  r0.x = cb0[69].w * r0.y + r0.x;
+  r0.y = cb0[70].w + -r0.x;
+  r0.x = cb0[71].x * r0.y + r0.x;
+  r0.x = -1 + r0.x;
+  r0.xy = cb0[70].yx * r0.xx + float2(1,1);
+  r0.z = cb0[76].w * r0.x + -1;
+  r0.z = saturate(-6.66666794 * r0.z);
+  r0.w = r0.z * -2 + 3;
+  r0.z = r0.z * r0.z;
+  r0.z = r0.w * r0.z;
+  r0.x = -cb0[76].w * r0.x + 1;
+  r1.xyzw = t5.Sample(s6_s, v5.xy).xyzw;
+  r1.xy = r1.zw * float2(2,2) + float2(-1,-1);
+  r1.xy = r1.xy * cb0[77].xy + v3.zw;
+  r1.xyzw = t6.Sample(s5_s, r1.xy).xyzw;
+  r0.x = saturate(-r1.w * 0.930000007 + r0.x);
+  r0.w = 1 + -r1.w;
+  r0.w = r0.w * 0.930000007 + 0.0700000003;
+  r0.w = cb0[77].z * r0.w;
+  r0.w = 0.5 * r0.w;
+  r0.x = r0.x / r0.w;
+  r0.z = r0.x * r0.z;
+  r0.x = 1 + -r0.x;
+  r0.z = log2(r0.z);
+  r0.w = 1 / cb0[77].w;
+  r0.z = r0.w * r0.z;
+  r0.z = exp2(r0.z);
+  r1.xyzw = t0.Sample(s1_s, v2.xy).xyzw;
+  r1.xy = r1.wz * float2(2,2) + float2(-1,-1);
+  r1.xy = cb0[32].yx * r1.xy;
+  r2.xyzw = t1.Sample(s2_s, v2.zw).xyzw;
+  r1.xy = r1.xy * r2.ww + v1.yx;
+  r1.xy = frac(r1.xy);
+  r1.xy = -cb0[20].yx + r1.xy;
+  r1.xy = saturate(r1.xy / cb0[20].wz);
+  r1.zw = cb0[7].yy * r1.xy;
+  r0.w = 1 + -cb0[7].y;
+  r1.xy = r1.yx * r0.ww + r1.zw;
+  r1.xy = r1.xy * cb0[19].zw + cb0[19].xy;
+  r1.xyzw = t2.Sample(s0_s, r1.xy).xyzw;
+  r0.w = saturate(dot(r1.xyzw, cb0[8].xyzw));
+  r1.xyzw = r0.wwww * cb0[9].xyzw + r1.xyzw;
+  r1.xyz = r1.xyz / r1.www;
+  r1.xyzw = cb0[21].xyzw * r1.xyzw;
+  r1.xyzw = r1.xyzw + r1.xyzw;
+  o0.xyz = cb0[76].xyz * r0.zzz + r1.xyz;
+  r2.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r0.z = -1 + r2.w;
+  r0.z = cb0[39].x * r0.z + 1;
+  r0.z = r1.w * r0.z;
+  r0.y = r0.z * r0.y;
+  o0.w = r0.y * r0.x;
+
+o0 = saturate(o0);
+
+  return;
+}

--- a/src/games/ori1definitive/artifacts/artifact_0xA5B9F647.ps_4_0.hlsl
+++ b/src/games/ori1definitive/artifacts/artifact_0xA5B9F647.ps_4_0.hlsl
@@ -1,0 +1,82 @@
+// ---- Created with 3Dmigoto v1.4.1 on Sat Apr  5 00:33:01 2025
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[33];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  float4 v4 : TEXCOORD3,
+  float4 v5 : TEXCOORD4,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = saturate(v1.yx);
+  r0.xy = -cb0[21].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[21].wz);
+  r0.zw = cb0[8].yy * r0.xy;
+  r1.x = 1 + -cb0[8].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[20].zw + cb0[20].xy;
+  r0.xyzw = t0.Sample(s0_s, r0.xy).xyzw;
+  r1.x = saturate(dot(r0.xyzw, cb0[9].xyzw));
+  r0.xyzw = r1.xxxx * cb0[10].xyzw + r0.xyzw;
+  r0.xyz = r0.xyz / r0.www;
+  r0.xyzw = cb0[22].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.xyzw = t1.Sample(s1_s, v2.xy).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[27].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t2.Sample(s2_s, v2.zw).xyzw;
+  r1.w = cb0[27].w * r2.w;
+  r0.xyz = r1.www * r1.xyz + r0.xyz;
+  o0.w = r0.w;
+  r1.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[32].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t4.Sample(s4_s, v3.zw).xyzw;
+  r0.w = cb0[32].w * r2.w;
+  r0.xyz = r0.www * r1.xyz + r0.xyz;
+  r1.xyz = v5.xyz + -r0.xyz;
+  r0.xyz = v5.www * r1.xyz + r0.xyz;
+  r1.xyz = v4.xyz + -r0.xyz;
+  o0.xyz = v4.www * r1.xyz + r0.xyz;
+
+  o0 = saturate(o0);
+  return;
+}

--- a/src/games/ori1definitive/artifacts/artifact_0xB8F1C5BC.ps_4_0.hlsl
+++ b/src/games/ori1definitive/artifacts/artifact_0xB8F1C5BC.ps_4_0.hlsl
@@ -1,0 +1,85 @@
+// ---- Created with 3Dmigoto v1.4.1 on Sat Apr  5 00:33:07 2025
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[46];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  float4 v4 : TEXCOORD3,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = saturate(v1.yx);
+  r0.xy = -cb0[21].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[21].wz);
+  r0.zw = cb0[8].yy * r0.xy;
+  r1.x = 1 + -cb0[8].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[20].zw + cb0[20].xy;
+  r0.xyzw = t0.Sample(s0_s, r0.xy).xyzw;
+  r1.x = saturate(dot(r0.xyzw, cb0[9].xyzw));
+  r0.xyzw = r1.xxxx * cb0[10].xyzw + r0.xyzw;
+  r0.xyz = r0.xyz / r0.www;
+  r0.xyzw = cb0[22].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.x = cmp(r0.y < r0.z);
+  r2.xy = r0.zy;
+  r3.xy = r2.yx;
+  r2.zw = float2(-1,0.666666687);
+  r3.zw = float2(0,-0.333333343);
+  r1.xyzw = r1.xxxx ? r2.xywz : r3.xywz;
+  r0.y = cmp(r0.x < r1.x);
+  r2.z = r1.w;
+  r1.w = r0.x;
+  r2.xyw = r1.wyx;
+  r1.xyzw = r0.yyyy ? r1.xyzw : r2.xyzw;
+  r0.x = min(r1.w, r1.y);
+  r0.x = r1.x + -r0.x;
+  r0.y = r0.x * 6 + cb0[45].z;
+  r0.z = r1.w + -r1.y;
+  r0.y = r0.z / r0.y;
+  r0.y = r0.y + r1.z;
+  r0.y = cb0[45].y + abs(r0.y);
+  r0.y = frac(r0.y);
+  r1.yzw = r0.yyy * float3(6,6,6) + float3(-3,-2,-4);
+  r1.yzw = saturate(abs(r1.yzw) * float3(1,-1,-1) + float3(-1,2,2));
+  r1.yzw = float3(-1,-1,-1) + r1.yzw;
+  r0.y = cb0[45].z + r1.x;
+  r0.x = r0.x / r0.y;
+  r0.xyz = r1.yzw * r0.xxx + float3(1,1,1);
+  r1.yzw = r0.xyz * r1.xxx;
+  r0.xyz = -r0.xyz * r1.xxx + v4.xyz;
+  r0.xyz = v4.www * r0.xyz + r1.yzw;
+  r1.xyz = v3.xyz + -r0.xyz;
+  o0.xyz = v3.www * r1.xyz + r0.xyz;
+  r1.xyzw = t1.Sample(s1_s, v2.xy).xyzw;
+  r0.x = -1 + r1.w;
+  r0.x = cb0[45].x * r0.x + 1;
+  o0.w = r0.w * r0.x;
+
+  o0 = saturate(o0);
+  
+  return;
+}

--- a/src/games/ori1definitive/artifacts/artifact_0xB932F19B.ps_4_0.hlsl
+++ b/src/games/ori1definitive/artifacts/artifact_0xB932F19B.ps_4_0.hlsl
@@ -1,0 +1,109 @@
+// ---- Created with 3Dmigoto v1.4.1 on Sat Apr  5 00:33:07 2025
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[46];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  float4 v4 : TEXCOORD3,
+  float4 v5 : TEXCOORD4,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = saturate(v1.yx);
+  r0.xy = -cb0[21].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[21].wz);
+  r0.zw = cb0[8].yy * r0.xy;
+  r1.x = 1 + -cb0[8].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[20].zw + cb0[20].xy;
+  r0.xyzw = t0.Sample(s0_s, r0.xy).xyzw;
+  r1.x = saturate(dot(r0.xyzw, cb0[9].xyzw));
+  r0.xyzw = r1.xxxx * cb0[10].xyzw + r0.xyzw;
+  r0.xyz = r0.xyz / r0.www;
+  r0.xyzw = cb0[22].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.x = cmp(r0.y < r0.z);
+  r2.xy = r0.zy;
+  r3.xy = r2.yx;
+  r2.zw = float2(-1,0.666666687);
+  r3.zw = float2(0,-0.333333343);
+  r1.xyzw = r1.xxxx ? r2.xywz : r3.xywz;
+  r0.y = cmp(r0.x < r1.x);
+  r2.z = r1.w;
+  r1.w = r0.x;
+  o0.w = r0.w;
+  r2.xyw = r1.wyx;
+  r0.xyzw = r0.yyyy ? r1.xyzw : r2.xyzw;
+  r1.x = min(r0.w, r0.y);
+  r1.x = -r1.x + r0.x;
+  r1.y = r1.x * 6 + cb0[45].x;
+  r0.y = r0.w + -r0.y;
+  r0.y = r0.y / r1.y;
+  r0.y = r0.y + r0.z;
+  r0.y = cb0[34].x + abs(r0.y);
+  r0.y = frac(r0.y);
+  r0.yzw = r0.yyy * float3(6,6,6) + float3(-3,-2,-4);
+  r0.yzw = saturate(abs(r0.yzw) * float3(1,-1,-1) + float3(-1,2,2));
+  r0.yzw = float3(-1,-1,-1) + r0.yzw;
+  r1.y = cb0[45].x + r0.x;
+  r1.x = r1.x / r1.y;
+  r0.yzw = r0.yzw * r1.xxx + float3(1,1,1);
+  r0.xyz = r0.yzw * r0.xxx;
+  r1.xyzw = t1.Sample(s1_s, v2.xy).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[39].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t2.Sample(s2_s, v2.zw).xyzw;
+  r0.w = cb0[39].w * r2.w;
+  r0.xyz = r0.www * r1.xyz + r0.xyz;
+  r1.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[44].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t4.Sample(s4_s, v3.zw).xyzw;
+  r0.w = cb0[44].w * r2.w;
+  r0.xyz = r0.www * r1.xyz + r0.xyz;
+  r1.xyz = v5.xyz + -r0.xyz;
+  r0.xyz = v5.www * r1.xyz + r0.xyz;
+  r1.xyz = v4.xyz + -r0.xyz;
+  o0.xyz = v4.www * r1.xyz + r0.xyz;
+
+  o0 = saturate(o0);
+  
+  return;
+}

--- a/src/games/ori1definitive/artifacts/artifact_0xBC4BB886.ps_4_0.hlsl
+++ b/src/games/ori1definitive/artifacts/artifact_0xBC4BB886.ps_4_0.hlsl
@@ -1,0 +1,50 @@
+// ---- Created with 3Dmigoto v1.4.1 on Sat Apr  5 00:33:08 2025
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[23];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = saturate(v1.yx);
+  r0.xy = -cb0[21].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[21].wz);
+  r0.zw = cb0[8].yy * r0.xy;
+  r1.x = 1 + -cb0[8].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[20].zw + cb0[20].xy;
+  r0.xyzw = t0.Sample(s0_s, r0.xy).xyzw;
+  r1.x = saturate(dot(r0.xyzw, cb0[9].xyzw));
+  r0.xyzw = r1.xxxx * cb0[10].xyzw + r0.xyzw;
+  r0.xyz = r0.xyz / r0.www;
+  r0.xyzw = cb0[22].xyzw * r0.xyzw;
+  r1.xyz = -r0.xyz * float3(2,2,2) + v3.xyz;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r0.xyz = v3.www * r1.xyz + r0.xyz;
+  o0.w = r0.w;
+  r1.xyz = v2.xyz + -r0.xyz;
+  o0.xyz = v2.www * r1.xyz + r0.xyz;
+
+  o0 = saturate(o0);
+  return;
+}

--- a/src/games/ori1definitive/artifacts/artifact_0xC997373E.ps_4_0.hlsl
+++ b/src/games/ori1definitive/artifacts/artifact_0xC997373E.ps_4_0.hlsl
@@ -1,0 +1,105 @@
+// ---- Created with 3Dmigoto v1.4.1 on Sat Apr  5 00:33:11 2025
+Texture2D<float4> t7 : register(t7);
+
+Texture2D<float4> t6 : register(t6);
+
+Texture2D<float4> t5 : register(t5);
+
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s7_s : register(s7);
+
+SamplerState s6_s : register(s6);
+
+SamplerState s5_s : register(s5);
+
+SamplerState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[41];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  float4 v4 : TEXCOORD3,
+  float4 v5 : TEXCOORD4,
+  float4 v6 : TEXCOORD5,
+  float4 v7 : TEXCOORD6,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = saturate(v1.yx);
+  r0.xy = -cb0[21].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[21].wz);
+  r0.zw = cb0[8].yy * r0.xy;
+  r1.x = 1 + -cb0[8].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[20].zw + cb0[20].xy;
+  r0.xyzw = t0.Sample(s0_s, r0.xy).xyzw;
+  r1.x = saturate(dot(r0.xyzw, cb0[9].xyzw));
+  r0.xyzw = r1.xxxx * cb0[10].xyzw + r0.xyzw;
+  r0.xyz = r0.xyz / r0.www;
+  r0.xyzw = cb0[22].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.xyzw = t2.Sample(s2_s, v2.zw).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[30].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r1.w = cb0[30].w * r2.w;
+  r0.xyz = r1.www * r1.xyz + r0.xyz;
+  r1.xyzw = t4.Sample(s4_s, v3.zw).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[35].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t5.Sample(s5_s, v4.xy).xyzw;
+  r1.w = cb0[35].w * r2.w;
+  r0.xyz = r1.www * r1.xyz + r0.xyz;
+  r1.xyzw = t6.Sample(s6_s, v4.zw).xyzw;
+  r1.xyz = cb0[40].xyz * r1.xyz;
+  r2.xyzw = t7.Sample(s7_s, v5.xy).xyzw;
+  r1.xyz = r2.www * r1.xyz;
+  r1.xyz = cb0[40].www * r1.xyz;
+  r0.xyz = r1.xyz * float3(2,2,2) + r0.xyz;
+  r1.xyz = v7.xyz + -r0.xyz;
+  r0.xyz = v7.www * r1.xyz + r0.xyz;
+  r1.xyz = v6.xyz + -r0.xyz;
+  o0.xyz = v6.www * r1.xyz + r0.xyz;
+  r1.xyzw = t1.Sample(s1_s, v2.xy).xyzw;
+  r0.x = -1 + r1.w;
+  r0.x = cb0[25].x * r0.x + 1;
+  o0.w = r0.w * r0.x;
+
+  o0 = saturate(o0);
+  return;
+}

--- a/src/games/ori1definitive/artifacts/artifact_0xCC3D6FF7.ps_4_0.hlsl
+++ b/src/games/ori1definitive/artifacts/artifact_0xCC3D6FF7.ps_4_0.hlsl
@@ -1,0 +1,47 @@
+// ---- Created with 3Dmigoto v1.4.1 on Sat Apr  5 00:33:12 2025
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[23];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = saturate(v1.yx);
+  r0.xy = -cb0[21].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[21].wz);
+  r0.zw = cb0[8].yy * r0.xy;
+  r1.x = 1 + -cb0[8].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[20].zw + cb0[20].xy;
+  r0.xyzw = t0.Sample(s0_s, r0.xy).xyzw;
+  r0.xyzw = cb0[22].xyzw * r0.xyzw;
+  r1.xyz = -r0.xyz * float3(2,2,2) + v3.xyz;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r0.xyz = v3.www * r1.xyz + r0.xyz;
+  o0.w = r0.w;
+  r1.xyz = v2.xyz + -r0.xyz;
+  o0.xyz = v2.www * r1.xyz + r0.xyz;
+
+  o0 = saturate(o0);
+  return;
+}

--- a/src/games/ori1definitive/artifacts/artifact_0xE311E5C3.ps_4_0.hlsl
+++ b/src/games/ori1definitive/artifacts/artifact_0xE311E5C3.ps_4_0.hlsl
@@ -1,0 +1,103 @@
+// ---- Created with 3Dmigoto v1.4.1 on Sat Apr  5 00:33:17 2025
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[45];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = saturate(v1.yx);
+  r0.xy = -cb0[20].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[20].wz);
+  r0.zw = cb0[7].yy * r0.xy;
+  r1.x = 1 + -cb0[7].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[19].zw + cb0[19].xy;
+  r0.xyzw = t0.Sample(s0_s, r0.xy).xyzw;
+  r1.x = saturate(dot(r0.xyzw, cb0[8].xyzw));
+  r0.xyzw = r1.xxxx * cb0[9].xyzw + r0.xyzw;
+  r0.xyz = r0.xyz / r0.www;
+  r0.xyzw = cb0[21].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.x = cmp(r0.y < r0.z);
+  r2.xy = r0.zy;
+  r3.xy = r2.yx;
+  r2.zw = float2(-1,0.666666687);
+  r3.zw = float2(0,-0.333333343);
+  r1.xyzw = r1.xxxx ? r2.xywz : r3.xywz;
+  r0.y = cmp(r0.x < r1.x);
+  r2.z = r1.w;
+  r1.w = r0.x;
+  o0.w = r0.w;
+  r2.xyw = r1.wyx;
+  r0.xyzw = r0.yyyy ? r1.xyzw : r2.xyzw;
+  r1.x = min(r0.w, r0.y);
+  r1.x = -r1.x + r0.x;
+  r1.y = r1.x * 6 + cb0[44].x;
+  r0.y = r0.w + -r0.y;
+  r0.y = r0.y / r1.y;
+  r0.y = r0.y + r0.z;
+  r0.y = cb0[33].x + abs(r0.y);
+  r0.y = frac(r0.y);
+  r0.yzw = r0.yyy * float3(6,6,6) + float3(-3,-2,-4);
+  r0.yzw = saturate(abs(r0.yzw) * float3(1,-1,-1) + float3(-1,2,2));
+  r0.yzw = float3(-1,-1,-1) + r0.yzw;
+  r1.y = cb0[44].x + r0.x;
+  r1.x = r1.x / r1.y;
+  r0.yzw = r0.yzw * r1.xxx + float3(1,1,1);
+  r0.xyz = r0.yzw * r0.xxx;
+  r1.xyzw = t1.Sample(s1_s, v2.xy).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[38].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t2.Sample(s2_s, v2.zw).xyzw;
+  r0.w = cb0[38].w * r2.w;
+  r0.xyz = r0.www * r1.xyz + r0.xyz;
+  r1.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[43].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t4.Sample(s4_s, v3.zw).xyzw;
+  r0.w = cb0[43].w * r2.w;
+  o0.xyz = r0.www * r1.xyz + r0.xyz;
+
+  o0 = saturate(o0);
+
+  return;
+}

--- a/src/games/ori1definitive/artifacts/artifact_0xEDD7A595.ps_4_0.hlsl
+++ b/src/games/ori1definitive/artifacts/artifact_0xEDD7A595.ps_4_0.hlsl
@@ -1,0 +1,97 @@
+// ---- Created with 3Dmigoto v1.4.1 on Sat Apr  5 00:33:20 2025
+Texture2D<float4> t6 : register(t6);
+
+Texture2D<float4> t5 : register(t5);
+
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s6_s : register(s6);
+
+SamplerState s5_s : register(s5);
+
+SamplerState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[38];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  float4 v4 : TEXCOORD3,
+  float4 v5 : TEXCOORD4,
+  float4 v6 : TEXCOORD5,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = saturate(v1.yx);
+  r0.xy = -cb0[21].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[21].wz);
+  r0.zw = cb0[8].yy * r0.xy;
+  r1.x = 1 + -cb0[8].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[20].zw + cb0[20].xy;
+  r0.xyzw = t0.Sample(s0_s, r0.xy).xyzw;
+  r1.x = saturate(dot(r0.xyzw, cb0[9].xyzw));
+  r0.xyzw = r1.xxxx * cb0[10].xyzw + r0.xyzw;
+  r0.xyz = r0.xyz / r0.www;
+  r0.xyzw = cb0[22].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.xyzw = t1.Sample(s1_s, v2.xy).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[27].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t2.Sample(s2_s, v2.zw).xyzw;
+  r1.w = cb0[27].w * r2.w;
+  r0.xyz = r1.www * r1.xyz + r0.xyz;
+  o0.w = r0.w;
+  r1.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[32].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t4.Sample(s4_s, v3.zw).xyzw;
+  r0.w = cb0[32].w * r2.w;
+  r0.xyz = r0.www * r1.xyz + r0.xyz;
+  r1.xyzw = t5.Sample(s5_s, v4.xy).xyzw;
+  r1.xyz = cb0[37].xyz * r1.xyz;
+  r2.xyzw = t6.Sample(s6_s, v4.zw).xyzw;
+  r1.xyz = r2.www * r1.xyz;
+  r1.xyz = cb0[37].www * r1.xyz;
+  r0.xyz = r1.xyz * float3(2,2,2) + r0.xyz;
+  r1.xyz = v6.xyz + -r0.xyz;
+  r0.xyz = v6.www * r1.xyz + r0.xyz;
+  r1.xyz = v5.xyz + -r0.xyz;
+  o0.xyz = v5.www * r1.xyz + r0.xyz;
+
+  o0 = saturate(o0);
+  return;
+}

--- a/src/games/ori1definitive/artifacts/artifact_0xF2280F92.ps_4_0.hlsl
+++ b/src/games/ori1definitive/artifacts/artifact_0xF2280F92.ps_4_0.hlsl
@@ -1,0 +1,59 @@
+// ---- Created with 3Dmigoto v1.4.1 on Sat Apr  5 00:33:21 2025
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[26];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  float4 v4 : TEXCOORD3,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = saturate(v1.yx);
+  r0.xy = -cb0[21].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[21].wz);
+  r0.zw = cb0[8].yy * r0.xy;
+  r1.x = 1 + -cb0[8].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[20].zw + cb0[20].xy;
+  r0.xyzw = t0.Sample(s0_s, r0.xy).xyzw;
+  r1.x = saturate(dot(r0.xyzw, cb0[9].xyzw));
+  r0.xyzw = r1.xxxx * cb0[10].xyzw + r0.xyzw;
+  r0.xyz = r0.xyz / r0.www;
+  r0.xyzw = cb0[22].xyzw * r0.xyzw;
+  r1.xyz = -r0.xyz * float3(2,2,2) + v4.xyz;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r0.xyz = v4.www * r1.xyz + r0.xyz;
+  r1.xyz = v3.xyz + -r0.xyz;
+  o0.xyz = v3.www * r1.xyz + r0.xyz;
+  r1.xyzw = t1.Sample(s1_s, v2.xy).xyzw;
+  r0.x = -1 + r1.w;
+  r0.x = cb0[25].x * r0.x + 1;
+  o0.w = r0.w * r0.x;
+
+  o0 = saturate(o0);
+
+  return;
+}

--- a/src/games/ori1definitive/artifacts/artifact_0xFD5E9187.ps_4_0.hlsl
+++ b/src/games/ori1definitive/artifacts/artifact_0xFD5E9187.ps_4_0.hlsl
@@ -1,0 +1,66 @@
+// ---- Created with 3Dmigoto v1.4.1 on Sat Apr  5 00:33:24 2025
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[28];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  float4 v4 : TEXCOORD3,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = saturate(v1.yx);
+  r0.xy = -cb0[21].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[21].wz);
+  r0.zw = cb0[8].yy * r0.xy;
+  r1.x = 1 + -cb0[8].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[20].zw + cb0[20].xy;
+  r0.xyzw = t0.Sample(s0_s, r0.xy).xyzw;
+  r1.x = saturate(dot(r0.xyzw, cb0[9].xyzw));
+  r0.xyzw = r1.xxxx * cb0[10].xyzw + r0.xyzw;
+  r0.xyz = r0.xyz / r0.www;
+  r0.xyzw = cb0[22].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.xyzw = t1.Sample(s1_s, v2.xy).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[27].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t2.Sample(s2_s, v2.zw).xyzw;
+  r1.w = cb0[27].w * r2.w;
+  r0.xyz = r1.www * r1.xyz + r0.xyz;
+  o0.w = r0.w;
+  r1.xyz = v4.xyz + -r0.xyz;
+  r0.xyz = v4.www * r1.xyz + r0.xyz;
+  r1.xyz = v3.xyz + -r0.xyz;
+  o0.xyz = v3.www * r1.xyz + r0.xyz;
+
+  o0 = saturate(o0);
+  return;
+}

--- a/src/games/ori1definitive/artifacts/artifact_map_0xD6DBC682.ps_4_0.hlsl
+++ b/src/games/ori1definitive/artifacts/artifact_map_0xD6DBC682.ps_4_0.hlsl
@@ -1,0 +1,58 @@
+// ---- Created with 3Dmigoto v1.4.1 on Sat Apr  5 00:33:14 2025
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[27];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = saturate(v1.yx);
+  r0.xy = -cb0[20].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[20].wz);
+  r0.zw = cb0[7].yy * r0.xy;
+  r1.x = 1 + -cb0[7].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[19].zw + cb0[19].xy;
+  r0.xyzw = t0.Sample(s0_s, r0.xy).xyzw;
+  r0.xyzw = cb0[21].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.x = dot(r0.xyz, float3(0.0638099983,0.214560002,0.0216600001));
+  r2.xyzw = t2.Sample(s2_s, v2.zw).xyzw;
+  r3.xyzw = t1.Sample(s1_s, v2.xy).xyzw;
+  r1.zw = -r3.yw + r2.yw;
+  r2.yz = cb0[26].xx * r1.zw + r3.yw;
+  r1.y = r2.z * r0.w;
+  r2.x = r2.y / r2.z;
+  r0.xyzw = r0.xyzw * r2.xxxz + -r1.xxxy;
+  o0.xyzw = r2.xxxx * r0.xyzw + r1.xxxy;
+
+  o0 = saturate(o0);
+  return;
+}

--- a/src/games/ori1definitive/artifacts/artifact_memory_prologue_0x9A326CB2.ps_4_0.hlsl
+++ b/src/games/ori1definitive/artifacts/artifact_memory_prologue_0x9A326CB2.ps_4_0.hlsl
@@ -1,0 +1,67 @@
+// ---- Created with 3Dmigoto v1.4.1 on Sat Apr  5 00:32:58 2025
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[30];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = t0.Sample(s1_s, v2.xy).xyzw;
+  r0.xy = r0.wz * float2(2,2) + float2(-1,-1);
+  r0.xy = cb0[22].yx * r0.xy;
+  r1.xyzw = t1.Sample(s2_s, v2.zw).xyzw;
+  r0.xy = saturate(r0.xy * r1.ww + v1.yx);
+  r0.xy = -cb0[20].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[20].wz);
+  r0.zw = cb0[7].yy * r0.xy;
+  r1.x = 1 + -cb0[7].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[19].zw + cb0[19].xy;
+  r0.xyzw = t2.Sample(s0_s, r0.xy).xyzw;
+  r1.x = saturate(dot(r0.xyzw, cb0[8].xyzw));
+  r0.xyzw = r1.xxxx * cb0[9].xyzw + r0.xyzw;
+  r0.xyz = r0.xyz / r0.www;
+  r0.xyzw = cb0[21].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r1.x = -1 + r1.w;
+  r1.x = cb0[29].x * r1.x + 1;
+  r0.w = r1.x * r0.w;
+  o0.xyz = r0.xyz * r0.www;
+  o0.w = r0.w;
+
+  o0 = saturate(o0);
+  return;
+}

--- a/src/games/ori1definitive/artifacts/artifact_memory_prologue_0xA0679E6A.ps_4_0.hlsl
+++ b/src/games/ori1definitive/artifacts/artifact_memory_prologue_0xA0679E6A.ps_4_0.hlsl
@@ -1,0 +1,58 @@
+// ---- Created with 3Dmigoto v1.4.1 on Sat Apr  5 00:33:00 2025
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[23];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = t0.Sample(s1_s, v2.xy).xyzw;
+  r0.xy = r0.wz * float2(2,2) + float2(-1,-1);
+  r0.xy = cb0[22].yx * r0.xy;
+  r1.xyzw = t1.Sample(s2_s, v2.zw).xyzw;
+  r0.xy = saturate(r0.xy * r1.ww + v1.yx);
+  r0.xy = -cb0[20].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[20].wz);
+  r0.zw = cb0[7].yy * r0.xy;
+  r1.x = 1 + -cb0[7].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[19].zw + cb0[19].xy;
+  r0.xyzw = t2.Sample(s0_s, r0.xy).xyzw;
+  r1.x = saturate(dot(r0.xyzw, cb0[8].xyzw));
+  r0.xyzw = r1.xxxx * cb0[9].xyzw + r0.xyzw;
+  r0.xyz = r0.xyz / r0.www;
+  r0.xyzw = cb0[21].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  o0.xyz = r0.xyz * r0.www;
+  o0.w = r0.w;
+
+  o0 = saturate(o0);
+  return;
+}

--- a/src/games/ori1definitive/artifacts/artifact_plant_0x69935E20.ps_4_0.hlsl
+++ b/src/games/ori1definitive/artifacts/artifact_plant_0x69935E20.ps_4_0.hlsl
@@ -1,0 +1,66 @@
+// ---- Created with 3Dmigoto v1.4.1 on Sat Apr  5 00:32:46 2025
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[43];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  float4 v4 : TEXCOORD3,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = saturate(v1.yx);
+  r0.xy = -cb0[21].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[21].wz);
+  r0.zw = cb0[8].yy * r0.xy;
+  r1.x = 1 + -cb0[8].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[20].zw + cb0[20].xy;
+  r0.xyzw = t0.Sample(s0_s, r0.xy).xyzw;
+  r1.x = saturate(dot(r0.xyzw, cb0[9].xyzw));
+  r0.xyzw = r1.xxxx * cb0[10].xyzw + r0.xyzw;
+  r0.xyz = r0.xyz / r0.www;
+  r0.xyzw = cb0[22].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.xyzw = t1.Sample(s1_s, v2.xy).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[42].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t2.Sample(s2_s, v2.zw).xyzw;
+  r1.w = cb0[42].w * r2.w;
+  r0.xyz = r1.www * r1.xyz + r0.xyz;
+  o0.w = r0.w;
+  r1.xyz = v4.xyz + -r0.xyz;
+  r0.xyz = v4.www * r1.xyz + r0.xyz;
+  r1.xyz = v3.xyz + -r0.xyz;
+  o0.xyz = v3.www * r1.xyz + r0.xyz;
+
+  o0 = saturate(o0);
+  return;
+}

--- a/src/games/ori1definitive/artifacts/artifact_water_0xDBE2402A.ps_4_0.hlsl
+++ b/src/games/ori1definitive/artifacts/artifact_water_0xDBE2402A.ps_4_0.hlsl
@@ -1,0 +1,54 @@
+// ---- Created with 3Dmigoto v1.4.1 on Sat Apr  5 00:33:15 2025
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[11];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float2 v1 : TEXCOORD0,
+  float2 w1 : TEXCOORD1,
+  float2 v2 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.x = v2.x;
+  r0.y = cb0[6].w;
+  r0.xyzw = t0.Sample(s0_s, r0.xy).xyzw;
+  r0.x = abs(r0.y) + abs(r0.x);
+  r0.x = saturate(r0.x * cb0[10].z + 0.300000012);
+  r1.xyzw = t1.Sample(s1_s, v1.xy).xyzw;
+  r1.xyzw = saturate(r1.xyzw * r0.xxxx);
+  r0.y = 0.00999999978 + r1.w;
+  r1.xyz = r1.xyz / r0.yyy;
+  r2.xyzw = t1.Sample(s1_s, w1.xy).xyzw;
+  r0.xyzw = saturate(r2.xyzw * r0.xxxx);
+  r2.x = 0.00999999978 + r0.w;
+  r0.xyz = r0.xyz / r2.xxx;
+  r0.xyzw = r1.xyzw + r0.xyzw;
+  r0.xyzw = cb0[8].xyzw * r0.xyzw;
+  o0.xyzw = r0.xyzw + r0.xyzw;
+
+
+  o0 = saturate(o0);
+
+  return;
+}

--- a/src/games/ori1definitive/artifacts/background_tree_artifact_0x08EC9524.ps_4_0.hlsl
+++ b/src/games/ori1definitive/artifacts/background_tree_artifact_0x08EC9524.ps_4_0.hlsl
@@ -1,0 +1,79 @@
+// ---- Created with 3Dmigoto v1.4.1 on Sat Apr  5 00:32:22 2025
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[44];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  float4 v4 : TEXCOORD3,
+  float4 v5 : TEXCOORD4,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = t0.Sample(s2_s, v2.zw).xyzw;
+  r0.xy = r0.wz * float2(2,2) + float2(-1,-1);
+  r0.xy = cb0[34].yx * r0.xy;
+  r1.xyzw = t1.Sample(s1_s, v2.xy).xyzw;
+  r0.xy = saturate(r0.xy * r1.ww + v1.yx);
+  r0.xy = -cb0[21].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[21].wz);
+  r0.zw = cb0[8].yy * r0.xy;
+  r1.x = 1 + -cb0[8].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[20].zw + cb0[20].xy;
+  r0.xyzw = t2.Sample(s0_s, r0.xy).xyzw;
+  r1.x = saturate(dot(r0.xyzw, cb0[9].xyzw));
+  r0.xyzw = r1.xxxx * cb0[10].xyzw + r0.xyzw;
+  r0.xyz = r0.xyz / r0.www;
+  r1.xyzw = cb0[22].xyzw + cb0[22].xyzw;
+  r0.xyzw = r1.xyzw * r0.xyzw;
+  r1.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[43].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t4.Sample(s4_s, v3.zw).xyzw;
+  r1.w = cb0[43].w * r2.w;
+  r0.xyz = r1.www * r1.xyz + r0.xyz;
+  o0.w = r0.w;
+  r1.xyz = v5.xyz + -r0.xyz;
+  r0.xyz = v5.www * r1.xyz + r0.xyz;
+  r1.xyz = v4.xyz + -r0.xyz;
+  o0.xyz = v4.www * r1.xyz + r0.xyz;
+
+  o0 = saturate(o0);
+  return;
+}

--- a/src/games/ori1definitive/artifacts/cloud_artifact_0x0F10CE07.ps_4_0.hlsl
+++ b/src/games/ori1definitive/artifacts/cloud_artifact_0x0F10CE07.ps_4_0.hlsl
@@ -1,0 +1,63 @@
+// ---- Created with 3Dmigoto v1.4.1 on Sat Apr  5 00:32:23 2025
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[24];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  float4 v4 : TEXCOORD3,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = t0.Sample(s1_s, v2.xy).xyzw;
+  r0.xy = r0.wz * float2(2,2) + float2(-1,-1);
+  r0.xy = cb0[23].yx * r0.xy;
+  r1.xyzw = t1.Sample(s2_s, v2.zw).xyzw;
+  r0.xy = saturate(r0.xy * r1.ww + v1.yx);
+  r0.xy = -cb0[21].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[21].wz);
+  r0.zw = cb0[8].yy * r0.xy;
+  r1.x = 1 + -cb0[8].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[20].zw + cb0[20].xy;
+  r0.xyzw = t2.Sample(s0_s, r0.xy).xyzw;
+  r1.x = saturate(dot(r0.xyzw, cb0[9].xyzw));
+  r0.xyzw = r1.xxxx * cb0[10].xyzw + r0.xyzw;
+  r0.xyz = r0.xyz / r0.www;
+  r0.xyzw = cb0[22].xyzw * r0.xyzw;
+  r1.xyz = -r0.xyz * float3(2,2,2) + v4.xyz;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r0.xyz = v4.www * r1.xyz + r0.xyz;
+  o0.w = r0.w;
+  r1.xyz = v3.xyz + -r0.xyz;
+  o0.xyz = v3.www * r1.xyz + r0.xyz;
+
+  o0 = saturate(o0);
+  return;
+}

--- a/src/games/ori1definitive/artifacts/flower_artifact_0x791C6897.ps_4_0.hlsl
+++ b/src/games/ori1definitive/artifacts/flower_artifact_0x791C6897.ps_4_0.hlsl
@@ -1,0 +1,118 @@
+// ---- Created with 3Dmigoto v1.4.1 on Sat Apr  5 00:32:50 2025
+Texture2D<float4> t9 : register(t9);
+
+Texture2D<float4> t8 : register(t8);
+
+Texture2D<float4> t7 : register(t7);
+
+Texture2D<float4> t6 : register(t6);
+
+Texture2D<float4> t5 : register(t5);
+
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s9_s : register(s9);
+
+SamplerState s8_s : register(s8);
+
+SamplerState s7_s : register(s7);
+
+SamplerState s6_s : register(s6);
+
+SamplerState s5_s : register(s5);
+
+SamplerState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[46];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  float4 v4 : TEXCOORD3,
+  float4 v5 : TEXCOORD4,
+  float4 v6 : TEXCOORD5,
+  float4 v7 : TEXCOORD6,
+  float4 v8 : TEXCOORD7,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = t0.Sample(s2_s, v2.zw).xyzw;
+  r0.xy = r0.wz * float2(2,2) + float2(-1,-1);
+  r0.xy = cb0[23].yx * r0.xy;
+  r1.xyzw = t1.Sample(s1_s, v2.xy).xyzw;
+  r0.xy = saturate(r0.xy * r1.ww + v1.yx);
+  r0.xy = -cb0[21].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[21].wz);
+  r0.zw = cb0[8].yy * r0.xy;
+  r1.x = 1 + -cb0[8].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[20].zw + cb0[20].xy;
+  r0.xyzw = t2.Sample(s0_s, r0.xy).xyzw;
+  r1.x = saturate(dot(r0.xyzw, cb0[9].xyzw));
+  r0.xyzw = r1.xxxx * cb0[10].xyzw + r0.xyzw;
+  r0.xyz = r0.xyz / r0.www;
+  r1.xyzw = cb0[22].xyzw + cb0[22].xyzw;
+  r0.xyzw = r1.xyzw * r0.xyzw;
+  r1.xyzw = t4.Sample(s4_s, v3.zw).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[35].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t5.Sample(s5_s, v4.xy).xyzw;
+  r1.w = cb0[35].w * r2.w;
+  r0.xyz = r1.www * r1.xyz + r0.xyz;
+  r1.xyzw = t6.Sample(s6_s, v4.zw).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[40].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t7.Sample(s7_s, v5.xy).xyzw;
+  r1.w = cb0[40].w * r2.w;
+  r0.xyz = r1.www * r1.xyz + r0.xyz;
+  r1.xyzw = t8.Sample(s8_s, v5.zw).xyzw;
+  r1.xyz = cb0[45].xyz * r1.xyz;
+  r2.xyzw = t9.Sample(s9_s, v6.xy).xyzw;
+  r1.xyz = r2.www * r1.xyz;
+  r1.xyz = cb0[45].www * r1.xyz;
+  r0.xyz = r1.xyz * float3(2,2,2) + r0.xyz;
+  r1.xyz = v8.xyz + -r0.xyz;
+  r0.xyz = v8.www * r1.xyz + r0.xyz;
+  r1.xyz = v7.xyz + -r0.xyz;
+  o0.xyz = v7.www * r1.xyz + r0.xyz;
+  r1.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r0.x = -1 + r1.w;
+  r0.x = cb0[30].x * r0.x + 1;
+  o0.w = r0.w * r0.x;
+
+  o0 = saturate(o0);
+  return;
+}

--- a/src/games/ori1definitive/artifacts/fruit_artifact_0x1018F519.ps_4_0.hlsl
+++ b/src/games/ori1definitive/artifacts/fruit_artifact_0x1018F519.ps_4_0.hlsl
@@ -1,0 +1,90 @@
+// ---- Created with 3Dmigoto v1.4.1 on Sat Apr  5 00:32:24 2025
+Texture2D<float4> t5 : register(t5);
+
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s5_s : register(s5);
+
+SamplerState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[36];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  float4 v4 : TEXCOORD3,
+  float4 v5 : TEXCOORD4,
+  float4 v6 : TEXCOORD5,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = saturate(v1.yx);
+  r0.xy = -cb0[21].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[21].wz);
+  r0.zw = cb0[8].yy * r0.xy;
+  r1.x = 1 + -cb0[8].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[20].zw + cb0[20].xy;
+  r0.xyzw = t0.Sample(s0_s, r0.xy).xyzw;
+  r1.x = saturate(dot(r0.xyzw, cb0[9].xyzw));
+  r0.xyzw = r1.xxxx * cb0[10].xyzw + r0.xyzw;
+  r0.xyz = r0.xyz / r0.www;
+  r0.xyzw = cb0[22].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.xyzw = t2.Sample(s2_s, v2.zw).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[30].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r1.w = cb0[30].w * r2.w;
+  r0.xyz = r1.www * r1.xyz + r0.xyz;
+  r1.xyzw = t4.Sample(s4_s, v3.zw).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[35].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t5.Sample(s5_s, v4.xy).xyzw;
+  r1.w = cb0[35].w * r2.w;
+  r0.xyz = r1.www * r1.xyz + r0.xyz;
+  r1.xyz = v6.xyz + -r0.xyz;
+  r0.xyz = v6.www * r1.xyz + r0.xyz;
+  r1.xyz = v5.xyz + -r0.xyz;
+  o0.xyz = v5.www * r1.xyz + r0.xyz;
+  r1.xyzw = t1.Sample(s1_s, v2.xy).xyzw;
+  r0.x = -1 + r1.w;
+  r0.x = cb0[25].x * r0.x + 1;
+  o0.w = r0.w * r0.x;
+
+  o0 = saturate(o0);
+  return;
+}

--- a/src/games/ori1definitive/artifacts/fruit_artifact_0x6743CB50.ps_4_0.hlsl
+++ b/src/games/ori1definitive/artifacts/fruit_artifact_0x6743CB50.ps_4_0.hlsl
@@ -1,0 +1,98 @@
+// ---- Created with 3Dmigoto v1.4.1 on Sat Apr  5 00:32:46 2025
+Texture2D<float4> t5 : register(t5);
+
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s5_s : register(s5);
+
+SamplerState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb1 : register(b1)
+{
+  float4 cb1[5];
+}
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[42];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  float4 v4 : TEXCOORD3,
+  float4 v5 : TEXCOORD4,
+  float4 v6 : TEXCOORD5,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = saturate(v1.yx);
+  r0.xy = -cb0[22].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[22].wz);
+  r0.zw = cb0[8].yy * r0.xy;
+  r1.x = 1 + -cb0[8].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[21].zw + cb0[21].xy;
+  r0.xyzw = t0.Sample(s0_s, r0.xy).xyzw;
+  r1.x = saturate(dot(r0.xyzw, cb0[9].xyzw));
+  r0.xyzw = r1.xxxx * cb0[10].xyzw + r0.xyzw;
+  r0.xyz = r0.xyz / r0.www;
+  r0.xyzw = cb0[23].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.xyzw = t2.Sample(s2_s, v2.zw).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[34].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r1.w = cb0[34].w * r2.w;
+  r0.xyz = r1.www * r1.xyz + r0.xyz;
+  r1.xy = cb1[4].xy + -cb0[37].zw;
+  r1.xy = r1.xy * cb0[37].xx + v3.zw;
+  r1.xyzw = t4.Sample(s4_s, r1.xy).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[41].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t5.Sample(s5_s, v4.xy).xyzw;
+  r1.w = cb0[41].w * r2.w;
+  r0.xyz = r1.www * r1.xyz + r0.xyz;
+  r1.xyz = v6.xyz + -r0.xyz;
+  r0.xyz = v6.www * r1.xyz + r0.xyz;
+  r1.xyz = v5.xyz + -r0.xyz;
+  o0.xyz = v5.www * r1.xyz + r0.xyz;
+  r1.xyzw = t1.Sample(s1_s, v2.xy).xyzw;
+  r0.x = -1 + r1.w;
+  r0.x = cb0[27].x * r0.x + 1;
+  o0.w = r0.w * r0.x;
+
+  o0 = saturate(o0);
+
+  return;
+}

--- a/src/games/ori1definitive/artifacts/fruit_artifact_0xE020E0E3.ps_4_0.hlsl
+++ b/src/games/ori1definitive/artifacts/fruit_artifact_0xE020E0E3.ps_4_0.hlsl
@@ -1,0 +1,87 @@
+// ---- Created with 3Dmigoto v1.4.1 on Sat Apr  5 00:33:16 2025
+Texture2D<float4> t5 : register(t5);
+
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s5_s : register(s5);
+
+SamplerState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[36];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  float4 v4 : TEXCOORD3,
+  float4 v5 : TEXCOORD4,
+  float4 v6 : TEXCOORD5,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = t0.Sample(s2_s, v2.zw).xyzw;
+  r0.xy = r0.wz * float2(2,2) + float2(-1,-1);
+  r0.xy = cb0[23].yx * r0.xy;
+  r1.xyzw = t1.Sample(s1_s, v2.xy).xyzw;
+  r0.xy = saturate(r0.xy * r1.ww + v1.yx);
+  r0.xy = -cb0[21].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[21].wz);
+  r0.zw = cb0[8].yy * r0.xy;
+  r1.x = 1 + -cb0[8].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[20].zw + cb0[20].xy;
+  r0.xyzw = t2.Sample(s0_s, r0.xy).xyzw;
+  r1.x = saturate(dot(r0.xyzw, cb0[9].xyzw));
+  r0.xyzw = r1.xxxx * cb0[10].xyzw + r0.xyzw;
+  r0.xyz = r0.xyz / r0.www;
+  r1.xyzw = cb0[22].xyzw + cb0[22].xyzw;
+  r0.xyzw = r1.xyzw * r0.xyzw;
+  r1.xyzw = t4.Sample(s4_s, v3.zw).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[35].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t5.Sample(s5_s, v4.xy).xyzw;
+  r1.w = cb0[35].w * r2.w;
+  r0.xyz = r1.www * r1.xyz + r0.xyz;
+  r1.xyz = v6.xyz + -r0.xyz;
+  r0.xyz = v6.www * r1.xyz + r0.xyz;
+  r1.xyz = v5.xyz + -r0.xyz;
+  o0.xyz = v5.www * r1.xyz + r0.xyz;
+  r1.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r0.x = -1 + r1.w;
+  r0.x = cb0[30].x * r0.x + 1;
+  o0.w = r0.w * r0.x;
+
+  o0 = saturate(o0);
+  return;
+}

--- a/src/games/ori1definitive/artifacts/tree_alpha_0xD327EDF9.ps_4_0.hlsl
+++ b/src/games/ori1definitive/artifacts/tree_alpha_0xD327EDF9.ps_4_0.hlsl
@@ -1,0 +1,119 @@
+// ---- Created with 3Dmigoto v1.4.1 on Sat Apr  5 00:33:13 2025
+Texture2D<float4> t9 : register(t9);
+
+Texture2D<float4> t8 : register(t8);
+
+Texture2D<float4> t7 : register(t7);
+
+Texture2D<float4> t6 : register(t6);
+
+Texture2D<float4> t5 : register(t5);
+
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s9_s : register(s9);
+
+SamplerState s8_s : register(s8);
+
+SamplerState s7_s : register(s7);
+
+SamplerState s6_s : register(s6);
+
+SamplerState s5_s : register(s5);
+
+SamplerState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[46];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  float4 v4 : TEXCOORD3,
+  float4 v5 : TEXCOORD4,
+  float4 v6 : TEXCOORD5,
+  float4 v7 : TEXCOORD6,
+  float4 v8 : TEXCOORD7,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = t0.Sample(s1_s, v2.xy).xyzw;
+  r0.xy = r0.wz * float2(2,2) + float2(-1,-1);
+  r0.xy = cb0[23].yx * r0.xy;
+  r1.xyzw = t1.Sample(s2_s, v2.zw).xyzw;
+  r0.xy = saturate(r0.xy * r1.ww + v1.yx);
+  r0.xy = -cb0[21].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[21].wz);
+  r0.zw = cb0[8].yy * r0.xy;
+  r1.x = 1 + -cb0[8].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[20].zw + cb0[20].xy;
+  r0.xyzw = t2.Sample(s0_s, r0.xy).xyzw;
+  r1.x = saturate(dot(r0.xyzw, cb0[9].xyzw));
+  r0.xyzw = r1.xxxx * cb0[10].xyzw + r0.xyzw;
+  r0.xyz = r0.xyz / r0.www;
+  r0.xyzw = cb0[22].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.xyzw = t4.Sample(s4_s, v3.zw).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[35].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t5.Sample(s5_s, v4.xy).xyzw;
+  r1.w = cb0[35].w * r2.w;
+  r0.xyz = r1.www * r1.xyz + r0.xyz;
+  r1.xyzw = t6.Sample(s6_s, v4.zw).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[40].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t7.Sample(s7_s, v5.xy).xyzw;
+  r1.w = cb0[40].w * r2.w;
+  r0.xyz = r1.www * r1.xyz + r0.xyz;
+  r1.xyzw = t8.Sample(s8_s, v5.zw).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[45].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t9.Sample(s9_s, v6.xy).xyzw;
+  r1.w = cb0[45].w * r2.w;
+  r0.xyz = r1.www * r1.xyz + r0.xyz;
+  r1.xyz = v8.xyz + -r0.xyz;
+  r0.xyz = v8.www * r1.xyz + r0.xyz;
+  r1.xyz = v7.xyz + -r0.xyz;
+  o0.xyz = v7.www * r1.xyz + r0.xyz;
+  r1.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r0.x = -1 + r1.w;
+  r0.x = cb0[30].x * r0.x + 1;
+  o0.w = r0.w * r0.x;
+
+  o0.a = saturate(o0.a);
+  return;
+}

--- a/src/games/ori1definitive/artifacts/tree_artifact_0xEF83C032.ps_4_0.hlsl
+++ b/src/games/ori1definitive/artifacts/tree_artifact_0xEF83C032.ps_4_0.hlsl
@@ -1,0 +1,74 @@
+// ---- Created with 3Dmigoto v1.4.1 on Sat Apr  5 00:33:20 2025
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[31];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  float4 v4 : TEXCOORD3,
+  float4 v5 : TEXCOORD4,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = saturate(v1.yx);
+  r0.xy = -cb0[21].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[21].wz);
+  r0.zw = cb0[8].yy * r0.xy;
+  r1.x = 1 + -cb0[8].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[20].zw + cb0[20].xy;
+  r0.xyzw = t0.Sample(s0_s, r0.xy).xyzw;
+  r1.x = saturate(dot(r0.xyzw, cb0[9].xyzw));
+  r0.xyzw = r1.xxxx * cb0[10].xyzw + r0.xyzw;
+  r0.xyz = r0.xyz / r0.www;
+  r0.xyzw = cb0[22].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.xyzw = t2.Sample(s2_s, v2.zw).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[30].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r1.w = cb0[30].w * r2.w;
+  r0.xyz = r1.www * r1.xyz + r0.xyz;
+  r1.xyz = v5.xyz + -r0.xyz;
+  r0.xyz = v5.www * r1.xyz + r0.xyz;
+  r1.xyz = v4.xyz + -r0.xyz;
+  o0.xyz = v4.www * r1.xyz + r0.xyz;
+  r1.xyzw = t1.Sample(s1_s, v2.xy).xyzw;
+  r0.x = -1 + r1.w;
+  r0.x = cb0[25].x * r0.x + 1;
+  o0.w = r0.w * r0.x;
+
+  o0 = saturate(o0);
+  return;
+}

--- a/src/games/ori1definitive/common.hlsl
+++ b/src/games/ori1definitive/common.hlsl
@@ -1,0 +1,75 @@
+#include "./shared.h"
+
+/// Applies a customized version of RenoDRT tonemapper that tonemaps down to 1.0.
+/// This function is used to compress HDR color to SDR range for use alongside `UpgradeToneMap`.
+///
+/// @param lutInputColor The color input that needs to be tonemapped.
+/// @return The tonemapped color compressed to the SDR range, ensuring that it can be applied to SDR color grading with `UpgradeToneMap`.
+float3 renoDRTSmoothClamp(float3 untonemapped) {
+  renodx::tonemap::renodrt::Config renodrt_config = renodx::tonemap::renodrt::config::Create();
+  renodrt_config.nits_peak = 100.f;
+  renodrt_config.mid_gray_value = 0.18f;
+  renodrt_config.mid_gray_nits = 18.f;
+  renodrt_config.exposure = 1.f;
+  renodrt_config.highlights = 1.f;
+  renodrt_config.shadows = 1.f;
+  renodrt_config.contrast = 1.05f;
+  renodrt_config.saturation = 1.025f;
+  renodrt_config.dechroma = 0.f;
+  renodrt_config.flare = 0.f;
+  renodrt_config.hue_correction_strength = 0.f;
+  renodrt_config.hue_correction_method = renodx::tonemap::renodrt::config::hue_correction_method::OKLAB;
+  renodrt_config.tone_map_method = renodx::tonemap::renodrt::config::tone_map_method::DANIELE;
+  renodrt_config.hue_correction_type = renodx::tonemap::renodrt::config::hue_correction_type::INPUT;
+  renodrt_config.working_color_space = 1u;
+  renodrt_config.per_channel = false;
+
+  float3 renoDRTColor = renodx::tonemap::renodrt::BT709(untonemapped, renodrt_config);
+
+  float HDRBlendFactor = lerp(1.f, renodrt_config.mid_gray_value, saturate(1.f));
+  renoDRTColor = lerp(untonemapped, renoDRTColor, saturate(untonemapped / HDRBlendFactor));
+
+  return renoDRTColor;
+}
+
+float3 ApplyToneMap(float3 color_post_process, float3 color_hdr, float3 color_sdr) {
+  if (RENODX_TONE_MAP_TYPE) {
+    // upgradetonemap
+    color_post_process = renodx::math::SignPow(color_post_process, 2.2f);
+    color_post_process = renodx::color::bt709::clamp::BT2020(color_post_process);
+    color_post_process = renodx::tonemap::UpgradeToneMap(color_hdr, color_sdr, color_post_process, RENODX_COLOR_GRADE_STRENGTH);
+
+    // user color grading
+    color_post_process = renodx::color::grade::UserColorGrading(
+        color_post_process,
+        RENODX_TONE_MAP_EXPOSURE,
+        RENODX_TONE_MAP_HIGHLIGHTS,
+        RENODX_TONE_MAP_SHADOWS,
+        RENODX_TONE_MAP_CONTRAST,
+        RENODX_TONE_MAP_SATURATION,
+        RENODX_TONE_MAP_BLOWOUT,
+        0.f);
+
+    color_post_process = renodx::color::bt2020::from::BT709(color_post_process);
+    if (RENODX_TONE_MAP_TYPE == 2.f) {  // exponential rolloff
+      const float peak_white = max(1.f, RENODX_PEAK_WHITE_NITS / RENODX_DIFFUSE_WHITE_NITS);
+      const float shoulder = peak_white;
+      color_post_process = renodx::tonemap::ExponentialRollOff(color_post_process, shoulder, peak_white);
+    }
+    color_post_process = max(0, color_post_process);  // clamp to BT.2020
+    color_post_process = renodx::color::bt709::from::BT2020(color_post_process);
+    color_post_process *= RENODX_DIFFUSE_WHITE_NITS / RENODX_GRAPHICS_WHITE_NITS;
+    color_post_process = renodx::math::SignPow(color_post_process, 1.f / 2.2f);
+  } else {
+    color_post_process = saturate(color_post_process);
+    color_post_process = pow(color_post_process, 2.2f);
+    color_post_process *= RENODX_DIFFUSE_WHITE_NITS / RENODX_GRAPHICS_WHITE_NITS;
+    color_post_process = pow(color_post_process, 1.f / 2.2f);
+  }
+  return color_post_process;
+}
+
+float4 ClampUI(float4 ui_texture) {
+  ui_texture = saturate(ui_texture);
+  return ui_texture;
+}

--- a/src/games/ori1definitive/final_0x52BC2F1B.ps_4_0.hlsl
+++ b/src/games/ori1definitive/final_0x52BC2F1B.ps_4_0.hlsl
@@ -1,0 +1,28 @@
+#include "./shared.h"
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0) {
+  float4 cb0[25];
+}
+
+void main(
+    float4 v0: SV_POSITION0,
+    float2 v1: TEXCOORD0,
+    float2 w1: TEXCOORD1,
+    float2 v2: TEXCOORD2,
+    out float4 o0: SV_Target0) {
+  float4 r0;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = t0.Sample(s0_s, v1.xy).xyzw;
+  o0.xyz = r0.xyz * cb0[24].xxx + cb0[24].yyy;
+  o0.w = r0.w;
+
+  o0 = renodx::math::SignPow(o0, 2.2f);
+  o0.rgb *= RENODX_GRAPHICS_WHITE_NITS / renodx::color::srgb::REFERENCE_WHITE;
+  o0.rgb = renodx::color::bt709::clamp::BT2020(o0.rgb);
+  return;
+}

--- a/src/games/ori1definitive/game_final_0x470BECFA.ps_4_0.hlsl
+++ b/src/games/ori1definitive/game_final_0x470BECFA.ps_4_0.hlsl
@@ -1,0 +1,144 @@
+#include "./common.hlsl"
+
+// ---- Created with 3Dmigoto v1.4.1 on Sat Apr  5 00:32:38 2025
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0) {
+  float4 cb0[21];
+}
+
+/// Blends between exposure-scaled and offset-lifted versions of a color based on offset strength.
+/// Preserves midgray and dynamic range while retaining the artistic haze look.
+float3 BlendOffsetHDR(float3 color_pre_offset, float3 color_post_offset, float offset) {
+  if (offset <= 0.f) return color_post_offset;  // don't scale if black floor is not raised
+
+  float3 linearized_pre_offset = renodx::math::SignPow(color_pre_offset, 2.2f);
+  float3 linearized_post_offset = renodx::math::SignPow(color_post_offset, 2.2f);
+  float linearized_offset = pow(offset, 2.2f);
+  float3 corrected_color = renodx::lut::CorrectBlack(linearized_pre_offset, linearized_post_offset, linearized_offset, 0.1f);
+
+  float3 gammified_correct_color = renodx::math::SignPow(corrected_color, 1.f / 2.2f);
+
+  return lerp(color_post_offset, gammified_correct_color, RENODX_COLOR_GRADE_SCALING);
+}
+
+void main(
+    float4 v0: SV_POSITION0,
+    float2 v1: TEXCOORD0,
+    float2 w1: TEXCOORD1,
+    float2 v2: TEXCOORD2,
+    out float4 o0: SV_Target0) {
+  float4 r0, r1, r2, r3, r4, r5, r6, r7, r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = -cb0[16].xy + v1.xy;
+  r0.x = dot(r0.xy, r0.xy);
+  r0.x = saturate(cb0[16].w * r0.x);
+  r0.yz = -cb0[17].xy + v1.xy;
+  r0.y = dot(r0.yz, r0.yz);
+  r0.y = saturate(cb0[17].w * r0.y);
+  r0.x = r0.x * r0.y;
+  r0.yz = -cb0[18].xy + v1.xy;
+  r0.y = dot(r0.yz, r0.yz);
+  r0.y = saturate(cb0[18].w * r0.y);
+  r0.x = r0.x * r0.y;
+  r0.yz = v1.xy * float2(2, 2) + float2(-1, -1);
+  r0.y = dot(r0.yz, r0.yz);
+  r0.z = 2.5 * r0.y;
+  r0.yz = min(float2(1, 1), r0.yz);
+  r0.y = r0.y * cb0[8].x + 0.142849997;
+  r0.x = r0.x * r0.z;
+  r0.xz = cb0[20].xy * r0.xx;
+  r1.xyzw = t0.Sample(s2_s, v2.xy).xyzw;
+  r1.xy = float2(-0.498039216, -0.498039216) + r1.xy;
+  r1.zw = r1.xy * float2(0.100000001, 0.100000001) + v1.xy;
+  r1.xy = r1.xy * float2(0.100000001, 0.100000001) + v2.xy;
+  r2.xyzw = t2.Sample(s1_s, r1.xy).xyzw;  // blur
+  r2.xyzw = saturate(-r2.xyzw * cb0[19].xxxx + float4(1, 1, 1, 1));
+
+  r3.xyzw = t1.Sample(s0_s, r1.zw).xyzw;  // game render
+
+  r0.w = r3.w * 0.5 + 1;
+  r1.xy = r0.xz * r0.ww + r1.zw;
+  r4.xyzw = t1.Sample(s0_s, r1.xy).xyzw;
+  r3.xyzw = r4.xyzw + r3.xyzw;
+  r1.xy = -r0.xz * r0.ww + r1.zw;
+  r0.xz = r0.xz * r0.ww;
+  r4.xyzw = t1.Sample(s0_s, r1.xy).xyzw;
+  r3.xyzw = r4.xyzw + r3.xyzw;
+  r1.xy = r0.xz * float2(2, 2) + r1.zw;
+  r4.xyzw = t1.Sample(s0_s, r1.xy).xyzw;
+  r3.xyzw = r4.xyzw + r3.xyzw;
+  r1.xy = -r0.xz * float2(2, 2) + r1.zw;
+  r4.xyzw = t1.Sample(s0_s, r1.xy).xyzw;
+  r3.xyzw = r4.xyzw + r3.xyzw;
+  r1.xy = r0.xz * float2(3, 3) + r1.zw;
+  r0.xz = -r0.xz * float2(3, 3) + r1.zw;
+  r4.xyzw = t1.Sample(s0_s, r0.xz).xyzw;
+  r1.xyzw = t1.Sample(s0_s, r1.xy).xyzw;
+  r1.xyzw = r3.xyzw + r1.xyzw;
+  r1.xyzw = r1.xyzw + r4.xyzw;
+  r0.xyzw = r1.xyzw * r0.yyyy;
+  r1.xyz = (cb0[15].xyz * r0.xyz);
+
+  float3 color_hdr, color_sdr;
+  if (RENODX_TONE_MAP_TYPE) {
+    color_hdr = renodx::math::SignPow(r1.rgb, 2.2f);
+    color_sdr = renoDRTSmoothClamp(color_hdr);
+    r1.rgb = renodx::math::SignPow((color_sdr), 1.f / 2.2f);
+  }
+
+  r1.rgb = saturate(r1.rgb);
+
+  r3.xyz = r1.xyz * r1.xyz;
+  r4.xyz = r3.xyz * r1.xyz;
+  r5.w = r4.x;
+  r6.xyz = float3(1, 1, 1) + -r1.xyz;
+  r7.xyz = r6.xyz * r6.xyz;
+  r8.xyz = r7.yxz * r6.yxz;
+  r3.xyz = r6.xyz * r3.xyz;
+  r1.xyz = r7.xzy * r1.xzy;
+  r5.x = r8.y;
+  r5.y = r1.x;
+  r5.z = r3.x;
+  r5.x = dot(r5.xyzw, cb0[12].xyzw);
+  r1.x = r8.z;
+  r8.y = r1.z;
+  r8.z = r3.y;
+  r1.z = r3.z;
+  r8.w = r4.y;
+  r1.w = r4.z;
+  r5.z = dot(r1.xyzw, cb0[14].xyzw);
+  r5.y = dot(r8.xyzw, cb0[13].xyzw);
+  r0.xyz = r5.xyz * cb0[9].xxx;
+
+  float3 color_pre_offset = r0.rgb;
+
+  r0.rgb += cb0[9].y;  // offset
+
+  float3 color_post_offset = r0.rgb;
+
+  r0.rgb = BlendOffsetHDR(color_pre_offset, color_post_offset, cb0[9].y);
+
+  r1.x = saturate(dot(r0.xyz, float3(0.219999999, 0.707000017, 0.0710000023)));
+  r1.xyzw = r1.xxxx + -r0.xyzw;
+  r0.xyzw = cb0[10].xxxx * r1.xyzw + r0.xyzw;
+  r0.xyzw = float4(1, 1, 1, 1) + -r0.xyzw;
+  o0.xyzw = -r2.xyzw * r0.xyzw + float4(1, 1, 1, 1);
+
+  o0.rgb = ApplyToneMap(o0.rgb, color_hdr, color_sdr);
+  o0.a = saturate(o0.a);
+
+  return;
+}

--- a/src/games/ori1definitive/game_final_no_mb_0xB31E6B7C.ps_4_0.hlsl
+++ b/src/games/ori1definitive/game_final_no_mb_0xB31E6B7C.ps_4_0.hlsl
@@ -1,6 +1,6 @@
 #include "./common.hlsl"
 
-// ---- Created with 3Dmigoto v1.4.1 on Sat Apr  5 00:32:38 2025
+// ---- Created with 3Dmigoto v1.4.1 on Thu May  8 19:21:04 2025
 Texture2D<float4> t2 : register(t2);
 
 Texture2D<float4> t1 : register(t1);
@@ -14,7 +14,7 @@ SamplerState s1_s : register(s1);
 SamplerState s0_s : register(s0);
 
 cbuffer cb0 : register(b0) {
-  float4 cb0[21];
+  float4 cb0[20];
 }
 
 /// Correct black levels after applying a black floor offset
@@ -41,56 +41,23 @@ void main(
   uint4 bitmask, uiDest;
   float4 fDest;
 
-  r0.xy = -cb0[16].xy + v1.xy;
+  r0.xy = v1.xy * float2(2, 2) + float2(-1, -1);
   r0.x = dot(r0.xy, r0.xy);
-  r0.x = saturate(cb0[16].w * r0.x);
-  r0.yz = -cb0[17].xy + v1.xy;
-  r0.y = dot(r0.yz, r0.yz);
-  r0.y = saturate(cb0[17].w * r0.y);
-  r0.x = r0.x * r0.y;
-  r0.yz = -cb0[18].xy + v1.xy;
-  r0.y = dot(r0.yz, r0.yz);
-  r0.y = saturate(cb0[18].w * r0.y);
-  r0.x = r0.x * r0.y;
-  r0.yz = v1.xy * float2(2, 2) + float2(-1, -1);
-  r0.y = dot(r0.yz, r0.yz);
-  r0.z = 2.5 * r0.y;
-  r0.yz = min(float2(1, 1), r0.yz);
-  r0.y = r0.y * cb0[8].x + 0.142849997;
-  r0.x = r0.x * r0.z;
-  r0.xz = cb0[20].xy * r0.xx;
+  r0.x = min(1, r0.x);
+  r0.x = cb0[8].x * r0.x;
+  r0.x = r0.x * 7 + 1;
   r1.xyzw = t0.Sample(s2_s, v2.xy).xyzw;
-  r1.xy = float2(-0.498039216, -0.498039216) + r1.xy;
-  r1.zw = r1.xy * float2(0.100000001, 0.100000001) + v1.xy;
-  r1.xy = r1.xy * float2(0.100000001, 0.100000001) + v2.xy;
-  r2.xyzw = t2.Sample(s1_s, r1.xy).xyzw;  // blur
+  r0.yz = float2(-0.498039216, -0.498039216) + r1.xy;
+  r1.xy = r0.yz * float2(0.100000001, 0.100000001) + v1.xy;
+  r0.yz = r0.yz * float2(0.100000001, 0.100000001) + v2.xy;
+  r2.xyzw = t2.Sample(s1_s, r0.yz).xyzw;
   r2.xyzw = saturate(-r2.xyzw * cb0[19].xxxx + float4(1, 1, 1, 1));
 
-  r3.xyzw = t1.Sample(s0_s, r1.zw).xyzw;  // game render
+  r1.xyzw = t1.Sample(s0_s, r1.xy).xyzw;  // game render
 
-  r0.w = r3.w * 0.5 + 1;
-  r1.xy = r0.xz * r0.ww + r1.zw;
-  r4.xyzw = t1.Sample(s0_s, r1.xy).xyzw;
-  r3.xyzw = r4.xyzw + r3.xyzw;
-  r1.xy = -r0.xz * r0.ww + r1.zw;
-  r0.xz = r0.xz * r0.ww;
-  r4.xyzw = t1.Sample(s0_s, r1.xy).xyzw;
-  r3.xyzw = r4.xyzw + r3.xyzw;
-  r1.xy = r0.xz * float2(2, 2) + r1.zw;
-  r4.xyzw = t1.Sample(s0_s, r1.xy).xyzw;
-  r3.xyzw = r4.xyzw + r3.xyzw;
-  r1.xy = -r0.xz * float2(2, 2) + r1.zw;
-  r4.xyzw = t1.Sample(s0_s, r1.xy).xyzw;
-  r3.xyzw = r4.xyzw + r3.xyzw;
-  r1.xy = r0.xz * float2(3, 3) + r1.zw;
-  r0.xz = -r0.xz * float2(3, 3) + r1.zw;
-  r4.xyzw = t1.Sample(s0_s, r0.xz).xyzw;
-  r1.xyzw = t1.Sample(s0_s, r1.xy).xyzw;
-  r1.xyzw = r3.xyzw + r1.xyzw;
-  r1.xyzw = r1.xyzw + r4.xyzw;
-  r0.xyzw = r1.xyzw * r0.yyyy;
+  r0.xyzw = r1.xyzw * r0.xxxx;
+
   r1.xyz = (cb0[15].xyz * r0.xyz);
-
   float3 color_hdr, color_sdr;
   if (RENODX_TONE_MAP_TYPE) {
     color_hdr = renodx::math::SignPow(r1.rgb, 2.2f);
@@ -124,7 +91,7 @@ void main(
 
   float3 color_pre_offset = r0.rgb;
 
-  r0.rgb += cb0[9].y;  // offset
+  r0.rgb += cb0[9].yyy; // offset
 
   float3 color_post_offset = r0.rgb;
 

--- a/src/games/ori1definitive/shared.h
+++ b/src/games/ori1definitive/shared.h
@@ -1,0 +1,47 @@
+#ifndef SRC_ORI1DEFINITIVE_SHARED_H_
+#define SRC_ORI1DEFINITIVE_SHARED_H_
+
+// Must be 32bit aligned
+// Should be 4x32
+struct ShaderInjectData {
+  float peak_white_nits;
+  float diffuse_white_nits;
+  float graphics_white_nits;
+  float color_grade_strength;
+  float color_grade_scaling;
+  float tone_map_type;
+  float tone_map_exposure;
+  float tone_map_highlights;
+  float tone_map_shadows;
+  float tone_map_contrast;
+  float tone_map_saturation;
+  float tone_map_blowout;
+};
+
+#ifndef __cplusplus
+#if ((__SHADER_TARGET_MAJOR == 5 && __SHADER_TARGET_MINOR >= 1) || __SHADER_TARGET_MAJOR >= 6)
+cbuffer shader_injection : register(b13, space50) {
+#elif (__SHADER_TARGET_MAJOR < 5) || ((__SHADER_TARGET_MAJOR == 5) && (__SHADER_TARGET_MINOR < 1))
+cbuffer shader_injection : register(b13) {
+#endif
+  ShaderInjectData shader_injection : packoffset(c0);
+}
+
+#define RENODX_TONE_MAP_TYPE        shader_injection.tone_map_type
+#define RENODX_PEAK_WHITE_NITS      shader_injection.peak_white_nits
+#define RENODX_DIFFUSE_WHITE_NITS   shader_injection.diffuse_white_nits
+#define RENODX_GRAPHICS_WHITE_NITS  shader_injection.graphics_white_nits
+#define RENODX_TONE_MAP_EXPOSURE    shader_injection.tone_map_exposure
+#define RENODX_TONE_MAP_HIGHLIGHTS  shader_injection.tone_map_highlights
+#define RENODX_TONE_MAP_SHADOWS     shader_injection.tone_map_shadows
+#define RENODX_TONE_MAP_CONTRAST    shader_injection.tone_map_contrast
+#define RENODX_TONE_MAP_SATURATION  shader_injection.tone_map_saturation
+#define RENODX_TONE_MAP_BLOWOUT     shader_injection.tone_map_blowout
+#define RENODX_COLOR_GRADE_STRENGTH shader_injection.color_grade_strength
+#define RENODX_COLOR_GRADE_SCALING  shader_injection.color_grade_scaling
+
+#include "../../shaders/renodx.hlsl"
+
+#endif
+
+#endif  // SRC_ORI1DEFINITIVE_SHARED_H_

--- a/src/games/ori1definitive/uishaders/0x0BC8B7AD.ps_4_0.hlsl
+++ b/src/games/ori1definitive/uishaders/0x0BC8B7AD.ps_4_0.hlsl
@@ -1,0 +1,58 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[28];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = saturate(v1.yx);
+  r0.xy = -cb0[20].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[20].wz);
+  r0.zw = cb0[7].yy * r0.xy;
+  r1.x = 1 + -cb0[7].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[19].zw + cb0[19].xy;
+  r0.xyzw = t0.Sample(s0_s, r0.xy).xyzw;
+  r0.xyzw = cb0[21].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.xyzw = t1.Sample(s1_s, v2.xy).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[27].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t2.Sample(s2_s, v2.zw).xyzw;
+  r1.w = cb0[27].w * r2.w;
+  o0.xyz = r1.www * r1.xyz + r0.xyz;
+  o0.w = r0.w;
+
+  o0 = ClampUI(o0);
+  return;
+}

--- a/src/games/ori1definitive/uishaders/0x89FB32DC.ps_4_0.hlsl
+++ b/src/games/ori1definitive/uishaders/0x89FB32DC.ps_4_0.hlsl
@@ -1,0 +1,57 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[33];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = t1.Sample(s1_s, v2.xy).xyzw;
+  r0.xyz = cb0[32].xyz * r0.xyz;
+  r1.xyzw = t2.Sample(s2_s, v2.zw).xyzw;
+  r0.xyz = r1.www * r0.xyz;
+  r0.xyz = cb0[32].www * r0.xyz;
+  r1.xy = saturate(v1.yx);
+  r1.xy = -cb0[20].yx + r1.xy;
+  r1.xy = saturate(r1.xy / cb0[20].wz);
+  r1.zw = cb0[7].yy * r1.xy;
+  r0.w = 1 + -cb0[7].y;
+  r1.xy = r1.yx * r0.ww + r1.zw;
+  r1.xy = r1.xy * cb0[19].zw + cb0[19].xy;
+  r1.xyzw = t0.Sample(s0_s, r1.xy).xyzw;
+  r1.xyzw = cb0[21].xyzw * r1.xyzw;
+  r1.xyzw = r1.xyzw + r1.xyzw;
+  o0.xyz = r0.xyz * float3(2,2,2) + r1.xyz;
+  o0.w = r1.w;
+
+  o0 = ClampUI(o0);
+  return;
+}

--- a/src/games/ori1definitive/uishaders/0xF1446A0F.ps_4_0.hlsl
+++ b/src/games/ori1definitive/uishaders/0xF1446A0F.ps_4_0.hlsl
@@ -1,0 +1,89 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t6 : register(t6);
+
+Texture2D<float4> t5 : register(t5);
+
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s6_s : register(s6);
+
+SamplerState s5_s : register(s5);
+
+SamplerState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[44];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  float4 v4 : TEXCOORD3,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = saturate(v1.yx);
+  r0.xy = -cb0[20].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[20].wz);
+  r0.zw = cb0[7].yy * r0.xy;
+  r1.x = 1 + -cb0[7].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[19].zw + cb0[19].xy;
+  r0.xyzw = t0.Sample(s0_s, r0.xy).xyzw;
+  r0.xyzw = cb0[21].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[38].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t4.Sample(s4_s, v3.zw).xyzw;
+  r1.w = cb0[38].w * r2.w;
+  r0.xyz = r1.www * r1.xyz + r0.xyz;
+  r1.xyzw = t5.Sample(s5_s, v4.xy).xyzw;
+  r1.xyz = cb0[43].xyz * r1.xyz;
+  r2.xyzw = t6.Sample(s6_s, v4.zw).xyzw;
+  r1.xyz = r2.www * r1.xyz;
+  r1.xyz = cb0[43].www * r1.xyz;
+  o0.xyz = r1.xyz * float3(2,2,2) + r0.xyz;
+  r1.xyzw = t1.Sample(s1_s, v2.xy).xyzw;
+  r0.x = -1 + r1.w;
+  r0.x = cb0[30].x * r0.x + 1;
+  r0.x = r0.w * r0.x;
+  r1.xyzw = t2.Sample(s2_s, v2.zw).xyzw;
+  r0.y = -1 + r1.w;
+  r0.y = cb0[33].x * r0.y + 1;
+  o0.w = r0.x * r0.y;
+
+  o0 = ClampUI(o0);
+  return;
+}

--- a/src/games/ori1definitive/uishaders/ui_0x06E0FF55.ps_4_0.hlsl
+++ b/src/games/ori1definitive/uishaders/ui_0x06E0FF55.ps_4_0.hlsl
@@ -1,0 +1,119 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[32];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float3 v3 : TEXCOORD2,
+  float4 v4 : COLOR0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.x = ddx(v2.x);
+  r0.x = 0.5 * r0.x;
+  r0.y = 0;
+  r0.xy = v2.xy + r0.xy;
+  r1.xyzw = t1.SampleLevel(s1_s, r0.xy, 0).xyzw;
+  r2.xyzw = t1.SampleLevel(s1_s, r0.xy, 1).xyzw;
+  r0.z = r2.w + r1.w;
+  r1.xyzw = t1.SampleLevel(s1_s, r0.xy, 2).xyzw;
+  r2.xyzw = t1.SampleLevel(s1_s, r0.xy, 3).xyzw;
+  r0.x = r1.w + r0.z;
+  r0.x = r0.x + r2.w;
+  r1.xyzw = t1.SampleLevel(s1_s, v2.xy, 0).xyzw;
+  r2.xyzw = t1.SampleLevel(s1_s, v2.xy, 1).xyzw;
+  r0.y = r2.w + r1.w;
+  r1.xyzw = t1.SampleLevel(s1_s, v2.xy, 2).xyzw;
+  r0.y = r1.w + r0.y;
+  r1.xyzw = t1.SampleLevel(s1_s, v2.xy, 3).xyzw;
+  r0.y = r1.w + r0.y;
+  r0.z = 0.25 * r0.y;
+  r0.w = ddx(r0.z);
+  r0.z = ddy(r0.z);
+  r0.z = abs(r0.w) + abs(r0.z);
+  r0.w = -r0.z * 0.5 + cb0[22].x;
+  r0.z = r0.z * 0.5 + cb0[22].x;
+  r0.z = r0.z + -r0.w;
+  r0.z = 1 / r0.z;
+  r0.x = r0.x * 0.25 + -r0.w;
+  r0.y = r0.y * 0.25 + -r0.w;
+  r0.xy = saturate(r0.xy * r0.zz);
+  r0.z = r0.x * -2 + 3;
+  r0.x = r0.x * r0.x;
+  r0.x = r0.z * r0.x;
+  r0.z = r0.y * -2 + 3;
+  r0.y = r0.y * r0.y;
+  r0.x = r0.z * r0.y + r0.x;
+  r0.x = 0.5 * r0.x;
+  r0.x = min(1, r0.x);
+  r0.x = sqrt(r0.x);
+  r0.yz = saturate(v1.yx);
+  r0.yz = -cb0[20].yx + r0.yz;
+  r0.yz = saturate(r0.yz / cb0[20].wz);
+  r1.xy = cb0[7].yy * r0.yz;
+  r0.w = 1 + -cb0[7].y;
+  r0.yz = r0.zy * r0.ww + r1.xy;
+  r0.yz = r0.yz * cb0[19].zw + cb0[19].xy;
+  r1.xyzw = t0.Sample(s0_s, r0.yz).xyzw;
+  r0.y = -r0.x * r1.w + 1;
+  r0.zw = -cb0[28].xy + v2.xy;
+  r2.xyzw = t1.SampleLevel(s1_s, r0.zw, 0).xyzw;
+  r3.xyzw = t1.SampleLevel(s1_s, r0.zw, 1).xyzw;
+  r2.x = r3.w + r2.w;
+  r3.xyzw = t1.SampleLevel(s1_s, r0.zw, 2).xyzw;
+  r4.xyzw = t1.SampleLevel(s1_s, r0.zw, 3).xyzw;
+  r0.z = r3.w + r2.x;
+  r0.z = r0.z + r4.w;
+  r0.w = -0.0250000004 + cb0[22].x;
+  r0.z = r0.z * 0.25 + -r0.w;
+  r0.z = saturate(20 * r0.z);
+  r0.w = r0.z * -2 + 3;
+  r0.z = r0.z * r0.z;
+  r2.x = -r0.w * r0.z + 1;
+  r0.z = r0.w * r0.z;
+  r2.xyz = r2.xxx * r1.xyz;
+  r2.xyz = cb0[27].xyz * r0.zzz + r2.xyz;
+  r0.z = saturate(r0.x * r1.w + r0.z);
+  r0.x = r1.w * r0.x;
+  r2.xyz = r2.xyz * r0.yyy;
+  r1.xyz = r1.xyz * r0.xxx + r2.xyz;
+  r0.x = saturate(-cb0[26].x + v3.x);
+  r0.x = cb0[31].x * r0.x;
+  r2.xyzw = t2.Sample(s2_s, v2.zw).xyzw;
+  r0.y = -1 + r2.x;
+  r0.x = r0.x * r0.y + 1;
+  r1.w = r0.z * r0.x;
+  r0.xyzw = cb0[21].xyzw + cb0[21].xyzw;
+  r0.xyzw = r1.xyzw * r0.xyzw;
+  o0.xyzw = v4.xyzw * r0.xyzw;
+
+  o0 = ClampUI(o0);
+  return;
+}

--- a/src/games/ori1definitive/uishaders/ui_0x0B9EF709.ps_4_0.hlsl
+++ b/src/games/ori1definitive/uishaders/ui_0x0B9EF709.ps_4_0.hlsl
@@ -1,0 +1,72 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[33];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = t0.Sample(s1_s, v2.xy).xyzw;
+  r0.xy = r0.wz * float2(2,2) + float2(-1,-1);
+  r0.xy = cb0[22].yx * r0.xy;
+  r1.xyzw = t1.Sample(s2_s, v2.zw).xyzw;
+  r0.xy = saturate(r0.xy * r1.ww + v1.yx);
+  r0.xy = -cb0[20].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[20].wz);
+  r0.zw = cb0[7].yy * r0.xy;
+  r1.x = 1 + -cb0[7].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[19].zw + cb0[19].xy;
+  r0.xyzw = t2.Sample(s0_s, r0.xy).xyzw;
+  r0.xyzw = cb0[21].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r1.x = -1 + r1.w;
+  r1.x = cb0[29].x * r1.x + 1;
+  r0.w = r1.x * r0.w;
+  o0.xyz = r0.xyz;
+  r1.xyzw = t4.Sample(s4_s, v3.zw).xyzw;
+  r0.x = -1 + r1.w;
+  r0.x = cb0[32].x * r0.x + 1;
+  o0.w = r0.w * r0.x;
+
+  o0 = ClampUI(o0);
+  return;
+}

--- a/src/games/ori1definitive/uishaders/ui_0x0CBCCA15.ps_4_0.hlsl
+++ b/src/games/ori1definitive/uishaders/ui_0x0CBCCA15.ps_4_0.hlsl
@@ -1,0 +1,89 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t6 : register(t6);
+
+Texture2D<float4> t5 : register(t5);
+
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s6_s : register(s6);
+
+SamplerState s5_s : register(s5);
+
+SamplerState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[38];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  float4 v4 : TEXCOORD3,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = t0.Sample(s1_s, v2.xy).xyzw;
+  r0.xy = r0.wz * float2(2,2) + float2(-1,-1);
+  r0.xy = cb0[22].yx * r0.xy;
+  r1.xyzw = t1.Sample(s2_s, v2.zw).xyzw;
+  r0.xy = saturate(r0.xy * r1.ww + v1.yx);
+  r0.xy = -cb0[20].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[20].wz);
+  r0.zw = cb0[7].yy * r0.xy;
+  r1.x = 1 + -cb0[7].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[19].zw + cb0[19].xy;
+  r0.xyzw = t2.Sample(s0_s, r0.xy).xyzw;
+  r1.x = saturate(dot(r0.xyzw, cb0[8].xyzw));
+  r0.xyzw = r1.xxxx * cb0[9].xyzw + r0.xyzw;
+  r0.xyz = r0.xyz / r0.www;
+  r0.xyzw = cb0[21].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r1.x = -1 + r1.w;
+  r1.x = cb0[29].x * r1.x + 1;
+  r0.w = r1.x * r0.w;
+  r1.xyzw = t4.Sample(s4_s, v3.zw).xyzw;
+  r1.x = -1 + r1.w;
+  r1.x = cb0[32].x * r1.x + 1;
+  o0.w = r1.x * r0.w;
+  r1.xyzw = t5.Sample(s5_s, v4.xy).xyzw;
+  r1.xyz = cb0[37].xyz * r1.xyz;
+  r2.xyzw = t6.Sample(s6_s, v4.zw).xyzw;
+  r1.xyz = r2.www * r1.xyz;
+  r1.xyz = cb0[37].www * r1.xyz;
+  o0.xyz = r1.xyz * float3(2,2,2) + r0.xyz;
+
+  o0 = ClampUI(o0);
+  return;
+}

--- a/src/games/ori1definitive/uishaders/ui_0x110CBF45.ps_4_0.hlsl
+++ b/src/games/ori1definitive/uishaders/ui_0x110CBF45.ps_4_0.hlsl
@@ -1,0 +1,102 @@
+// ---- Created with 3Dmigoto v1.4.1 on Sat Apr  5 00:32:24 2025
+Texture2D<float4> t8 : register(t8);
+
+Texture2D<float4> t7 : register(t7);
+
+Texture2D<float4> t6 : register(t6);
+
+Texture2D<float4> t5 : register(t5);
+
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s8_s : register(s8);
+
+SamplerState s7_s : register(s7);
+
+SamplerState s6_s : register(s6);
+
+SamplerState s5_s : register(s5);
+
+SamplerState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[43];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  float4 v4 : TEXCOORD3,
+  float4 v5 : TEXCOORD4,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = t0.Sample(s1_s, v2.xy).xyzw;
+  r0.xy = r0.wz * float2(2,2) + float2(-1,-1);
+  r0.xy = cb0[22].yx * r0.xy;
+  r1.xyzw = t1.Sample(s2_s, v2.zw).xyzw;
+  r0.xy = saturate(r0.xy * r1.ww + v1.yx);
+  r0.xy = -cb0[20].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[20].wz);
+  r0.zw = cb0[7].yy * r0.xy;
+  r1.x = 1 + -cb0[7].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[19].zw + cb0[19].xy;
+  r0.xyzw = t2.Sample(s0_s, r0.xy).xyzw;
+  r0.xyzw = cb0[21].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.xyzw = t5.Sample(s5_s, v4.xy).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[37].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t6.Sample(s6_s, v4.zw).xyzw;
+  r1.w = cb0[37].w * r2.w;
+  r0.xyz = r1.www * r1.xyz + r0.xyz;
+  r1.xyzw = t7.Sample(s7_s, v5.xy).xyzw;
+  r1.xyz = cb0[42].xyz * r1.xyz;
+  r2.xyzw = t8.Sample(s8_s, v5.zw).xyzw;
+  r1.xyz = r2.www * r1.xyz;
+  r1.xyz = cb0[42].www * r1.xyz;
+  o0.xyz = r1.xyz * float3(2,2,2) + r0.xyz;
+  r1.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r0.x = -1 + r1.w;
+  r0.x = cb0[29].x * r0.x + 1;
+  r0.x = r0.w * r0.x;
+  r1.xyzw = t4.Sample(s4_s, v3.zw).xyzw;
+  r0.y = -1 + r1.w;
+  r0.y = cb0[32].x * r0.y + 1;
+  o0.w = r0.x * r0.y;
+
+  o0 = saturate(o0);
+
+  return;
+}

--- a/src/games/ori1definitive/uishaders/ui_0x2776C84A.ps_4_0.hlsl
+++ b/src/games/ori1definitive/uishaders/ui_0x2776C84A.ps_4_0.hlsl
@@ -1,0 +1,56 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[23];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : COLOR0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = t0.Sample(s1_s, v2.xy).xyzw;
+  r0.xy = r0.wz * float2(2,2) + float2(-1,-1);
+  r0.xy = cb0[22].yx * r0.xy;
+  r1.xyzw = t1.Sample(s2_s, v2.zw).xyzw;
+  r0.xy = saturate(r0.xy * r1.ww + v1.yx);
+  r0.xy = -cb0[20].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[20].wz);
+  r0.zw = cb0[7].yy * r0.xy;
+  r1.x = 1 + -cb0[7].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[19].zw + cb0[19].xy;
+  r0.xyzw = t2.Sample(s0_s, r0.xy).xyzw;
+  r0.xyzw = cb0[21].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  o0.xyzw = v3.xyzw * r0.xyzw;
+
+  o0 = ClampUI(o0);
+  return;
+}

--- a/src/games/ori1definitive/uishaders/ui_0x32BBB6EC.ps_4_0.hlsl
+++ b/src/games/ori1definitive/uishaders/ui_0x32BBB6EC.ps_4_0.hlsl
@@ -1,0 +1,93 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t7 : register(t7);
+
+Texture2D<float4> t6 : register(t6);
+
+Texture2D<float4> t5 : register(t5);
+
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s7_s : register(s7);
+
+SamplerState s6_s : register(s6);
+
+SamplerState s5_s : register(s5);
+
+SamplerState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[40];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  float4 v4 : TEXCOORD3,
+  float4 v5 : TEXCOORD4,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = t0.Sample(s1_s, v2.xy).xyzw;
+  r0.xy = r0.wz * float2(2,2) + float2(-1,-1);
+  r0.xy = cb0[22].yx * r0.xy;
+  r1.xyzw = t1.Sample(s2_s, v2.zw).xyzw;
+  r0.xy = saturate(r0.xy * r1.ww + v1.yx);
+  r0.xy = -cb0[20].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[20].wz);
+  r0.zw = cb0[7].yy * r0.xy;
+  r1.x = 1 + -cb0[7].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[19].zw + cb0[19].xy;
+  r0.xyzw = t2.Sample(s0_s, r0.xy).xyzw;
+  r0.xyzw = cb0[21].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.xyzw = t4.Sample(s4_s, v3.zw).xyzw;
+  r1.xyz = cb0[34].xyz * r1.xyz;
+  r2.xyzw = t5.Sample(s5_s, v4.xy).xyzw;
+  r1.xyz = r2.www * r1.xyz;
+  r1.xyz = cb0[34].www * r1.xyz;
+  r0.xyz = r1.xyz * float3(2,2,2) + r0.xyz;
+  r1.xyzw = t6.Sample(s6_s, v4.zw).xyzw;
+  r1.xyz = cb0[39].xyz * r1.xyz;
+  r2.xyzw = t7.Sample(s7_s, v5.xy).xyzw;
+  r1.xyz = r2.www * r1.xyz;
+  r1.xyz = cb0[39].www * r1.xyz;
+  o0.xyz = r1.xyz * float3(2,2,2) + r0.xyz;
+  r1.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r0.x = -1 + r1.w;
+  r0.x = cb0[29].x * r0.x + 1;
+  o0.w = r0.w * r0.x;
+
+  o0 = ClampUI(o0);
+  return;
+}

--- a/src/games/ori1definitive/uishaders/ui_0x3610A504.ps_4_0.hlsl
+++ b/src/games/ori1definitive/uishaders/ui_0x3610A504.ps_4_0.hlsl
@@ -1,0 +1,71 @@
+// ---- Created with 3Dmigoto v1.4.1 on Sat Apr  5 00:32:33 2025
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[33];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = t0.Sample(s1_s, v2.xy).xyzw;
+  r0.xy = r0.wz * float2(2,2) + float2(-1,-1);
+  r0.xy = cb0[23].yx * r0.xy;
+  r1.xyzw = t1.Sample(s2_s, v2.zw).xyzw;
+  r0.xy = saturate(r0.xy * r1.ww + v1.yx);
+  r0.xy = -cb0[20].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[20].wz);
+  r0.zw = cb0[7].yy * r0.xy;
+  r1.x = 1 + -cb0[7].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[19].zw + cb0[19].xy;
+  r0.xyzw = t2.Sample(s0_s, r0.xy).xyzw;
+  r0.xyzw = cb0[21].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[32].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t4.Sample(s4_s, v3.zw).xyzw;
+  r1.w = cb0[32].w * r2.w;
+  o0.xyz = r1.www * r1.xyz + r0.xyz;
+  o0.w = r0.w;
+
+o0 = saturate(o0);
+
+  return;
+}

--- a/src/games/ori1definitive/uishaders/ui_0x3EE35D33.ps_4_0.hlsl
+++ b/src/games/ori1definitive/uishaders/ui_0x3EE35D33.ps_4_0.hlsl
@@ -1,0 +1,75 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[33];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = t0.Sample(s1_s, v2.xy).xyzw;
+  r0.xy = r0.wz * float2(2,2) + float2(-1,-1);
+  r0.xy = cb0[22].yx * r0.xy;
+  r1.xyzw = t1.Sample(s2_s, v2.zw).xyzw;
+  r0.xy = saturate(r0.xy * r1.ww + v1.yx);
+  r0.xy = -cb0[20].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[20].wz);
+  r0.zw = cb0[7].yy * r0.xy;
+  r1.x = 1 + -cb0[7].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[19].zw + cb0[19].xy;
+  r0.xyzw = t2.Sample(s0_s, r0.xy).xyzw;
+  r1.x = saturate(dot(r0.xyzw, cb0[8].xyzw));
+  r0.xyzw = r1.xxxx * cb0[9].xyzw + r0.xyzw;
+  r0.xyz = r0.xyz / r0.www;
+  r0.xyzw = cb0[21].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r1.x = -1 + r1.w;
+  r1.x = cb0[29].x * r1.x + 1;
+  r0.w = r1.x * r0.w;
+  o0.xyz = r0.xyz;
+  r1.xyzw = t4.Sample(s4_s, v3.zw).xyzw;
+  r0.x = -1 + r1.w;
+  r0.x = cb0[32].x * r0.x + 1;
+  o0.w = r0.w * r0.x;
+
+  o0 = ClampUI(o0);
+  return;
+}

--- a/src/games/ori1definitive/uishaders/ui_0x405A953B.ps_4_0.hlsl
+++ b/src/games/ori1definitive/uishaders/ui_0x405A953B.ps_4_0.hlsl
@@ -1,0 +1,43 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[22];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = saturate(v1.yx);
+  r0.xy = -cb0[20].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[20].wz);
+  r0.zw = cb0[7].yy * r0.xy;
+  r1.x = 1 + -cb0[7].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[19].zw + cb0[19].xy;
+  r0.xyzw = t0.Sample(s0_s, r0.xy).xyzw;
+  r0.xyzw = saturate(cb0[21].xyzw * r0.xyzw);
+  r1.x = -r0.w * 0.5 + 0.5;
+  o0.xyz = r0.xyz * r0.www + r1.xxx;
+  o0.w = r0.w;
+
+  o0 = ClampUI(o0);
+  return;
+}

--- a/src/games/ori1definitive/uishaders/ui_0x57172B6F.ps_4_0.hlsl
+++ b/src/games/ori1definitive/uishaders/ui_0x57172B6F.ps_4_0.hlsl
@@ -1,0 +1,88 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t6 : register(t6);
+
+Texture2D<float4> t5 : register(t5);
+
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s6_s : register(s6);
+
+SamplerState s5_s : register(s5);
+
+SamplerState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[38];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  float4 v4 : TEXCOORD3,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = saturate(v1.yx);
+  r0.xy = -cb0[20].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[20].wz);
+  r0.zw = cb0[7].yy * r0.xy;
+  r1.x = 1 + -cb0[7].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[19].zw + cb0[19].xy;
+  r0.xyzw = t0.Sample(s0_s, r0.xy).xyzw;
+  r0.xyzw = cb0[21].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.xyzw = t1.Sample(s1_s, v2.xy).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[27].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t2.Sample(s2_s, v2.zw).xyzw;
+  r1.w = cb0[27].w * r2.w;
+  r0.xyz = r1.www * r1.xyz + r0.xyz;
+  o0.w = r0.w;
+  r1.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r1.xyz = cb0[32].xyz * r1.xyz;
+  r2.xyzw = t4.Sample(s4_s, v3.zw).xyzw;
+  r1.xyz = r2.www * r1.xyz;
+  r1.xyz = cb0[32].www * r1.xyz;
+  r0.xyz = r1.xyz * float3(2,2,2) + r0.xyz;
+  r1.xyzw = t5.Sample(s5_s, v4.xy).xyzw;
+  r1.xyz = cb0[37].xyz * r1.xyz;
+  r2.xyzw = t6.Sample(s6_s, v4.zw).xyzw;
+  r1.xyz = r2.www * r1.xyz;
+  r1.xyz = cb0[37].www * r1.xyz;
+  o0.xyz = r1.xyz * float3(2,2,2) + r0.xyz;
+
+  o0 = ClampUI(o0);
+  return;
+}

--- a/src/games/ori1definitive/uishaders/ui_0xA3665A61.ps_4_0.hlsl
+++ b/src/games/ori1definitive/uishaders/ui_0xA3665A61.ps_4_0.hlsl
@@ -1,0 +1,64 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[30];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = t0.Sample(s1_s, v2.xy).xyzw;
+  r0.xy = r0.wz * float2(2,2) + float2(-1,-1);
+  r0.xy = cb0[22].yx * r0.xy;
+  r1.xyzw = t1.Sample(s2_s, v2.zw).xyzw;
+  r0.xy = saturate(r0.xy * r1.ww + v1.yx);
+  r0.xy = -cb0[20].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[20].wz);
+  r0.zw = cb0[7].yy * r0.xy;
+  r1.x = 1 + -cb0[7].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[19].zw + cb0[19].xy;
+  r0.xyzw = t2.Sample(s0_s, r0.xy).xyzw;
+  r0.xyzw = cb0[21].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r1.x = -1 + r1.w;
+  r1.x = cb0[29].x * r1.x + 1;
+  o0.w = r1.x * r0.w;
+  o0.xyz = r0.xyz;
+
+  o0 = ClampUI(o0);
+  return;
+}

--- a/src/games/ori1definitive/uishaders/ui_0xE534D964.ps_4_0.hlsl
+++ b/src/games/ori1definitive/uishaders/ui_0xE534D964.ps_4_0.hlsl
@@ -1,0 +1,67 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[31];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  float4 v4 : COLOR0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = t0.Sample(s1_s, v2.xy).xyzw;
+  r0.xy = r0.wz * float2(2,2) + float2(-1,-1);
+  r0.xy = cb0[22].yx * r0.xy;
+  r1.xyzw = t1.Sample(s2_s, v2.zw).xyzw;
+  r0.xy = saturate(r0.xy * r1.ww + v1.yx);
+  r0.xy = -cb0[20].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[20].wz);
+  r0.zw = cb0[7].yy * r0.xy;
+  r1.x = 1 + -cb0[7].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[19].zw + cb0[19].xy;
+  r0.xyzw = t2.Sample(s0_s, r0.xy).xyzw;
+  r0.xyzw = cb0[21].xyzw * r0.xyzw;
+  r1.xyz = -r0.xyz * float3(2,2,2) + cb0[30].xyz;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.xyz = cb0[30].www * r1.xyz + r0.xyz;
+  r2.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r0.x = -1 + r2.w;
+  r0.x = cb0[29].x * r0.x + 1;
+  r1.w = r0.w * r0.x;
+  o0.xyzw = v4.xyzw * r1.xyzw;
+
+  o0 = ClampUI(o0);
+  return;
+}

--- a/src/games/ori1definitive/uishaders/ui_0xE63F1AA1.ps_4_0.hlsl
+++ b/src/games/ori1definitive/uishaders/ui_0xE63F1AA1.ps_4_0.hlsl
@@ -1,0 +1,67 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[30];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = t0.Sample(s1_s, v2.xy).xyzw;
+  r0.xy = r0.wz * float2(2,2) + float2(-1,-1);
+  r0.xy = cb0[22].yx * r0.xy;
+  r1.xyzw = t1.Sample(s2_s, v2.zw).xyzw;
+  r0.xy = saturate(r0.xy * r1.ww + v1.yx);
+  r0.xy = -cb0[20].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[20].wz);
+  r0.zw = cb0[7].yy * r0.xy;
+  r1.x = 1 + -cb0[7].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[19].zw + cb0[19].xy;
+  r0.xyzw = t2.Sample(s0_s, r0.xy).xyzw;
+  r1.x = saturate(dot(r0.xyzw, cb0[8].xyzw));
+  r0.xyzw = r1.xxxx * cb0[9].xyzw + r0.xyzw;
+  r0.xyz = r0.xyz / r0.www;
+  r0.xyzw = cb0[21].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r1.x = -1 + r1.w;
+  r1.x = cb0[29].x * r1.x + 1;
+  o0.w = r1.x * r0.w;
+  o0.xyz = r0.xyz;
+
+  o0 = ClampUI(o0);
+  return;
+}

--- a/src/games/ori1definitive/uishaders/ui_0xEEDE4B16.ps_4_0.hlsl
+++ b/src/games/ori1definitive/uishaders/ui_0xEEDE4B16.ps_4_0.hlsl
@@ -1,0 +1,51 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[25];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = saturate(v1.yx);
+  r0.xy = -cb0[20].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[20].wz);
+  r0.zw = cb0[7].yy * r0.xy;
+  r1.x = 1 + -cb0[7].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[19].zw + cb0[19].xy;
+  r0.xyzw = t0.Sample(s0_s, r0.xy).xyzw;
+  r0.xyzw = cb0[21].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.xyzw = t1.Sample(s1_s, v2.xy).xyzw;
+  r1.x = -1 + r1.w;
+  r1.x = cb0[24].x * r1.x + 1;
+  o0.w = r1.x * r0.w;
+  o0.xyz = r0.xyz;
+
+  o0 = ClampUI(o0);
+  return;
+}

--- a/src/games/ori1definitive/uishaders/ui_0xF5017B78.ps_4_0.hlsl
+++ b/src/games/ori1definitive/uishaders/ui_0xF5017B78.ps_4_0.hlsl
@@ -1,0 +1,86 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t6 : register(t6);
+
+Texture2D<float4> t5 : register(t5);
+
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s6_s : register(s6);
+
+SamplerState s5_s : register(s5);
+
+SamplerState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[38];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  float4 v4 : TEXCOORD3,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = t0.Sample(s1_s, v2.xy).xyzw;
+  r0.xy = r0.wz * float2(2,2) + float2(-1,-1);
+  r0.xy = cb0[22].yx * r0.xy;
+  r1.xyzw = t1.Sample(s2_s, v2.zw).xyzw;
+  r0.xy = saturate(r0.xy * r1.ww + v1.yx);
+  r0.xy = -cb0[20].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[20].wz);
+  r0.zw = cb0[7].yy * r0.xy;
+  r1.x = 1 + -cb0[7].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[19].zw + cb0[19].xy;
+  r0.xyzw = t2.Sample(s0_s, r0.xy).xyzw;
+  r0.xyzw = cb0[21].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r1.x = -1 + r1.w;
+  r1.x = cb0[29].x * r1.x + 1;
+  r0.w = r1.x * r0.w;
+  r1.xyzw = t4.Sample(s4_s, v3.zw).xyzw;
+  r1.x = -1 + r1.w;
+  r1.x = cb0[32].x * r1.x + 1;
+  o0.w = r1.x * r0.w;
+  r1.xyzw = t5.Sample(s5_s, v4.xy).xyzw;
+  r1.xyz = cb0[37].xyz * r1.xyz;
+  r2.xyzw = t6.Sample(s6_s, v4.zw).xyzw;
+  r1.xyz = r2.www * r1.xyz;
+  r1.xyz = cb0[37].www * r1.xyz;
+  o0.xyz = r1.xyz * float3(2,2,2) + r0.xyz;
+
+  o0 = ClampUI(o0);
+  return;
+}

--- a/src/games/ori1definitive/untesteduishaders/0x0BF7ABF5.ps_4_0.hlsl
+++ b/src/games/ori1definitive/untesteduishaders/0x0BF7ABF5.ps_4_0.hlsl
@@ -1,0 +1,110 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[29];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : COLOR0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.x = ddx(v2.x);
+  r0.x = 0.5 * r0.x;
+  r0.y = 0;
+  r0.xy = v2.xy + r0.xy;
+  r1.xyzw = t1.SampleLevel(s1_s, r0.xy, 0).xyzw;
+  r2.xyzw = t1.SampleLevel(s1_s, r0.xy, 1).xyzw;
+  r0.z = r2.w + r1.w;
+  r1.xyzw = t1.SampleLevel(s1_s, r0.xy, 2).xyzw;
+  r2.xyzw = t1.SampleLevel(s1_s, r0.xy, 3).xyzw;
+  r0.x = r1.w + r0.z;
+  r0.x = r0.x + r2.w;
+  r1.xyzw = t1.SampleLevel(s1_s, v2.xy, 0).xyzw;
+  r2.xyzw = t1.SampleLevel(s1_s, v2.xy, 1).xyzw;
+  r0.y = r2.w + r1.w;
+  r1.xyzw = t1.SampleLevel(s1_s, v2.xy, 2).xyzw;
+  r0.y = r1.w + r0.y;
+  r1.xyzw = t1.SampleLevel(s1_s, v2.xy, 3).xyzw;
+  r0.y = r1.w + r0.y;
+  r0.z = 0.25 * r0.y;
+  r0.w = ddx(r0.z);
+  r0.z = ddy(r0.z);
+  r0.z = abs(r0.w) + abs(r0.z);
+  r0.w = -r0.z * 0.5 + cb0[22].x;
+  r0.z = r0.z * 0.5 + cb0[22].x;
+  r0.z = r0.z + -r0.w;
+  r0.z = 1 / r0.z;
+  r0.x = r0.x * 0.25 + -r0.w;
+  r0.y = r0.y * 0.25 + -r0.w;
+  r0.xy = saturate(r0.xy * r0.zz);
+  r0.z = r0.x * -2 + 3;
+  r0.x = r0.x * r0.x;
+  r0.x = r0.z * r0.x;
+  r0.z = r0.y * -2 + 3;
+  r0.y = r0.y * r0.y;
+  r0.x = r0.z * r0.y + r0.x;
+  r0.x = 0.5 * r0.x;
+  r0.x = min(1, r0.x);
+  r0.x = sqrt(r0.x);
+  r0.yz = saturate(v1.yx);
+  r0.yz = -cb0[20].yx + r0.yz;
+  r0.yz = saturate(r0.yz / cb0[20].wz);
+  r1.xy = cb0[7].yy * r0.yz;
+  r0.w = 1 + -cb0[7].y;
+  r0.yz = r0.zy * r0.ww + r1.xy;
+  r0.yz = r0.yz * cb0[19].zw + cb0[19].xy;
+  r1.xyzw = t0.Sample(s0_s, r0.yz).xyzw;
+  r0.y = -r0.x * r1.w + 1;
+  r0.zw = -cb0[28].xy + v2.xy;
+  r2.xyzw = t1.SampleLevel(s1_s, r0.zw, 0).xyzw;
+  r3.xyzw = t1.SampleLevel(s1_s, r0.zw, 1).xyzw;
+  r2.x = r3.w + r2.w;
+  r3.xyzw = t1.SampleLevel(s1_s, r0.zw, 2).xyzw;
+  r4.xyzw = t1.SampleLevel(s1_s, r0.zw, 3).xyzw;
+  r0.z = r3.w + r2.x;
+  r0.z = r0.z + r4.w;
+  r0.w = -0.0250000004 + cb0[22].x;
+  r0.z = r0.z * 0.25 + -r0.w;
+  r0.z = saturate(20 * r0.z);
+  r0.w = r0.z * -2 + 3;
+  r0.z = r0.z * r0.z;
+  r2.x = -r0.w * r0.z + 1;
+  r0.z = r0.w * r0.z;
+  r2.xyz = r2.xxx * r1.xyz;
+  r2.xyz = cb0[27].xyz * r0.zzz + r2.xyz;
+  r3.w = saturate(r0.x * r1.w + r0.z);
+  r0.x = r1.w * r0.x;
+  r0.yzw = r2.xyz * r0.yyy;
+  r3.xyz = r1.xyz * r0.xxx + r0.yzw;
+  r0.xyzw = cb0[21].xyzw + cb0[21].xyzw;
+  r0.xyzw = r3.xyzw * r0.xyzw;
+  o0.xyzw = v3.xyzw * r0.xyzw;
+
+  o0 = ClampUI(o0);
+
+  return;
+
+}

--- a/src/games/ori1definitive/untesteduishaders/0x4185B9AB.ps_4_0.hlsl
+++ b/src/games/ori1definitive/untesteduishaders/0x4185B9AB.ps_4_0.hlsl
@@ -1,0 +1,76 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[33];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = saturate(v1.yx);
+  r0.xy = -cb0[20].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[20].wz);
+  r0.zw = cb0[7].yy * r0.xy;
+  r1.x = 1 + -cb0[7].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[19].zw + cb0[19].xy;
+  r0.xyzw = t0.Sample(s0_s, r0.xy).xyzw;
+  r0.xyzw = cb0[21].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[32].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t4.Sample(s4_s, v3.zw).xyzw;
+  r1.w = cb0[32].w * r2.w;
+  o0.xyz = r1.www * r1.xyz + r0.xyz;
+  r1.xyzw = t1.Sample(s1_s, v2.xy).xyzw;
+  r0.x = -1 + r1.w;
+  r0.x = cb0[24].x * r0.x + 1;
+  r0.x = r0.w * r0.x;
+  r1.xyzw = t2.Sample(s2_s, v2.zw).xyzw;
+  r0.y = -1 + r1.w;
+  r0.y = cb0[27].x * r0.y + 1;
+  o0.w = r0.x * r0.y;
+
+  o0 = ClampUI(o0);
+
+  return;
+
+}

--- a/src/games/ori1definitive/untesteduishaders/0x7E661BCB.ps_4_0.hlsl
+++ b/src/games/ori1definitive/untesteduishaders/0x7E661BCB.ps_4_0.hlsl
@@ -1,0 +1,60 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[33];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = saturate(v1.yx);
+  r0.xy = -cb0[20].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[20].wz);
+  r0.zw = cb0[7].yy * r0.xy;
+  r1.x = 1 + -cb0[7].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[19].zw + cb0[19].xy;
+  r0.xyzw = t0.Sample(s0_s, r0.xy).xyzw;
+  r0.xyzw = cb0[21].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.xyzw = t1.Sample(s1_s, v2.xy).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[32].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t2.Sample(s2_s, v2.zw).xyzw;
+  r1.w = cb0[32].w * r2.w;
+  o0.xyz = r1.www * r1.xyz + r0.xyz;
+  o0.w = r0.w;
+
+  o0 = ClampUI(o0);
+
+  return;
+
+}

--- a/src/games/ori1definitive/untesteduishaders/0x844C51B1.ps_4_0.hlsl
+++ b/src/games/ori1definitive/untesteduishaders/0x844C51B1.ps_4_0.hlsl
@@ -1,0 +1,105 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t8 : register(t8);
+
+Texture2D<float4> t7 : register(t7);
+
+Texture2D<float4> t6 : register(t6);
+
+Texture2D<float4> t5 : register(t5);
+
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s8_s : register(s8);
+
+SamplerState s7_s : register(s7);
+
+SamplerState s6_s : register(s6);
+
+SamplerState s5_s : register(s5);
+
+SamplerState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[43];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  float4 v4 : TEXCOORD3,
+  float4 v5 : TEXCOORD4,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = t0.Sample(s1_s, v2.xy).xyzw;
+  r0.xy = r0.wz * float2(2,2) + float2(-1,-1);
+  r0.xy = cb0[22].yx * r0.xy;
+  r1.xyzw = t1.Sample(s2_s, v2.zw).xyzw;
+  r0.xy = saturate(r0.xy * r1.ww + v1.yx);
+  r0.xy = -cb0[20].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[20].wz);
+  r0.zw = cb0[7].yy * r0.xy;
+  r1.x = 1 + -cb0[7].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[19].zw + cb0[19].xy;
+  r0.xyzw = t2.Sample(s0_s, r0.xy).xyzw;
+  r0.xyzw = cb0[21].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.xyzw = t5.Sample(s5_s, v4.xy).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[37].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t6.Sample(s6_s, v4.zw).xyzw;
+  r1.w = cb0[37].w * r2.w;
+  r0.xyz = r1.www * r1.xyz + r0.xyz;
+  r1.xyzw = t7.Sample(s7_s, v5.xy).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[42].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t8.Sample(s8_s, v5.zw).xyzw;
+  r1.w = cb0[42].w * r2.w;
+  o0.xyz = r1.www * r1.xyz + r0.xyz;
+  r1.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r0.x = -1 + r1.w;
+  r0.x = cb0[29].x * r0.x + 1;
+  r0.x = r0.w * r0.x;
+  r1.xyzw = t4.Sample(s4_s, v3.zw).xyzw;
+  r0.y = -1 + r1.w;
+  r0.y = cb0[32].x * r0.y + 1;
+  o0.w = r0.x * r0.y;
+
+  o0 = ClampUI(o0);
+
+  return;
+
+}

--- a/src/games/ori1definitive/untesteduishaders/0x93682B5C.ps_4_0.hlsl
+++ b/src/games/ori1definitive/untesteduishaders/0x93682B5C.ps_4_0.hlsl
@@ -1,0 +1,90 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t6 : register(t6);
+
+Texture2D<float4> t5 : register(t5);
+
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s6_s : register(s6);
+
+SamplerState s5_s : register(s5);
+
+SamplerState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[43];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  float4 v4 : TEXCOORD3,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = saturate(v1.yx);
+  r0.xy = -cb0[20].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[20].wz);
+  r0.zw = cb0[7].yy * r0.xy;
+  r1.x = 1 + -cb0[7].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[19].zw + cb0[19].xy;
+  r0.xyzw = t0.Sample(s0_s, r0.xy).xyzw;
+  r0.xyzw = cb0[21].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.xyzw = t1.Sample(s1_s, v2.xy).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[32].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t2.Sample(s2_s, v2.zw).xyzw;
+  r1.w = cb0[32].w * r2.w;
+  r0.xyz = r1.www * r1.xyz + r0.xyz;
+  o0.w = r0.w;
+  r1.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r1.xyz = cb0[37].xyz * r1.xyz;
+  r2.xyzw = t4.Sample(s4_s, v3.zw).xyzw;
+  r1.xyz = r2.www * r1.xyz;
+  r1.xyz = cb0[37].www * r1.xyz;
+  r0.xyz = r1.xyz * float3(2,2,2) + r0.xyz;
+  r1.xyzw = t5.Sample(s5_s, v4.xy).xyzw;
+  r1.xyz = cb0[42].xyz * r1.xyz;
+  r2.xyzw = t6.Sample(s6_s, v4.zw).xyzw;
+  r1.xyz = r2.www * r1.xyz;
+  r1.xyz = cb0[42].www * r1.xyz;
+  o0.xyz = r1.xyz * float3(2,2,2) + r0.xyz;
+
+  o0 = ClampUI(o0);
+
+  return;
+
+}

--- a/src/games/ori1definitive/untesteduishaders/0x9EF7455E.ps_4_0.hlsl
+++ b/src/games/ori1definitive/untesteduishaders/0x9EF7455E.ps_4_0.hlsl
@@ -1,0 +1,91 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t6 : register(t6);
+
+Texture2D<float4> t5 : register(t5);
+
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s6_s : register(s6);
+
+SamplerState s5_s : register(s5);
+
+SamplerState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[38];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  float4 v4 : TEXCOORD3,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = saturate(v1.yx);
+  r0.xy = -cb0[20].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[20].wz);
+  r0.zw = cb0[7].yy * r0.xy;
+  r1.x = 1 + -cb0[7].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[19].zw + cb0[19].xy;
+  r0.xyzw = t0.Sample(s0_s, r0.xy).xyzw;
+  r0.xyzw = cb0[21].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[32].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t4.Sample(s4_s, v3.zw).xyzw;
+  r1.w = cb0[32].w * r2.w;
+  r0.xyz = r1.www * r1.xyz + r0.xyz;
+  r1.xyzw = t5.Sample(s5_s, v4.xy).xyzw;
+  r1.xyz = cb0[37].xyz * r1.xyz;
+  r2.xyzw = t6.Sample(s6_s, v4.zw).xyzw;
+  r1.xyz = r2.www * r1.xyz;
+  r1.xyz = cb0[37].www * r1.xyz;
+  o0.xyz = r1.xyz * float3(2,2,2) + r0.xyz;
+  r1.xyzw = t1.Sample(s1_s, v2.xy).xyzw;
+  r0.x = -1 + r1.w;
+  r0.x = cb0[24].x * r0.x + 1;
+  r0.x = r0.w * r0.x;
+  r1.xyzw = t2.Sample(s2_s, v2.zw).xyzw;
+  r0.y = -1 + r1.w;
+  r0.y = cb0[27].x * r0.y + 1;
+  o0.w = r0.x * r0.y;
+
+  o0 = ClampUI(o0);
+
+  return;
+
+}

--- a/src/games/ori1definitive/untesteduishaders/0xB39B9252.ps_4_0.hlsl
+++ b/src/games/ori1definitive/untesteduishaders/0xB39B9252.ps_4_0.hlsl
@@ -1,0 +1,70 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[31];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = saturate(v1.yx);
+  r0.xy = -cb0[20].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[20].wz);
+  r0.zw = cb0[7].yy * r0.xy;
+  r1.x = 1 + -cb0[7].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[19].zw + cb0[19].xy;
+  r0.xyzw = t0.Sample(s0_s, r0.xy).xyzw;
+  r0.xyzw = cb0[21].xyzw * r0.xyzw;
+  r1.xyz = -r0.xyz * float3(2,2,2) + cb0[25].xyz;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r0.xyz = cb0[25].www * r1.xyz + r0.xyz;
+  r1.xyzw = t2.Sample(s2_s, v2.zw).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[30].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r1.w = cb0[30].w * r2.w;
+  o0.xyz = r1.www * r1.xyz + r0.xyz;
+  r1.xyzw = t1.Sample(s1_s, v2.xy).xyzw;
+  r0.x = -1 + r1.w;
+  r0.x = cb0[24].x * r0.x + 1;
+  o0.w = r0.w * r0.x;
+
+  o0 = ClampUI(o0);
+
+  return;
+
+}

--- a/src/games/ori1definitive/untesteduishaders/0xB56D6357.ps_4_0.hlsl
+++ b/src/games/ori1definitive/untesteduishaders/0xB56D6357.ps_4_0.hlsl
@@ -1,0 +1,67 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[30];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = t2.Sample(s2_s, v2.zw).xyzw;
+  r0.xyz = cb0[29].xyz * r0.xyz;
+  r1.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r0.xyz = r1.www * r0.xyz;
+  r0.xyz = cb0[29].www * r0.xyz;
+  r1.xy = saturate(v1.yx);
+  r1.xy = -cb0[20].yx + r1.xy;
+  r1.xy = saturate(r1.xy / cb0[20].wz);
+  r1.zw = cb0[7].yy * r1.xy;
+  r0.w = 1 + -cb0[7].y;
+  r1.xy = r1.yx * r0.ww + r1.zw;
+  r1.xy = r1.xy * cb0[19].zw + cb0[19].xy;
+  r1.xyzw = t0.Sample(s0_s, r1.xy).xyzw;
+  r1.xyzw = cb0[21].xyzw * r1.xyzw;
+  r1.xyzw = r1.xyzw + r1.xyzw;
+  o0.xyz = r0.xyz * float3(2,2,2) + r1.xyz;
+  r0.xyzw = t1.Sample(s1_s, v2.xy).xyzw;
+  r0.x = -1 + r0.w;
+  r0.x = cb0[24].x * r0.x + 1;
+  o0.w = r1.w * r0.x;
+
+  o0 = ClampUI(o0);
+
+  return;
+
+}

--- a/src/games/ori1definitive/untesteduishaders/0xB68ED355.ps_4_0.hlsl
+++ b/src/games/ori1definitive/untesteduishaders/0xB68ED355.ps_4_0.hlsl
@@ -1,0 +1,75 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[33];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  float4 v4 : COLOR0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = t0.Sample(s1_s, v2.xy).xyzw;
+  r0.xy = r0.wz * float2(2,2) + float2(-1,-1);
+  r0.xy = cb0[22].yx * r0.xy;
+  r1.xyzw = t1.Sample(s2_s, v2.zw).xyzw;
+  r0.xy = saturate(r0.xy * r1.ww + v1.yx);
+  r0.xy = -cb0[20].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[20].wz);
+  r0.zw = cb0[7].yy * r0.xy;
+  r1.x = 1 + -cb0[7].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[19].zw + cb0[19].xy;
+  r0.xyzw = t2.Sample(s0_s, r0.xy).xyzw;
+  r0.xyzw = cb0[21].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r1.x = -1 + r1.w;
+  r1.x = cb0[29].x * r1.x + 1;
+  r1.x = r1.x * r0.w;
+  r2.xyzw = t4.Sample(s4_s, v3.zw).xyzw;
+  r1.y = -1 + r2.w;
+  r1.y = cb0[32].x * r1.y + 1;
+  r0.w = r1.x * r1.y;
+  o0.xyzw = v4.xyzw * r0.xyzw;
+
+  o0 = ClampUI(o0);
+
+  return;
+
+}

--- a/src/games/ori1definitive/untesteduishaders/0xCA28B653.ps_4_0.hlsl
+++ b/src/games/ori1definitive/untesteduishaders/0xCA28B653.ps_4_0.hlsl
@@ -1,0 +1,45 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[22];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : COLOR0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = saturate(v1.yx);
+  r0.xy = -cb0[20].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[20].wz);
+  r0.zw = cb0[7].yy * r0.xy;
+  r1.x = 1 + -cb0[7].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[19].zw + cb0[19].xy;
+  r0.xyzw = t0.Sample(s0_s, r0.xy).xyzw;
+  r0.xyzw = cb0[21].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  o0.xyzw = v2.xyzw * r0.xyzw;
+
+  o0 = ClampUI(o0);
+
+  return;
+
+}

--- a/src/games/ori1definitive/untesteduishaders/0xCCC2E9D3.ps_4_0.hlsl
+++ b/src/games/ori1definitive/untesteduishaders/0xCCC2E9D3.ps_4_0.hlsl
@@ -1,0 +1,62 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[29];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = saturate(v1.yx);
+  r0.xy = -cb0[20].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[20].wz);
+  r0.zw = cb0[7].yy * r0.xy;
+  r1.x = 1 + -cb0[7].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[19].zw + cb0[19].xy;
+  r0.xyzw = t0.Sample(s0_s, r0.xy).xyzw;
+  r0.xyzw = cb0[21].xyzw * r0.xyzw;
+  r1.xyz = -r0.xyz * float3(2,2,2) + cb0[28].xyz;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  o0.xyz = cb0[28].www * r1.xyz + r0.xyz;
+  r1.xyzw = t1.Sample(s1_s, v2.xy).xyzw;
+  r0.x = -1 + r1.w;
+  r0.x = cb0[24].x * r0.x + 1;
+  r0.x = r0.w * r0.x;
+  r1.xyzw = t2.Sample(s2_s, v2.zw).xyzw;
+  r0.y = -1 + r1.w;
+  r0.y = cb0[27].x * r0.y + 1;
+  o0.w = r0.x * r0.y;
+
+  o0 = ClampUI(o0);
+
+  return;
+
+}

--- a/src/games/ori1definitive/untesteduishaders/0xD6874AF6.ps_4_0.hlsl
+++ b/src/games/ori1definitive/untesteduishaders/0xD6874AF6.ps_4_0.hlsl
@@ -1,0 +1,89 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t6 : register(t6);
+
+Texture2D<float4> t5 : register(t5);
+
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s6_s : register(s6);
+
+SamplerState s5_s : register(s5);
+
+SamplerState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[38];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  float4 v4 : TEXCOORD3,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = t0.Sample(s1_s, v2.xy).xyzw;
+  r0.xy = r0.wz * float2(2,2) + float2(-1,-1);
+  r0.xy = cb0[22].yx * r0.xy;
+  r1.xyzw = t1.Sample(s2_s, v2.zw).xyzw;
+  r0.xy = saturate(r0.xy * r1.ww + v1.yx);
+  r0.xy = -cb0[20].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[20].wz);
+  r0.zw = cb0[7].yy * r0.xy;
+  r1.x = 1 + -cb0[7].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[19].zw + cb0[19].xy;
+  r0.xyzw = t2.Sample(s0_s, r0.xy).xyzw;
+  r0.xyzw = cb0[21].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.xyzw = t5.Sample(s5_s, v4.xy).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[37].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t6.Sample(s6_s, v4.zw).xyzw;
+  r1.w = cb0[37].w * r2.w;
+  o0.xyz = r1.www * r1.xyz + r0.xyz;
+  r1.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r0.x = -1 + r1.w;
+  r0.x = cb0[29].x * r0.x + 1;
+  r0.x = r0.w * r0.x;
+  r1.xyzw = t4.Sample(s4_s, v3.zw).xyzw;
+  r0.y = -1 + r1.w;
+  r0.y = cb0[32].x * r0.y + 1;
+  o0.w = r0.x * r0.y;
+
+  o0 = ClampUI(o0);
+
+  return;
+
+}

--- a/src/games/ori1definitive/untesteduishaders/0xDDCCAB25.ps_4_0.hlsl
+++ b/src/games/ori1definitive/untesteduishaders/0xDDCCAB25.ps_4_0.hlsl
@@ -1,0 +1,83 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t5 : register(t5);
+
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s5_s : register(s5);
+
+SamplerState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[35];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  float4 v4 : TEXCOORD3,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = saturate(v1.yx);
+  r0.xy = -cb0[20].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[20].wz);
+  r0.zw = cb0[7].yy * r0.xy;
+  r1.x = 1 + -cb0[7].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[19].zw + cb0[19].xy;
+  r0.xyzw = t0.Sample(s0_s, r0.xy).xyzw;
+  r0.xyzw = cb0[21].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.xyzw = t2.Sample(s2_s, v2.zw).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[29].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r1.w = cb0[29].w * r2.w;
+  r0.xyz = r1.www * r1.xyz + r0.xyz;
+  r1.xyzw = t4.Sample(s4_s, v3.zw).xyzw;
+  r1.xyz = cb0[34].xyz * r1.xyz;
+  r2.xyzw = t5.Sample(s5_s, v4.xy).xyzw;
+  r1.xyz = r2.www * r1.xyz;
+  r1.xyz = cb0[34].www * r1.xyz;
+  o0.xyz = r1.xyz * float3(2,2,2) + r0.xyz;
+  r1.xyzw = t1.Sample(s1_s, v2.xy).xyzw;
+  r0.x = -1 + r1.w;
+  r0.x = cb0[24].x * r0.x + 1;
+  o0.w = r0.w * r0.x;
+
+  o0 = ClampUI(o0);
+
+  return;
+
+}

--- a/src/games/ori1definitive/untesteduishaders/0xE6C66A25.ps_4_0.hlsl
+++ b/src/games/ori1definitive/untesteduishaders/0xE6C66A25.ps_4_0.hlsl
@@ -1,0 +1,71 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[32];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = t0.Sample(s1_s, v2.xy).xyzw;
+  r0.xy = r0.wz * float2(2,2) + float2(-1,-1);
+  r0.xy = cb0[22].yx * r0.xy;
+  r1.xyzw = t1.Sample(s2_s, v2.zw).xyzw;
+  r0.xy = saturate(r0.xy * r1.ww + v1.yx);
+  r0.xy = -cb0[20].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[20].wz);
+  r0.zw = cb0[7].yy * r0.xy;
+  r1.x = 1 + -cb0[7].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[19].zw + cb0[19].xy;
+  r0.xyzw = t2.Sample(s0_s, r0.xy).xyzw;
+  r0.xyzw = cb0[21].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r1.xyz = cb0[31].xyz * r1.xyz;
+  r2.xyzw = t4.Sample(s4_s, v3.zw).xyzw;
+  r1.xyz = r2.www * r1.xyz;
+  r1.xyz = cb0[31].www * r1.xyz;
+  o0.xyz = r1.xyz * float3(2,2,2) + r0.xyz;
+  o0.w = r0.w;
+
+  o0 = ClampUI(o0);
+
+  return;
+}

--- a/src/games/ori1definitive/untesteduishaders/0xF976A2A9.ps_4_0.hlsl
+++ b/src/games/ori1definitive/untesteduishaders/0xF976A2A9.ps_4_0.hlsl
@@ -1,0 +1,68 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[30];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = saturate(v1.yx);
+  r0.xy = -cb0[20].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[20].wz);
+  r0.zw = cb0[7].yy * r0.xy;
+  r1.x = 1 + -cb0[7].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[19].zw + cb0[19].xy;
+  r0.xyzw = t0.Sample(s0_s, r0.xy).xyzw;
+  r0.xyzw = cb0[21].xyzw * r0.xyzw;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r1.xyzw = t2.Sample(s2_s, v2.zw).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[29].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r1.w = cb0[29].w * r2.w;
+  o0.xyz = r1.www * r1.xyz + r0.xyz;
+  r1.xyzw = t1.Sample(s1_s, v2.xy).xyzw;
+  r0.x = -1 + r1.w;
+  r0.x = cb0[24].x * r0.x + 1;
+  o0.w = r0.w * r0.x;
+
+  o0 = ClampUI(o0);
+
+  return;
+
+}

--- a/src/games/ori1definitive/untesteduishaders/0xFE58A410.ps_4_0.hlsl
+++ b/src/games/ori1definitive/untesteduishaders/0xFE58A410.ps_4_0.hlsl
@@ -1,0 +1,93 @@
+#include "../common.hlsl"
+
+Texture2D<float4> t6 : register(t6);
+
+Texture2D<float4> t5 : register(t5);
+
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s6_s : register(s6);
+
+SamplerState s5_s : register(s5);
+
+SamplerState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[39];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : TEXCOORD0,
+  float4 v2 : TEXCOORD1,
+  float4 v3 : TEXCOORD2,
+  float4 v4 : TEXCOORD3,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = saturate(v1.yx);
+  r0.xy = -cb0[20].yx + r0.xy;
+  r0.xy = saturate(r0.xy / cb0[20].wz);
+  r0.zw = cb0[7].yy * r0.xy;
+  r1.x = 1 + -cb0[7].y;
+  r0.xy = r0.yx * r1.xx + r0.zw;
+  r0.xy = r0.xy * cb0[19].zw + cb0[19].xy;
+  r0.xyzw = t0.Sample(s0_s, r0.xy).xyzw;
+  r0.xyzw = cb0[21].xyzw * r0.xyzw;
+  r1.xyz = -r0.xyz * float3(2,2,2) + cb0[28].xyz;
+  r0.xyzw = r0.xyzw + r0.xyzw;
+  r0.xyz = cb0[28].www * r1.xyz + r0.xyz;
+  r1.xyzw = t3.Sample(s3_s, v3.xy).xyzw;
+  r1.xyz = r1.xyz * r0.xyz;
+  r1.xyz = cb0[33].xyz * r1.xyz;
+  r1.xyz = r1.xyz * float3(10,10,10) + -r0.xyz;
+  r2.xyzw = t4.Sample(s4_s, v3.zw).xyzw;
+  r1.w = cb0[33].w * r2.w;
+  r0.xyz = r1.www * r1.xyz + r0.xyz;
+  r1.xyzw = t5.Sample(s5_s, v4.xy).xyzw;
+  r1.xyz = cb0[38].xyz * r1.xyz;
+  r2.xyzw = t6.Sample(s6_s, v4.zw).xyzw;
+  r1.xyz = r2.www * r1.xyz;
+  r1.xyz = cb0[38].www * r1.xyz;
+  o0.xyz = r1.xyz * float3(2,2,2) + r0.xyz;
+  r1.xyzw = t1.Sample(s1_s, v2.xy).xyzw;
+  r0.x = -1 + r1.w;
+  r0.x = cb0[24].x * r0.x + 1;
+  r0.x = r0.w * r0.x;
+  r1.xyzw = t2.Sample(s2_s, v2.zw).xyzw;
+  r0.y = -1 + r1.w;
+  r0.y = cb0[27].x * r0.y + 1;
+  o0.w = r0.x * r0.y;
+
+  o0 = ClampUI(o0);
+
+  return;
+
+}

--- a/src/games/ori1definitive/video_final_0x591107A5.ps_4_0.hlsl
+++ b/src/games/ori1definitive/video_final_0x591107A5.ps_4_0.hlsl
@@ -1,0 +1,29 @@
+#include "./shared.h"
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+void main(
+    float4 v0: SV_POSITION0,
+    float4 v1: COLOR0,
+    float2 v2: TEXCOORD0,
+    float2 w2: TEXCOORD1,
+    out float4 o0: SV_Target0) {
+  float4 r0;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = t0.Sample(s0_s, v2.xy).xyzw;
+  o0.xyz = v1.xyz * r0.xyz;
+  r0.xyzw = t1.Sample(s1_s, w2.xy).xyzw;
+  o0.w = v1.w * r0.w;
+
+  o0 = renodx::math::SignPow(o0, 2.2f);
+  o0.rgb *= RENODX_DIFFUSE_WHITE_NITS / renodx::color::srgb::REFERENCE_WHITE;
+  o0.rgb = renodx::color::bt709::clamp::BT2020(o0.rgb);
+  return;
+}


### PR DESCRIPTION
# RenoDX: HDR Support for Ori and the Blind Forest – Definitive Edition

## Summary
This pull request adds **native HDR support** to *Ori and the Blind Forest: Definitive Edition* using **RenoDX**. The original game does not support HDR and is built around 8-bit UNORM color precision. This mod upgrades the rendering pipeline to support **16-bit float targets**, implements **HDR output**, and applies manual fixes to resolve color artifacts and preserve artistic intent.

## Features

### Tone Mapping
- **Vanilla** – Original game tonemapping behavior (clamping to SDR).
- **None** – No display mapping, unclamped peak nits.
- **Exponential Rolloff** – Roll off peak nits by channel.
- **Peak Brightness** – Adjust max display luminance.
- **Game Brightness** – Scaling for scene output intensity.
- **UI Brightness** – Independent HUD/UI brightness control.

### Color Grading Controls
(Enabled when not using `Vanilla` tone mapper)
- **Exposure**
- **Highlights**
- **Shadows**
- **Contrast**
- **Saturation**
- **Blowout**
- **Color Grade Strength** – Controls overall color grading strength.
- **Color Grade Scaling** – Corrects black levels when there is a black floor offset.

### Resource Enhancements
- Upgrades the swapchain and many intermediate render targets from **RGBA8 UNORM** to **RGBA16 FLOAT**, unlocking full HDR rendering.
- Auto-detects and applies **Peak Brightness** based on display capabilities.

## Artifact Fixes
Ori was originally built on a heavily clamped, 8-bit SDR pipeline. When upgrading to 16-bit float render targets for HDR, the game began exhibiting **rendering artifacts**.

These issues were resolved by **manually identifying and clamping many problematic shaders with `saturate()`**.

## Installation
1. Install **Reshade 6.4.1 or later** with addon support (no Reshade effects required).
2. Copy `renodx-ori1definitive.addon64` into the *Ori and the Blind Forest* installation directory (same location as the game executable).
3. Launch the game with HDR enabled in Windows.
4. Press `<HOME>` to open the ReShade UI and access the **RenoDX** tab.

---

This PR modernizes *Ori and the Blind Forest*’s 8-bit SDR pipeline into a flexible HDR implementation with fine-grained grading tools and dynamic tonemapping support using RenoDX.
