### PR TITLE
fix(ffxiv): upgrade b8g8r8a8_unorm to fix the mod w/ in-game gamma correction.

### DIFF
--- a/src/games/ffxiv/addon.cpp
+++ b/src/games/ffxiv/addon.cpp
@@ -495,6 +495,12 @@ BOOL APIENTRY DllMain(HMODULE h_module, DWORD fdw_reason, LPVOID lpv_reserved) {
           .new_format = reshade::api::format::r16g16b16a16_float,
       });
 
+      //Only needed if Gamma Correction is active?????? (GammaCorrection != 50)
+      renodx::mods::swapchain::swap_chain_upgrade_targets.push_back({
+          .old_format = reshade::api::format::b8g8r8a8_unorm,
+          .new_format = reshade::api::format::r16g16b16a16_float,
+      });
+
       reshade::register_event<reshade::addon_event::init_device>(OnInitDevice);
       reshade::register_event<reshade::addon_event::destroy_device>(OnDestroyDevice);
       reshade::register_event<reshade::addon_event::init_swapchain>(OnInitSwapchain);


### PR DESCRIPTION
Game seems to use b8g8r8a8_unorm for it's RTV *only* if Gamma Correction is active, otherwise, it uses r8g8b8a8_unorm.
I don't know why the game does this, or since when it started doing this (it didn't do it on a previous version), but alas...