### PR TITLE
Add support for Anno: Mutationem

### DIFF
--- a/src/games/annomutationem/addon.cpp
+++ b/src/games/annomutationem/addon.cpp
@@ -1,0 +1,560 @@
+/*
+ * Copyright (C) 2024 Carlos Lopez
+ * SPDX-License-Identifier: MIT
+ */
+
+#define ImTextureID ImU64
+
+#define DEBUG_LEVEL_0
+
+#include <deps/imgui/imgui.h>
+#include <include/reshade.hpp>
+
+#include <embed/shaders.h>
+
+#include "../../mods/shader.hpp"
+#include "../../mods/swapchain.hpp"
+#include "../../utils/settings.hpp"
+#include "./shared.h"
+
+namespace {
+
+renodx::mods::shader::CustomShaders custom_shaders = {
+    CustomShaderEntry(0x567C3CF7), // fixes brighness in main menu and adds clipping
+    CustomShaderEntry(0x3A44273D), // ui brighness fix
+    CustomShaderEntry(0x20133A8B), // final
+    CustomShaderEntry(0x49E25D6C),
+};
+
+ShaderInjectData shader_injection;
+
+float current_settings_mode = 0;
+
+renodx::utils::settings::Settings settings = {
+    new renodx::utils::settings::Setting{
+        .key = "SettingsMode",
+        .binding = &current_settings_mode,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 0.f,
+        .can_reset = false,
+        .label = "Settings Mode",
+        .labels = {"Simple", "Intermediate", "Advanced"},
+        .is_global = true,
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapType",
+        .binding = &shader_injection.tone_map_type,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 3.f,
+        .can_reset = true,
+        .label = "Tone Mapper",
+        .section = "Tone Mapping",
+        .tooltip = "Sets the tone mapper type",
+        .labels = {"Vanilla", "None", "ACES", "RenoDRT"},
+        .is_visible = []() { return current_settings_mode >= 1; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapPeakNits",
+        .binding = &shader_injection.peak_white_nits,
+        .default_value = 1000.f,
+        .can_reset = false,
+        .label = "Peak Brightness",
+        .section = "Tone Mapping",
+        .tooltip = "Sets the value of peak white in nits",
+        .min = 48.f,
+        .max = 4000.f,
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapGameNits",
+        .binding = &shader_injection.diffuse_white_nits,
+        .default_value = 203.f,
+        .label = "Game Brightness",
+        .section = "Tone Mapping",
+        .tooltip = "Sets the value of 100% white in nits",
+        .min = 48.f,
+        .max = 500.f,
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapUINits",
+        .binding = &shader_injection.graphics_white_nits,
+        .default_value = 203.f,
+        .label = "UI Brightness",
+        .section = "Tone Mapping",
+        .tooltip = "Sets the brightness of UI and HUD elements in nits",
+        .min = 48.f,
+        .max = 500.f,
+    },
+    new renodx::utils::settings::Setting{
+        .key = "GammaCorrection",
+        .binding = &shader_injection.gamma_correction,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 1.f,
+        .label = "Gamma Correction",
+        .section = "Tone Mapping",
+        .tooltip = "Emulates a display EOTF.",
+        .labels = {"Off", "2.2", "BT.1886"},
+        .is_visible = []() { return current_settings_mode >= 1; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapScaling",
+        .binding = &shader_injection.tone_map_per_channel,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 0.f,
+        .label = "Scaling",
+        .section = "Tone Mapping",
+        .tooltip = "Luminance scales colors consistently while per-channel saturates and blows out sooner",
+        .labels = {"Luminance", "Per Channel"},
+        .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+        .is_visible = []() { return current_settings_mode >= 2; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapWorkingColorSpace",
+        .binding = &shader_injection.tone_map_working_color_space,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 0.f,
+        .label = "Working Color Space",
+        .section = "Tone Mapping",
+        .labels = {"BT709", "BT2020", "AP1"},
+        .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+        .is_visible = []() { return current_settings_mode >= 2; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapHueProcessor",
+        .binding = &shader_injection.tone_map_hue_processor,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 0.f,
+        .label = "Hue Processor",
+        .section = "Tone Mapping",
+        .tooltip = "Selects hue processor",
+        .labels = {"OKLab", "ICtCp", "darkTable UCS"},
+        .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+        .is_visible = []() { return current_settings_mode >= 2; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapHueCorrection",
+        .binding = &shader_injection.tone_map_hue_correction,
+        .default_value = 100.f,
+        .label = "Hue Correction",
+        .section = "Tone Mapping",
+        .tooltip = "Hue retention strength.",
+        .min = 0.f,
+        .max = 100.f,
+        .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+        .parse = [](float value) { return value * 0.01f; },
+        .is_visible = []() { return current_settings_mode >= 2; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapHueShift",
+        .binding = &shader_injection.tone_map_hue_shift,
+        .default_value = 50.f,
+        .label = "Hue Shift",
+        .section = "Tone Mapping",
+        .tooltip = "Hue-shift emulation strength.",
+        .min = 0.f,
+        .max = 100.f,
+        .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+        .parse = [](float value) { return value * 0.01f; },
+        .is_visible = []() { return current_settings_mode >= 1; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapClampColorSpace",
+        .binding = &shader_injection.tone_map_clamp_color_space,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 0.f,
+        .label = "Clamp Color Space",
+        .section = "Tone Mapping",
+        .tooltip = "Hue-shift emulation strength.",
+        .labels = {"None", "BT709", "BT2020", "AP1"},
+        .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+        .parse = [](float value) { return value - 1.f; },
+        .is_visible = []() { return current_settings_mode >= 2; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapClampPeak",
+        .binding = &shader_injection.tone_map_clamp_peak,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 0.f,
+        .label = "Clamp Peak",
+        .section = "Tone Mapping",
+        .tooltip = "Hue-shift emulation strength.",
+        .labels = {"None", "BT709", "BT2020", "AP1"},
+        .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+        .parse = [](float value) { return value - 1.f; },
+        .is_visible = []() { return current_settings_mode >= 2; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeExposure",
+        .binding = &shader_injection.tone_map_exposure,
+        .default_value = 1.f,
+        .label = "Exposure",
+        .section = "Color Grading",
+        .max = 2.f,
+        .format = "%.2f",
+        .is_visible = []() { return current_settings_mode >= 1; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeHighlights",
+        .binding = &shader_injection.tone_map_highlights,
+        .default_value = 50.f,
+        .label = "Highlights",
+        .section = "Color Grading",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+        .is_visible = []() { return current_settings_mode >= 1; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeShadows",
+        .binding = &shader_injection.tone_map_shadows,
+        .default_value = 50.f,
+        .label = "Shadows",
+        .section = "Color Grading",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+        .is_visible = []() { return current_settings_mode >= 1; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeContrast",
+        .binding = &shader_injection.tone_map_contrast,
+        .default_value = 50.f,
+        .label = "Contrast",
+        .section = "Color Grading",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeSaturation",
+        .binding = &shader_injection.tone_map_saturation,
+        .default_value = 50.f,
+        .label = "Saturation",
+        .section = "Color Grading",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeHighlightSaturation",
+        .binding = &shader_injection.tone_map_highlight_saturation,
+        .default_value = 50.f,
+        .label = "Highlight Saturation",
+        .section = "Color Grading",
+        .tooltip = "Adds or removes highlight color.",
+        .max = 100.f,
+        .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+        .parse = [](float value) { return value * 0.02f; },
+        .is_visible = []() { return current_settings_mode >= 1; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeBlowout",
+        .binding = &shader_injection.tone_map_blowout,
+        .default_value = 0.f,
+        .label = "Blowout",
+        .section = "Color Grading",
+        .tooltip = "Controls highlight desaturation due to overexposure.",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.01f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeFlare",
+        .binding = &shader_injection.tone_map_flare,
+        .default_value = 0.f,
+        .label = "Flare",
+        .section = "Color Grading",
+        .tooltip = "Flare/Glare Compensation",
+        .max = 100.f,
+        .is_enabled = []() { return shader_injection.tone_map_type == 3; },
+        .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeScene",
+        .binding = &shader_injection.color_grade_strength,
+        .default_value = 100.f,
+        .label = "Scene Grading",
+        .section = "Color Grading",
+        .tooltip = "Scene grading as applied by the game",
+        .max = 100.f,
+        .is_enabled = []() { return shader_injection.tone_map_type > 0; },
+        .parse = [](float value) { return value * 0.01f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "SwapChainCustomColorSpace",
+        .binding = &shader_injection.swap_chain_custom_color_space,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 0.f,
+        .label = "Custom Color Space",
+        .section = "Display Output",
+        .tooltip = "Selects output color space"
+                   "\nUS Modern for BT.709 D65."
+                   "\nJPN Modern for BT.709 D93."
+                   "\nUS CRT for BT.601 (NTSC-U)."
+                   "\nJPN CRT for BT.601 ARIB-TR-B9 D93 (NTSC-J)."
+                   "\nDefault: US CRT",
+        .labels = {
+            "US Modern",
+            "JPN Modern",
+            "US CRT",
+            "JPN CRT",
+        },
+        .is_visible = []() { return settings[0]->GetValue() >= 1; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "IntermediateDecoding",
+        .binding = &shader_injection.intermediate_encoding,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 1.f,
+        .label = "Intermediate Encoding",
+        .section = "Display Output",
+        .labels = {"Auto", "None", "SRGB", "2.2", "2.4"},
+        .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+        .parse = [](float value) {
+            if (value == 0) return shader_injection.gamma_correction + 1.f;
+            return value - 1.f; },
+        .is_visible = []() { return current_settings_mode >= 2; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "SwapChainDecoding",
+        .binding = &shader_injection.swap_chain_decoding,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 1.f,
+        .label = "Swapchain Decoding",
+        .section = "Display Output",
+        .labels = {"Auto", "None", "SRGB", "2.2", "2.4"},
+        .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+        .parse = [](float value) {
+            if (value == 0) return shader_injection.intermediate_encoding;
+            return value - 1.f; },
+        .is_visible = []() { return current_settings_mode >= 2; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "SwapChainGammaCorrection",
+        .binding = &shader_injection.swap_chain_gamma_correction,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 0.f,
+        .label = "Gamma Correction",
+        .section = "Display Output",
+        .labels = {"None", "2.2", "2.4"},
+        .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+        .is_visible = []() { return current_settings_mode >= 2; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "SwapChainClampColorSpace",
+        .binding = &shader_injection.swap_chain_clamp_color_space,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 2.f,
+        .label = "Clamp Color Space",
+        .section = "Display Output",
+        .labels = {"None", "BT709", "BT2020", "AP1"},
+        .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+        .parse = [](float value) { return value - 1.f; },
+        .is_visible = []() { return current_settings_mode >= 2; },
+    },
+};
+
+const std::unordered_map<std::string, reshade::api::format> UPGRADE_TARGETS = {
+    {"R8G8B8A8_TYPELESS", reshade::api::format::r8g8b8a8_typeless},
+    {"B8G8R8A8_TYPELESS", reshade::api::format::b8g8r8a8_typeless},
+    {"R8G8B8A8_UNORM", reshade::api::format::r8g8b8a8_unorm},
+    {"B8G8R8A8_UNORM", reshade::api::format::b8g8r8a8_unorm},
+    {"R8G8B8A8_SNORM", reshade::api::format::r8g8b8a8_snorm},
+    {"R8G8B8A8_UNORM_SRGB", reshade::api::format::r8g8b8a8_unorm_srgb},
+    {"B8G8R8A8_UNORM_SRGB", reshade::api::format::b8g8r8a8_unorm_srgb},
+    {"R10G10B10A2_TYPELESS", reshade::api::format::r10g10b10a2_typeless},
+    {"R10G10B10A2_UNORM", reshade::api::format::r10g10b10a2_unorm},
+    {"B10G10R10A2_UNORM", reshade::api::format::b10g10r10a2_unorm},
+    {"R11G11B10_FLOAT", reshade::api::format::r11g11b10_float},
+    {"R16G16B16A16_TYPELESS", reshade::api::format::r16g16b16a16_typeless},
+};
+
+void OnPresetOff() {
+  //   renodx::utils::settings::UpdateSetting("toneMapType", 0.f);
+  //   renodx::utils::settings::UpdateSetting("toneMapPeakNits", 203.f);
+  //   renodx::utils::settings::UpdateSetting("toneMapGameNits", 203.f);
+  //   renodx::utils::settings::UpdateSetting("toneMapUINits", 203.f);
+  //   renodx::utils::settings::UpdateSetting("toneMapGammaCorrection", 0);
+  //   renodx::utils::settings::UpdateSetting("colorGradeExposure", 1.f);
+  //   renodx::utils::settings::UpdateSetting("colorGradeHighlights", 50.f);
+  //   renodx::utils::settings::UpdateSetting("colorGradeShadows", 50.f);
+  //   renodx::utils::settings::UpdateSetting("colorGradeContrast", 50.f);
+  //   renodx::utils::settings::UpdateSetting("colorGradeSaturation", 50.f);
+  //   renodx::utils::settings::UpdateSetting("colorGradeLUTStrength", 100.f);
+  //   renodx::utils::settings::UpdateSetting("colorGradeLUTScaling", 0.f);
+}
+
+const auto UPGRADE_TYPE_NONE = 0.f;
+const auto UPGRADE_TYPE_OUTPUT_SIZE = 1.f;
+const auto UPGRADE_TYPE_OUTPUT_RATIO = 2.f;
+const auto UPGRADE_TYPE_ANY = 3.f;
+
+bool initialized = false;
+
+}  // namespace
+
+extern "C" __declspec(dllexport) constexpr const char* NAME = "RenoDX";
+extern "C" __declspec(dllexport) constexpr const char* DESCRIPTION = "RenoDX (Generic)";
+
+BOOL APIENTRY DllMain(HMODULE h_module, DWORD fdw_reason, LPVOID lpv_reserved) {
+  switch (fdw_reason) {
+    case DLL_PROCESS_ATTACH:
+      if (!reshade::register_addon(h_module)) return FALSE;
+
+      if (!initialized) {
+        renodx::mods::shader::force_pipeline_cloning = true;
+        renodx::mods::shader::expected_constant_buffer_space = 50;
+        renodx::mods::shader::expected_constant_buffer_index = 13;
+        renodx::mods::shader::allow_multiple_push_constants = true;
+
+        renodx::mods::swapchain::expected_constant_buffer_index = 13;
+        renodx::mods::swapchain::expected_constant_buffer_space = 50;
+        renodx::mods::swapchain::use_resource_cloning = true;
+        renodx::mods::swapchain::swap_chain_proxy_shaders = {
+       /*     {
+                reshade::api::device_api::d3d11,
+                {
+                    .vertex_shader = __swap_chain_proxy_vertex_shader_dx11,
+                    .pixel_shader = __swap_chain_proxy_pixel_shader_dx11,
+                },
+            },
+            {
+                reshade::api::device_api::d3d12,
+                {
+                    .vertex_shader = __swap_chain_proxy_vertex_shader_dx12,
+                    .pixel_shader = __swap_chain_proxy_pixel_shader_dx12,
+                },
+            },*/
+        };
+
+        {
+          auto* setting = new renodx::utils::settings::Setting{
+              .key = "SwapChainForceBorderless",
+              .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+              .default_value = 1.f,
+              .label = "Force Borderless",
+              .section = "Display Output",
+              .tooltip = "Forces fullscreen to be borderless for proper HDR",
+              .labels = {
+                  "Disabled",
+                  "Enabled",
+              },
+              .on_change_value = [](float previous, float current) { renodx::mods::swapchain::force_borderless = (current == 1.f); },
+              .is_global = true,
+              .is_visible = []() { return current_settings_mode >= 2; },
+          };
+          renodx::utils::settings::LoadSetting(renodx::utils::settings::global_name, setting);
+          renodx::mods::swapchain::force_borderless = (setting->GetValue() == 1.f);
+          settings.push_back(setting);
+        }
+
+        {
+          auto* setting = new renodx::utils::settings::Setting{
+              .key = "SwapChainPreventFullscreen",
+              .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+              .default_value = 1.f,
+              .label = "Prevent Fullscreen",
+              .section = "Display Output",
+              .tooltip = "Prevent exclusive fullscreen for proper HDR",
+              .labels = {
+                  "Disabled",
+                  "Enabled",
+              },
+              .on_change_value = [](float previous, float current) { renodx::mods::swapchain::prevent_full_screen = (current == 1.f); },
+              .is_global = true,
+              .is_visible = []() { return current_settings_mode >= 2; },
+          };
+          renodx::utils::settings::LoadSetting(renodx::utils::settings::global_name, setting);
+          renodx::mods::swapchain::prevent_full_screen = (setting->GetValue() == 1.f);
+          settings.push_back(setting);
+        }
+
+        {
+          auto* setting = new renodx::utils::settings::Setting{
+              .key = "SwapChainEncoding",
+              .binding = &shader_injection.swap_chain_encoding,
+              .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+              .default_value = 5.f,
+              .label = "Encoding",
+              .section = "Display Output",
+              .labels = {"None", "SRGB", "2.2", "2.4", "HDR10", "scRGB"},
+              .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+              .on_change_value = [](float previous, float current) {
+                bool is_hdr10 = current == 4;
+                shader_injection.swap_chain_encoding_color_space = (is_hdr10 ? 1.f : 0.f);
+                // return void
+              },
+              .is_global = true,
+              .is_visible = []() { return current_settings_mode >= 2; },
+          };
+          renodx::utils::settings::LoadSetting(renodx::utils::settings::global_name, setting);
+          bool is_hdr10 = setting->GetValue() == 4;
+          renodx::mods::swapchain::SetUseHDR10(is_hdr10);
+          renodx::mods::swapchain::use_resize_buffer = setting->GetValue() < 4;
+          shader_injection.swap_chain_encoding_color_space = is_hdr10 ? 1.f : 0.f;
+
+
+        std::stringstream s;
+        s << "PMNOX setting->GetValue(";
+        s << "GetValue: " << setting->GetValue() << ")";
+        reshade::log::message(reshade::log::level::info, s.str().c_str());
+
+          settings.push_back(setting);
+        }
+
+        /*
+        for (const auto& [key, format] : UPGRADE_TARGETS) {
+          auto* setting = new renodx::utils::settings::Setting{
+              .key = "Upgrade_" + key,
+              .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+              .default_value = 0.f,
+              .label = key,
+              .section = "Resource Upgrades",
+              .labels = {
+                  "Off",
+                  "Output size",
+                  "Output ratio",
+                  "Any size",
+              },
+              .is_global = true,
+              .is_visible = []() { return settings[0]->GetValue() >= 2; },
+          };
+          renodx::utils::settings::LoadSetting(renodx::utils::settings::global_name, setting);
+          settings.push_back(setting);
+
+          auto value = setting->GetValue();
+          if (value > 0) {
+            renodx::mods::swapchain::swap_chain_upgrade_targets.push_back({
+                .old_format = format,
+                .new_format = reshade::api::format::r16g16b16a16_float,
+                .ignore_size = (value == UPGRADE_TYPE_ANY),
+                .use_resource_view_cloning = true,
+                .aspect_ratio = static_cast<float>((value == UPGRADE_TYPE_OUTPUT_RATIO)
+                                                       ? renodx::mods::swapchain::SwapChainUpgradeTarget::BACK_BUFFER
+                                                       : renodx::mods::swapchain::SwapChainUpgradeTarget::ANY),
+                .usage_include = reshade::api::resource_usage::render_target,
+            });
+            std::stringstream s;
+            s << "Applying user resource upgrade for ";
+            s << format << ": " << value;
+            reshade::log::message(reshade::log::level::info, s.str().c_str());
+          }
+        }*/
+
+        initialized = true;
+      }
+
+      break;
+    case DLL_PROCESS_DETACH:
+      reshade::unregister_addon(h_module);
+      break;
+  }
+  //  RGBA8_typeless
+  renodx::mods::swapchain::swap_chain_upgrade_targets.push_back({
+    .old_format = reshade::api::format::r8g8b8a8_typeless,
+    .new_format = reshade::api::format::r16g16b16a16_typeless,
+    .ignore_size = false,
+  });
+
+  renodx::utils::settings::Use(fdw_reason, &settings, &OnPresetOff);
+  renodx::mods::swapchain::Use(fdw_reason, &shader_injection);
+  renodx::mods::shader::Use(fdw_reason, custom_shaders, &shader_injection);
+
+
+
+  return TRUE;
+}

--- a/src/games/annomutationem/bit_copy_0x49E25D6C.ps_4_0.hlsl
+++ b/src/games/annomutationem/bit_copy_0x49E25D6C.ps_4_0.hlsl
@@ -1,0 +1,34 @@
+// ---- Created with 3Dmigoto v1.4.1 on Sun Jun  1 02:16:58 2025
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[4];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = t0.Sample(s0_s, v1.xy).xyzw;
+  o0.xyzw = cb0[3].xyzw * r0.xyzw;
+
+  // Fix blending with UI.
+  o0.w = max(0.f, min(1.f, o0.w));
+
+  return;
+}

--- a/src/games/annomutationem/final_0x20133A8B.ps_4_0.hlsl
+++ b/src/games/annomutationem/final_0x20133A8B.ps_4_0.hlsl
@@ -1,0 +1,17 @@
+#include "./shared.h"
+
+SamplerState BlitSampler_s : register(s0);
+Texture2D<float4> BlitTexture : register(t0);
+
+#define cmp -
+
+void main(
+    float2 v0: TEXCOORD0,
+    float4 v1: SV_POSITION0,
+    out float4 o0: SV_Target0) {
+  o0.xyzw = BlitTexture.Sample(BlitSampler_s, v0.xy).xyzw;
+  o0.xyz = renodx::draw::ToneMapPass(o0.xyz);
+  o0.xyz = renodx::draw::RenderIntermediatePass(o0.xyz);
+  o0.xyzw = renodx::draw::SwapChainPass(o0.xyzw);
+  return;
+}

--- a/src/games/annomutationem/shared.h
+++ b/src/games/annomutationem/shared.h
@@ -1,0 +1,123 @@
+#ifndef SRC_TEMPLATE_SHARED_H_
+#define SRC_TEMPLATE_SHARED_H_
+
+#define DEBUG 0.f
+
+// #define RENODX_PEAK_WHITE_NITS                 1000.f
+// #define RENODX_DIFFUSE_WHITE_NITS              renodx::color::bt2408::REFERENCE_WHITE
+// #define RENODX_GRAPHICS_WHITE_NITS             renodx::color::bt2408::GRAPHICS_WHITE
+// #define RENODX_COLOR_GRADE_STRENGTH            1.f
+// #define RENODX_TONE_MAP_TYPE                   TONE_MAP_TYPE_RENO_DRT
+// #define RENODX_TONE_MAP_EXPOSURE               1.f
+// #define RENODX_TONE_MAP_HIGHLIGHTS             1.f
+// #define RENODX_TONE_MAP_SHADOWS                1.f
+// #define RENODX_TONE_MAP_CONTRAST               1.f
+// #define RENODX_TONE_MAP_SATURATION             1.f
+// #define RENODX_TONE_MAP_HIGHLIGHT_SATURATION   1.f
+// #define RENODX_TONE_MAP_BLOWOUT                0
+// #define RENODX_TONE_MAP_FLARE                  0
+// #define RENODX_TONE_MAP_HUE_CORRECTION         1.f
+// #define RENODX_TONE_MAP_HUE_SHIFT              0
+// #define RENODX_TONE_MAP_WORKING_COLOR_SPACE    color::convert::COLOR_SPACE_BT709
+// #define RENODX_TONE_MAP_CLAMP_COLOR_SPACE      color::convert::COLOR_SPACE_NONE
+// #define RENODX_TONE_MAP_CLAMP_PEAK             color::convert::COLOR_SPACE_BT709
+// #define RENODX_TONE_MAP_HUE_PROCESSOR          HUE_PROCESSOR_OKLAB
+// #define RENODX_TONE_MAP_PER_CHANNEL            0
+// #define RENODX_GAMMA_CORRECTION                GAMMA_CORRECTION_GAMMA_2_2
+// #define RENODX_INTERMEDIATE_SCALING            (RENODX_DIFFUSE_WHITE_NITS / RENODX_GRAPHICS_WHITE_NITS)
+// #define RENODX_INTERMEDIATE_ENCODING           (RENODX_GAMMA_CORRECTION + 1.f)
+// #define RENODX_INTERMEDIATE_COLOR_SPACE        color::convert::COLOR_SPACE_BT709
+// #define RENODX_SWAP_CHAIN_DECODING             RENODX_INTERMEDIATE_ENCODING
+// #define RENODX_SWAP_CHAIN_DECODING_COLOR_SPACE RENODX_INTERMEDIATE_COLOR_SPACE
+// #define RENODX_SWAP_CHAIN_CUSTOM_COLOR_SPACE   COLOR_SPACE_CUSTOM_BT709D65
+// #define RENODX_SWAP_CHAIN_SCALING_NITS         RENODX_GRAPHICS_WHITE_NITS
+// #define RENODX_SWAP_CHAIN_CLAMP_NITS           RENODX_PEAK_WHITE_NITS
+// #define RENODX_SWAP_CHAIN_CLAMP_COLOR_SPACE    color::convert::COLOR_SPACE_UNKNOWN
+// #define RENODX_SWAP_CHAIN_ENCODING             ENCODING_SCRGB
+// #define RENODX_SWAP_CHAIN_ENCODING_COLOR_SPACE color::convert::COLOR_SPACE_BT709
+
+// Must be 32bit aligned
+// Should be 4x32
+struct ShaderInjectData {
+  float peak_white_nits;
+  float diffuse_white_nits;
+  float graphics_white_nits;
+  float color_grade_strength;
+  float tone_map_type;
+  float tone_map_exposure;
+  float tone_map_highlights;
+  float tone_map_shadows;
+  float tone_map_contrast;
+  float tone_map_saturation;
+  float tone_map_highlight_saturation;
+  float tone_map_blowout;
+  float tone_map_flare;
+  float tone_map_hue_correction;
+  float tone_map_hue_shift;
+  float tone_map_working_color_space;
+  float tone_map_clamp_color_space;
+  float tone_map_clamp_peak;
+  float tone_map_hue_processor;
+  float tone_map_per_channel;
+  float gamma_correction;
+  float intermediate_scaling;
+  float intermediate_encoding;
+  float intermediate_color_space;
+  float swap_chain_decoding;
+  float swap_chain_gamma_correction;
+  //  float swap_chain_decoding_color_space;
+  float swap_chain_custom_color_space;
+  // float swap_chain_scaling_nits;
+  // float swap_chain_clamp_nits;
+  float swap_chain_clamp_color_space;
+  float swap_chain_encoding;
+  float swap_chain_encoding_color_space;
+};
+
+#ifndef __cplusplus
+#if ((__SHADER_TARGET_MAJOR == 5 && __SHADER_TARGET_MINOR >= 1) || __SHADER_TARGET_MAJOR >= 6)
+cbuffer shader_injection : register(b13, space50) {
+#elif (__SHADER_TARGET_MAJOR < 5) || ((__SHADER_TARGET_MAJOR == 5) && (__SHADER_TARGET_MINOR < 1))
+cbuffer shader_injection : register(b13) {
+#endif
+  ShaderInjectData shader_injection : packoffset(c0);
+}
+
+#define RENODX_TONE_MAP_TYPE                 shader_injection.tone_map_type
+#define RENODX_PEAK_WHITE_NITS               shader_injection.peak_white_nits
+#define RENODX_DIFFUSE_WHITE_NITS            shader_injection.diffuse_white_nits
+#define RENODX_GRAPHICS_WHITE_NITS           shader_injection.graphics_white_nits
+#define RENODX_GAMMA_CORRECTION              shader_injection.gamma_correction
+#define RENODX_TONE_MAP_PER_CHANNEL          shader_injection.tone_map_per_channel
+#define RENODX_TONE_MAP_WORKING_COLOR_SPACE  shader_injection.tone_map_working_color_space
+#define RENODX_TONE_MAP_HUE_PROCESSOR        shader_injection.tone_map_hue_processor
+#define RENODX_TONE_MAP_HUE_CORRECTION       shader_injection.tone_map_hue_correction
+#define RENODX_TONE_MAP_HUE_SHIFT            shader_injection.tone_map_hue_shift
+#define RENODX_TONE_MAP_CLAMP_COLOR_SPACE    shader_injection.tone_map_clamp_color_space
+#define RENODX_TONE_MAP_CLAMP_PEAK           shader_injection.tone_map_clamp_peak
+#define RENODX_TONE_MAP_EXPOSURE             shader_injection.tone_map_exposure
+#define RENODX_TONE_MAP_HIGHLIGHTS           shader_injection.tone_map_highlights
+#define RENODX_TONE_MAP_SHADOWS              shader_injection.tone_map_shadows
+#define RENODX_TONE_MAP_CONTRAST             shader_injection.tone_map_contrast
+#define RENODX_TONE_MAP_SATURATION           shader_injection.tone_map_saturation
+#define RENODX_TONE_MAP_HIGHLIGHT_SATURATION shader_injection.tone_map_highlight_saturation
+#define RENODX_TONE_MAP_BLOWOUT              shader_injection.tone_map_blowout
+#define RENODX_TONE_MAP_FLARE                shader_injection.tone_map_flare
+#define RENODX_COLOR_GRADE_STRENGTH          shader_injection.color_grade_strength
+#define RENODX_INTERMEDIATE_ENCODING         shader_injection.intermediate_encoding
+#define RENODX_SWAP_CHAIN_DECODING           shader_injection.swap_chain_decoding
+#define RENODX_SWAP_CHAIN_GAMMA_CORRECTION   shader_injection.swap_chain_gamma_correction
+// #define RENODX_SWAP_CHAIN_DECODING_COLOR_SPACE shader_injection.swap_chain_decoding_color_space
+#define RENODX_SWAP_CHAIN_CUSTOM_COLOR_SPACE shader_injection.swap_chain_custom_color_space
+// #define RENODX_SWAP_CHAIN_SCALING_NITS         shader_injection.swap_chain_scaling_nits
+// #define RENODX_SWAP_CHAIN_CLAMP_NITS           shader_injection.swap_chain_clamp_nits
+#define RENODX_SWAP_CHAIN_CLAMP_COLOR_SPACE    shader_injection.swap_chain_clamp_color_space
+#define RENODX_SWAP_CHAIN_ENCODING             shader_injection.swap_chain_encoding
+#define RENODX_SWAP_CHAIN_ENCODING_COLOR_SPACE shader_injection.swap_chain_encoding_color_space
+#define RENODX_RENO_DRT_TONE_MAP_METHOD        renodx::tonemap::renodrt::config::tone_map_method::REINHARD
+
+#include "../../shaders/renodx.hlsl"
+
+#endif
+
+#endif  // SRC_TEMPLATE_SHARED_H_

--- a/src/games/annomutationem/ui_fix_0x3A44273D.ps_4_0.hlsl
+++ b/src/games/annomutationem/ui_fix_0x3A44273D.ps_4_0.hlsl
@@ -1,0 +1,28 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.4.1 on Sat May 31 23:11:05 2025
+
+SamplerState _UITex_s : register(s0);
+Texture2D<float4> _UITex : register(t0);
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float2 v0 : TEXCOORD0,
+  float4 v1 : SV_POSITION0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = _UITex.Sample(_UITex_s, v0.xy).xyzw;
+  o0.xyz = r0.xyz * r0.www;
+  o0.w = r0.w;
+
+  o0.xyz *= max(0, shader_injection.graphics_white_nits / shader_injection.diffuse_white_nits);
+  return;
+}

--- a/src/games/annomutationem/ui_main_0x567C3CF7.ps_4_0.hlsl
+++ b/src/games/annomutationem/ui_main_0x567C3CF7.ps_4_0.hlsl
@@ -1,0 +1,37 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.4.1 on Wed May 28 01:30:14 2025
+
+SamplerState _MainTex_s : register(s0);
+SamplerState _UITex_s : register(s1);
+Texture2D<float4> _UITex : register(t0);
+Texture2D<float4> _MainTex : register(t1);
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float2 v0 : TEXCOORD0,
+  float4 v1 : SV_POSITION0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = _UITex.Sample(_UITex_s, v0.xy).xyzw;
+  r0.xyz *= shader_injection.graphics_white_nits / shader_injection.diffuse_white_nits;
+  r1.xyzw = _MainTex.Sample(_MainTex_s, v0.xy).xyzw;
+
+  r0.w = 1 - r0.w;
+
+  //  r0.xyz = r1.xyz * r0.www + r0.xyz;
+  // Fix for invalid colors
+  r0.xyz = max(0.0, r1.xyz * r0.www + r0.xyz);
+  r0.w = 1;
+  o0.xyzw = r0.xyzw;
+
+  return;
+}


### PR DESCRIPTION
Add HDR Support for Anno: Mutationem

This PR implements HDR support for Anno: Mutationem, bringing enhanced visual quality and dynamic range to the game. The implementation includes:

Technical Details:
- Added fixes to make UI work properly with R16G16B16A16_FLOAT.
- Added custom code for adjusting UI brightness. (Game uses chain of uber shaders, there was no way to do the separation).

Testing:
- Tested by playing the game from start to finish.
