### PR TITLE
feat(madmax): Add film grain + Fix highlights

### DIFF
--- a/src/games/madmax/addon.cpp
+++ b/src/games/madmax/addon.cpp
@@ -301,6 +301,27 @@ renodx::utils::settings::Settings settings = {
         .max = 100.f,
         .parse = [](float value) { return value * 0.01f; },
     },
+        new renodx::utils::settings::Setting{
+        .key = "SwapChainCustomColorSpace",
+        .binding = &shader_injection.swap_chain_custom_color_space,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 0.f,
+        .label = "Custom Color Space",
+        .section = "Display Output",
+        .tooltip = "Selects output color space"
+                   "\nUS Modern for BT.709 D65."
+                   "\nJPN Modern for BT.709 D93."
+                   "\nUS CRT for BT.601 (NTSC-U)."
+                   "\nJPN CRT for BT.601 ARIB-TR-B9 D93 (NTSC-J)."
+                   "\nDefault: US CRT",
+        .labels = {
+            "US Modern",
+            "JPN Modern",
+            "US CRT",
+            "JPN CRT",
+        },
+        .is_visible = []() { return settings[0]->GetValue() >= 1; },
+    },
     new renodx::utils::settings::Setting{
         .key = "World_Map",
         .binding = &shader_injection.world_map,

--- a/src/games/madmax/output_dhc_0xB755AB0F.ps_5_0.hlsl
+++ b/src/games/madmax/output_dhc_0xB755AB0F.ps_5_0.hlsl
@@ -180,6 +180,14 @@ void main(
   if (RENODX_TONE_MAP_TYPE != 0) {
     o0.rgb = renodx::draw::ToneMapPass(untonemapped, o0.rgb);
   }
+  if (CUSTOM_FILM_GRAIN_STRENGTH != 0) {
+    o0.rgb = renodx::effects::ApplyFilmGrain(
+        o0.rgb,
+        v2.xy,
+        CUSTOM_RANDOM,
+        CUSTOM_FILM_GRAIN_STRENGTH * 0.03f,
+        1.f);
+  }
   o0.rgb = renodx::draw::RenderIntermediatePass(o0.rgb);
   return;
 }

--- a/src/games/madmax/output_dhig_0xBEC13FF0.ps_5_0.hlsl
+++ b/src/games/madmax/output_dhig_0xBEC13FF0.ps_5_0.hlsl
@@ -156,6 +156,14 @@ void main(
   if (RENODX_TONE_MAP_TYPE != 0) {
     o0.rgb = renodx::draw::ToneMapPass(untonemapped, o0.rgb);
   }
+  if (CUSTOM_FILM_GRAIN_STRENGTH != 0) {
+    o0.rgb = renodx::effects::ApplyFilmGrain(
+        o0.rgb,
+        v2.xy,
+        CUSTOM_RANDOM,
+        CUSTOM_FILM_GRAIN_STRENGTH * 0.03f,
+        1.f);
+  }
   o0.rgb = renodx::draw::RenderIntermediatePass(o0.rgb);
   return;
 }

--- a/src/games/madmax/output_dhm_0x1FD18E12.ps_5_0.hlsl
+++ b/src/games/madmax/output_dhm_0x1FD18E12.ps_5_0.hlsl
@@ -147,7 +147,6 @@ void main(
   r0.xyz = r1.xyz * Consts[2].xxx + r0.xyz;
 
   float3 untonemapped = r0.rgb;
-  untonemapped = renodx::color::srgb::DecodeSafe(untonemapped);
   
   r0.xyz = max(float3(1.00000001e-07, 1.00000001e-07, 1.00000001e-07), r0.xyz);
   r1.xyz = r0.xyz * float3(0.150000006, 0.150000006, 0.150000006) + float3(0.0500000007, 0.0500000007, 0.0500000007);
@@ -168,6 +167,14 @@ void main(
 
   if (RENODX_TONE_MAP_TYPE != 0){
     o0.rgb = renodx::draw::ToneMapPass(untonemapped, o0.rgb);
+  }
+  if (CUSTOM_FILM_GRAIN_STRENGTH != 0) {
+    o0.rgb = renodx::effects::ApplyFilmGrain(
+        o0.rgb,
+        v2.xy,
+        CUSTOM_RANDOM,
+        CUSTOM_FILM_GRAIN_STRENGTH * 0.03f,
+        1.f);
   }
   o0.rgb = renodx::draw::RenderIntermediatePass(o0.rgb);
   return;

--- a/src/games/madmax/output_dhs_0xF6A0E5D2.ps_5_0.hlsl
+++ b/src/games/madmax/output_dhs_0xF6A0E5D2.ps_5_0.hlsl
@@ -168,6 +168,14 @@ void main(
   if (RENODX_TONE_MAP_TYPE != 0) {
     o0.rgb = renodx::draw::ToneMapPass(untonemapped, o0.rgb);
   }
+  if (CUSTOM_FILM_GRAIN_STRENGTH != 0) {
+    o0.rgb = renodx::effects::ApplyFilmGrain(
+        o0.rgb,
+        v2.xy,
+        CUSTOM_RANDOM,
+        CUSTOM_FILM_GRAIN_STRENGTH * 0.03f,
+        1.f);
+  }
   o0.rgb = renodx::draw::RenderIntermediatePass(o0.rgb);
   return;
 }

--- a/src/games/madmax/output_dnc_0x4DCDF058.ps_5_0.hlsl
+++ b/src/games/madmax/output_dnc_0x4DCDF058.ps_5_0.hlsl
@@ -185,6 +185,14 @@ void main(
   if (RENODX_TONE_MAP_TYPE != 0) {
     o0.rgb = renodx::draw::ToneMapPass(untonemapped, o0.rgb);
   }
+  if (CUSTOM_FILM_GRAIN_STRENGTH != 0) {
+    o0.rgb = renodx::effects::ApplyFilmGrain(
+        o0.rgb,
+        v2.xy,
+        CUSTOM_RANDOM,
+        CUSTOM_FILM_GRAIN_STRENGTH * 0.03f,
+        1.f);
+  }
   o0.rgb = renodx::draw::RenderIntermediatePass(o0.rgb);
   return;
 }

--- a/src/games/madmax/output_dnig_0xDF35C719.ps_5_0.hlsl
+++ b/src/games/madmax/output_dnig_0xDF35C719.ps_5_0.hlsl
@@ -156,6 +156,14 @@ void main(
   if (RENODX_TONE_MAP_TYPE != 0) {
     o0.rgb = renodx::draw::ToneMapPass(untonemapped, o0.rgb);
   }
+  if (CUSTOM_FILM_GRAIN_STRENGTH != 0) {
+    o0.rgb = renodx::effects::ApplyFilmGrain(
+        o0.rgb,
+        v2.xy,
+        CUSTOM_RANDOM,
+        CUSTOM_FILM_GRAIN_STRENGTH * 0.03f,
+        1.f);
+  }
   o0.rgb = renodx::draw::RenderIntermediatePass(o0.rgb);
   return;
 }

--- a/src/games/madmax/output_dnm_0x569C5E86.ps_5_0.hlsl
+++ b/src/games/madmax/output_dnm_0x569C5E86.ps_5_0.hlsl
@@ -152,7 +152,6 @@ void main(
   r0.xyz = r1.xyz * Consts[2].xxx + r0.xyz;
 
   float3 untonemapped = r0.rgb;
-  untonemapped = renodx::color::srgb::DecodeSafe(untonemapped);
 
   r0.xyz = max(float3(1.00000001e-07,1.00000001e-07,1.00000001e-07), r0.xyz);
   r1.xyz = r0.xyz * float3(0.150000006,0.150000006,0.150000006) + float3(0.0500000007,0.0500000007,0.0500000007);
@@ -173,6 +172,14 @@ void main(
 
   if (RENODX_TONE_MAP_TYPE != 0) {
     o0.rgb = renodx::draw::ToneMapPass(untonemapped, o0.rgb);
+  }
+  if (CUSTOM_FILM_GRAIN_STRENGTH != 0) {
+    o0.rgb = renodx::effects::ApplyFilmGrain(
+        o0.rgb,
+        v2.xy,
+        CUSTOM_RANDOM,
+        CUSTOM_FILM_GRAIN_STRENGTH * 0.03f,
+        1.f);
   }
   o0.rgb = renodx::draw::RenderIntermediatePass(o0.rgb);
   return;

--- a/src/games/madmax/output_dns_0xC39EC40D.ps_5_0.hlsl
+++ b/src/games/madmax/output_dns_0xC39EC40D.ps_5_0.hlsl
@@ -168,6 +168,14 @@ void main(
   if (RENODX_TONE_MAP_TYPE != 0) {
     o0.rgb = renodx::draw::ToneMapPass(untonemapped, o0.rgb);
   }
+  if (CUSTOM_FILM_GRAIN_STRENGTH != 0) {
+    o0.rgb = renodx::effects::ApplyFilmGrain(
+        o0.rgb,
+        v2.xy,
+        CUSTOM_RANDOM,
+        CUSTOM_FILM_GRAIN_STRENGTH * 0.03f,
+        1.f);
+  }
   o0.rgb = renodx::draw::RenderIntermediatePass(o0.rgb);
   return;
 }

--- a/src/games/madmax/output_fe_0x57CE885C.ps_5_0.hlsl
+++ b/src/games/madmax/output_fe_0x57CE885C.ps_5_0.hlsl
@@ -72,6 +72,14 @@ void main(
   if (RENODX_TONE_MAP_TYPE != 0) {
     o0.rgb = renodx::draw::ToneMapPass(untonemapped, o0.rgb);
   }
+  if (CUSTOM_FILM_GRAIN_STRENGTH != 0) {
+    o0.rgb = renodx::effects::ApplyFilmGrain(
+        o0.rgb,
+        v2.xy,
+        CUSTOM_RANDOM,
+        CUSTOM_FILM_GRAIN_STRENGTH * 0.03f,
+        1.f);
+  }
   o0.rgb = renodx::draw::RenderIntermediatePass(o0.rgb);
   return;
 }

--- a/src/games/madmax/output_s_0x254ED214.ps_5_0.hlsl
+++ b/src/games/madmax/output_s_0x254ED214.ps_5_0.hlsl
@@ -84,6 +84,14 @@ void main(
   if (RENODX_TONE_MAP_TYPE != 0) {
     o0.rgb = renodx::draw::ToneMapPass(untonemapped, o0.rgb);
   }
+  if (CUSTOM_FILM_GRAIN_STRENGTH != 0) {
+    o0.rgb = renodx::effects::ApplyFilmGrain(
+        o0.rgb,
+        v2.xy,
+        CUSTOM_RANDOM,
+        CUSTOM_FILM_GRAIN_STRENGTH * 0.03f,
+        1.f);
+  }
   o0.rgb = renodx::draw::RenderIntermediatePass(o0.rgb);
   return;
 }

--- a/src/games/madmax/shared.h
+++ b/src/games/madmax/shared.h
@@ -22,9 +22,12 @@
 #define RENODX_TONE_MAP_BLOWOUT              shader_injection.tone_map_blowout
 #define RENODX_TONE_MAP_FLARE                shader_injection.tone_map_flare
 #define RENODX_COLOR_GRADE_STRENGTH          shader_injection.color_grade_strength
+#define RENODX_SWAP_CHAIN_CUSTOM_COLOR_SPACE shader_injection.swap_chain_custom_color_space
 #define RENODX_RENO_DRT_TONE_MAP_METHOD        renodx::tonemap::renodrt::config::tone_map_method::REINHARD
 #define RENODX_SWAP_CHAIN_ENCODING_COLOR_SPACE color::convert::COLOR_SPACE_BT709
 #define RENODX_SWAP_CHAIN_ENCODING             ENCODING_SCRGB
+#define CUSTOM_FILM_GRAIN_STRENGTH           shader_injection.custom_film_grain
+#define CUSTOM_RANDOM                        shader_injection.custom_random
 #define RENODX_WORLD_MAP                     shader_injection.world_map
 
 // Must be 32bit aligned
@@ -51,6 +54,9 @@ struct ShaderInjectData {
   float tone_map_hue_processor;
   float tone_map_per_channel;
   float gamma_correction;
+  float swap_chain_custom_color_space;
+  float custom_film_grain;
+  float custom_random;
   float world_map;
 };
 

--- a/src/games/madmax/tonemap_ig_0x83FCCE5D.ps_5_0.hlsl
+++ b/src/games/madmax/tonemap_ig_0x83FCCE5D.ps_5_0.hlsl
@@ -1,0 +1,187 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.4.1 on Fri Jun 20 20:06:03 2025
+
+cbuffer cbInstanceConsts : register(b1)
+{
+  float4 InstanceConsts[6] : packoffset(c0);
+}
+
+SamplerState SceneTexture_s : register(s0);
+SamplerState VelocityTexture_s : register(s3);
+Texture2D<float4> SceneTexture : register(t0);
+Texture2D<float4> VelocityTexture : register(t3);
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_Position0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0,r1,r2,r3,r4,r5;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = SceneTexture.SampleLevel(SceneTexture_s, v1.xy, 0).xyzw;
+  r1.xyzw = VelocityTexture.SampleLevel(VelocityTexture_s, v1.xy, 0).xyzw;
+  r1.xy = float2(-0.5,-0.5) + r1.xy;
+  r1.w = 0.0299999993 * r1.w;
+  r1.w = max(InstanceConsts[0].x, r1.w);
+  r2.xy = r1.xy * r1.ww;
+  r2.z = dot(r2.xy, r2.xy);
+  r2.w = cmp(9.99999994e-09 < r2.z);
+  if (r2.w != 0) {
+    r3.xyzw = float4(-4,-4,-3,-3) * r2.xyxy;
+    r4.xyzw = r2.xyxy * float4(-4,-4,-3,-3) + v1.xyxy;
+    r5.xyzw = VelocityTexture.SampleLevel(VelocityTexture_s, r4.xy, 0).xyzw;
+    r5.xy = float2(-0.5,-0.5) + r5.xy;
+    r2.w = 0.0299999993 * r5.w;
+    r2.w = max(InstanceConsts[0].x, r2.w);
+    r5.xy = r5.xy * r2.ww;
+    r2.w = cmp(r5.z >= r1.z);
+    r5.x = dot(r5.xy, r5.xy);
+    r5.x = 16 * r5.x;
+    r3.x = dot(r3.xy, r3.xy);
+    r3.x = cmp(r5.x >= r3.x);
+    r2.w = (int)r2.w | (int)r3.x;
+    if (r2.w != 0) {
+      r5.xyzw = SceneTexture.SampleLevel(SceneTexture_s, r4.xy, 0).xyzw;
+      r0.xyzw = r5.xyzw + r0.xyzw;
+      r2.w = 2;
+    } else {
+      r2.w = 1;
+    }
+    r5.xyzw = VelocityTexture.SampleLevel(VelocityTexture_s, r4.zw, 0).xyzw;
+    r3.xy = float2(-0.5,-0.5) + r5.xy;
+    r4.x = 0.0299999993 * r5.w;
+    r4.x = max(InstanceConsts[0].x, r4.x);
+    r3.xy = r4.xx * r3.xy;
+    r4.x = cmp(r5.z >= r1.z);
+    r3.x = dot(r3.xy, r3.xy);
+    r3.x = 16 * r3.x;
+    r3.y = dot(r3.zw, r3.zw);
+    r3.x = cmp(r3.x >= r3.y);
+    r3.x = (int)r3.x | (int)r4.x;
+    if (r3.x != 0) {
+      r3.xyzw = SceneTexture.SampleLevel(SceneTexture_s, r4.zw, 0).xyzw;
+      r0.xyzw = r3.xyzw + r0.xyzw;
+      r2.w = 1 + r2.w;
+    }
+    r3.xyzw = float4(-2,-2,3,3) * r2.xyxy;
+    r4.xyzw = r2.xyxy * float4(-2,-2,3,3) + v1.xyxy;
+    r5.xyzw = VelocityTexture.SampleLevel(VelocityTexture_s, r4.xy, 0).xyzw;
+    r5.xy = float2(-0.5,-0.5) + r5.xy;
+    r5.w = 0.0299999993 * r5.w;
+    r5.w = max(InstanceConsts[0].x, r5.w);
+    r5.xy = r5.xy * r5.ww;
+    r5.z = cmp(r5.z >= r1.z);
+    r5.x = dot(r5.xy, r5.xy);
+    r5.x = 16 * r5.x;
+    r3.x = dot(r3.xy, r3.xy);
+    r3.x = cmp(r5.x >= r3.x);
+    r3.x = (int)r3.x | (int)r5.z;
+    if (r3.x != 0) {
+      r5.xyzw = SceneTexture.SampleLevel(SceneTexture_s, r4.xy, 0).xyzw;
+      r0.xyzw = r5.xyzw + r0.xyzw;
+      r2.w = 1 + r2.w;
+    }
+    r3.xy = -r1.xy * r1.ww + v1.xy;
+    r5.xyzw = VelocityTexture.SampleLevel(VelocityTexture_s, r3.xy, 0).xyzw;
+    r4.xy = float2(-0.5,-0.5) + r5.xy;
+    r5.x = 0.0299999993 * r5.w;
+    r5.x = max(InstanceConsts[0].x, r5.x);
+    r4.xy = r5.xx * r4.xy;
+    r5.x = cmp(r5.z >= r1.z);
+    r4.x = dot(r4.xy, r4.xy);
+    r4.x = 16 * r4.x;
+    r4.y = dot(-r2.xy, -r2.xy);
+    r4.x = cmp(r4.x >= r4.y);
+    r4.x = (int)r4.x | (int)r5.x;
+    if (r4.x != 0) {
+      r5.xyzw = SceneTexture.SampleLevel(SceneTexture_s, r3.xy, 0).xyzw;
+      r0.xyzw = r5.xyzw + r0.xyzw;
+      r2.w = 1 + r2.w;
+    }
+    r1.xy = r1.xy * r1.ww + v1.xy;
+    r5.xyzw = VelocityTexture.SampleLevel(VelocityTexture_s, r1.xy, 0).xyzw;
+    r3.xy = float2(-0.5,-0.5) + r5.xy;
+    r1.w = 0.0299999993 * r5.w;
+    r1.w = max(InstanceConsts[0].x, r1.w);
+    r3.xy = r3.xy * r1.ww;
+    r1.w = cmp(r5.z >= r1.z);
+    r3.x = dot(r3.xy, r3.xy);
+    r3.x = 16 * r3.x;
+    r2.z = cmp(r3.x >= r2.z);
+    r1.w = (int)r1.w | (int)r2.z;
+    if (r1.w != 0) {
+      r5.xyzw = SceneTexture.SampleLevel(SceneTexture_s, r1.xy, 0).xyzw;
+      r0.xyzw = r5.xyzw + r0.xyzw;
+      r2.w = 1 + r2.w;
+    }
+    r1.xy = r2.xy + r2.xy;
+    r3.xy = r2.xy * float2(2,2) + v1.xy;
+    r5.xyzw = VelocityTexture.SampleLevel(VelocityTexture_s, r3.xy, 0).xyzw;
+    r4.xy = float2(-0.5,-0.5) + r5.xy;
+    r1.w = 0.0299999993 * r5.w;
+    r1.w = max(InstanceConsts[0].x, r1.w);
+    r4.xy = r4.xy * r1.ww;
+    r1.w = cmp(r5.z >= r1.z);
+    r2.z = dot(r4.xy, r4.xy);
+    r2.z = 16 * r2.z;
+    r1.x = dot(r1.xy, r1.xy);
+    r1.x = cmp(r2.z >= r1.x);
+    r1.x = (int)r1.x | (int)r1.w;
+    if (r1.x != 0) {
+      r5.xyzw = SceneTexture.SampleLevel(SceneTexture_s, r3.xy, 0).xyzw;
+      r0.xyzw = r5.xyzw + r0.xyzw;
+      r2.w = 1 + r2.w;
+    }
+    r5.xyzw = VelocityTexture.SampleLevel(VelocityTexture_s, r4.zw, 0).xyzw;
+    r1.xy = float2(-0.5,-0.5) + r5.xy;
+    r1.w = 0.0299999993 * r5.w;
+    r1.w = max(InstanceConsts[0].x, r1.w);
+    r1.xy = r1.xy * r1.ww;
+    r1.w = cmp(r5.z >= r1.z);
+    r1.x = dot(r1.xy, r1.xy);
+    r1.x = 16 * r1.x;
+    r1.y = dot(r3.zw, r3.zw);
+    r1.x = cmp(r1.x >= r1.y);
+    r1.x = (int)r1.x | (int)r1.w;
+    if (r1.x != 0) {
+      r3.xyzw = SceneTexture.SampleLevel(SceneTexture_s, r4.zw, 0).xyzw;
+      r0.xyzw = r3.xyzw + r0.xyzw;
+      r2.w = 1 + r2.w;
+    }
+    r1.xy = float2(4,4) * r2.xy;
+    r2.xy = r2.xy * float2(4,4) + v1.xy;
+    r3.xyzw = VelocityTexture.SampleLevel(VelocityTexture_s, r2.xy, 0).xyzw;
+    r3.xy = float2(-0.5,-0.5) + r3.xy;
+    r1.w = 0.0299999993 * r3.w;
+    r1.w = max(InstanceConsts[0].x, r1.w);
+    r3.xy = r3.xy * r1.ww;
+    r1.z = cmp(r3.z >= r1.z);
+    r1.w = dot(r3.xy, r3.xy);
+    r1.w = 16 * r1.w;
+    r1.x = dot(r1.xy, r1.xy);
+    r1.x = cmp(r1.w >= r1.x);
+    r1.x = (int)r1.x | (int)r1.z;
+    if (r1.x != 0) {
+      r1.xyzw = SceneTexture.SampleLevel(SceneTexture_s, r2.xy, 0).xyzw;
+      r0.xyzw = r1.xyzw + r0.xyzw;
+      r2.w = 1 + r2.w;
+    }
+    r0.xyzw = r0.xyzw / r2.wwww;
+    o0.w = r0.w;
+  } else {
+    o0.w = r0.w;
+  }
+  //r0.xyz = log2(r0.xyz);
+  //r0.xyz = InstanceConsts[0].yyy * r0.xyz;
+  //o0.xyz = exp2(r0.xyz);
+  o0.xyz = r0.rgb;
+  return;
+}

--- a/src/games/madmax/tonemap_menu_0x058D8234.ps_5_0.hlsl
+++ b/src/games/madmax/tonemap_menu_0x058D8234.ps_5_0.hlsl
@@ -1,0 +1,34 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.4.1 on Sat Jun 21 11:20:03 2025
+
+cbuffer cbInstanceConsts : register(b1)
+{
+  float4 InstanceConsts[6] : packoffset(c0);
+}
+
+SamplerState SceneTexture_s : register(s0);
+Texture2D<float4> SceneTexture : register(t0);
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_Position0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_Target0)
+{
+  float4 r0;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = SceneTexture.SampleLevel(SceneTexture_s, v1.xy, 0).xyzw;
+  //r0.xyz = log2(r0.xyz);
+  //o0.w = r0.w;
+  //r0.xyz = InstanceConsts[0].yyy * r0.xyz;
+  //o0.xyz = exp2(r0.xyz);
+  o0 = r0;
+  return;
+}


### PR DESCRIPTION
turns out the shader that comes after outputs has tonemap at the end which caused highlights to become purple without bt709 clamp