### PR TITLE
feat(finalfantasyxv): rewrite HDR, extend color grading, add option to restore highlight saturation

### DIFF
--- a/src/games/ffxv/RenoDRTSmoothClamp.hlsl
+++ b/src/games/ffxv/RenoDRTSmoothClamp.hlsl
@@ -1,0 +1,34 @@
+#include "./shared.h"
+
+/// Applies a customized version of RenoDRT tonemapper that tonemaps down to 1.0.
+/// This function is used to compress HDR color to SDR range for use alongside `UpgradeToneMap`.
+///
+/// @param lutInputColor The color input that needs to be tonemapped.
+/// @return The tonemapped color compressed to the SDR range, ensuring that it can be applied to SDR color grading with `UpgradeToneMap`.
+float3 renoDRTSmoothClamp(float3 untonemapped) {
+  renodx::tonemap::renodrt::Config renodrt_config = renodx::tonemap::renodrt::config::Create();
+  renodrt_config.nits_peak = 100.f;
+  renodrt_config.mid_gray_value = 0.18f;
+  renodrt_config.mid_gray_nits = 18.f;
+  renodrt_config.exposure = 1.f;
+  renodrt_config.highlights = 1.f;
+  renodrt_config.shadows = 1.f;
+  renodrt_config.contrast = 1.05f;
+  renodrt_config.saturation = 1.025f;
+  renodrt_config.dechroma = 0.f;
+  renodrt_config.flare = 0.f;
+  renodrt_config.hue_correction_strength = 0.f;
+  // renodrt_config.hue_correction_source = renodx::tonemap::uncharted2::BT709(untonemapped);
+  renodrt_config.hue_correction_method = renodx::tonemap::renodrt::config::hue_correction_method::OKLAB;
+  renodrt_config.tone_map_method = renodx::tonemap::renodrt::config::tone_map_method::DANIELE;
+  renodrt_config.hue_correction_type = renodx::tonemap::renodrt::config::hue_correction_type::INPUT;
+  renodrt_config.working_color_space = 2u;
+  renodrt_config.per_channel = false;
+
+  float3 renoDRTColor = renodx::tonemap::renodrt::BT709(untonemapped, renodrt_config);
+
+  float HDRBlendFactor = lerp(1.f, renodrt_config.mid_gray_value, saturate(injectedData.toneMapHDRBlendFactor));
+  renoDRTColor = lerp(min(1.f, untonemapped), renoDRTColor, saturate(untonemapped / HDRBlendFactor));
+
+  return renoDRTColor;
+}

--- a/src/games/ffxv/addon.cpp
+++ b/src/games/ffxv/addon.cpp
@@ -1,0 +1,615 @@
+/*
+ * Copyright (C) 2024 Carlos Lopez
+ * SPDX-License-Identifier: MIT
+ */
+
+#define ImTextureID ImU64
+
+#define DEBUG_LEVEL_0
+
+#include <deps/imgui/imgui.h>
+#include <include/reshade.hpp>
+
+#include <embed/shaders.h>
+
+#include "../../mods/shader.hpp"
+#include "../../mods/swapchain.hpp"
+#include "../../utils/settings.hpp"
+#include "./shared.h"
+
+namespace {
+
+renodx::mods::shader::CustomShaders custom_shaders = {
+    CustomShaderEntry(0xDD4C5B74),  // output processing
+    CustomShaderEntry(0x75DFE4B0),  // tonemapper
+    CustomShaderEntry(0x18EF8C72),  // tonemapper
+    CustomShaderEntry(0x3F4687F4),  // dithering
+    CustomShaderEntry(0x369A4C39),  // ui
+    CustomShaderEntry(0xB4EADB83),  // ui
+    CustomShaderEntry(0xF2940481),  // ui
+    CustomShaderEntry(0xBBC1036C),  // glare
+    CustomShaderEntry(0x66EDB0A6),  // glare
+    // CustomSwapchainShader(0x00000000),
+    // BypassShaderEntry(0x00000000)
+};
+
+ShaderInjectData shader_injection;
+
+float current_settings_mode = 0;
+
+renodx::utils::settings::Settings settings = {
+    new renodx::utils::settings::Setting{
+        .key = "SettingsMode",
+        .binding = &current_settings_mode,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 0.f,
+        .can_reset = false,
+        .label = "Settings Mode",
+        .labels = {"Simple", "Intermediate", "Advanced"},
+        .is_global = true,
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapType",
+        .binding = &shader_injection.tone_map_type,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 3.f,
+        .can_reset = true,
+        .label = "Tone Mapper",
+        .section = "Tone Mapping",
+        .tooltip = "Sets the tone mapper type",
+        // .labels = {"Vanilla", "SDR", "ACES", "RenoDRT w/ ColorGrading", "RenoDRT"},
+        .labels = {"Vanilla", "SDR", "ACES", "RenoDRT w/ ColorGrading"},
+        .is_visible = []() { return current_settings_mode >= 1; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapPeakNits",
+        .binding = &shader_injection.peak_white_nits,
+        .default_value = 1000.f,
+        .can_reset = false,
+        .label = "Peak Brightness",
+        .section = "Tone Mapping",
+        .tooltip = "Sets the value of peak white in nits",
+        .min = 48.f,
+        .max = 4000.f,
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapGameNits",
+        .binding = &shader_injection.diffuse_white_nits,
+        .default_value = 203.f,
+        .label = "Game Brightness",        
+        .section = "Tone Mapping",
+        .tooltip = "Sets the value of 100% white in nits",
+        .min = 48.f,
+        .max = 500.f,
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapUINits",
+        .binding = &shader_injection.graphics_white_nits,
+        .default_value = 203.f,
+        .label = "UI Brightness",
+        .section = "Tone Mapping",
+        .tooltip = "Sets the brightness of UI and HUD elements in nits",
+        .min = 48.f,
+        .max = 500.f,
+    },
+    // new renodx::utils::settings::Setting{
+    //     .key = "PeakBrightnessClamp",
+    //     .binding = &shader_injection.peak_clamp,
+    //     .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+    //     .default_value = 0.f,
+    //     .label = "Clamp Peak Brightness",
+    //     .section = "Tone Mapping",
+    //     .tooltip = "Either clamp the brightness or exponentially rolloff.",
+    //     .labels = {"Clamp", "Exponential "},
+    //     .is_visible = []() { return current_settings_mode >= 1; },
+    // },
+    
+    // new renodx::utils::settings::Setting{
+    //     .key = "ToneMapStrength",
+    //     .binding = &shader_injection.tone_map_strength,
+    //     .default_value = 0.8,
+    //     .label = "Tone Mapping Strength",
+    //     .section = "Tone Mapping",
+    //     .max = 4.f,
+    //     .format = "%.2f",
+    //     .is_visible = []() { return current_settings_mode >= 1; },
+    // },
+    new renodx::utils::settings::Setting{
+        .key = "GammaCorrection",
+        .binding = &shader_injection.gamma_correction,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 1.f,
+        .label = "Gamma Correction",
+        .section = "Tone Mapping",
+        .tooltip = "Emulates a display EOTF.",
+        .labels = {"Off", "2.2", "BT.1886"},
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapScaling",
+        .binding = &shader_injection.tone_map_per_channel,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 0.f,
+        .label = "Scaling",
+        .section = "Tone Mapping",
+        .tooltip = "Luminance scales colors consistently while per-channel saturates and blows out sooner",
+        .labels = {"Luminance", "Per Channel"},
+        .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+        .is_visible = []() { return false; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapWorkingColorSpace",
+        .binding = &shader_injection.tone_map_working_color_space,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 0.f,
+        .label = "Working Color Space",
+        .section = "Tone Mapping",
+        .labels = {"BT709", "BT2020", "AP1"},
+        .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+        .is_visible = []() { return current_settings_mode >= 2; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapHueProcessor",
+        .binding = &shader_injection.tone_map_hue_processor,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 0.f,
+        .label = "Hue Processor",
+        .section = "Tone Mapping",
+        .tooltip = "Selects hue processor",
+        .labels = {"OKLab", "ICtCp", "darkTable UCS"},
+        .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+        // .is_visible = []() { return current_settings_mode >= 2; },
+        .is_visible = []() { return false; },
+    },
+    
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapHueProcessor",
+        .binding = &shader_injection.tone_map_hue_processor,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 0.f,
+        .label = "Hue Processor",
+        .section = "Tone Mapping",
+        .tooltip = "Selects hue processor",
+        .labels = {"OKLab", "ICtCp", "darkTable UCS"},
+        .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+        // .is_visible = []() { return current_settings_mode >= 2; },
+        .is_visible = []() { return false; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapHueCorrection",
+        .binding = &shader_injection.tone_map_hue_correction,
+        .default_value = 100.f,
+        .label = "Hue Correction",
+        .section = "Tone Mapping",
+        .tooltip = "Hue retention strength.",
+        .min = 0.f,
+        .max = 100.f,
+        .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+        .parse = [](float value) { return value * 0.01f; },
+        // .is_visible = []() { return current_settings_mode >= 2; },
+        .is_visible = []() { return false; },
+    },
+    // new renodx::utils::settings::Setting{
+    //     .key = "PostToneMapHueCorrection",
+    //     .binding = &shader_injection.post_tone_map_hue_correction,
+    //     .default_value = 100.f,
+    //     .label = "Post Tonemap Hue Correction",
+    //     .section = "Tone Mapping",
+    //     .tooltip = "Hue retention strength.",
+    //     .min = 0.f,
+    //     .max = 100.f,
+    //     .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+    //     .parse = [](float value) { return value * 0.01f; },
+    //     .is_visible = []() { return current_settings_mode >= 2; },
+    // },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapHueShift",
+        .binding = &shader_injection.tone_map_hue_shift,
+        .default_value = 0.f,
+        .label = "Hue Shift",
+        .section = "Tone Mapping",
+        .tooltip = "Hue-shift emulation strength.",
+        .min = 0.f,
+        .max = 100.f,
+        .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+        .parse = [](float value) { return value * 0.01f; },
+        // .is_visible = []() { return current_settings_mode >= 1; },
+        .is_visible = []() { return false; },
+    },
+    // new renodx::utils::settings::Setting{
+    //     .key = "ToneMapClampColorSpace",
+    //     .binding = &shader_injection.tone_map_clamp_color_space,
+    //     .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+    //     .default_value = 0.f,
+    //     .label = "Clamp Color Space",
+    //     .section = "Tone Mapping",
+    //     .tooltip = "Hue-shift emulation strength.",
+    //     .labels = {"None", "BT709", "BT2020", "AP1"},
+    //     .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+    //     .parse = [](float value) { return value - 1.f; },
+    //     .is_visible = []() { return current_settings_mode >= 2; },
+    // },
+    // new renodx::utils::settings::Setting{
+    //     .key = "ToneMapClampPeak",
+    //     .binding = &shader_injection.tone_map_clamp_peak,
+    //     .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+    //     .default_value = 0.f,
+    //     .label = "Clamp Peak",
+    //     .section = "Tone Mapping",
+    //     .tooltip = "Hue-shift emulation strength.",
+    //     .labels = {"None", "BT709", "BT2020", "AP1"},
+    //     .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+    //     .parse = [](float value) { return value - 1.f; },
+    //     .is_visible = []() { return current_settings_mode >= 2; },
+    // },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeExposure",
+        .binding = &shader_injection.tone_map_exposure,
+        .default_value = 1.f,
+        .label = "Exposure",
+        .section = "Color Grading",
+        .max = 2.f,
+        .format = "%.2f",
+        .is_visible = []() { return current_settings_mode >= 1; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeHighlights",
+        .binding = &shader_injection.tone_map_highlights,
+        .default_value = 50.f,
+        .label = "Highlights",
+        .section = "Color Grading",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+        // .is_visible = []() { return current_settings_mode >= 1; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeShadows",
+        .binding = &shader_injection.tone_map_shadows,
+        .default_value = 50.f,
+        .label = "Shadows",
+        .section = "Color Grading",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+        .is_visible = []() { return current_settings_mode >= 1; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeContrast",
+        .binding = &shader_injection.tone_map_contrast,
+        .default_value = 50.f,
+        .label = "Contrast",
+        .section = "Color Grading",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeSaturation",
+        .binding = &shader_injection.tone_map_saturation,
+        .default_value = 50.f,
+        .label = "Saturation",
+        .section = "Color Grading",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeHighlightSaturation",
+        .binding = &shader_injection.tone_map_highlight_saturation,
+        .default_value = 50.f,
+        .label = "Highlight Saturation",
+        .section = "Color Grading",
+        .tooltip = "Adds or removes highlight color.",
+        .max = 100.f,
+        .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+        .parse = [](float value) { return value * 0.02f; },
+        // .is_visible = []() { return current_settings_mode >= 1; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeBlowout",
+        .binding = &shader_injection.tone_map_blowout,
+        .default_value = 0.f,
+        .label = "Blowout",
+        .section = "Color Grading",
+        .tooltip = "Controls highlight desaturation due to overexposure.",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.01f; },
+        .is_visible = []() { return current_settings_mode >= 1; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeFlare",
+        .binding = &shader_injection.tone_map_flare,
+        .default_value = 0.f,
+        .label = "Flare",
+        .section = "Color Grading",
+        .tooltip = "Flare/Glare Compensation",
+        .max = 100.f,
+        .is_enabled = []() { return shader_injection.tone_map_type == 3; },
+        .parse = [](float value) { return value * 0.02f; },
+        .is_visible = []() { return current_settings_mode >= 1; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeScene",
+        .binding = &shader_injection.color_grade_strength,
+        .default_value = 100.f,
+        .label = "Scene Grading",
+        .section = "Color Grading",
+        .tooltip = "Scene grading as applied by the game",
+        .max = 100.f,
+        .is_enabled = []() { return shader_injection.tone_map_type > 0; },
+        .parse = [](float value) { return value * 0.01f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "Per channel correction",
+        .binding = &shader_injection.per_channel_correction,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 2.f,
+        .can_reset = true,
+        .label = "Per Channel Scene Grading",
+        .section = "Restoring Highlight Saturation",
+        .tooltip = "Select the blending type",
+        .labels = {"Disabled", "RGB", "OKLAB"}
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeBlowoutRestoration",
+        .binding = &shader_injection.color_grade_per_channel_blowout_restoration,
+        .default_value = 100.f,
+        .label = "Per Channel Blowout Restoration",
+        .section = "Restoring Highlight Saturation",
+        .tooltip = "Restores color from blowout from per-channel grading.",
+        .min = 0.f,
+        .max = 100.f,
+        .is_enabled = []() { return shader_injection.per_channel_correction >= 1; },
+        .parse = [](float value) { return value * 0.01f; },
+        .is_visible = []() { return shader_injection.per_channel_correction >= 1 && current_settings_mode >= 1; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeChrominanceCorrection",
+        .binding = &shader_injection.color_grade_per_channel_chrominance_correction,
+        .default_value = 100.f,
+        .label = "Per Channel Chrominance Correction",
+        .section = "Restoring Highlight Saturation",
+        .tooltip = "Corrects unbalanced chrominance (?) from per-channel grading.",
+        .min = 0.f,
+        .max = 100.f,
+        .is_enabled = []() { return shader_injection.per_channel_correction >= 1; },
+        .parse = [](float value) { return value * 0.01f; },
+        .is_visible = []() { return shader_injection.per_channel_correction >= 1 && current_settings_mode >= 1; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeHueCorrection",
+        .binding = &shader_injection.color_grade_per_channel_hue_correction,
+        .default_value = 100.f,
+        .label = "Per Channel Hue Correction",
+        .section = "Restoring Highlight Saturation",
+        .tooltip = "Corrects per-channel hue shifts from per-channel grading.",
+        .min = 0.f,
+        .max = 100.f,
+        .is_enabled = []() { return shader_injection.per_channel_correction >= 1; },
+        .parse = [](float value) { return value * 0.01f; },
+        .is_visible = []() { return shader_injection.per_channel_correction >= 1 && current_settings_mode >= 1; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeHueShift",
+        .binding = &shader_injection.color_grade_per_channel_hue_shift_strength,
+        .default_value = 0.f,
+        .label = "Per Channel Hue Shift Strength",
+        .section = "Restoring Highlight Saturation",
+        .tooltip = "Hue-shift strength.",
+        .min = 0.f,
+        .max = 100.f,
+        .is_enabled = []() { return shader_injection.per_channel_correction >= 1; },
+        .parse = [](float value) { return value * 0.01f; },
+        .is_visible = []() { return shader_injection.per_channel_correction >= 1 && current_settings_mode >= 1; },
+    },
+
+    // new renodx::utils::settings::Setting{
+    //     .key = "DisplayMapType",
+    //     .binding = &shader_injection.displayMapType,
+    //     .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+    //     .default_value = 0.f,
+    //     .can_reset = true,
+    //     .label = "Display Map Type",
+    //     .section = "Highlight Saturation Restoration",
+    //     .tooltip = "Sets the Display mapper used",
+    //     .labels = {"None", "DICE", "Frostbite", "NaturalSDR"},
+    //     .is_visible = []() { return settings[0]->GetValue() >= 1; },
+    // },
+
+    // new renodx::utils::settings::Setting{
+    //     .key = "DisplayMapPeak",
+    //     .binding = &shader_injection.displayMapPeak,
+    //     .value_type = renodx::utils::settings::SettingValueType::FLOAT,
+    //     .default_value = 2.f,
+    //     .can_reset = true,
+    //     .label = "Display Map Peak",
+    //     .section = "Highlight Saturation Restoration",
+    //     .tooltip = "What nit value we want to display map down to -- 2.f is solid",
+    //     .max = 5.f,
+    //     .is_visible = []() { return shader_injection.displayMapType == 1 && shader_injection.displayMapType == 2 && 
+    //         settings[0]->GetValue() >= 2; },
+    // },
+
+    // new renodx::utils::settings::Setting{
+    //     .key = "DisplayMapShoulder",
+    //     .binding = &shader_injection.displayMapShoulder,
+    //     .value_type = renodx::utils::settings::SettingValueType::FLOAT,
+    //     .default_value = 0.25f,
+    //     .can_reset = true,
+    //     .label = "Display Map Shoulder",
+    //     .section = "Highlight Saturation Restoration",
+    //     .tooltip = "Determines where the highlights curve (shoulder) starts in the display mapper.",
+    //     .max = 1.f,
+    //     .format = "%.2f",
+    //     .is_visible = []() { return shader_injection.displayMapType == 1 && shader_injection.displayMapType == 2 && 
+    //         settings[0]->GetValue() >= 2; },
+    // },
+    new renodx::utils::settings::Setting{
+        .key = "SwapChainCustomColorSpace",
+        .binding = &shader_injection.swap_chain_custom_color_space,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 0.f,
+        .label = "Custom Color Space",
+        .section = "Display Output",
+        .tooltip = "Selects output color space"
+                   "\nUS Modern for BT.709 D65."
+                   "\nJPN Modern for BT.709 D93."
+                   "\nUS CRT for BT.601 (NTSC-U)."
+                   "\nJPN CRT for BT.601 ARIB-TR-B9 D93 (NTSC-J)."
+                   "\nDefault: US CRT",
+        .labels = {
+            "US Modern",
+            "JPN Modern",
+            "US CRT",
+            "JPN CRT",
+        },
+        .is_visible = []() { return settings[0]->GetValue() >= 1; },
+    },
+    
+    // new renodx::utils::settings::Setting{
+    //     .key = "IntermediateDecoding",
+    //     .binding = &shader_injection.intermediate_encoding,
+    //     .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+    //     .default_value = 0.f,
+    //     .label = "Intermediate Encoding",
+    //     .section = "Display Output",
+    //     .labels = {"Auto", "None", "SRGB", "2.2", "2.4"},
+    //     .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+    //     .parse = [](float value) {
+    //         if (value == 0) return shader_injection.gamma_correction + 1.f;
+    //         return value - 1.f; },
+    //     .is_visible = []() { return current_settings_mode >= 2; },
+    // },
+    // new renodx::utils::settings::Setting{
+    //     .key = "SwapChainDecoding",
+    //     .binding = &shader_injection.swap_chain_decoding,
+    //     .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+    //     .default_value = 0.f,
+    //     .label = "Swapchain Decoding",
+    //     .section = "Display Output",
+    //     .labels = {"Auto", "None", "SRGB", "2.2", "2.4"},
+    //     .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+    //     .parse = [](float value) {
+    //         if (value == 0) return shader_injection.intermediate_encoding;
+    //         return value - 1.f; },
+    //     .is_visible = []() { return current_settings_mode >= 2; },
+    // },
+    // new renodx::utils::settings::Setting{
+    //     .key = "SwapChainGammaCorrection",
+    //     .binding = &shader_injection.swap_chain_gamma_correction,
+    //     .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+    //     .default_value = 0.f,
+    //     .label = "Gamma Correction",
+    //     .section = "Display Output",
+    //     .labels = {"None", "2.2", "2.4"},
+    //     .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+    //     .is_visible = []() { return current_settings_mode >= 2; },
+    // },
+    new renodx::utils::settings::Setting{
+        .key = "SwapChainClampColorSpace",
+        .binding = &shader_injection.swap_chain_clamp_color_space,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 2.f,
+        .label = "Clamp Color Space",
+        .section = "Display Output",
+        .labels = {"None", "BT709", "BT2020", "AP1"},
+        .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+        .parse = [](float value) { return value - 1.f; },
+        .is_visible = []() { return current_settings_mode >= 2; },
+    },
+};
+
+const std::unordered_map<std::string, reshade::api::format> UPGRADE_TARGETS = {
+    {"R8G8B8A8_TYPELESS", reshade::api::format::r8g8b8a8_typeless},
+    {"B8G8R8A8_TYPELESS", reshade::api::format::b8g8r8a8_typeless},
+    {"R8G8B8A8_UNORM", reshade::api::format::r8g8b8a8_unorm},
+    {"B8G8R8A8_UNORM", reshade::api::format::b8g8r8a8_unorm},
+    {"R8G8B8A8_SNORM", reshade::api::format::r8g8b8a8_snorm},
+    {"R8G8B8A8_UNORM_SRGB", reshade::api::format::r8g8b8a8_unorm_srgb},
+    {"B8G8R8A8_UNORM_SRGB", reshade::api::format::b8g8r8a8_unorm_srgb},
+    {"R10G10B10A2_TYPELESS", reshade::api::format::r10g10b10a2_typeless},
+    {"R10G10B10A2_UNORM", reshade::api::format::r10g10b10a2_unorm},
+    {"B10G10R10A2_UNORM", reshade::api::format::b10g10r10a2_unorm},
+    {"R11G11B10_FLOAT", reshade::api::format::r11g11b10_float},
+    {"R16G16B16A16_TYPELESS", reshade::api::format::r16g16b16a16_typeless},
+};
+
+void OnPresetOff() {
+  //   renodx::utils::settings::UpdateSetting("toneMapType", 0.f);
+  //   renodx::utils::settings::UpdateSetting("toneMapPeakNits", 203.f);
+  //   renodx::utils::settings::UpdateSetting("toneMapGameNits", 203.f);
+  //   renodx::utils::settings::UpdateSetting("toneMapUINits", 203.f);
+  //   renodx::utils::settings::UpdateSetting("toneMapGammaCorrection", 0);
+  //   renodx::utils::settings::UpdateSetting("colorGradeExposure", 1.f);
+  //   renodx::utils::settings::UpdateSetting("colorGradeHighlights", 50.f);
+  //   renodx::utils::settings::UpdateSetting("colorGradeShadows", 50.f);
+  //   renodx::utils::settings::UpdateSetting("colorGradeContrast", 50.f);
+  //   renodx::utils::settings::UpdateSetting("colorGradeSaturation", 50.f);
+  //   renodx::utils::settings::UpdateSetting("colorGradeLUTStrength", 100.f);
+  //   renodx::utils::settings::UpdateSetting("colorGradeLUTScaling", 0.f);
+}
+
+const auto UPGRADE_TYPE_NONE = 0.f;
+const auto UPGRADE_TYPE_OUTPUT_SIZE = 1.f;
+const auto UPGRADE_TYPE_OUTPUT_RATIO = 2.f;
+const auto UPGRADE_TYPE_ANY = 3.f;
+
+bool initialized = false;
+
+}  // namespace
+
+extern "C" __declspec(dllexport) constexpr const char* NAME = "RenoDX";
+extern "C" __declspec(dllexport) constexpr const char* DESCRIPTION = "RenoDX (Generic)";
+
+BOOL APIENTRY DllMain(HMODULE h_module, DWORD fdw_reason, LPVOID lpv_reserved) {
+  switch (fdw_reason) {
+    case DLL_PROCESS_ATTACH:
+      if (!reshade::register_addon(h_module)) return FALSE;
+
+      if (!initialized) {
+        renodx::mods::shader::force_pipeline_cloning = true;
+        renodx::mods::shader::expected_constant_buffer_space = 50;
+        renodx::mods::shader::expected_constant_buffer_index = 13;
+        renodx::mods::shader::allow_multiple_push_constants = true;
+        
+        // renodx::mods::swapchain::SetUseHDR10(false);
+
+        renodx::mods::swapchain::swap_chain_upgrade_targets.push_back({
+          .old_format = reshade::api::format::r8g8b8a8_unorm,
+          .new_format = reshade::api::format::r16g16b16a16_float,
+          .use_resource_view_cloning = true,
+          .aspect_ratio = static_cast<float>((true)
+                                                ? renodx::mods::swapchain::SwapChainUpgradeTarget::BACK_BUFFER
+                                                : renodx::mods::swapchain::SwapChainUpgradeTarget::ANY),
+          .usage_include = reshade::api::resource_usage::render_target,
+          
+        });
+        renodx::mods::swapchain::swap_chain_upgrade_targets.push_back({
+          .old_format = reshade::api::format::b8g8r8a8_unorm,
+          .new_format = reshade::api::format::r16g16b16a16_float,
+          
+        });
+        renodx::mods::swapchain::swap_chain_upgrade_targets.push_back({
+          .old_format = reshade::api::format::r11g11b10_float,
+          .new_format = reshade::api::format::r16g16b16a16_float,
+        });
+        renodx::mods::swapchain::swap_chain_upgrade_targets.push_back({
+          .old_format = reshade::api::format::r10g10b10a2_typeless,
+          .new_format = reshade::api::format::r16g16b16a16_typeless,
+        });
+
+        bool is_hdr10 = false;
+        renodx::mods::swapchain::SetUseHDR10(is_hdr10);
+        renodx::mods::swapchain::use_resize_buffer = false;
+
+        initialized = true;
+      }
+
+      break;
+    case DLL_PROCESS_DETACH:
+      reshade::unregister_addon(h_module);
+      break;
+  }
+
+  renodx::utils::settings::Use(fdw_reason, &settings, &OnPresetOff);
+  renodx::mods::swapchain::Use(fdw_reason, &shader_injection);
+  renodx::mods::shader::Use(fdw_reason, custom_shaders, &shader_injection);
+
+  return TRUE;
+}

--- a/src/games/ffxv/common.hlsl
+++ b/src/games/ffxv/common.hlsl
@@ -1,0 +1,182 @@
+
+#include "./shared.h"
+
+static const float M1 = 2610.f / 16384.f;           // 0.1593017578125f;
+static const float M2 = 128.f * (2523.f / 4096.f);  // 78.84375f;
+static const float C1 = 3424.f / 4096.f;            // 0.8359375f;
+static const float C2 = 32.f * (2413.f / 4096.f);   // 18.8515625f;
+static const float C3 = 32.f * (2392.f / 4096.f);   // 18.6875f;
+
+float PQEncode(float color, float scaling = 10000.f) {
+  color *= (scaling / 10000.f);
+  float3 y_m1 = pow(color, M1);
+  return pow((C1 + C2 * y_m1) / (1.f + C3 * y_m1), M2);
+}
+
+/// Applies Exponential Roll-Off tonemapping using the maximum channel.
+/// Used to fit the color into a 0–output_max range for SDR LUT compatibility.
+float3 ToneMapMaxCLL(float3 color, float rolloff_start = 0.375f, float output_max = 1.f) {
+  if (RENODX_TONE_MAP_TYPE == 0.f) {
+    return color;
+  }
+  color = min(color, 100.f);
+  float peak = max(color.r, max(color.g, color.b));
+  peak = min(peak, 100.f);
+  float log_peak = log2(peak);
+
+  // Apply exponential shoulder in log space
+  float log_mapped = renodx::tonemap::ExponentialRollOff(log_peak, log2(rolloff_start), log2(output_max));
+  float scale = exp2(log_mapped - log_peak);  // How much to compress all channels
+
+  return min(output_max, color * scale);
+}
+
+
+float3 PostToneMapScale(float3 color) {
+  if (shader_injection.gamma_correction == 2.f) {
+    color = renodx::color::srgb::EncodeSafe(color);
+    color = renodx::color::gamma::DecodeSafe(color, 2.4f);
+    color *= shader_injection.diffuse_white_nits / shader_injection.graphics_white_nits;
+    color = renodx::color::gamma::EncodeSafe(color, 2.4f);
+  } else if (shader_injection.gamma_correction == 1.f) {
+    color = renodx::color::srgb::EncodeSafe(color);
+    color = renodx::color::gamma::DecodeSafe(color, 2.2f);
+    color *= shader_injection.diffuse_white_nits / shader_injection.graphics_white_nits;
+    color = renodx::color::gamma::EncodeSafe(color, 2.2f);
+  } else {
+    color *= shader_injection.diffuse_white_nits / shader_injection.graphics_white_nits;
+    color = renodx::color::srgb::EncodeSafe(color);
+  }
+  return color;
+}
+
+float3 RestoreHighlightSaturation(float3 color) {
+  if (RENODX_TONE_MAP_TYPE != 0.f && DISPLAY_MAP_TYPE != 0.f) {
+    if (DISPLAY_MAP_TYPE == 1.f) {  // Dice
+
+      float dicePeak = DISPLAY_MAP_PEAK;          // 2.f default
+      float diceShoulder = DISPLAY_MAP_SHOULDER;  // 0.5f default
+      color = renodx::tonemap::dice::BT709(color, dicePeak, diceShoulder);
+
+    } else if (DISPLAY_MAP_TYPE == 2.f) {  // Frostbite
+
+      float3 neutral_sdr_color = renodx::tonemap::renodrt::NeutralSDR(color);
+      float color_y = renodx::color::y::from::BT709(color);
+      // Lerp color and NeutralSDR(color) based on luminance
+      // Normally using NeutralSDR alone messes up midtones
+      // But the lerp makes sure it only gets applied to highlights
+      color = lerp(color, neutral_sdr_color, saturate(color_y));
+    } else if (DISPLAY_MAP_TYPE == 3.f) {
+      float3 neutral_sdr_color = renodx::tonemap::renodrt::NeutralSDR(color);
+      float color_y = renodx::color::y::from::BT709(color);
+      // Lerp color and NeutralSDR(color) based on luminance
+      // Normally using NeutralSDR alone messes up midtones
+      // But the lerp makes sure it only gets applied to highlights
+      color = lerp(color, neutral_sdr_color, saturate(color_y));
+    }
+  } else {
+    // We dont want to Display Map if the tonemapper is vanilla/preset off or display map is none
+    color = color;
+  }
+
+  return color;
+}
+
+float3 ToneMapPass(float3 untonemapped, 
+  float3 graded_sdr, 
+  float3 neutral_sdr,
+  float3 mid_gray=0.18f,
+  bool regrade=false) {
+  renodx::draw::Config draw_config = renodx::draw::BuildConfig();
+  draw_config.reno_drt_tone_map_method = renodx::tonemap::renodrt::config::tone_map_method::REINHARD;
+  // draw_config.tone_map_pass_autocorrection = 0.5;
+  
+  draw_config.color_grade_strength = 1;
+
+  float3 color = renodx::tonemap::UpgradeToneMap(
+      untonemapped,
+      neutral_sdr,
+      // renodx::tonemap::renodrt::NeutralSDR(untonemapped),
+      graded_sdr,
+      draw_config.color_grade_strength,
+      draw_config.tone_map_pass_autocorrection);
+
+  renodx::tonemap::Config tone_map_config = renodx::tonemap::config::Create();
+  tone_map_config.peak_nits = draw_config.peak_white_nits;
+  tone_map_config.game_nits = draw_config.diffuse_white_nits;
+  tone_map_config.type = min(draw_config.tone_map_type, 3.f);
+  tone_map_config.gamma_correction = draw_config.gamma_correction;
+  tone_map_config.exposure = draw_config.tone_map_exposure;
+  tone_map_config.highlights = draw_config.tone_map_highlights;
+  tone_map_config.shadows = draw_config.tone_map_shadows;
+  tone_map_config.contrast = draw_config.tone_map_contrast;
+  tone_map_config.saturation = draw_config.tone_map_saturation;
+
+  tone_map_config.mid_gray_value = mid_gray;
+  tone_map_config.mid_gray_nits = tone_map_config.mid_gray_value * 100.f;
+
+  tone_map_config.reno_drt_highlights = 1.0f;
+  tone_map_config.reno_drt_shadows = 1.0f;
+  tone_map_config.reno_drt_contrast = 1.0f;
+  tone_map_config.reno_drt_saturation = 1.0f;
+  tone_map_config.reno_drt_blowout = -1.f * (draw_config.tone_map_highlight_saturation - 1.f);
+  tone_map_config.reno_drt_dechroma = draw_config.tone_map_blowout;
+  tone_map_config.reno_drt_flare = 0.10f * pow(draw_config.tone_map_flare, 10.f);
+  tone_map_config.reno_drt_working_color_space = (uint)draw_config.tone_map_working_color_space;
+  tone_map_config.reno_drt_per_channel = draw_config.tone_map_per_channel == 1.f;
+  tone_map_config.reno_drt_hue_correction_method = (uint)draw_config.tone_map_hue_processor;
+  tone_map_config.reno_drt_clamp_color_space = draw_config.tone_map_clamp_color_space;
+  tone_map_config.reno_drt_clamp_peak = draw_config.tone_map_clamp_peak;
+  tone_map_config.reno_drt_tone_map_method = (uint)draw_config.reno_drt_tone_map_method;
+  tone_map_config.reno_drt_white_clip = draw_config.reno_drt_white_clip;
+
+  tone_map_config.hue_correction_strength = draw_config.tone_map_hue_correction;
+  draw_config.tone_map_hue_shift = 0.f;
+
+  if (draw_config.tone_map_hue_shift != 0.f) {
+    tone_map_config.hue_correction_type = renodx::tonemap::config::hue_correction_type::CUSTOM;
+
+    float3 hue_shifted_color;
+    if (draw_config.tone_map_hue_shift_method == renodx::draw::HUE_SHIFT_METHOD_CLIP) {
+      hue_shifted_color = saturate(color);
+    } else if (draw_config.tone_map_hue_shift_method == renodx::draw::HUE_SHIFT_METHOD_SDR_MODIFIED) {
+      renodx::tonemap::renodrt::Config renodrt_config = renodx::tonemap::renodrt::config::Create();
+      renodrt_config.nits_peak = 100.f;
+      renodrt_config.mid_gray_value = 0.18f;
+      renodrt_config.mid_gray_nits = 18.f;
+      renodrt_config.exposure = 1.f;
+      renodrt_config.highlights = 1.f;
+      renodrt_config.shadows = 1.f;
+      renodrt_config.contrast = 1.0f;
+      renodrt_config.saturation = draw_config.tone_map_hue_shift_modifier;
+      renodrt_config.dechroma = 0.f;
+      renodrt_config.flare = 0.f;
+      renodrt_config.per_channel = false;
+      renodrt_config.tone_map_method = 1u;
+      renodrt_config.white_clip = 1.f;
+      renodrt_config.hue_correction_strength = 0.f;
+      renodrt_config.working_color_space = 0u;
+      renodrt_config.clamp_color_space = 0u;
+      hue_shifted_color = renodx::tonemap::renodrt::BT709(color, renodrt_config);
+    } else if (draw_config.tone_map_hue_shift_method == renodx::draw::HUE_SHIFT_METHOD_AP1_ROLL_OFF) {
+      float3 incorrect_hue_ap1 = renodx::color::ap1::from::BT709(color * tone_map_config.mid_gray_value / 0.18f);
+      hue_shifted_color = renodx::color::bt709::from::AP1(renodx::tonemap::ExponentialRollOff(incorrect_hue_ap1, tone_map_config.mid_gray_value, 2.f));
+    } else if (draw_config.tone_map_hue_shift_method == renodx::draw::HUE_SHIFT_METHOD_ACES_FITTED_BT709) {
+      hue_shifted_color = renodx::tonemap::ACESFittedBT709(color);
+    } else if (draw_config.tone_map_hue_shift_method == renodx::draw::HUE_SHIFT_METHOD_ACES_FITTED_AP1) {
+      hue_shifted_color = renodx::tonemap::ACESFittedAP1(color);
+    }
+    tone_map_config.hue_correction_color = lerp(
+        color,
+        hue_shifted_color,
+        draw_config.tone_map_hue_shift);
+  }
+
+  float3 tonemapped = renodx::tonemap::config::Apply(color, tone_map_config);
+
+  return tonemapped;
+}
+
+///////////////////////////////////////////////////////////////////////////
+////////// CUSTOM TONEMAPPASS//////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////

--- a/src/games/ffxv/dithering_0x3F4687F4.ps_5_0.hlsl
+++ b/src/games/ffxv/dithering_0x3F4687F4.ps_5_0.hlsl
@@ -1,0 +1,140 @@
+// ---- Created with 3Dmigoto v1.3.16 on Fri May 30 13:09:53 2025
+#include "common.hlsl"
+#include "shared.h"
+
+cbuffer COLOR_FILTER_PARMS : register(b0)
+{
+  float WhiteX : packoffset(c0);
+  float WhiteY : packoffset(c0.y);
+  float WhiteZ : packoffset(c0.z);
+  float HighRange : packoffset(c0.w);
+  float TenPowLogHighRangePlusContrastMinusOne : packoffset(c1);
+  float TenPowDispositionTimesTwoPowHighRange_PlusOne_Log_Inverse : packoffset(c1.y);
+  float ZeroSlopeByTenPowDispositionPlusOne : packoffset(c1.z);
+  float Param_n37 : packoffset(c1.w);
+  float Param_n46 : packoffset(c2);
+  float Param_n49 : packoffset(c2.y);
+  float rotM : packoffset(c2.z);
+  float rotY : packoffset(c2.w);
+  float rotG : packoffset(c3);
+  float rotB : packoffset(c3.y);
+  float sAllsMExp2 : packoffset(c3.z);
+  float sAllsYExp2 : packoffset(c3.w);
+  float sAllsGExp2 : packoffset(c4);
+  float sAllsBExp2 : packoffset(c4.y);
+  float scAllscM : packoffset(c4.z);
+  float scAllscY : packoffset(c4.w);
+  float scAllscG : packoffset(c5);
+  float scAllscB : packoffset(c5.y);
+  float sM0Final : packoffset(c5.z);
+  float sM1Final : packoffset(c5.w);
+  float sM2Final : packoffset(c6);
+  float sM3Final : packoffset(c6.y);
+  float sM4Final : packoffset(c6.z);
+  float sY0Final : packoffset(c6.w);
+  float sY1Final : packoffset(c7);
+  float sY2Final : packoffset(c7.y);
+  float sY3Final : packoffset(c7.z);
+  float sY4Final : packoffset(c7.w);
+  float sG0Final : packoffset(c8);
+  float sG1Final : packoffset(c8.y);
+  float sG2Final : packoffset(c8.z);
+  float sG3Final : packoffset(c8.w);
+  float sG4Final : packoffset(c9);
+  float sB0Final : packoffset(c9.y);
+  float sB1Final : packoffset(c9.z);
+  float sB2Final : packoffset(c9.w);
+  float sB3Final : packoffset(c10);
+  float sB4Final : packoffset(c10.y);
+  bool CAT : packoffset(c10.z);
+  bool HDR : packoffset(c10.w);
+  bool Gamma : packoffset(c11);
+  bool Dither : packoffset(c11.y);
+  bool EnabledToneCurve : packoffset(c11.z);
+  bool EnabledHue : packoffset(c11.w);
+  bool EnabledSaturationALL : packoffset(c12);
+  bool EnabledSaturation : packoffset(c12.y);
+  bool EnabledSaturationClamp : packoffset(c12.z);
+  bool EnabledSaturationByKido : packoffset(c12.w);
+  bool EnabledTemporalAACheckerboard : packoffset(c13);
+  float HDRGamutRatio : packoffset(c13.y);
+  float ToneCurveInterpolation : packoffset(c13.z);
+}
+
+SamplerState g_sSampler_s : register(s0);
+Texture2D<float4> g_tTex : register(t0);
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_TARGET0)
+{
+  float4 r0,r1,r2,r3,r4,r5;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = g_tTex.SampleLevel(g_sSampler_s, v1.xy, 0).xyzw;
+
+  if (HDR != 0) {
+    // BT2020 -> BT709?
+    // r1.x = dot(r0.xyz, float3(0.627399981,0.329299986,0.0432999991));
+    // r1.y = dot(r0.xyz, float3(0.0691,0.919499993,0.0114000002));
+    // r1.z = dot(r0.xyz, float3(0.0164000001,0.0879999995,0.895600021));
+    r0.xyz = r0.xyz;
+  };
+
+  // srgb conversion
+  // r1.xyz = cmp(float3(0.00313080009,0.00313080009,0.00313080009) >= r0.xyz);
+  // r2.xyz = float3(12.9200001,12.9200001,12.9200001) * r0.xyz;
+  // r3.xyz = log2(r0.xyz);
+  // r3.xyz = float3(0.416666657,0.416666657,0.416666657) * r3.xyz;
+  // r3.xyz = exp2(r3.xyz);
+  // r3.xyz = r3.xyz * float3(1.05499995,1.05499995,1.05499995) + float3(-0.0549999997,-0.0549999997,-0.0549999997);
+  // r1.xyz = r1.xyz ? r2.xyz : r3.xyz;
+
+  // r1.xyz = renodx::color::srgb::EncodeSafe(r0.xyz);
+  r0.xyz = Gamma ? renodx::color::srgb::EncodeSafe(r0.xyz) : r0.xyz;
+
+  // dithering?
+  r0.xyz = float3(256,256,256) * r0.xyz;
+  r1.xyz = frac(r0.xyz);
+  r2.xyzw = (int4)v0.xyxy;
+  r3.xy = (int2)r2.zw & int2(1,1);
+  r2.xyzw = (uint4)r2.xyzw >> int4(1,1,2,2);
+  r2.xyzw = (int4)r2.xyzw & int4(1,1,1,1);
+  r1.w = (int)r3.y ^ (int)r3.x;
+  r4.xyzw = (int4)r2.yyww ^ (int4)r2.xxzz;
+  r3.z = (int)r3.y & (int)r3.x;
+  r5.xy = (int2)r2.yw & (int2)r2.xz;
+  r3.xy = (int2)r1.ww * (int2)r3.xy;
+  r2.xyzw = (int4)r2.zwxy * (int4)r4.zwxy;
+  r3.xy = (int2)r3.xy * int2(2,3);
+  r1.w = (int)r3.y + (int)r3.x;
+  r1.w = mad((int)r3.z, 1, (int)r1.w);
+  r2.zw = (int2)r2.zw * int2(2,3);
+  r2.z = (int)r2.w + (int)r2.z;
+  r2.z = mad((int)r5.x, 1, (int)r2.z);
+  r1.w = (uint)r1.w << 2;
+  r1.w = (int)r2.z + (int)r1.w;
+  r2.x = (uint)r2.x << 1;
+  r1.w = mad((int)r1.w, 4, (int)r2.x);
+  r1.w = mad((int)r2.y, 3, (int)r1.w);
+  r1.w = (int)r5.y + (int)r1.w;
+  r1.xyz = float3(64,64,64) * r1.xyz;
+  r1.xyz = (uint3)r1.xyz;
+  r1.xyz = cmp((uint3)r1.www < (uint3)r1.xyz);
+  r1.xyz = r1.xyz ? float3(1,1,1) : 0;
+  r0.xyz = floor(r0.xyz);
+  r0.xyz = r0.xyz + r1.xyz;
+  o0.xyz = float3(0.00390625,0.00390625,0.00390625) * r0.xyz;
+
+  o0.xyz = Gamma ? renodx::color::srgb::DecodeSafe(o0.xyz) : r0.xyz;
+
+  o0.w = r0.w;
+  return;
+}

--- a/src/games/ffxv/fmv_0x66EDB0A6.ps_5_0.hlsl
+++ b/src/games/ffxv/fmv_0x66EDB0A6.ps_5_0.hlsl
@@ -1,0 +1,102 @@
+// ---- Created with 3Dmigoto v1.3.16 on Thu Jun 19 13:11:25 2025
+#include "shared.h"
+cbuffer BinkCB_PS : register(b0)
+{
+  float4 g_crc : packoffset(c0);
+  float4 g_cbc : packoffset(c1);
+  float4 g_adj : packoffset(c2);
+  float4 g_yscale : packoffset(c3);
+  uint g_flag : packoffset(c4);
+}
+
+SamplerState g_sampler_s : register(s0);
+Texture2D<float> g_texture_y : register(t0);
+Texture2D<float> g_texture_cr : register(t1);
+Texture2D<float> g_texture_cb : register(t2);
+Texture2D<float> g_texture_alpha : register(t3);
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float2 v1 : TEXCOORD0,
+  float2 w1 : TEXCOORD1,
+  out float4 o0 : SV_TARGET0)
+{
+  float4 r0,r1,r2,r3;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.x = g_texture_y.Sample(g_sampler_s, v1.xy).x;
+  r0.y = g_texture_cr.Sample(g_sampler_s, w1.xy).x;
+  r0.z = g_texture_cb.Sample(g_sampler_s, w1.xy).x;
+  r0.w = g_texture_alpha.Sample(g_sampler_s, v1.xy).x;
+  r1.xyz = g_crc.xyz * r0.yyy;
+  r1.xyz = g_yscale.xyz * r0.xxx + r1.xyz;
+  r0.xyz = g_cbc.xyz * r0.zzz + r1.xyz;
+  r0.xyz = g_adj.xyz + r0.xyz;
+  r1.xy = g_flag & int2(1,2);
+  o0.w = r1.x ? r0.w : 1;
+  if (r1.y != 0) {
+    r1.xyzw = cmp(float4(0.0392800011,0.0392800011,0.0392800011,0.0392800011) >= r0.yzxy);
+    r2.xyzw = float4(0.0773993805,0.0773993805,0.0773993805,0.0773993805) * r0.yzxy;
+    r3.xyzw = float4(0.0549999997,0.0549999997,0.0549999997,0.0549999997) + r0.yzxy;
+    r3.xyzw = float4(0.947867334,0.947867334,0.947867334,0.947867334) * r3.xyzw;
+    r3.xyzw = log2(r3.xyzw);
+    r3.xyzw = float4(2.4000001,2.4000001,2.4000001,2.4000001) * r3.xyzw;
+    r3.xyzw = exp2(r3.xyzw);
+    r1.xyzw = r1.xyzw ? r2.xyzw : r3.xyzw;
+    r2.xy = float2(0.627399981,0.329299986) * r1.zw;
+    r0.w = r2.x + r2.y;
+    r0.w = r1.y * 0.0432999991 + r0.w;
+    r2.xyz = float3(0.919499993,0.0164000001,0.0879999995) * r1.xzw;
+    r1.x = r1.z * 0.0691 + r2.x;
+    r1.x = r1.y * 0.0114000002 + r1.x;
+    r1.z = r2.y + r2.z;
+    r1.y = r1.y * 0.895600021 + r1.z;
+    r1.z = cmp(0.00313080009 >= r0.w);
+    r1.w = 12.9200001 * r0.w;
+    r0.w = log2(r0.w);
+    r0.w = 0.416666657 * r0.w;
+    r0.w = exp2(r0.w);
+    r0.w = r0.w * 1.05499995 + -0.0549999997;
+    o0.x = r1.z ? r1.w : r0.w;
+    r0.w = cmp(0.00313080009 >= r1.x);
+    r1.z = 12.9200001 * r1.x;
+    r1.x = log2(r1.x);
+    r1.x = 0.416666657 * r1.x;
+    r1.x = exp2(r1.x);
+    r1.x = r1.x * 1.05499995 + -0.0549999997;
+    o0.y = r0.w ? r1.z : r1.x;
+    r0.w = cmp(0.00313080009 >= r1.y);
+    r1.x = 12.9200001 * r1.y;
+    r1.y = log2(r1.y);
+    r1.y = 0.416666657 * r1.y;
+    r1.y = exp2(r1.y);
+    r1.y = r1.y * 1.05499995 + -0.0549999997;
+    o0.z = r0.w ? r1.x : r1.y;
+  } else {
+    o0.xyz = r0.xyz;
+  }
+
+  if (RENODX_TONE_MAP_TYPE > 0.f) {
+    o0.rgb = renodx::color::srgb::DecodeSafe(o0.rgb);
+
+    float videoPeak = min(RENODX_PEAK_WHITE_NITS, 400.f);
+
+    float peak = videoPeak / (RENODX_DIFFUSE_WHITE_NITS / 203.f);
+        
+    // o0.rgb = renodx::color::gamma::Decode(o0.rgb, 2.4f);  // 2.4 for BT2446a
+    o0.rgb = renodx::tonemap::inverse::bt2446a::BT709(o0.rgb, 100.f, videoPeak);
+    o0.rgb /= videoPeak;                                                          // Normalize to 1.0f = peak;
+    o0.rgb *= min(RENODX_PEAK_WHITE_NITS, 400.f) /
+                  RENODX_DIFFUSE_WHITE_NITS;     // 1.f = game nits
+
+    // Inverse AutoHDR?
+  }
+
+  return;
+}

--- a/src/games/ffxv/glare_0xBBC1036C.ps_5_0.hlsl
+++ b/src/games/ffxv/glare_0xBBC1036C.ps_5_0.hlsl
@@ -1,0 +1,68 @@
+// ---- Created with 3Dmigoto v1.3.16 on Wed May 28 12:53:51 2025
+#include "shared.h"
+cbuffer _Globals : register(b0)
+{
+  float4 graph_color : packoffset(c0);
+  float3 copy_srcColorFactor : packoffset(c1);
+  float3 copy_srcColorFactorArray[11] : packoffset(c2);
+  float3 highpass_gamma : packoffset(c13);
+  float2 highpass_pixelOffset : packoffset(c14);
+  float3 highpass_threshold : packoffset(c15);
+  float2 gauss_minUV : packoffset(c16);
+  float2 gauss_maxUV : packoffset(c16.z);
+  float3 gauss_mix : packoffset(c17);
+  float4 gauss_weights[65] : packoffset(c18);
+  float2 gauss_offsets[65] : packoffset(c83);
+  float3 compo_sparkBlend : packoffset(c148);
+  float3 compo_oneMinusSparkBlend : packoffset(c149);
+  float3 compo_glareGamma : packoffset(c150);
+  float4 compo_glareWeights[11] : packoffset(c151);
+  float4 compo_glareWeightsSumInv : packoffset(c162);
+  float compo_glareBaseBlurMip : packoffset(c163);
+  float3 compo_glareSoftAmount : packoffset(c163.y);
+  float3 compo_glareSoftExpand : packoffset(c164);
+  float3 compo_glareFoggyAmount : packoffset(c165);
+  float3 compo_glareFoggyExpand : packoffset(c166);
+  float4 compo_vignetteParam0 : packoffset(c167);
+  float4 compo_vignetteParam1 : packoffset(c168);
+  float4 compo_vignetteParam2 : packoffset(c169);
+}
+
+SamplerState srcSampler_s : register(s0);
+Texture2D<float4> compo_glareSamplerTexture : register(t0);
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float2 v1 : TEXCOORD0,
+  float2 w1 : TEXCOORD1,
+  out float4 o0 : SV_TARGET0,
+  out float4 o1 : SV_TARGET1)
+{
+  float4 r0,r1;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyz = compo_glareSamplerTexture.SampleLevel(srcSampler_s, v1.xy, 0).xyz;
+  r0.xyz = compo_glareWeights[1].xyz * r0.xyz;
+  // r0.xyz = log2(r0.xyz);
+  // r0.xyz = compo_glareGamma.xyz * r0.xyz;
+  // r0.xyz = exp2(r0.xyz);
+  r0.xyz = float3(renodx::math::SignPow(r0.x, compo_glareGamma.x), renodx::math::SignPow(r0.y, compo_glareGamma.y), renodx::math::SignPow(r0.z, compo_glareGamma.z));
+  r0.xyz = compo_glareWeightsSumInv.xyz * r0.xyz;
+  r0.w = dot(w1.xy, w1.xy);
+  r0.w = r0.w * compo_vignetteParam2.y + compo_vignetteParam2.z;
+  r0.w = compo_vignetteParam2.z / r0.w;
+  r0.w = r0.w * r0.w;
+  r0.w = r0.w * compo_vignetteParam2.x + -compo_vignetteParam2.x;
+  r1.xyz = r0.www * compo_vignetteParam1.xyz + float3(1,1,1);
+  o0.xyz = r1.xyz * r0.xyz;
+  o1.xyz = compo_glareWeightsSumInv.xyz * r1.xyz;
+  o0.w = 0;
+  o1.w = 0;
+  return;
+}

--- a/src/games/ffxv/postprocessing_0xDD4C5B74.ps_5_0.hlsl
+++ b/src/games/ffxv/postprocessing_0xDD4C5B74.ps_5_0.hlsl
@@ -1,0 +1,126 @@
+// ---- Created with 3Dmigoto v1.3.16 on Wed May 28 12:37:51 2025
+#include "shared.h"
+cbuffer _Globals : register(b0)
+{
+  float gamma : packoffset(c0);
+  float pqScale : packoffset(c0.y);
+}
+
+SamplerState samplerSrc0_s : register(s0);
+Texture2D<float4> samplerSrc0Texture : register(t0);
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_TARGET0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = samplerSrc0Texture.Sample(samplerSrc0_s, v1.xy).xyzw;
+  o0.w = r0.w;
+
+  // r0.xyz = renodx::color::srgb::DecodeSafe(r0.xyz);
+  o0.rgb = r0.xyz;
+
+  if (RENODX_TONE_MAP_TYPE <= 1.f) {
+    r0.xyz = max(float3(0,0,0), r0.xyz);
+
+    // srgb decoding
+    // r0.xyz = renodx::color::srgb::DecodeSafe(r0.xyz);
+
+    // gamma scaling
+    if (RENODX_TONE_MAP_TYPE == 0.f)
+
+      // SDR gamma = 1.0, HDR gamma = 1.3
+      r0.xyz = renodx::math::SignPow(r0.xyz, gamma);
+
+    if (RENODX_TONE_MAP_TYPE < 1.f) {
+      r0.w = 0.587700009 * r0.y;
+      r0.w = r0.x * 1.66050005 + -r0.w;
+      r1.x = -r0.z * 0.072800003 + r0.w;
+      r0.w = 0.100599997 * r0.y;
+      r0.w = r0.x * -0.0182000007 + -r0.w;
+      r1.z = r0.z * 1.11870003 + r0.w;
+      r0.x = dot(r0.xy, float2(-0.124600001, 1.13300002));
+      r1.y = -r0.z * 0.0083999997 + r0.x;
+
+      o0.xyz = pqScale * r1.xyz;
+
+      return;
+    }
+    else {
+      // r0.xyz = renodx::math::SignPow(r0.xyz, gamma);
+      // gamma should be 1.0 in SDR 
+      // o0.xyz = saturate(r0.xyz);
+      o0.xyz = (r0.xyz);
+
+    }
+    
+
+  }
+
+  // renodx swapchainpass
+  float3 color = o0.rgb;
+
+
+  // color = color * 80.f;
+  float swap_chain_decoding_color_space = renodx::color::convert::COLOR_SPACE_BT709;
+
+  if (RENODX_SWAP_CHAIN_GAMMA_CORRECTION == renodx::draw::GAMMA_CORRECTION_GAMMA_2_2) {
+    color = renodx::color::convert::ColorSpaces(color, swap_chain_decoding_color_space, renodx::color::convert::COLOR_SPACE_BT709);
+    swap_chain_decoding_color_space = renodx::color::convert::COLOR_SPACE_BT709;
+    color = renodx::color::correct::GammaSafe(color, false, 2.2f);
+  } else if (RENODX_SWAP_CHAIN_GAMMA_CORRECTION == renodx::draw::GAMMA_CORRECTION_GAMMA_2_4) {
+    color = renodx::color::convert::ColorSpaces(color, swap_chain_decoding_color_space, renodx::color::convert::COLOR_SPACE_BT709);
+    swap_chain_decoding_color_space = renodx::color::convert::COLOR_SPACE_BT709;
+    color = renodx::color::correct::GammaSafe(color, false, 2.4f);
+  }
+
+  color *= RENODX_GRAPHICS_WHITE_NITS;
+  
+  [branch]
+  if (RENODX_SWAP_CHAIN_CUSTOM_COLOR_SPACE == renodx::draw::COLOR_SPACE_CUSTOM_BT709D93) {
+    color = renodx::color::convert::ColorSpaces(color, swap_chain_decoding_color_space, renodx::color::convert::COLOR_SPACE_BT709);
+    color = renodx::color::bt709::from::BT709D93(color);
+    swap_chain_decoding_color_space = renodx::color::convert::COLOR_SPACE_BT709;
+  } else if (RENODX_SWAP_CHAIN_CUSTOM_COLOR_SPACE == renodx::draw::COLOR_SPACE_CUSTOM_NTSCU) {
+    color = renodx::color::convert::ColorSpaces(color, swap_chain_decoding_color_space, renodx::color::convert::COLOR_SPACE_BT709);
+    color = renodx::color::bt709::from::BT601NTSCU(color);
+    swap_chain_decoding_color_space = renodx::color::convert::COLOR_SPACE_BT709;
+  } else if (RENODX_SWAP_CHAIN_CUSTOM_COLOR_SPACE == renodx::draw::COLOR_SPACE_CUSTOM_NTSCJ) {
+    color = renodx::color::convert::ColorSpaces(color, swap_chain_decoding_color_space, renodx::color::convert::COLOR_SPACE_BT709);
+    color = renodx::color::bt709::from::ARIBTRB9(color);
+    swap_chain_decoding_color_space = renodx::color::convert::COLOR_SPACE_BT709;
+  }
+
+  color = min(color, RENODX_PEAK_WHITE_NITS);
+
+  [branch]
+  if (RENODX_SWAP_CHAIN_CLAMP_COLOR_SPACE != renodx::color::convert::COLOR_SPACE_UNKNOWN) {
+    [branch]
+    if (RENODX_SWAP_CHAIN_CLAMP_COLOR_SPACE == RENODX_SWAP_CHAIN_ENCODING_COLOR_SPACE) {
+      color = renodx::color::convert::ColorSpaces(color, swap_chain_decoding_color_space, RENODX_SWAP_CHAIN_ENCODING_COLOR_SPACE);
+      color = max(0, color);
+    } else {
+      if (RENODX_SWAP_CHAIN_CLAMP_COLOR_SPACE == swap_chain_decoding_color_space) {
+        color = max(0, color);
+      }
+      color = renodx::color::convert::ColorSpaces(color, swap_chain_decoding_color_space, RENODX_SWAP_CHAIN_ENCODING_COLOR_SPACE);
+    }
+  } else {
+    color = renodx::color::convert::ColorSpaces(color, swap_chain_decoding_color_space, RENODX_SWAP_CHAIN_ENCODING_COLOR_SPACE);
+  }
+
+  color = color / 80.f;
+
+  o0.rgb = color;
+
+  return;
+}

--- a/src/games/ffxv/postprocesssdr_0xD92625B9.ps_5_0.hlsl
+++ b/src/games/ffxv/postprocesssdr_0xD92625B9.ps_5_0.hlsl
@@ -1,0 +1,32 @@
+// ---- Created with 3Dmigoto v1.3.16 on Thu May 29 18:38:16 2025
+
+cbuffer _Globals : register(b0)
+{
+  float gamma : packoffset(c0);
+  float pqScale : packoffset(c0.y);
+}
+
+SamplerState samplerSrc0_s : register(s0);
+Texture2D<float4> samplerSrc0Texture : register(t0);
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_TARGET0)
+{
+  float4 r0;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = samplerSrc0Texture.Sample(samplerSrc0_s, v1.xy).xyzw;
+  r0.xyz = log2(r0.xyz);
+  o0.w = r0.w;
+  r0.xyz = gamma * r0.xyz;
+  o0.xyz = exp2(r0.xyz);
+  return;
+}

--- a/src/games/ffxv/shared.h
+++ b/src/games/ffxv/shared.h
@@ -1,0 +1,149 @@
+#ifndef SRC_TEMPLATE_SHARED_H_
+#define SRC_TEMPLATE_SHARED_H_
+
+// #define RENODX_PEAK_WHITE_NITS                 1000.f
+// #define RENODX_DIFFUSE_WHITE_NITS              renodx::color::bt2408::REFERENCE_WHITE
+// #define RENODX_GRAPHICS_WHITE_NITS             renodx::color::bt2408::GRAPHICS_WHITE
+// #define RENODX_COLOR_GRADE_STRENGTH            1.f
+// #define RENODX_TONE_MAP_TYPE                   TONE_MAP_TYPE_RENO_DRT
+// #define RENODX_TONE_MAP_EXPOSURE               1.f
+// #define RENODX_TONE_MAP_HIGHLIGHTS             1.f
+// #define RENODX_TONE_MAP_SHADOWS                1.f
+// #define RENODX_TONE_MAP_CONTRAST               1.f
+// #define RENODX_TONE_MAP_SATURATION             1.f
+// #define RENODX_TONE_MAP_HIGHLIGHT_SATURATION   1.f
+// #define RENODX_TONE_MAP_BLOWOUT                0
+// #define RENODX_TONE_MAP_FLARE                  0
+// #define RENODX_TONE_MAP_HUE_CORRECTION         1.f
+// #define RENODX_TONE_MAP_HUE_SHIFT              0
+// #define RENODX_TONE_MAP_WORKING_COLOR_SPACE    color::convert::COLOR_SPACE_BT709
+// #define RENODX_TONE_MAP_CLAMP_COLOR_SPACE      color::convert::COLOR_SPACE_NONE
+// #define RENODX_TONE_MAP_CLAMP_PEAK             color::convert::COLOR_SPACE_BT709
+// #define RENODX_TONE_MAP_HUE_PROCESSOR          HUE_PROCESSOR_OKLAB
+// #define RENODX_TONE_MAP_PER_CHANNEL            0
+// #define RENODX_GAMMA_CORRECTION                GAMMA_CORRECTION_GAMMA_2_2
+// #define RENODX_INTERMEDIATE_SCALING            (RENODX_DIFFUSE_WHITE_NITS / RENODX_GRAPHICS_WHITE_NITS)
+// #define RENODX_INTERMEDIATE_ENCODING           (RENODX_GAMMA_CORRECTION + 1.f)
+// #define RENODX_INTERMEDIATE_COLOR_SPACE        color::convert::COLOR_SPACE_BT709
+// #define RENODX_SWAP_CHAIN_DECODING             RENODX_INTERMEDIATE_ENCODING
+// #define RENODX_SWAP_CHAIN_DECODING_COLOR_SPACE RENODX_INTERMEDIATE_COLOR_SPACE
+// #define RENODX_SWAP_CHAIN_CUSTOM_COLOR_SPACE   COLOR_SPACE_CUSTOM_BT709D65
+// #define RENODX_SWAP_CHAIN_SCALING_NITS         RENODX_GRAPHICS_WHITE_NITS
+// #define RENODX_SWAP_CHAIN_CLAMP_NITS           RENODX_PEAK_WHITE_NITS
+// #define RENODX_SWAP_CHAIN_CLAMP_COLOR_SPACE    color::convert::COLOR_SPACE_UNKNOWN
+// #define RENODX_SWAP_CHAIN_ENCODING             ENCODING_SCRGB
+// #define RENODX_SWAP_CHAIN_ENCODING_COLOR_SPACE color::convert::COLOR_SPACE_BT709
+
+// Must be 32bit aligned
+// Should be 4x32
+struct ShaderInjectData {
+  float peak_white_nits;
+  float diffuse_white_nits;
+  float graphics_white_nits;
+  float color_grade_strength;
+  float tone_map_type;
+  float tone_map_exposure;
+  float tone_map_highlights;
+  float tone_map_shadows;
+  float tone_map_contrast;
+  float tone_map_saturation;
+  float tone_map_highlight_saturation;
+  float tone_map_blowout;
+  float tone_map_flare;
+  float tone_map_hue_correction;
+  // float post_tone_map_hue_correction;
+  float tone_map_hue_shift;
+  float tone_map_working_color_space;
+  float tone_map_clamp_color_space;
+  float tone_map_clamp_peak;
+  float tone_map_hue_processor;
+  float tone_map_per_channel;
+  float gamma_correction;
+  float intermediate_scaling;
+  float intermediate_encoding;
+  float intermediate_color_space;
+  float swap_chain_decoding;
+  float swap_chain_gamma_correction;
+  //  float swap_chain_decoding_color_space;
+  float swap_chain_custom_color_space;
+  // float swap_chain_scaling_nits;
+  // float swap_chain_clamp_nits;
+  float swap_chain_clamp_color_space;
+  float swap_chain_encoding;
+  float swap_chain_encoding_color_space;
+
+  float per_channel_correction;
+  float per_channel_correction_range;
+  float color_grade_per_channel_hue_correction;
+  float color_grade_per_channel_hue_shift_strength;
+  float color_grade_per_channel_chrominance_correction;
+  float color_grade_per_channel_blowout_restoration;
+
+  float displayMapType;
+  float displayMapPeak;
+  float displayMapShoulder;
+
+  float peak_clamp;
+
+  // float color_grade_hue_shift;
+};
+
+#ifndef __cplusplus
+#if ((__SHADER_TARGET_MAJOR == 5 && __SHADER_TARGET_MINOR >= 1) || __SHADER_TARGET_MAJOR >= 6)
+cbuffer shader_injection : register(b13, space50) {
+#elif (__SHADER_TARGET_MAJOR < 5) || ((__SHADER_TARGET_MAJOR == 5) && (__SHADER_TARGET_MINOR < 1))
+cbuffer shader_injection : register(b13) {
+#endif
+  ShaderInjectData shader_injection : packoffset(c0);
+}
+
+#define RENODX_TONE_MAP_TYPE                 shader_injection.tone_map_type
+#define RENODX_PEAK_WHITE_NITS               shader_injection.peak_white_nits
+#define RENODX_DIFFUSE_WHITE_NITS            shader_injection.diffuse_white_nits
+#define RENODX_GRAPHICS_WHITE_NITS           shader_injection.graphics_white_nits
+#define RENODX_GAMMA_CORRECTION              shader_injection.gamma_correction
+#define RENODX_TONE_MAP_PER_CHANNEL          shader_injection.tone_map_per_channel
+#define RENODX_TONE_MAP_WORKING_COLOR_SPACE  shader_injection.tone_map_working_color_space
+#define RENODX_TONE_MAP_HUE_PROCESSOR        shader_injection.tone_map_hue_processor
+#define RENODX_TONE_MAP_HUE_CORRECTION       shader_injection.tone_map_hue_correction
+#define RENODX_POST_TONE_MAP_HUE_CORRECTION       shader_injection.post_tone_map_hue_correction
+#define RENODX_TONE_MAP_HUE_SHIFT            shader_injection.tone_map_hue_shift
+#define RENODX_TONE_MAP_CLAMP_COLOR_SPACE    2.f // shader_injection.tone_map_clamp_color_space
+#define RENODX_TONE_MAP_CLAMP_PEAK           2.f // shader_injection.tone_map_clamp_peak
+#define RENODX_TONE_MAP_EXPOSURE             shader_injection.tone_map_exposure
+#define RENODX_TONE_MAP_HIGHLIGHTS           shader_injection.tone_map_highlights
+#define RENODX_TONE_MAP_SHADOWS              shader_injection.tone_map_shadows
+#define RENODX_TONE_MAP_CONTRAST             shader_injection.tone_map_contrast
+#define RENODX_TONE_MAP_SATURATION           shader_injection.tone_map_saturation
+#define RENODX_TONE_MAP_HIGHLIGHT_SATURATION shader_injection.tone_map_highlight_saturation
+#define RENODX_TONE_MAP_BLOWOUT              shader_injection.tone_map_blowout
+#define RENODX_TONE_MAP_FLARE                shader_injection.tone_map_flare
+#define RENODX_COLOR_GRADE_STRENGTH          shader_injection.color_grade_strength
+#define RENODX_INTERMEDIATE_ENCODING         0.f // shader_injection.intermediate_encoding
+#define RENODX_SWAP_CHAIN_DECODING           0.f // shader_injection.swap_chain_decoding
+#define RENODX_SWAP_CHAIN_GAMMA_CORRECTION   shader_injection.swap_chain_gamma_correction
+// #define RENODX_SWAP_CHAIN_DECODING_COLOR_SPACE shader_injection.swap_chain_decoding_color_space
+#define RENODX_SWAP_CHAIN_CUSTOM_COLOR_SPACE shader_injection.swap_chain_custom_color_space
+// #define RENODX_SWAP_CHAIN_SCALING_NITS         shader_injection.swap_chain_scaling_nits
+// #define RENODX_SWAP_CHAIN_CLAMP_NITS           shader_injection.swap_chain_clamp_nits
+#define RENODX_SWAP_CHAIN_CLAMP_COLOR_SPACE    shader_injection.swap_chain_clamp_color_space
+#define RENODX_SWAP_CHAIN_ENCODING             5.f //
+#define RENODX_SWAP_CHAIN_ENCODING_COLOR_SPACE 0.f // shader_injection.swap_chain_encoding_color_space
+#define RENODX_RENO_DRT_TONE_MAP_METHOD        renodx::tonemap::renodrt::config::tone_map_method::REINHARD
+
+#define RENODX_PER_CHANNEL_BLOWOUT_RESTORATION  shader_injection.color_grade_per_channel_blowout_restoration
+#define RENODX_PER_CHANNEL_HUE_CORRECTION  shader_injection.color_grade_per_channel_hue_correction
+#define RENODX_PER_CHANNEL_CHROMINANCE_CORRECTION  shader_injection.color_grade_per_channel_chrominance_correction
+
+#define DISPLAY_MAP_TYPE                     shader_injection.displayMapType
+#define DISPLAY_MAP_PEAK                     shader_injection.displayMapPeak
+#define DISPLAY_MAP_SHOULDER                 shader_injection.displayMapShoulder
+#define FFXV_PER_CHANNEL_CORRECTION                 shader_injection.per_channel_correction
+
+#define PEAK_CLAMP                 shader_injection.peak_clamp
+
+#include "../../shaders/renodx.hlsl"
+
+#endif
+
+#endif  // SRC_TEMPLATE_SHARED_H_

--- a/src/games/ffxv/tonemap2_0x18EF8C72.ps_5_0.hlsl
+++ b/src/games/ffxv/tonemap2_0x18EF8C72.ps_5_0.hlsl
@@ -1,0 +1,320 @@
+// ---- Created with 3Dmigoto v1.3.16 on Fri May 30 13:09:50 2025
+#include "common.hlsl"
+#include "shared.h"
+
+cbuffer COLOR_FILTER_PARMS : register(b0)
+{
+  float WhiteX : packoffset(c0);
+  float WhiteY : packoffset(c0.y);
+  float WhiteZ : packoffset(c0.z);
+  float HighRange : packoffset(c0.w);
+  float TenPowLogHighRangePlusContrastMinusOne : packoffset(c1);
+  float TenPowDispositionTimesTwoPowHighRange_PlusOne_Log_Inverse : packoffset(c1.y);
+  float ZeroSlopeByTenPowDispositionPlusOne : packoffset(c1.z);
+  float Param_n37 : packoffset(c1.w);
+  float Param_n46 : packoffset(c2);
+  float Param_n49 : packoffset(c2.y);
+  float rotM : packoffset(c2.z);
+  float rotY : packoffset(c2.w);
+  float rotG : packoffset(c3);
+  float rotB : packoffset(c3.y);
+  float sAllsMExp2 : packoffset(c3.z);
+  float sAllsYExp2 : packoffset(c3.w);
+  float sAllsGExp2 : packoffset(c4);
+  float sAllsBExp2 : packoffset(c4.y);
+  float scAllscM : packoffset(c4.z);
+  float scAllscY : packoffset(c4.w);
+  float scAllscG : packoffset(c5);
+  float scAllscB : packoffset(c5.y);
+  float sM0Final : packoffset(c5.z);
+  float sM1Final : packoffset(c5.w);
+  float sM2Final : packoffset(c6);
+  float sM3Final : packoffset(c6.y);
+  float sM4Final : packoffset(c6.z);
+  float sY0Final : packoffset(c6.w);
+  float sY1Final : packoffset(c7);
+  float sY2Final : packoffset(c7.y);
+  float sY3Final : packoffset(c7.z);
+  float sY4Final : packoffset(c7.w);
+  float sG0Final : packoffset(c8);
+  float sG1Final : packoffset(c8.y);
+  float sG2Final : packoffset(c8.z);
+  float sG3Final : packoffset(c8.w);
+  float sG4Final : packoffset(c9);
+  float sB0Final : packoffset(c9.y);
+  float sB1Final : packoffset(c9.z);
+  float sB2Final : packoffset(c9.w);
+  float sB3Final : packoffset(c10);
+  float sB4Final : packoffset(c10.y);
+  bool CAT : packoffset(c10.z);
+  bool HDR : packoffset(c10.w);
+  bool Gamma : packoffset(c11);
+  bool Dither : packoffset(c11.y);
+  bool EnabledToneCurve : packoffset(c11.z);
+  bool EnabledHue : packoffset(c11.w);
+  bool EnabledSaturationALL : packoffset(c12);
+  bool EnabledSaturation : packoffset(c12.y);
+  bool EnabledSaturationClamp : packoffset(c12.z);
+  bool EnabledSaturationByKido : packoffset(c12.w);
+  bool EnabledTemporalAACheckerboard : packoffset(c13);
+  float HDRGamutRatio : packoffset(c13.y);
+  float ToneCurveInterpolation : packoffset(c13.z);
+}
+
+SamplerState g_sSampler_s : register(s0);
+Texture2D<float4> g_tTex : register(t0);
+
+float3 colorGrade(float3 ungraded) {
+  float4 r0, r1, r2, r3, r4, r5;
+  r0.rgb = ungraded;
+
+  r1.x = dot(r0.xyz, float3(1.41498101, -0.400139987, -0.0148409996));
+  r1.y = dot(r0.xyz, float3(-0.0744709969, 1.081357, -0.00688599981));
+  r1.z = dot(r0.xyz, float3(-0.00750700012, -0.0244679991, 1.03197396));
+  r0.x = dot(r1.xyz, float3(0.343300015, 0.593299985, 0.0634000003));
+  r2.y = dot(r1.xyz, float3(0.40959999, -0.453200012, 0.0436000004));
+  r2.z = dot(r1.xyz, float3(0.286799997, 0.211300001, -0.498100013));
+  r2.xw = -r2.yz;
+  r1.xyzw = max(float4(0, 0, 0, 0), r2.yzxw);
+  // r1.zw = sAllsGExp2 * r1.zw;
+  r1.zw = float2(sAllsGExp2, sAllsBExp2) * r1.zw;
+  // r0.yz = r1.xy * sAllsMExp2 + -r1.zw;
+  r0.yz = r1.xy * float2(sAllsMExp2, sAllsYExp2) + -r1.zw;
+  r2.x = r0.x;
+  r0.xyz = EnabledSaturation ? r0.xyz : r2.xyz;
+  r1.xyzw = float4(1, 1, -1, -1) * r0.yzyz;
+  r1.xyzw = max(float4(0, 0, 0, 0), r1.xyzw);
+  // r2.xy = scAllscM;
+  r2.xy = float2(scAllscM, scAllscM); 
+  r2.zw = float2(scAllscG, scAllscB);
+  r3.xyzw = r2.xyzw + r1.xyzw;
+  r1.xyzw = r1.xyzw / r3.xyzw;
+  r1.zw = r1.zw * r2.zw;
+  r1.yz = r1.xy * r2.xy + -r1.zw;
+  r1.x = r0.x;
+  r0.xyz = EnabledSaturationALL ? r1.xyz : r0.xyz;
+
+  float peak = 1.0f;
+  if (RENODX_TONE_MAP_TYPE > 1.f)
+    peak = RENODX_PEAK_WHITE_NITS / RENODX_DIFFUSE_WHITE_NITS;
+  r1.xyzw = max(float4(0, 0.0199999996, 0.180000007, 0.5), r0.xxxx);
+  r1.xyzw = min(float4(0.0199999996, 0.180000007, 0.5, peak), r1.xyzw);
+  r1.xyzw = float4(-0, -0.0199999996, -0.180000007, -0.5) + r1.xyzw;
+  r2.x = sM2Final * r1.y;
+  r2.y = sY2Final * r1.y;
+  r2.z = sG2Final * r1.y;
+  r2.w = sB2Final * r1.y;
+  r3.x = sM3Final * r1.z;
+  r3.y = sY3Final * r1.z;
+  r3.z = sG3Final * r1.z;
+  r3.w = sB3Final * r1.z;
+  r4.x = sM4Final * r1.w;
+  r4.y = sY4Final * r1.w;
+  r4.z = sG4Final * r1.w;
+  r4.w = sB4Final * r1.w;
+  r5.x = r1.x * sM1Final + sM0Final;
+  r5.y = r1.x * sY1Final + sY0Final;
+  r5.z = r1.x * sG1Final + sG0Final;
+  r5.w = r1.x * sB1Final + sB0Final;
+  r1.xyzw = r5.xyzw + r2.xyzw;
+  r1.xyzw = r1.xyzw + r3.xyzw;
+  r1.xyzw = r1.xyzw + r4.xyzw;
+  r1.xyzw = max(float4(0, 0, 0, 0), r1.xyzw);
+  r2.xyzw = float4(1, 1, -1, -1) * r0.yzyz;
+  r2.xyzw = max(float4(0, 0, 0, 0), r2.xyzw);
+  r1.zw = r2.zw * r1.zw;
+  r1.yz = r2.xy * r1.xy + -r1.zw;
+  r1.x = r0.x;
+  r0.xyz = EnabledSaturationByKido ? r1.xyz : r0.xyz;
+  
+  r1.x = dot(r0.xyz, float3(1, 1.42680001, 0.252200007));
+  r1.y = dot(r0.xyz, float3(1, -0.87379998, 0.0509000011));
+  r1.z = dot(r0.xyz, float3(1, 0.450800002, -1.84089994));
+  r0.x = dot(r1.xyz, float3(1.91424894, -0.891185999, -0.0230620001));
+  r0.y = dot(r1.xyz, float3(-0.0863080025, 1.10471201, -0.0184039995));
+  r0.z = dot(r1.xyz, float3(-0.0281070005, -0.100798003, 1.12890506));
+
+  if (HDR != 0) {
+    // push colors a bit towards BT2020?
+    if (RENODX_TONE_MAP_TYPE == 0.f) {
+      r1.xyz = float3(0.329299986, 0.919499993, 0.0879999995) * r0.yyy;
+      r1.xyz = r0.xxx * float3(0.627399981, 0.0691, 0.0164000001) + r1.xyz;
+      r1.xyz = r0.zzz * float3(0.0432999991, 0.0114000002, 0.895600021) + r1.xyz;
+      r2.xyz = -r1.xyz + r0.xyz;
+      r0.xyz = HDRGamutRatio * r2.xyz + r1.xyz;
+    }
+  }
+
+  // negate all invalid colors
+  r0.rgb = renodx::color::bt709::clamp::AP1(r0.rgb);
+
+  return r0.rgb;
+}
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_TARGET0)
+{
+  float4 r0,r1,r2,r3,r4,r5;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = g_tTex.SampleLevel(g_sSampler_s, v1.xy, 0).xyzw;
+  float3 untonemapped = r0.xyz;
+
+  r1.x = dot(r0.xyz, float3(0.542472005,0.439283997,0.0182429999));
+  r1.y = dot(r0.xyz, float3(0.0426700003,0.941115022,0.0162140001));
+  r1.z = dot(r0.xyz, float3(0.0173160005, 0.0949679986, 0.887715995));
+  r0.xyz = float3(WhiteX, WhiteY, WhiteZ) * r1.xyz;
+  r1.x = dot(r0.xyz, float3(0.720840991,0.267010987,0.0121480003));
+  r1.y = dot(r0.xyz, float3(0.0496839993,0.943306983,0.00700900005));
+  r1.z = dot(r0.xyz, float3(0.00642100023,0.0243079998,0.969271004));
+  r0.xyz = r1.xyz * float3(39.8107185,39.8107185,39.8107185) + ZeroSlopeByTenPowDispositionPlusOne;
+  r0.xyz = log2(r0.xyz);
+  r0.xyz = TenPowDispositionTimesTwoPowHighRange_PlusOne_Log_Inverse * r0.xyz;
+  r0.xyz = float3(0.693147182,0.693147182,0.693147182) * r0.xyz;
+  // r0.xyz = log2(r0.xyz);
+  // r0.xyz = Param_n37 * r0.xyz;
+  // r0.xyz = exp2(r0.xyz);
+  r0.xyz = renodx::math::SignPow(r0.xyz, Param_n37);
+  
+  r0.xyz = r0.xyz * TenPowLogHighRangePlusContrastMinusOne + float3(1,1,1);
+  r0.xyz = log2(r0.xyz);
+  r0.xyz = Param_n46 * r0.xyz;
+  r0.xyz = r0.xyz * float3(0.693147182,0.693147182,0.693147182) + -Param_n49;
+  r0.xyz = max(float3(0, 0, 0), r0.xyz);
+  r0.xyz = EnabledToneCurve ? r0.xyz : r1.xyz;
+
+  float3 output;
+
+  // 0 =  Vanilla (fake HDR)
+  // 1 =  SDR
+  if (RENODX_TONE_MAP_TYPE == 0.f) {
+    // output = graded;
+    r0.rgb = colorGrade(r0.rgb);
+
+    // clamping
+    r0.xyz = max(float3(0, 0, 0), r0.xyz);
+
+    // o0.xyz = Gamma ? r1.xyz : r0.xyz;
+    o0.xyz = r0.xyz;
+
+  }
+  else
+  if (RENODX_TONE_MAP_TYPE == 1.f) {
+    r0.rgb = colorGrade(r0.rgb);
+
+    // clamping and srgb gamma encoding
+    r0.xyz = max(float3(0, 0, 0), r0.xyz);
+
+    // o0.xyz = Gamma ? r1.xyz : r0.xyz;
+    output = r0.xyz;
+
+    [branch]
+    if (RENODX_GAMMA_CORRECTION == renodx::draw::GAMMA_CORRECTION_GAMMA_2_2) {
+      output = renodx::color::correct::GammaSafe(output, false, 2.2f);
+    } else if (RENODX_GAMMA_CORRECTION == renodx::draw::GAMMA_CORRECTION_GAMMA_2_4) {
+      output = renodx::color::correct::GammaSafe(output, false, 2.4f);
+    }
+
+    output *= RENODX_DIFFUSE_WHITE_NITS / RENODX_GRAPHICS_WHITE_NITS;
+
+    [branch]
+    if (RENODX_SWAP_CHAIN_GAMMA_CORRECTION == renodx::draw::GAMMA_CORRECTION_GAMMA_2_2) {
+      output = renodx::color::correct::GammaSafe(output, true, 2.2f);
+    } else if (RENODX_SWAP_CHAIN_GAMMA_CORRECTION == renodx::draw::GAMMA_CORRECTION_GAMMA_2_4) {
+      output = renodx::color::correct::GammaSafe(output, true, 2.4f);
+    }
+
+    o0.rgb = output;
+  }
+  else {
+    // float3 sdr_graded = colorGrade(r0.rgb);
+
+    float3 hdr_ungraded, hdr_graded;
+
+    hdr_ungraded = ToneMapPass(untonemapped,
+                               r0.rgb,
+                               renodx::tonemap::renodrt::NeutralSDR(untonemapped),
+                               0.18f,
+                               false);
+
+    hdr_graded = colorGrade(hdr_ungraded);
+
+    if (FFXV_PER_CHANNEL_CORRECTION >= 1.f) {
+      // attempt to recover the highlight saturation from untonemapped
+      float color_y = renodx::color::y::from::BT709(hdr_graded);
+
+      float3 hdr_saturated = renodx::draw::ApplyPerChannelCorrection(
+          ToneMapMaxCLL(untonemapped),
+          hdr_graded,
+          RENODX_PER_CHANNEL_BLOWOUT_RESTORATION,
+          RENODX_PER_CHANNEL_HUE_CORRECTION,
+          RENODX_PER_CHANNEL_CHROMINANCE_CORRECTION,
+          shader_injection.color_grade_per_channel_hue_shift_strength);
+
+      float HDR_START = 1.0;
+      float HDR_PEAK = RENODX_PEAK_WHITE_NITS / RENODX_DIFFUSE_WHITE_NITS;
+      float weight = smoothstep(HDR_START, HDR_PEAK, color_y);
+      // float t = saturate((x - edge0) / (edge1 - edge0));
+      // return t * t * (3 - 2 * t);
+
+      if (FFXV_PER_CHANNEL_CORRECTION == 1) {  // rgb space
+        hdr_graded = lerp(hdr_graded, hdr_saturated, weight);
+      } else if (FFXV_PER_CHANNEL_CORRECTION == 2) {  // ok lab
+        float3 hdr_graded_oklab = renodx::color::oklab::from::BT709(hdr_graded);
+        float3 hdr_saturated_oklab = renodx::color::oklab::from::BT709(hdr_saturated);
+        hdr_graded_oklab = lerp(hdr_graded_oklab, hdr_saturated_oklab, weight);
+
+        hdr_graded = renodx::color::bt709::from::OkLab(hdr_graded_oklab);
+      } else if (FFXV_PER_CHANNEL_CORRECTION == 3) {  // ok lch
+        float3 hdr_graded_oklch = renodx::color::oklch::from::BT709(hdr_graded);
+        float3 hdr_saturated_oklch = renodx::color::oklch::from::BT709(hdr_saturated);
+
+        float L = lerp(hdr_graded_oklch.x, hdr_saturated_oklch.x, weight);
+        float C = lerp(hdr_graded_oklch.y, hdr_saturated_oklch.y, weight);
+        float H1 = hdr_graded_oklch.z;
+        float H2 = hdr_saturated_oklch.z;
+
+        // Shortest-path interpolation for hue (degrees or radians):
+        float deltaH = H2 - H1;
+        if (abs(deltaH) > 180.0) {
+          if (deltaH > 0.0) deltaH -= 360.0;
+          else deltaH += 360.0;
+        }
+
+        float H = H1 + weight * deltaH;
+        H = fmod(H + 360.0, 360.0);  // wrap to [0, 360)
+        hdr_graded = renodx::color::bt709::from::OkLCh(float3(L, C, H));
+      }
+    }
+
+    output = hdr_graded;
+
+    [branch]
+    if (RENODX_GAMMA_CORRECTION == renodx::draw::GAMMA_CORRECTION_GAMMA_2_2) {
+      output = renodx::color::correct::GammaSafe(output, false, 2.2f);
+    } else if (RENODX_GAMMA_CORRECTION == renodx::draw::GAMMA_CORRECTION_GAMMA_2_4) {
+      output = renodx::color::correct::GammaSafe(output, false, 2.4f);
+    }
+
+    output *= RENODX_DIFFUSE_WHITE_NITS / RENODX_GRAPHICS_WHITE_NITS;
+
+    [branch]
+    if (RENODX_SWAP_CHAIN_GAMMA_CORRECTION == renodx::draw::GAMMA_CORRECTION_GAMMA_2_2) {
+      output = renodx::color::correct::GammaSafe(output, true, 2.2f);
+    } else if (RENODX_SWAP_CHAIN_GAMMA_CORRECTION == renodx::draw::GAMMA_CORRECTION_GAMMA_2_4) {
+      output = renodx::color::correct::GammaSafe(output, true, 2.4f);
+    }
+
+    o0.rgb = output;
+  }
+  o0.w = r0.w;
+  return;
+}

--- a/src/games/ffxv/tonemap_0x75DFE4B0.ps_5_0.hlsl
+++ b/src/games/ffxv/tonemap_0x75DFE4B0.ps_5_0.hlsl
@@ -1,0 +1,411 @@
+// ---- Created with 3Dmigoto v1.3.16 on Wed May 28 12:37:51 2025
+#include "shared.h"
+#include "common.hlsl"
+
+cbuffer COLOR_FILTER_PARMS : register(b0)
+{
+  float WhiteX : packoffset(c0);
+  float WhiteY : packoffset(c0.y);
+  float WhiteZ : packoffset(c0.z);
+  float HighRange : packoffset(c0.w);
+  float TenPowLogHighRangePlusContrastMinusOne : packoffset(c1);
+  float TenPowDispositionTimesTwoPowHighRange_PlusOne_Log_Inverse : packoffset(c1.y);
+  float ZeroSlopeByTenPowDispositionPlusOne : packoffset(c1.z);
+  float Param_n37 : packoffset(c1.w);
+  float Param_n46 : packoffset(c2);
+  float Param_n49 : packoffset(c2.y);
+  float rotM : packoffset(c2.z);
+  float rotY : packoffset(c2.w);
+  float rotG : packoffset(c3);
+  float rotB : packoffset(c3.y);
+  float sAllsMExp2 : packoffset(c3.z);
+  float sAllsYExp2 : packoffset(c3.w);
+  float sAllsGExp2 : packoffset(c4);
+  float sAllsBExp2 : packoffset(c4.y);
+  float scAllscM : packoffset(c4.z);
+  float scAllscY : packoffset(c4.w);
+  float scAllscG : packoffset(c5);
+  float scAllscB : packoffset(c5.y);
+  float sM0Final : packoffset(c5.z);
+  float sM1Final : packoffset(c5.w);
+  float sM2Final : packoffset(c6);
+  float sM3Final : packoffset(c6.y);
+  float sM4Final : packoffset(c6.z);
+  float sY0Final : packoffset(c6.w);
+  float sY1Final : packoffset(c7);
+  float sY2Final : packoffset(c7.y);
+  float sY3Final : packoffset(c7.z);
+  float sY4Final : packoffset(c7.w);
+  float sG0Final : packoffset(c8);
+  float sG1Final : packoffset(c8.y);
+  float sG2Final : packoffset(c8.z);
+  float sG3Final : packoffset(c8.w);
+  float sG4Final : packoffset(c9);
+  float sB0Final : packoffset(c9.y);
+  float sB1Final : packoffset(c9.z);
+  float sB2Final : packoffset(c9.w);
+  float sB3Final : packoffset(c10);
+  float sB4Final : packoffset(c10.y);
+  bool CAT : packoffset(c10.z);
+  bool HDR : packoffset(c10.w);
+  bool Gamma : packoffset(c11);
+  bool Dither : packoffset(c11.y);
+  bool EnabledToneCurve : packoffset(c11.z);
+  bool EnabledHue : packoffset(c11.w);
+  bool EnabledSaturationALL : packoffset(c12);
+  bool EnabledSaturation : packoffset(c12.y);
+  bool EnabledSaturationClamp : packoffset(c12.z);
+  bool EnabledSaturationByKido : packoffset(c12.w);
+  bool EnabledTemporalAACheckerboard : packoffset(c13);
+  float HDRGamutRatio : packoffset(c13.y);
+  float ToneCurveInterpolation : packoffset(c13.z);
+}
+
+SamplerState g_sSampler_s : register(s0);
+Texture2D<float4> g_tTex : register(t0);
+
+float3 toneMapLogContrast(float3 color)  {
+  float4 r0, r1;
+  r0.rgb = color;
+
+  r1.x = dot(r0.xyz, float3(0.542472005, 0.439283997, 0.0182429999));
+  r1.y = dot(r0.xyz, float3(0.0426700003, 0.941115022, 0.0162140001));
+  r1.z = dot(r0.xyz, float3(0.0173160005, 0.0949679986, 0.887715995));
+  r0.xyz = float3(WhiteX, WhiteY, WhiteZ) * r1.xyz;
+
+  r1.x = dot(r0.xyz, float3(0.720840991, 0.267010987, 0.0121480003));
+  r1.y = dot(r0.xyz, float3(0.0496839993, 0.943306983, 0.00700900005));
+  r1.z = dot(r0.xyz, float3(0.00642100023, 0.0243079998, 0.969271004));
+  r0.xyz = r1.xyz * float3(39.8107185, 39.8107185, 39.8107185) + ZeroSlopeByTenPowDispositionPlusOne;
+
+  // ln(color) * constant
+  r0.xyz = log2(r0.xyz);
+  r0.xyz = TenPowDispositionTimesTwoPowHighRange_PlusOne_Log_Inverse * r0.xyz;
+  r0.xyz = float3(0.693147182, 0.693147182, 0.693147182) * r0.xyz;
+
+  r0.xyz = renodx::math::SignPow(r0.xyz, Param_n37);
+
+  r0.xyz = r0.xyz * TenPowLogHighRangePlusContrastMinusOne + float3(1, 1, 1);
+  r0.xyz = log2(r0.xyz);
+  r0.xyz = Param_n46 * r0.xyz;
+  r0.xyz = r0.xyz * float3(0.693147182, 0.693147182, 0.693147182) + -Param_n49;
+  r0.xyz = max(float3(0, 0, 0), r0.xyz);
+  r0.xyz = EnabledToneCurve ? r0.xyz : r1.xyz;
+
+  return r0.rgb;
+}
+
+float3 colorGrade(float3 color) {
+  float4 r0, r1, r2, r3, r4, r5;
+  float4 signs;
+  r0.rgb = color;
+
+  r1.x = dot(r0.xyz, float3(1.41498101, -0.400139987, -0.0148409996));
+  r1.y = dot(r0.xyz, float3(-0.0744709969, 1.081357, -0.00688599981));
+  r1.z = dot(r0.xyz, float3(-0.00750700012, -0.0244679991, 1.03197396));
+
+  r0.x = dot(r1.xyz, float3(0.343300015, 0.593299985, 0.0634000003));
+  r2.x = dot(r1.xyz, float3(0.40959999, -0.453200012, 0.0436000004)); // magenta (red + blue) vs green
+  r2.y = dot(r1.xyz, float3(0.286799997, 0.211300001, -0.498100013)); // yellow (red + green) vs blue
+  r2.zw = -r2.xy;
+
+  r1.xyzw = max(float4(0, 0, 0, 0), r2.xyzw);
+  
+  // r1.x = magenta
+  // r1.y = yellow
+  // r1.z = green
+  // r1.w = blue
+
+  r1.zw = float2(rotG, rotB) * r1.zw;  // scale green and blue
+  r1.xy = r1.xy * float2(rotM, rotY) + -r1.zw; // scale magenta/yellow and blend back
+  r1.z = -r1.y; // r1.z = blue vs yellow
+  r1.yz = r2.xy + r1.zx; 
+  // magenta vs green - blue vs yellow
+  // yellow vs blue + magenta vs green
+  r1.xw = -r1.yz;
+
+  r2.xyzw = max(float4(0, 0, 0, 0), r1.yzxw);
+  r2.zw *= float2(sAllsGExp2, sAllsBExp2);
+  r0.yz = r2.xy * float2(sAllsMExp2, sAllsYExp2) + -r2.zw;
+  r1.x = r0.x;
+  r0.xyz = EnabledSaturation ? r0.xyz : r1.xyz;
+
+  r1.xyzw = float4(1, 1, -1, -1) * r0.yzyz;
+
+  r1.xyzw = max(float4(0, 0, 0, 0), r1.xyzw);
+  r2.xy = float2(scAllscM, scAllscM);
+  r2.zw = float2(scAllscG, scAllscB);
+  r3.xyzw = r2.xyzw + r1.xyzw;
+  r1.xyzw = r1.xyzw / r3.xyzw;
+  r1.zw = r1.zw * r2.zw;
+  r1.yz = r1.xy * r2.xy + -r1.zw;
+  r1.x = r0.x;
+  r0.xyz = EnabledSaturationALL ? r1.xyz : r0.xyz;
+
+  // spline design
+  float peak = 1.0f;
+  if (RENODX_TONE_MAP_TYPE > 1.f)
+    peak = RENODX_PEAK_WHITE_NITS / RENODX_DIFFUSE_WHITE_NITS;
+  r1.xyzw = max(float4(0, 0.0199999996, 0.180000007, 0.5), r0.xxxx);
+  r1.xyzw = min(float4(0.0199999996, 0.180000007, 0.5, peak), r1.xyzw);
+
+  // four bins
+  // [0, 0.02]
+  // [0.02, 0.18]
+  // [0.18, 0.5]
+  // [0.5, 1]
+  r1.xyzw = float4(-0, -0.0199999996, -0.180000007, -0.5) + r1.xyzw;
+
+  // scale the last band for HDR. From 1.0 we might use PQ-scale instead of linear to avoid oversaturation
+  // float lum = r0.x;
+  // float pq = PQEncode(lum * RENODX_DIFFUSE_WHITE_NITS, 10000.f);
+  // float pq_one = PQEncode(1.0f * RENODX_DIFFUSE_WHITE_NITS, 10000.f);
+  // float pq_peak = PQEncode(RENODX_PEAK_WHITE_NITS, 10000.f);
+  // r1.w = 1.0f + (pq - pq_one) / (pq_peak - pq_one) ;
+    // weight4 = saturate((lum - 0.5f) / 0.5f);  // original behavior
+  // scale them back to zero
+
+  r2.x = sM2Final * r1.y;
+  r2.y = sY2Final * r1.y;
+  r2.z = sG2Final * r1.y;
+  r2.w = sB2Final * r1.y;
+  r3.x = sM3Final * r1.z;
+  r3.y = sY3Final * r1.z;
+  r3.z = sG3Final * r1.z;
+  r3.w = sB3Final * r1.z;
+  r4.x = sM4Final * r1.w;
+  r4.y = sY4Final * r1.w;
+  r4.z = sG4Final * r1.w;
+  r4.w = sB4Final * r1.w;
+  r5.x = r1.x * sM1Final + sM0Final;
+  r5.y = r1.x * sY1Final + sY0Final;
+  r5.z = r1.x * sG1Final + sG0Final;
+  r5.w = r1.x * sB1Final + sB0Final;
+  r1.xyzw = r5.xyzw + r2.xyzw;
+  r1.xyzw = r1.xyzw + r3.xyzw;
+  r1.xyzw = r1.xyzw + r4.xyzw;
+
+  r1.xyzw = max(float4(0, 0, 0, 0), r1.xyzw);
+  r2.xyzw = float4(1, 1, -1, -1) * r0.yzyz;
+  r2.xyzw = max(float4(0, 0, 0, 0), r2.xyzw);
+  r1.zw = r2.zw * r1.zw;
+  r1.yz = r2.xy * r1.xy + -r1.zw;
+  r1.x = r0.x;
+  r0.xyz = EnabledSaturationByKido ? r1.xyz : r0.xyz;
+
+  r1.x = dot(r0.xyz, float3(1, 1.42680001, 0.252200007));
+  r1.y = dot(r0.xyz, float3(1, -0.87379998, 0.0509000011));
+  r1.z = dot(r0.xyz, float3(1, 0.450800002, -1.84089994));
+
+  r0.x = dot(r1.xyz, float3(1.91424894, -0.891185999, -0.0230620001)); // Luminace 
+  r0.y = dot(r1.xyz, float3(-0.0863080025, 1.10471201, -0.0184039995)); // A
+  r0.z = dot(r1.xyz, float3(-0.0281070005, -0.100798003, 1.12890506));  // B
+
+  if (HDR != 0) {
+    // push colors a bit towards BT2020?
+    if (RENODX_TONE_MAP_TYPE == 0.f) {
+      r1.xyz = float3(0.329299986, 0.919499993, 0.0879999995) * r0.yyy;
+      r1.xyz = r0.xxx * float3(0.627399981, 0.0691, 0.0164000001) + r1.xyz;
+      r1.xyz = r0.zzz * float3(0.0432999991, 0.0114000002, 0.895600021) + r1.xyz;
+      r2.xyz = -r1.xyz + r0.xyz;
+      r0.xyz = HDRGamutRatio * r2.xyz + r1.xyz;
+    }
+  }
+
+  // negate all invalid colors
+  r0.rgb = renodx::color::bt709::clamp::AP1(r0.rgb);
+
+  return r0.rgb;
+}
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float2 v1 : TEXCOORD0,
+  out float4 o0 : SV_TARGET0)
+{
+  float4 r0,r1,r2,r3,r4,r5;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+  float3 output;
+
+  r0.xyzw = g_tTex.SampleLevel(g_sSampler_s, v1.xy, 0).xyzw;
+
+  float3 untonemapped = r0.xyz;
+
+  // r1.x = dot(r0.xyz, float3(0.542472005,0.439283997,0.0182429999));
+  // r1.y = dot(r0.xyz, float3(0.0426700003,0.941115022,0.0162140001));
+  // r1.z = dot(r0.xyz, float3(0.0173160005, 0.0949679986, 0.887715995));
+  // r0.xyz = float3(WhiteX, WhiteY, WhiteZ) * r1.xyz;
+  
+  // r1.x = dot(r0.xyz, float3(0.720840991,0.267010987,0.0121480003));
+  // r1.y = dot(r0.xyz, float3(0.0496839993,0.943306983,0.00700900005));
+  // r1.z = dot(r0.xyz, float3(0.00642100023,0.0243079998,0.969271004));
+  // r0.xyz = r1.xyz * float3(39.8107185,39.8107185,39.8107185) + ZeroSlopeByTenPowDispositionPlusOne;
+  // r0.xyz = log2(r0.xyz);
+  // r0.xyz = TenPowDispositionTimesTwoPowHighRange_PlusOne_Log_Inverse * r0.xyz;
+  // r0.xyz = float3(0.693147182,0.693147182,0.693147182) * r0.xyz;
+
+  // r0.xyz = renodx::math::SignPow(r0.xyz, Param_n37);
+
+  // r0.xyz = r0.xyz * TenPowLogHighRangePlusContrastMinusOne + float3(1,1,1);
+  // r0.xyz = log2(r0.xyz);
+  // r0.xyz = Param_n46 * r0.xyz;
+  // r0.xyz = r0.xyz * float3(0.693147182, 0.693147182, 0.693147182) + -Param_n49;
+  // r0.xyz = max(float3(0,0,0), r0.xyz);
+  // r0.xyz = EnabledToneCurve ? r0.xyz : r1.xyz;
+  r0.rgb = toneMapLogContrast(r0.rgb);
+  float midgray = renodx::color::y::from::BT709(toneMapLogContrast(0.18f));
+
+  // 0 =  Vanilla (fake HDR)
+  // 1 =  SDR
+  if (shader_injection.tone_map_type == 0.f) {
+    // output = graded;
+    r0.rgb = colorGrade(r0.rgb);
+
+    // clamping
+    r0.xyz = max(float3(0, 0, 0), r0.xyz);
+
+    // o0.xyz = Gamma ? r1.xyz : r0.xyz;
+    o0.xyz = r0.xyz;
+
+  }
+  else
+  if (shader_injection.tone_map_type == 1.f) {
+    r0.rgb = colorGrade(r0.rgb);
+
+    // clamping and srgb gamma encoding
+    r0.xyz = max(float3(0, 0, 0), r0.xyz);
+
+    // o0.xyz = Gamma ? r1.xyz : r0.xyz;
+    output = r0.xyz;
+
+    [branch]
+    if (RENODX_GAMMA_CORRECTION == renodx::draw::GAMMA_CORRECTION_GAMMA_2_2) {
+      output = renodx::color::correct::GammaSafe(output, false, 2.2f);
+    } else if (RENODX_GAMMA_CORRECTION == renodx::draw::GAMMA_CORRECTION_GAMMA_2_4) {
+      output = renodx::color::correct::GammaSafe(output, false, 2.4f);
+    }
+
+    output *= RENODX_DIFFUSE_WHITE_NITS / RENODX_GRAPHICS_WHITE_NITS;
+
+    [branch]
+    if (RENODX_SWAP_CHAIN_GAMMA_CORRECTION == renodx::draw::GAMMA_CORRECTION_GAMMA_2_2) {
+      output = renodx::color::correct::GammaSafe(output, true, 2.2f);
+    } else if (RENODX_SWAP_CHAIN_GAMMA_CORRECTION == renodx::draw::GAMMA_CORRECTION_GAMMA_2_4) {
+      output = renodx::color::correct::GammaSafe(output, true, 2.4f);
+    }
+
+    o0.rgb = output;
+  }
+  else if (shader_injection.tone_map_type == 3.f) {
+    // float3 sdr_graded = colorGrade(r0.rgb);
+
+    float3 hdr_ungraded, hdr_graded;
+
+    hdr_ungraded = ToneMapPass(untonemapped,
+                               r0.rgb,
+                               renodx::tonemap::renodrt::NeutralSDR(untonemapped),
+                               midgray,
+                               false);
+
+    hdr_graded = colorGrade(hdr_ungraded);
+
+    if (FFXV_PER_CHANNEL_CORRECTION >= 1.f) {
+      // attempt to recover the highlight saturation from untonemapped
+      float color_y = renodx::color::y::from::BT709(hdr_graded);
+
+      float3 hdr_saturated = renodx::draw::ApplyPerChannelCorrection(
+          ToneMapMaxCLL(untonemapped),
+          hdr_graded,
+          RENODX_PER_CHANNEL_BLOWOUT_RESTORATION,
+          RENODX_PER_CHANNEL_HUE_CORRECTION,
+          RENODX_PER_CHANNEL_CHROMINANCE_CORRECTION,
+          shader_injection.color_grade_per_channel_hue_shift_strength);
+
+      float HDR_START = 1.0;
+      float HDR_PEAK = RENODX_PEAK_WHITE_NITS / RENODX_DIFFUSE_WHITE_NITS;
+      float weight = smoothstep(HDR_START, HDR_PEAK, color_y);  
+      // float t = saturate((x - edge0) / (edge1 - edge0));
+      // return t * t * (3 - 2 * t);
+
+      if (FFXV_PER_CHANNEL_CORRECTION == 1) {  // rgb space
+        hdr_graded = lerp(hdr_graded, hdr_saturated, weight);
+      } else if (FFXV_PER_CHANNEL_CORRECTION == 2) {  // ok lab
+        float3 hdr_graded_oklab = renodx::color::oklab::from::BT709(hdr_graded);
+        float3 hdr_saturated_oklab = renodx::color::oklab::from::BT709(hdr_saturated);
+        hdr_graded_oklab = lerp(hdr_graded_oklab, hdr_saturated_oklab, weight);
+
+        hdr_graded = renodx::color::bt709::from::OkLab(hdr_graded_oklab);
+      } else if (FFXV_PER_CHANNEL_CORRECTION == 3) {  // ok lch
+        float3 hdr_graded_oklch = renodx::color::oklch::from::BT709(hdr_graded);
+        float3 hdr_saturated_oklch = renodx::color::oklch::from::BT709(hdr_saturated);
+
+        float L = lerp(hdr_graded_oklch.x, hdr_saturated_oklch.x, weight);
+        float C = lerp(hdr_graded_oklch.y, hdr_saturated_oklch.y, weight);
+        float H1 = hdr_graded_oklch.z;
+        float H2 = hdr_saturated_oklch.z;
+
+        // Shortest-path interpolation for hue (degrees or radians):
+        float deltaH = H2 - H1;
+        if (abs(deltaH) > 180.0) {
+          if (deltaH > 0.0) deltaH -= 360.0;
+          else deltaH += 360.0;
+        }
+
+        float H = H1 + weight * deltaH;
+        H = fmod(H + 360.0, 360.0);  // wrap to [0, 360)
+        hdr_graded = renodx::color::bt709::from::OkLCh(float3(L, C, H));
+      }
+    }
+
+    output = hdr_graded;
+
+    [branch]
+    if (RENODX_GAMMA_CORRECTION == renodx::draw::GAMMA_CORRECTION_GAMMA_2_2) {
+      output = renodx::color::correct::GammaSafe(output, false, 2.2f);
+    } else if (RENODX_GAMMA_CORRECTION == renodx::draw::GAMMA_CORRECTION_GAMMA_2_4) {
+      output = renodx::color::correct::GammaSafe(output, false, 2.4f);
+    }
+
+    output *= RENODX_DIFFUSE_WHITE_NITS / RENODX_GRAPHICS_WHITE_NITS;
+
+    [branch]
+    if (RENODX_SWAP_CHAIN_GAMMA_CORRECTION == renodx::draw::GAMMA_CORRECTION_GAMMA_2_2) {
+      output = renodx::color::correct::GammaSafe(output, true, 2.2f);
+    } else if (RENODX_SWAP_CHAIN_GAMMA_CORRECTION == renodx::draw::GAMMA_CORRECTION_GAMMA_2_4) {
+      output = renodx::color::correct::GammaSafe(output, true, 2.4f);
+    }
+
+    o0.rgb = output;
+  } else {
+    renodx::draw::Config draw_config = renodx::draw::BuildConfig();
+    draw_config.tone_map_type = min(RENODX_TONE_MAP_TYPE, 3.f);
+    float3 graded_sdr = colorGrade(r0.rgb);
+    output = renodx::draw::ToneMapPass(untonemapped, graded_sdr, draw_config);
+
+    [branch]
+    if (RENODX_GAMMA_CORRECTION == renodx::draw::GAMMA_CORRECTION_GAMMA_2_2) {
+      output = renodx::color::correct::GammaSafe(output, false, 2.2f);
+    } else if (RENODX_GAMMA_CORRECTION == renodx::draw::GAMMA_CORRECTION_GAMMA_2_4) {
+      output = renodx::color::correct::GammaSafe(output, false, 2.4f);
+    }
+
+    output *= RENODX_DIFFUSE_WHITE_NITS / RENODX_GRAPHICS_WHITE_NITS;
+
+    [branch]
+    if (RENODX_SWAP_CHAIN_GAMMA_CORRECTION == renodx::draw::GAMMA_CORRECTION_GAMMA_2_2) {
+      output = renodx::color::correct::GammaSafe(output, true, 2.2f);
+    } else if (RENODX_SWAP_CHAIN_GAMMA_CORRECTION == renodx::draw::GAMMA_CORRECTION_GAMMA_2_4) {
+      output = renodx::color::correct::GammaSafe(output, true, 2.4f);
+    }
+    
+    o0.rgb = output;
+  }
+  
+  o0.w = r0.w;
+  return;
+}

--- a/src/games/ffxv/ui_0x369A4C39.ps_5_0.hlsl
+++ b/src/games/ffxv/ui_0x369A4C39.ps_5_0.hlsl
@@ -1,0 +1,33 @@
+// ---- Created with 3Dmigoto v1.3.16 on Fri May 30 00:38:52 2025
+#include "shared.h"
+cbuffer MenuHDRParam : register(b0)
+{
+  float HDRSaturation : packoffset(c0);
+  float HDRLuminance : packoffset(c0.y);
+}
+
+SamplerState g_samp0_s : register(s0);
+Texture2D<float4> g_samp0Texture : register(t0);
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : COLOR0,
+  float2 v2 : TEXCOORD0,
+  out float4 o0 : SV_TARGET0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.x = g_samp0Texture.Sample(g_samp0_s, v2.xy).x;
+  o0.w = v1.w * r0.x;
+  o0.xyz = v1.xyz;
+
+  o0.xyz = renodx::color::srgb::DecodeSafe(o0.xyz);
+  return;
+}

--- a/src/games/ffxv/ui_0xB4EADB83.ps_5_0.hlsl
+++ b/src/games/ffxv/ui_0xB4EADB83.ps_5_0.hlsl
@@ -1,0 +1,47 @@
+// ---- Created with 3Dmigoto v1.3.16 on Fri May 30 00:38:52 2025
+#include "shared.h"
+cbuffer MenuHDRParam : register(b0)
+{
+  float HDRSaturation : packoffset(c0);
+  float HDRLuminance : packoffset(c0.y);
+}
+
+SamplerState g_samp0_s : register(s0);
+Texture2D<float4> g_samp0Texture : register(t0);
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : COLOR0,
+  float4 v2 : COLOR1,
+  float2 v3 : TEXCOORD0,
+  out float4 o0 : SV_TARGET0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.x = g_samp0Texture.Sample(g_samp0_s, v3.xy).x;
+  r0.x = v1.w * r0.x;
+  o0.w = r0.x * 1.33333337 + v2.w;
+  o0.xyz = v2.xyz + v1.xyz;
+
+  o0.xyz = renodx::color::srgb::DecodeSafe(o0.xyz);
+
+  if (RENODX_TONE_MAP_TYPE > 0.f) {
+    float3 color = o0.rgb * o0.w; 
+    float y = renodx::color::y::from::BT709(color);
+
+    if (y > 1.0) {
+      float scale = rcp(y);
+      color *= scale;
+    }
+
+    o0.rgb = color / o0.w;  
+  }
+  return;
+}

--- a/src/games/ffxv/ui_0xF2940481.ps_5_0.hlsl
+++ b/src/games/ffxv/ui_0xF2940481.ps_5_0.hlsl
@@ -1,0 +1,38 @@
+// ---- Created with 3Dmigoto v1.3.16 on Fri May 30 00:38:52 2025
+#include "shared.h"
+cbuffer MenuHDRParam : register(b0)
+{
+  float HDRSaturation : packoffset(c0);
+  float HDRLuminance : packoffset(c0.y);
+}
+
+SamplerState g_samp0_s : register(s0);
+Texture2D<float4> g_samp0Texture : register(t0);
+Texture2D<float4> g_samp1Mask : register(t1);
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : COLOR0,
+  float4 v2 : TEXCOORD0,
+  float4 v3 : TEXCOORD1,
+  out float4 o0 : SV_TARGET0)
+{
+  float4 r0,r1,r2;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.x = g_samp1Mask.Sample(g_samp0_s, v2.zw).x;
+  r1.xyzw = g_samp0Texture.Sample(g_samp0_s, v2.xy).xyzw;
+  r1.w = r1.w * r0.x;
+  r0.xyzw = v1.xyzw * r1.xyzw;
+  
+  o0.xyzw = saturate(r0.xyzw * float4(2, 2, 2, 2) + v3.xyzw);
+
+  o0.xyz = renodx::color::srgb::DecodeSafe(o0.xyz);
+  return;
+}

--- a/src/games/ffxv/uisdr_0x19D2AC4F.ps_5_0.hlsl
+++ b/src/games/ffxv/uisdr_0x19D2AC4F.ps_5_0.hlsl
@@ -1,0 +1,27 @@
+// ---- Created with 3Dmigoto v1.3.16 on Fri May 30 13:34:02 2025
+
+SamplerState g_samp0_s : register(s0);
+Texture2D<float4> g_samp0Texture : register(t0);
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : COLOR0,
+  float4 v2 : COLOR1,
+  float2 v3 : TEXCOORD0,
+  out float4 o0 : SV_TARGET0)
+{
+  float4 r0;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.x = g_samp0Texture.Sample(g_samp0_s, v3.xy).x;
+  r0.x = v1.w * r0.x;
+  o0.w = r0.x * 1.33333337 + v2.w;
+  o0.xyz = v2.xyz + v1.xyz;
+  return;
+}

--- a/src/games/ffxv/uisdr_0x4E3026D1.ps_5_0.hlsl
+++ b/src/games/ffxv/uisdr_0x4E3026D1.ps_5_0.hlsl
@@ -1,0 +1,25 @@
+// ---- Created with 3Dmigoto v1.3.16 on Fri May 30 13:34:02 2025
+
+SamplerState g_samp0_s : register(s0);
+Texture2D<float4> g_samp0Texture : register(t0);
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : COLOR0,
+  float2 v2 : TEXCOORD0,
+  out float4 o0 : SV_TARGET0)
+{
+  float4 r0;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.x = g_samp0Texture.Sample(g_samp0_s, v2.xy).x;
+  o0.w = v1.w * r0.x;
+  o0.xyz = v1.xyz;
+  return;
+}

--- a/src/games/ffxv/uisdr_0xA12C8B65.ps_5_0.hlsl
+++ b/src/games/ffxv/uisdr_0xA12C8B65.ps_5_0.hlsl
@@ -1,0 +1,29 @@
+// ---- Created with 3Dmigoto v1.3.16 on Fri May 30 13:34:02 2025
+
+SamplerState g_samp0_s : register(s0);
+Texture2D<float4> g_samp0Texture : register(t0);
+Texture2D<float4> g_samp1Mask : register(t1);
+
+
+// 3Dmigoto declarations
+#define cmp -
+
+
+void main(
+  float4 v0 : SV_POSITION0,
+  float4 v1 : COLOR0,
+  float4 v2 : TEXCOORD0,
+  float4 v3 : TEXCOORD1,
+  out float4 o0 : SV_TARGET0)
+{
+  float4 r0,r1;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.x = g_samp1Mask.Sample(g_samp0_s, v2.zw).x;
+  r1.xyzw = g_samp0Texture.Sample(g_samp0_s, v2.xy).xyzw;
+  r1.w = r1.w * r0.x;
+  r0.xyzw = v1.xyzw * r1.xyzw;
+  o0.xyzw = saturate(r0.xyzw * float4(2,2,2,2) + v3.xyzw);
+  return;
+}


### PR DESCRIPTION
The game HDR pipeline is SDR tonemapping -> SDR color grading -> brightness and saturation scaling without display mapping.

This PR rewrites the pipeline to get true HDR presentation:

- ToneMap to match midgray with the ungraded SDR, with respect to display peak brightness.
- Extend the color grading function, which controls saturation based on 4-band luminance, so the last band is now extended to RENODX_PEAK_NITS instead of SDR (1.0f) to get more saturation of bright elements.
- Add an option for "ApplyPerChannelCorrection" with respect to the untonemapped, to get more highlight saturation.
- SRGB decodes and inverse tonemaps pre-rendered videos. 