### PR TITLE
Unclamped Lighting and Other Enhancements for Dying Light

### DIFF
--- a/src/games/dyinglight/addon.cpp
+++ b/src/games/dyinglight/addon.cpp
@@ -70,14 +70,15 @@ ShaderInjectData shader_injection;
 
 const std::unordered_map<std::string, float> RECOMMENDED_VALUES = {
     {"GammaCorrection", 0.f},
-    {"ColorGradeShadows", 45.f},
-    {"ColorGradeSaturation", 55.f},
-    {"ColorGradeHighlightSaturation", 57.f},
-    {"ColorGradeBlowout", 50.f},
-    {"ColorGradeFlare", 32.f},
-    {"ColorGradeScene", 65.f},
+    {"ColorGradeShadows", 37.f},
+    {"ColorGradeSaturation", 58.f},
+    {"ColorGradeHighlightSaturation", 52.f},
+    {"ColorGradeBlowout", 60.f},
+    {"ColorGradeFlare", 30.f},
+    {"ColorGradeScene", 80.f},
     {"FxLensFlare", 0.f},
-    {"FxBloom", 20.f},
+    {"FxLensFlare2", 50.f},
+    {"FxBloom", 15.f},
 };
 
 renodx::utils::settings::Settings settings = {
@@ -126,16 +127,17 @@ renodx::utils::settings::Settings settings = {
     new renodx::utils::settings::Setting{
         .key = "GammaCorrection",
         .binding = &shader_injection.gamma_correction,
-        .value_type = renodx::utils::settings::SettingValueType::BOOLEAN,
-        .default_value = 1.f,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 2.f,
         .label = "Gamma Correction",
         .section = "Tone Mapping",
         .tooltip = "Emulates a 2.2 EOTF (use with HDR or sRGB)",
+        .labels = {"Off", "2.2 (Per Channel)", "2.2 (By Luminance with Per Channel Chrominance)"},
     },
     new renodx::utils::settings::Setting{
         .key = "ToneMapHueCorrection",
         .binding = &shader_injection.tone_map_hue_correction,
-        .default_value = 100.f,
+        .default_value = 50.f,
         .label = "Hue Correction",
         .section = "Tone Mapping",
         .tooltip = "Hue retention strength.",
@@ -249,8 +251,8 @@ renodx::utils::settings::Settings settings = {
     new renodx::utils::settings::Setting{
         .key = "FxLensFlare",
         .binding = &shader_injection.custom_lens_flare,
-        .default_value = 100.f,
-        .label = "Lens Flare",
+        .default_value = 50.f,
+        .label = "Lens Flare 1",
         .section = "Effects",
         .max = 100.f,
         .parse = [](float value) { return value * 0.01f; },
@@ -258,7 +260,7 @@ renodx::utils::settings::Settings settings = {
     new renodx::utils::settings::Setting{
         .key = "FxLensFlare2",
         .binding = &shader_injection.custom_lens_flare_2,
-        .default_value = 100.f,
+        .default_value = 50.f,
         .label = "Lens Flare 2",
         .section = "Effects",
         .max = 100.f,

--- a/src/games/dyinglight/addon.cpp
+++ b/src/games/dyinglight/addon.cpp
@@ -8,6 +8,8 @@
 
 #define DEBUG_LEVEL_0
 
+// 0x2f14b3e9 - moon
+
 // #include <embed/0x9165A474.h> // black smoke
 // #include <embed/0xEC3D14D2.h> // distant fog/smoke
 // #include <embed/0x32A56036.h> // distant fog/smoke
@@ -65,6 +67,18 @@ namespace {
 renodx::mods::shader::CustomShaders custom_shaders = {__ALL_CUSTOM_SHADERS};
 
 ShaderInjectData shader_injection;
+
+const std::unordered_map<std::string, float> RECOMMENDED_VALUES = {
+    {"GammaCorrection", 0.f},
+    {"ColorGradeShadows", 45.f},
+    {"ColorGradeSaturation", 55.f},
+    {"ColorGradeHighlightSaturation", 57.f},
+    {"ColorGradeBlowout", 50.f},
+    {"ColorGradeFlare", 32.f},
+    {"ColorGradeScene", 65.f},
+    {"FxLensFlare", 0.f},
+    {"FxBloom", 20.f},
+};
 
 renodx::utils::settings::Settings settings = {
     new renodx::utils::settings::Setting{
@@ -242,6 +256,15 @@ renodx::utils::settings::Settings settings = {
         .parse = [](float value) { return value * 0.01f; },
     },
     new renodx::utils::settings::Setting{
+        .key = "FxLensFlare2",
+        .binding = &shader_injection.custom_lens_flare_2,
+        .default_value = 100.f,
+        .label = "Lens Flare 2",
+        .section = "Effects",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.01f; },
+    },
+    new renodx::utils::settings::Setting{
         .key = "FxGrainStrength",
         .binding = &shader_injection.custom_grain_strength,
         .default_value = 50.f,
@@ -249,6 +272,24 @@ renodx::utils::settings::Settings settings = {
         .section = "Effects",
         .max = 100.f,
         .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "UnclampLighting",
+        .binding = &shader_injection.unclamp_lighting,
+        .value_type = renodx::utils::settings::SettingValueType::BOOLEAN,
+        .default_value = 1.f,
+        .label = "Unclamp Lighting",
+        .section = "Advanced",
+        .tooltip = "Unclamps specular reflections and fires",
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ImprovedSun",
+        .binding = &shader_injection.improved_sun,
+        .value_type = renodx::utils::settings::SettingValueType::BOOLEAN,
+        .default_value = 1.f,
+        .label = "Improved sun",
+        .section = "Advanced",
+        .tooltip = "Increases size of the sun and centers it",
     },
     new renodx::utils::settings::Setting{
         .value_type = renodx::utils::settings::SettingValueType::BUTTON,
@@ -260,6 +301,24 @@ renodx::utils::settings::Settings settings = {
             if (setting->key.empty()) continue;
             if (!setting->can_reset) continue;
             renodx::utils::settings::UpdateSetting(setting->key, setting->default_value);
+          }
+        },
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::BUTTON,
+        .label = "Recommended Settings",
+        .section = "Options",
+        .group = "button-line-1",
+        .on_change = []() {
+          for (auto* setting : settings) {
+            if (setting->key.empty()) continue;
+            if (!setting->can_reset) continue;
+
+            if (RECOMMENDED_VALUES.contains(setting->key)) {
+              renodx::utils::settings::UpdateSetting(setting->key, RECOMMENDED_VALUES.at(setting->key));
+            } else {
+              renodx::utils::settings::UpdateSetting(setting->key, setting->default_value);
+            }
           }
         },
     },
@@ -327,7 +386,10 @@ void OnPresetOff() {
       {"ColorGradeScene", 100.f},
       {"FxBloom", 100.f},
       {"FxLensFlare", 100.f},
+      {"FxLensFlare2", 100.f},
       {"FxGrainStrength", 50.f},
+      {"UnclampLighting", 0.f},
+      {"ImprovedSun", 0.f},
   });
 }
 

--- a/src/games/dyinglight/gamma_0x558540C8.ps_5_0.hlsl
+++ b/src/games/dyinglight/gamma_0x558540C8.ps_5_0.hlsl
@@ -9,7 +9,7 @@ cbuffer cb0 : register(b0) {
   float4 cb0[1];
 }
 
-float3 ApplyPreToneMapSliders(float3 untonemapped, renodx::color::grade::Config config) {
+float3 ApplyExposureContrastFlareHighlightsShadowsByLuminance(float3 untonemapped, float y, renodx::color::grade::Config config, float mid_gray = 0.18f) {
   if (config.exposure == 1.f && config.shadows == 1.f && config.highlights == 1.f && config.contrast == 1.f && config.flare == 0.f) {
     return untonemapped;
   }
@@ -17,8 +17,9 @@ float3 ApplyPreToneMapSliders(float3 untonemapped, renodx::color::grade::Config 
 
   color *= config.exposure;
 
-  float y = max(0, renodx::color::y::from::BT709(color));
-  const float y_normalized = y / 0.18f;
+  const float y_normalized = y / mid_gray;
+  const float highlight_mask = 1.f / mid_gray;
+  const float shadow_mask = mid_gray;
 
   // contrast & flare
   float flare = renodx::math::DivideSafe(y_normalized + config.flare, y_normalized, 1.f);
@@ -27,23 +28,92 @@ float3 ApplyPreToneMapSliders(float3 untonemapped, renodx::color::grade::Config 
 
   // highlights
   float y_highlighted = pow(y_contrasted, config.highlights);
-  y_highlighted = lerp(y_contrasted, y_highlighted, saturate(y_contrasted));
+  y_highlighted = lerp(y_contrasted, y_highlighted, saturate(y_contrasted / highlight_mask));
 
   // shadows
   float y_shadowed = pow(y_highlighted, -1.f * (config.shadows - 2.f));
-  y_shadowed = lerp(y_shadowed, y_highlighted, saturate(y_highlighted));
+  y_shadowed = lerp(y_shadowed, y_highlighted, saturate(y_highlighted / shadow_mask));
 
-  const float y_final = y_shadowed * 0.18f;
+  const float y_final = y_shadowed * mid_gray;
 
   color *= (y > 0 ? (y_final / y) : 0);
 
   return color;
 }
 
-float3 ApplyPostToneMapSliders(float3 tonemapped, float3 untonemapped, renodx::color::grade::Config config) {
+float3 ApplyExposureContrastFlareHighlightsShadowsPerChannel(float3 untonemapped, renodx::color::grade::Config config) {
+  if (config.exposure == 1.f && config.shadows == 1.f && config.highlights == 1.f && config.contrast == 1.f && config.flare == 0.f) {
+    return untonemapped;
+  }
+  float3 color = untonemapped;
+
+  color *= config.exposure;
+
+  float3 signs = sign(color);
+  float3 abs_color = abs(color);
+  float3 normalized = abs_color / 0.18f;
+
+  // contrast & flare
+  float3 flare = renodx::math::DivideSafe(normalized + config.flare, normalized, 1.0f);
+  float3 exponent = config.contrast * flare;
+  float3 contrasted = pow(normalized, exponent);
+
+  // highlights
+  float3 highlighted = pow(contrasted, config.highlights);
+  highlighted = lerp(contrasted, highlighted, saturate(contrasted));
+
+  // shadows
+  float3 shadowed = pow(highlighted, -1.0f * (config.shadows - 2.0f));
+  shadowed = lerp(highlighted, shadowed, saturate(highlighted));
+
+  float3 final = shadowed * 0.18f;
+
+  final *= signs;
+
+  return final;
+}
+
+void ApplyExposureContrastFlareHighlightsShadowsChannelAndLuminance(
+    float3 untonemapped,
+    renodx::color::grade::Config config,
+    float y,
+    out float3 luminance_graded,
+    out float3 channel_graded) {
+  if (config.exposure == 1.f && config.shadows == 1.f && config.highlights == 1.f && config.contrast == 1.f && config.flare == 0.f) {
+    luminance_graded = untonemapped;
+    channel_graded = untonemapped;
+  }
+
+  float4 signs = float4(sign(untonemapped), 1.f);
+  float4 color = float4(abs(untonemapped), y);
+
+  color *= config.exposure;
+  float4 normalized = color / 0.18f;
+
+  // contrast & flare
+  float4 flare = renodx::math::DivideSafe(normalized + config.flare, normalized, 1.0f);
+  float4 exponent = config.contrast * flare;
+  float4 contrasted = pow(normalized, exponent);
+
+  // highlights
+  float4 highlighted = pow(contrasted, config.highlights);
+  highlighted = lerp(contrasted, highlighted, saturate(contrasted));
+
+  // shadows
+  float4 shadowed = pow(highlighted, -1.0f * (config.shadows - 2.0f));
+  shadowed = lerp(shadowed, highlighted, saturate(highlighted));
+
+  float4 final = shadowed * 0.18f;
+
+  final *= signs;
+
+  luminance_graded = color.rgb * (y > 0 ? (final.a / y) : 0);
+  channel_graded = final.rgb;
+}
+
+float3 ApplySaturationBlowoutHueCorrectionHighlightSaturation(float3 tonemapped, float3 untonemapped, float y, renodx::color::grade::Config config) {
   float3 color = tonemapped;
   if (config.saturation != 1.f || config.dechroma != 0.f || config.hue_correction_strength != 0.f || config.blowout != 0.f) {
-    float y = max(0, renodx::color::y::from::BT709(untonemapped));
     float3 perceptual_new = renodx::color::oklab::from::BT709(color);
 
     if (config.hue_correction_strength != 0.f) {
@@ -85,17 +155,52 @@ float3 ApplyPostToneMapSliders(float3 tonemapped, float3 untonemapped, renodx::c
   return color;
 }
 
-void main(
-    float4 v0: SV_POSITION0,
-    float2 v1: TEXCOORD0,
-    out float4 o0: SV_TARGET0) {
-  float4 r0;
+float3 ChrominanceOKLab(float3 incorrect_color, float3 correct_color, float strength = 1.f) {
+  if (strength == 0.f) return incorrect_color;
 
-  r0.xyzw = t0.SampleLevel(s0_s, v1.xy, 0).xyzw;
-  o0.xyzw = r0.xyzw;
+  float3 incorrect_lab = renodx::color::oklab::from::BT709(incorrect_color);
+  float3 correct_lab = renodx::color::oklab::from::BT709(correct_color);
 
-  // o0.xyz = sign(o0.xyz) * pow(abs(o0.xyz), cb0[0].xxx);  // disable in game gamma slider
+  float2 incorrect_ab = incorrect_lab.yz;
+  float2 correct_ab = correct_lab.yz;
 
+  // Compute chrominance (magnitude of the a–b vector)
+  float incorrect_chrominance = length(incorrect_ab);
+  float correct_chrominance = length(correct_ab);
+
+  // Scale original chrominance vector toward target chrominance
+  float chrominance_ratio = renodx::math::DivideSafe(correct_chrominance, incorrect_chrominance, 1.f);
+  float scale = lerp(1.f, chrominance_ratio, strength);
+  incorrect_lab.yz = incorrect_ab * scale;
+
+  float3 result = renodx::color::bt709::from::OkLab(incorrect_lab);
+  return renodx::color::bt709::clamp::BT2020(result);
+}
+
+float3 ApplyGammaCorrectionByLuminance(float3 color_input) {
+  float y_in = renodx::color::y::from::BT709(color_input);
+  float y_out = renodx::color::correct::Gamma(max(0, y_in));
+  float3 color_output = color_input * ((y_in > 0) ? (y_out / y_in) : 0.f);
+
+  return color_output;
+}
+
+float3 ApplyGammaCorrection(float3 color_input) {
+  float3 color_output;
+  if (RENODX_GAMMA_CORRECTION == 1.f) {
+    color_output = renodx::color::correct::GammaSafe(color_input);
+  } else {
+    float3 ch = renodx::color::correct::GammaSafe(color_input);
+    float y_in = renodx::color::y::from::BT709(color_input);
+    float y_out = renodx::color::correct::Gamma(max(0, y_in));
+    float3 lum = color_input * ((y_in > 0) ? (y_out / y_in) : 0.f);
+    color_output = ChrominanceOKLab(lum, ch);
+  }
+
+  return color_output;
+}
+
+float3 ApplyGammaCorrectionToneMapAndScale(float3 untonemapped) {
   renodx::color::grade::Config cg_config = renodx::color::grade::config::Create();
   cg_config.exposure = RENODX_TONE_MAP_EXPOSURE;
   cg_config.highlights = RENODX_TONE_MAP_HIGHLIGHTS;
@@ -107,33 +212,48 @@ void main(
   cg_config.hue_correction_strength = RENODX_TONE_MAP_HUE_CORRECTION;
   cg_config.blowout = -1.f * (RENODX_TONE_MAP_HIGHLIGHT_SATURATION - 1.f);
 
-  if (RENODX_GAMMA_CORRECTION) {  // 2.2 Gamma
-    o0.xyz = renodx::color::correct::GammaSafe(o0.xyz);
+  float3 lum, ch;
+  float y = renodx::color::y::from::BT709(abs(untonemapped));
+  float3 untonemapped_graded = ApplyExposureContrastFlareHighlightsShadowsByLuminance(untonemapped, y, cg_config);
 
-    if (RENODX_TONE_MAP_TYPE == 0) {  // vanilla tonemap flickers if left unclamped
-      o0.xyz = saturate(o0.xyz);
-    } else if (RENODX_TONE_MAP_TYPE == 2) {  // tonemap after gamma correction for correct highlights
-      float3 untonemapped = o0.rgb;
-      o0.rgb = ApplyPreToneMapSliders(o0.rgb, cg_config);
-      o0.rgb = renodx::tonemap::ExponentialRollOff(o0.rgb, 1.f, (RENODX_PEAK_WHITE_NITS / RENODX_DIFFUSE_WHITE_NITS));
-      o0.rgb = ApplyPostToneMapSliders(o0.rgb, untonemapped, cg_config);
-    }
-
-    o0.xyz *= RENODX_DIFFUSE_WHITE_NITS / RENODX_GRAPHICS_WHITE_NITS;
-    o0.xyz = renodx::color::correct::GammaSafe(o0.xyz, true);
-
-  } else {                            // sRGB Gamma
-    if (RENODX_TONE_MAP_TYPE == 0) {  // vanilla tonemap flickers if left unclamped
-      o0.xyz = saturate(o0.xyz);
-    } else if (RENODX_TONE_MAP_TYPE == 2) {
-      float3 untonemapped = o0.rgb;
-      o0.rgb = ApplyPreToneMapSliders(o0.rgb, cg_config);
-      o0.rgb = renodx::tonemap::ExponentialRollOff(o0.rgb, 1.f, RENODX_PEAK_WHITE_NITS / RENODX_DIFFUSE_WHITE_NITS);
-      o0.rgb = ApplyPostToneMapSliders(o0.rgb, untonemapped, cg_config);
-    }
-
-    o0.xyz *= RENODX_DIFFUSE_WHITE_NITS / RENODX_GRAPHICS_WHITE_NITS;
+  float3 final_untonemapped = untonemapped_graded;
+  if (RENODX_GAMMA_CORRECTION == 2.f) {  // 2.2 luminance with per channel chrominance
+    lum = ApplyGammaCorrectionByLuminance(untonemapped_graded);
+    ch = renodx::color::correct::GammaSafe(untonemapped_graded);
+    final_untonemapped = ChrominanceOKLab(lum, ch);
+  } else if (RENODX_GAMMA_CORRECTION) {
+    final_untonemapped = renodx::color::correct::GammaSafe(untonemapped_graded);
   }
+
+  float3 tonemapped = final_untonemapped;
+  if (RENODX_TONE_MAP_TYPE == 0) {  // vanilla tonemap flickers if left unclamped
+    tonemapped = saturate(final_untonemapped);
+  } else if (RENODX_TONE_MAP_TYPE == 2.f) {
+    tonemapped = renodx::tonemap::ExponentialRollOff(final_untonemapped, 1.f, (RENODX_PEAK_WHITE_NITS / RENODX_DIFFUSE_WHITE_NITS));
+  }
+
+  tonemapped = ApplySaturationBlowoutHueCorrectionHighlightSaturation(tonemapped, final_untonemapped, y, cg_config);
+
+  tonemapped *= RENODX_DIFFUSE_WHITE_NITS / RENODX_GRAPHICS_WHITE_NITS;
+
+  if (RENODX_GAMMA_CORRECTION != 0.f) {
+    tonemapped = renodx::color::correct::GammaSafe(tonemapped, true);
+  }
+
+  return tonemapped;
+}
+
+void main(
+    float4 v0: SV_POSITION0,
+    float2 v1: TEXCOORD0,
+    out float4 o0: SV_TARGET0) {
+  float4 r0;
+
+  r0.xyzw = t0.SampleLevel(s0_s, v1.xy, 0).xyzw;
+  o0.xyzw = r0.xyzw;
+
+  o0.rgb = ApplyGammaCorrectionToneMapAndScale(o0.rgb);
+
   o0.w = saturate(o0.w);
   return;
 }

--- a/src/games/dyinglight/lens effects/lensflare2_0x7B8A6DC4.ps_5_0.hlsl
+++ b/src/games/dyinglight/lens effects/lensflare2_0x7B8A6DC4.ps_5_0.hlsl
@@ -1,4 +1,4 @@
-#include "./shared.h"
+#include "../shared.h"
 // ---- Created with 3Dmigoto v1.4.1 on Wed Jul  2 02:45:00 2025
 Texture2D<float4> t2 : register(t2);
 

--- a/src/games/dyinglight/lens effects/lensflare_0x3F53E66E.ps_5_0.hlsl
+++ b/src/games/dyinglight/lens effects/lensflare_0x3F53E66E.ps_5_0.hlsl
@@ -1,4 +1,4 @@
-#include "./shared.h"
+#include "../shared.h"
 
 // ---- Created with 3Dmigoto v1.3.16 on Sat May 25 22:39:05 2024
 Texture2D<float4> t2 : register(t2);

--- a/src/games/dyinglight/lensflare2_0x7B8A6DC4.ps_5_0.hlsl
+++ b/src/games/dyinglight/lensflare2_0x7B8A6DC4.ps_5_0.hlsl
@@ -1,0 +1,35 @@
+#include "./shared.h"
+// ---- Created with 3Dmigoto v1.4.1 on Wed Jul  2 02:45:00 2025
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(
+    float4 v0: SV_POSITION0,
+    float4 v1: TEXCOORD0,
+    float2 v2: TEXCOORD1,
+    out float4 o0: SV_TARGET0) {
+  float4 r0;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.x = t0.Sample(s0_s, v1.xy).y;
+  r0.y = t1.Sample(s1_s, v1.zw).y;
+  o0.w = saturate(r0.y + r0.x);
+  r0.xyz = t2.Sample(s2_s, v2.xy).xyz;
+  o0.xyz = r0.xyz;
+
+  o0.w *= CUSTOM_LENS_FLARE_2;
+  return;
+}

--- a/src/games/dyinglight/lighting/0x06A58024.ps_5_0.hlsl
+++ b/src/games/dyinglight/lighting/0x06A58024.ps_5_0.hlsl
@@ -1,0 +1,125 @@
+#include "./lighting.hlsli"
+
+// ---- Created with 3Dmigoto v1.4.1 on Wed Jul  2 02:43:45 2025
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+cbuffer cb2 : register(b2) {
+  float4 cb2[10];
+}
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(
+    float4 v0: SV_POSITION0,
+    float4 v1: TEXCOORD0,
+    float4 v2: TEXCOORD1,
+    float4 v3: TEXCOORD2,
+    float4 v4: TEXCOORD3,
+    float4 v5: TEXCOORD4,
+    float4 v6: TEXCOORD5,
+    float4 v7: TEXCOORD6,
+    float4 v8: TEXCOORD7,
+    out float3 o0: SV_TARGET0,
+    out float3 o1: SV_TARGET1) {
+  float4 r0, r1, r2, r3, r4, r5, r6, r7;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = v0.xy * cb2[7].xy + cb2[7].zw;
+  r0.z = t2.SampleLevel(s3_s, r0.xy, 0).x;
+  r0.zw = r0.zz * cb2[8].xy + cb2[8].zw;
+  r0.z = r0.z / -r0.w;
+  r1.xy = v0.xy * cb2[9].xy + cb2[9].zw;
+  r1.xy = r1.xy * abs(r0.zz);
+  r1.z = -abs(r0.z);
+  r1.w = 1;
+  r2.x = dot(r1.xyzw, v3.xyzw);
+  r2.y = dot(r1.xyzw, v4.xyzw);
+  r2.z = dot(r1.xyzw, v5.xyzw);
+  r0.z = dot(-r2.xyz, -r2.xyz);
+  r0.w = dot(r1.xyzw, v6.xyzw);
+  r2.x = dot(r1.xyzw, v7.xyzw);
+  r1.w = dot(r1.xyzw, v8.xyzw);
+  r0.w = max(r0.z, abs(r0.w));
+  r1.w = max(abs(r2.x), abs(r1.w));
+  r0.w = max(r1.w, r0.w);
+  r0.w = cmp(r0.w < 1);
+  if (r0.w != 0) {
+    r0.z = 1 + -r0.z;
+    r0.z = max(0, r0.z);
+    r0.z = r0.z * r0.z;
+    r2.xyzw = t0.SampleLevel(s1_s, r0.xy, 0).xyzw;
+    r2.xyzw = r2.xyzw * float4(2, 2, 2, 2) + float4(-1, -1, -1, -1);
+    r0.w = dot(r2.xyz, r2.xyz);
+    r0.w = rsqrt(r0.w);
+    r2.xyz = r2.xyz * r0.www;
+    r3.xyz = v1.xyz + -r1.xyz;
+    r0.w = dot(r3.xyz, r3.xyz);
+    r0.w = rsqrt(r0.w);
+    r4.xyz = r3.xyz * r0.www;
+    r5.w = dot(r4.xyz, r2.xyz);
+    r1.w = saturate(r5.w);
+    r3.w = cmp(r2.w < 0);
+    r1.w = r3.w ? r5.w : r1.w;
+    r6.xyz = v2.xyz * r0.zzz;
+    r7.xyzw = t1.SampleLevel(s2_s, r0.xy, 0).xyzw;
+    r0.x = r7.w * r7.w;
+    r0.y = dot(-r1.xyz, -r1.xyz);
+    r0.y = rsqrt(r0.y);
+    r1.xyz = -r1.xyz * r0.yyy;
+    r5.z = saturate(dot(r2.xyz, r1.xyz));
+    r0.yzw = r3.xyz * r0.www + r1.xyz;
+    r1.x = dot(r0.yzw, r0.yzw);
+    r1.x = rsqrt(r1.x);
+    r0.yzw = r1.xxx * r0.yzw;
+    r5.x = dot(r2.xyz, r0.yzw);
+    r5.y = dot(r4.xyz, r0.yzw);
+    r3.xyzw = max(float4(0.00999999978, 0.00999999978, 0.00999999978, 0.00999999978), r5.xyzw);
+    r0.y = -8.65616989 * r3.y;
+    r0.y = exp2(r0.y);
+    r1.xyz = float3(1, 1, 1) + -r7.xyz;
+    r0.yzw = saturate(r1.xyz * r0.yyy + r7.xyz);
+    r1.x = cmp(-1 >= r2.w);
+    r0.yzw = r1.xxx ? float3(0, 0, 0) : r0.yzw;
+    r1.y = r0.x * 0.997500002 + 0.00249999994;
+    r1.z = r1.y * r1.y;
+    r2.x = r3.x * r3.x;
+    r2.y = r1.y * r1.y + -1;
+    r2.x = r2.x * r2.y + 1;
+    r2.x = r2.x * r2.x;
+    r2.x = 4 * r2.x;
+    r2.yz = r1.yy * float2(0.797884583, -0.797884583) + float2(0, 1);
+    r2.yz = r3.zw * r2.zz + r2.yy;
+    r1.y = r2.y * r2.z;
+    r1.y = r2.x * r1.y;
+    r1.y = r1.z / r1.y;
+    r2.xyz = r1.yyy * r0.yzw;
+    r1.y = cmp(0 < r1.w);
+    r0.yzw = r1.yyy ? r0.yzw : 0;
+    r2.xyz = ApplyCustomClampSpecular(r2.xyz * r1.www);
+    o0.xyz = r2.xyz * r6.xyz;
+    r1.y = saturate(r1.w * 0.5 + 0.5);
+    r1.y = r1.y * r1.y;
+    r1.z = sqrt(abs(r1.w));
+    r1.z = r1.z + -abs(r1.w);
+    r0.x = r0.x * r1.z + abs(r1.w);
+    r0.x = r1.x ? r1.y : r0.x;
+    r0.xyz = -r0.yzw * r0.xxx + r0.xxx;
+    o1.xyz = r0.xyz * r6.xyz;
+  } else {
+    o0.xyz = float3(0, 0, 0);
+    o1.xyz = float3(0, 0, 0);
+  }
+  return;
+}

--- a/src/games/dyinglight/lighting/0x1D09E8D5.ps_5_0.hlsl
+++ b/src/games/dyinglight/lighting/0x1D09E8D5.ps_5_0.hlsl
@@ -1,0 +1,126 @@
+#include "./lighting.hlsli"
+
+// ---- Created with 3Dmigoto v1.4.1 on Wed Jul  2 02:43:59 2025
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb2 : register(b2) {
+  float4 cb2[10];
+}
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(
+    float4 v0: SV_POSITION0,
+    float4 v1: TEXCOORD0,
+    float4 v2: TEXCOORD1,
+    float4 v3: TEXCOORD2,
+    float4 v4: TEXCOORD3,
+    float4 v5: TEXCOORD4,
+    out float3 o0: SV_TARGET0,
+    out float3 o1: SV_TARGET1) {
+  float4 r0, r1, r2, r3, r4, r5, r6;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = v0.xy * cb2[7].xy + cb2[7].zw;
+  r0.z = t2.SampleLevel(s3_s, r0.xy, 0).x;
+  r0.zw = r0.zz * cb2[8].xy + cb2[8].zw;
+  r0.z = r0.z / -r0.w;
+  r1.xy = v0.xy * cb2[9].xy + cb2[9].zw;
+  r1.xy = r1.xy * abs(r0.zz);
+  r1.z = -abs(r0.z);
+  r1.w = 1;
+  r2.x = dot(r1.xyzw, v3.xyzw);
+  r2.y = dot(r1.xyzw, v4.xyzw);
+  r0.z = dot(r1.xyzw, v5.xyzw);
+  r3.x = abs(r0.z) * 0.5 + 0.5;
+  r3.y = 0.5;
+  r0.z = t3.SampleLevel(s0_s, r3.xy, 0).w;
+  r0.z = r0.z * r0.z;
+  r0.z = r0.z * r0.z;
+  r2.xy = r2.xy * float2(-0.5, -0.5) + float2(0.5, 0.5);
+  r2.xyz = t3.SampleLevel(s0_s, r2.xy, 0).xyz;
+  r3.xyzw = t0.SampleLevel(s1_s, r0.xy, 0).xyzw;
+  r3.xyzw = r3.xyzw * float4(2, 2, 2, 2) + float4(-1, -1, -1, -1);
+  r0.w = dot(r3.xyz, r3.xyz);
+  r0.w = rsqrt(r0.w);
+  r3.xyz = r3.xyz * r0.www;
+  r0.w = dot(v1.xyz, v1.xyz);
+  r0.w = rsqrt(r0.w);
+  r4.xyz = v1.xyz * r0.www;
+  r5.w = dot(r4.xyz, r3.xyz);
+  r1.w = saturate(r5.w);
+  r2.w = cmp(r3.w < 0);
+  r1.w = r2.w ? r5.w : r1.w;
+  r2.w = abs(r1.w) * r0.z;
+  r2.w = min(1, r2.w);
+  r2.w = saturate(dot(r2.xyz, r2.www));
+  r2.w = cmp(0 < r2.w);
+  if (r2.w != 0) {
+    r2.xyz = v2.xyz * r2.xyz;
+    r2.xyz = r2.xyz * r0.zzz;
+    r6.xyzw = t1.SampleLevel(s2_s, r0.xy, 0).xyzw;
+    r0.x = r6.w * r6.w;
+    r0.y = dot(-r1.xyz, -r1.xyz);
+    r0.y = rsqrt(r0.y);
+    r1.xyz = -r1.xyz * r0.yyy;
+    r5.z = saturate(dot(r3.xyz, r1.xyz));
+    r0.yzw = v1.xyz * r0.www + r1.xyz;
+    r1.x = dot(r0.yzw, r0.yzw);
+    r1.x = rsqrt(r1.x);
+    r0.yzw = r1.xxx * r0.yzw;
+    r5.x = dot(r3.xyz, r0.yzw);
+    r5.y = dot(r4.xyz, r0.yzw);
+    r4.xyzw = max(float4(0.00999999978, 0.00999999978, 0.00999999978, 0.00999999978), r5.xyzw);
+    r0.y = -8.65616989 * r4.y;
+    r0.y = exp2(r0.y);
+    r1.xyz = float3(1, 1, 1) + -r6.xyz;
+    r0.yzw = saturate(r1.xyz * r0.yyy + r6.xyz);
+    r1.x = cmp(-1 >= r3.w);
+    r0.yzw = r1.xxx ? float3(0, 0, 0) : r0.yzw;
+    r1.y = r0.x * 0.997500002 + 0.00249999994;
+    r1.z = r1.y * r1.y;
+    r2.w = r4.x * r4.x;
+    r3.x = r1.y * r1.y + -1;
+    r2.w = r2.w * r3.x + 1;
+    r2.w = r2.w * r2.w;
+    r2.w = 4 * r2.w;
+    r3.xy = r1.yy * float2(0.797884583, -0.797884583) + float2(0, 1);
+    r3.xy = r4.zw * r3.yy + r3.xx;
+    r1.y = r3.x * r3.y;
+    r1.y = r2.w * r1.y;
+    r1.y = r1.z / r1.y;
+    r3.xyz = r1.yyy * r0.yzw;
+    r1.y = cmp(0 < r1.w);
+    r0.yzw = r1.yyy ? r0.yzw : 0;
+    r3.xyz = ApplyCustomClampSpecular(r3.xyz * r1.www);
+    o0.xyz = r3.xyz * r2.xyz;
+    r1.y = saturate(r1.w * 0.5 + 0.5);
+    r1.y = r1.y * r1.y;
+    r1.z = sqrt(abs(r1.w));
+    r1.z = r1.z + -abs(r1.w);
+    r0.x = r0.x * r1.z + abs(r1.w);
+    r0.x = r1.x ? r1.y : r0.x;
+    r0.xyz = -r0.yzw * r0.xxx + r0.xxx;
+    o1.xyz = r0.xyz * r2.xyz;
+  } else {
+    o0.xyz = float3(0, 0, 0);
+    o1.xyz = float3(0, 0, 0);
+  }
+  return;
+}

--- a/src/games/dyinglight/lighting/0x50CFC334.ps_5_0.hlsl
+++ b/src/games/dyinglight/lighting/0x50CFC334.ps_5_0.hlsl
@@ -1,0 +1,132 @@
+#include "./lighting.hlsli"
+
+// ---- Created with 3Dmigoto v1.4.1 on Wed Jul  2 02:44:32 2025
+TextureCube<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb2 : register(b2) {
+  float4 cb2[10];
+}
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(
+    float4 v0: SV_POSITION0,
+    float4 v1: TEXCOORD0,
+    float4 v2: TEXCOORD1,
+    float4 v3: TEXCOORD2,
+    float4 v4: TEXCOORD3,
+    float4 v5: TEXCOORD4,
+    float4 v6: TEXCOORD5,
+    float4 v7: TEXCOORD6,
+    float4 v8: TEXCOORD7,
+    out float3 o0: SV_TARGET0,
+    out float3 o1: SV_TARGET1) {
+  float4 r0, r1, r2, r3, r4, r5, r6, r7;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = v0.xy * cb2[7].xy + cb2[7].zw;
+  r0.z = t2.SampleLevel(s3_s, r0.xy, 0).x;
+  r0.zw = r0.zz * cb2[8].xy + cb2[8].zw;
+  r0.z = r0.z / -r0.w;
+  r1.xy = v0.xy * cb2[9].xy + cb2[9].zw;
+  r1.xy = r1.xy * abs(r0.zz);
+  r1.z = -abs(r0.z);
+  r1.w = 1;
+  r2.x = dot(r1.xyzw, v3.xyzw);
+  r2.y = dot(r1.xyzw, v4.xyzw);
+  r2.z = dot(r1.xyzw, v5.xyzw);
+  r2.xyz = -r2.xyz;
+  r0.z = dot(r2.xyz, r2.xyz);
+  r0.w = dot(r1.xyzw, v6.xyzw);
+  r2.w = dot(r1.xyzw, v7.xyzw);
+  r1.w = dot(r1.xyzw, v8.xyzw);
+  r0.w = max(r0.z, abs(r0.w));
+  r1.w = max(abs(r2.w), abs(r1.w));
+  r0.w = max(r1.w, r0.w);
+  r0.w = cmp(r0.w < 1);
+  if (r0.w != 0) {
+    r0.z = 1 + -r0.z;
+    r0.z = max(0, r0.z);
+    r0.z = r0.z * r0.z;
+    r2.xyz = t3.SampleLevel(s0_s, r2.xyz, 0).xyz;
+    r3.xyzw = t0.SampleLevel(s1_s, r0.xy, 0).xyzw;
+    r3.xyzw = r3.xyzw * float4(2, 2, 2, 2) + float4(-1, -1, -1, -1);
+    r0.w = dot(r3.xyz, r3.xyz);
+    r0.w = rsqrt(r0.w);
+    r3.xyz = r3.xyz * r0.www;
+    r4.xyz = v1.xyz + -r1.xyz;
+    r0.w = dot(r4.xyz, r4.xyz);
+    r0.w = rsqrt(r0.w);
+    r5.xyz = r4.xyz * r0.www;
+    r6.w = dot(r5.xyz, r3.xyz);
+    r1.w = saturate(r6.w);
+    r2.w = cmp(r3.w < 0);
+    r1.w = r2.w ? r6.w : r1.w;
+    r2.xyz = v2.xyz * r2.xyz;
+    r2.xyz = r2.xyz * r0.zzz;
+    r7.xyzw = t1.SampleLevel(s2_s, r0.xy, 0).xyzw;
+    r0.x = r7.w * r7.w;
+    r0.y = dot(-r1.xyz, -r1.xyz);
+    r0.y = rsqrt(r0.y);
+    r1.xyz = -r1.xyz * r0.yyy;
+    r6.z = saturate(dot(r3.xyz, r1.xyz));
+    r0.yzw = r4.xyz * r0.www + r1.xyz;
+    r1.x = dot(r0.yzw, r0.yzw);
+    r1.x = rsqrt(r1.x);
+    r0.yzw = r1.xxx * r0.yzw;
+    r6.x = dot(r3.xyz, r0.yzw);
+    r6.y = dot(r5.xyz, r0.yzw);
+    r4.xyzw = max(float4(0.00999999978, 0.00999999978, 0.00999999978, 0.00999999978), r6.xyzw);
+    r0.y = -8.65616989 * r4.y;
+    r0.y = exp2(r0.y);
+    r1.xyz = float3(1, 1, 1) + -r7.xyz;
+    r0.yzw = saturate(r1.xyz * r0.yyy + r7.xyz);
+    r1.x = cmp(-1 >= r3.w);
+    r0.yzw = r1.xxx ? float3(0, 0, 0) : r0.yzw;
+    r1.y = r0.x * 0.997500002 + 0.00249999994;
+    r1.z = r1.y * r1.y;
+    r2.w = r4.x * r4.x;
+    r3.x = r1.y * r1.y + -1;
+    r2.w = r2.w * r3.x + 1;
+    r2.w = r2.w * r2.w;
+    r2.w = 4 * r2.w;
+    r3.xy = r1.yy * float2(0.797884583, -0.797884583) + float2(0, 1);
+    r3.xy = r4.zw * r3.yy + r3.xx;
+    r1.y = r3.x * r3.y;
+    r1.y = r2.w * r1.y;
+    r1.y = r1.z / r1.y;
+    r3.xyz = r1.yyy * r0.yzw;
+    r1.y = cmp(0 < r1.w);
+    r0.yzw = r1.yyy ? r0.yzw : 0;
+    r3.xyz = ApplyCustomClampSpecular(r3.xyz * r1.www);
+    o0.xyz = r3.xyz * r2.xyz;
+    r1.y = saturate(r1.w * 0.5 + 0.5);
+    r1.y = r1.y * r1.y;
+    r1.z = sqrt(abs(r1.w));
+    r1.z = r1.z + -abs(r1.w);
+    r0.x = r0.x * r1.z + abs(r1.w);
+    r0.x = r1.x ? r1.y : r0.x;
+    r0.xyz = -r0.yzw * r0.xxx + r0.xxx;
+    o1.xyz = r0.xyz * r2.xyz;
+  } else {
+    o0.xyz = float3(0, 0, 0);
+    o1.xyz = float3(0, 0, 0);
+  }
+  return;
+}

--- a/src/games/dyinglight/lighting/0x5731A4EC.ps_5_0.hlsl
+++ b/src/games/dyinglight/lighting/0x5731A4EC.ps_5_0.hlsl
@@ -1,0 +1,126 @@
+#include "./lighting.hlsli"
+
+// ---- Created with 3Dmigoto v1.4.1 on Wed Jul  2 02:44:37 2025
+TextureCube<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb2 : register(b2) {
+  float4 cb2[10];
+}
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(
+    float4 v0: SV_POSITION0,
+    float4 v1: TEXCOORD0,
+    float4 v2: TEXCOORD1,
+    float4 v3: TEXCOORD2,
+    float4 v4: TEXCOORD3,
+    float4 v5: TEXCOORD4,
+    out float3 o0: SV_TARGET0,
+    out float3 o1: SV_TARGET1) {
+  float4 r0, r1, r2, r3, r4, r5, r6, r7;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = v0.xy * cb2[7].xy + cb2[7].zw;
+  r0.z = t2.SampleLevel(s3_s, r0.xy, 0).x;
+  r0.zw = r0.zz * cb2[8].xy + cb2[8].zw;
+  r0.z = r0.z / -r0.w;
+  r1.xy = v0.xy * cb2[9].xy + cb2[9].zw;
+  r1.xy = r1.xy * abs(r0.zz);
+  r1.z = -abs(r0.z);
+  r1.w = 1;
+  r2.x = dot(r1.xyzw, v3.xyzw);
+  r2.y = dot(r1.xyzw, v4.xyzw);
+  r2.z = dot(r1.xyzw, v5.xyzw);
+  r2.xyz = -r2.xyz;
+  r0.z = dot(r2.xyz, r2.xyz);
+  r0.z = 1 + -r0.z;
+  r0.z = max(0, r0.z);
+  r0.z = r0.z * r0.z;
+  r2.xyz = t3.SampleLevel(s0_s, r2.xyz, 0).xyz;
+  r3.xyzw = t0.SampleLevel(s1_s, r0.xy, 0).xyzw;
+  r3.xyzw = r3.xyzw * float4(2, 2, 2, 2) + float4(-1, -1, -1, -1);
+  r0.w = dot(r3.xyz, r3.xyz);
+  r0.w = rsqrt(r0.w);
+  r3.xyz = r3.xyz * r0.www;
+  r4.xyz = v1.xyz + -r1.xyz;
+  r0.w = dot(r4.xyz, r4.xyz);
+  r0.w = rsqrt(r0.w);
+  r5.xyz = r4.xyz * r0.www;
+  r6.w = dot(r5.xyz, r3.xyz);
+  r1.w = saturate(r6.w);
+  r2.w = cmp(r3.w < 0);
+  r1.w = r2.w ? r6.w : r1.w;
+  r2.w = abs(r1.w) * r0.z;
+  r2.w = min(1, r2.w);
+  r2.w = saturate(dot(r2.xyz, r2.www));
+  r2.w = cmp(0 < r2.w);
+  if (r2.w != 0) {
+    r2.xyz = v2.xyz * r2.xyz;
+    r2.xyz = r2.xyz * r0.zzz;
+    r7.xyzw = t1.SampleLevel(s2_s, r0.xy, 0).xyzw;
+    r0.x = r7.w * r7.w;
+    r0.y = dot(-r1.xyz, -r1.xyz);
+    r0.y = rsqrt(r0.y);
+    r1.xyz = -r1.xyz * r0.yyy;
+    r6.z = saturate(dot(r3.xyz, r1.xyz));
+    r0.yzw = r4.xyz * r0.www + r1.xyz;
+    r1.x = dot(r0.yzw, r0.yzw);
+    r1.x = rsqrt(r1.x);
+    r0.yzw = r1.xxx * r0.yzw;
+    r6.x = dot(r3.xyz, r0.yzw);
+    r6.y = dot(r5.xyz, r0.yzw);
+    r4.xyzw = max(float4(0.00999999978, 0.00999999978, 0.00999999978, 0.00999999978), r6.xyzw);
+    r0.y = -8.65616989 * r4.y;
+    r0.y = exp2(r0.y);
+    r1.xyz = float3(1, 1, 1) + -r7.xyz;
+    r0.yzw = saturate(r1.xyz * r0.yyy + r7.xyz);
+    r1.x = cmp(-1 >= r3.w);
+    r0.yzw = r1.xxx ? float3(0, 0, 0) : r0.yzw;
+    r1.y = r0.x * 0.997500002 + 0.00249999994;
+    r1.z = r1.y * r1.y;
+    r2.w = r4.x * r4.x;
+    r3.x = r1.y * r1.y + -1;
+    r2.w = r2.w * r3.x + 1;
+    r2.w = r2.w * r2.w;
+    r2.w = 4 * r2.w;
+    r3.xy = r1.yy * float2(0.797884583, -0.797884583) + float2(0, 1);
+    r3.xy = r4.zw * r3.yy + r3.xx;
+    r1.y = r3.x * r3.y;
+    r1.y = r2.w * r1.y;
+    r1.y = r1.z / r1.y;
+    r3.xyz = r1.yyy * r0.yzw;
+    r1.y = cmp(0 < r1.w);
+    r0.yzw = r1.yyy ? r0.yzw : 0;
+    r3.xyz = ApplyCustomClampSpecular(r3.xyz * r1.www);
+    o0.xyz = r3.xyz * r2.xyz;
+    r1.y = saturate(r1.w * 0.5 + 0.5);
+    r1.y = r1.y * r1.y;
+    r1.z = sqrt(abs(r1.w));
+    r1.z = r1.z + -abs(r1.w);
+    r0.x = r0.x * r1.z + abs(r1.w);
+    r0.x = r1.x ? r1.y : r0.x;
+    r0.xyz = -r0.yzw * r0.xxx + r0.xxx;
+    o1.xyz = r0.xyz * r2.xyz;
+  } else {
+    o0.xyz = float3(0, 0, 0);
+    o1.xyz = float3(0, 0, 0);
+  }
+  return;
+}

--- a/src/games/dyinglight/lighting/0x5B869E40.ps_5_0.hlsl
+++ b/src/games/dyinglight/lighting/0x5B869E40.ps_5_0.hlsl
@@ -1,0 +1,182 @@
+#include "./lighting.hlsli"
+
+// ---- Created with 3Dmigoto v1.4.1 on Wed Jul  2 02:44:39 2025
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerComparisonState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb2 : register(b2) {
+  float4 cb2[10];
+}
+
+cbuffer cb0 : register(b0) {
+  float4 cb0[2];
+}
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(
+    float4 v0: SV_POSITION0,
+    float4 v1: TEXCOORD0,
+    float4 v2: TEXCOORD1,
+    float4 v3: TEXCOORD2,
+    float4 v4: TEXCOORD3,
+    float4 v5: TEXCOORD4,
+    float4 v6: TEXCOORD5,
+    float4 v7: TEXCOORD6,
+    float4 v8: TEXCOORD7,
+    float4 v9: TEXCOORD8,
+    float4 v10: TEXCOORD9,
+    out float3 o0: SV_TARGET0,
+    out float3 o1: SV_TARGET1) {
+  float4 r0, r1, r2, r3, r4, r5, r6, r7, r8, r9;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = v0.xy * cb2[7].xy + cb2[7].zw;
+  r0.z = t2.SampleLevel(s3_s, r0.xy, 0).x;
+  r0.zw = r0.zz * cb2[8].xy + cb2[8].zw;
+  r0.z = r0.z / -r0.w;
+  r1.xy = v0.xy * cb2[9].xy + cb2[9].zw;
+  r1.xy = r1.xy * abs(r0.zz);
+  r1.z = -abs(r0.z);
+  r1.w = 1;
+  r2.x = dot(r1.xyzw, v4.xyzw);
+  r2.y = dot(r1.xyzw, v5.xyzw);
+  r3.x = dot(r1.xyzw, v7.xyzw);
+  r0.z = max(abs(r2.x), abs(r2.y));
+  r0.z = cmp(r3.x < r0.z);
+  r0.w = dot(r1.xyzw, v8.xyzw);
+  r2.w = dot(r1.xyzw, v9.xyzw);
+  r3.z = dot(r1.xyzw, v10.xyzw);
+  r0.z = r0.z ? 2 : abs(r3.x);
+  r0.z = max(r0.z, abs(r0.w));
+  r0.w = max(abs(r3.z), abs(r2.w));
+  r0.z = max(r0.z, r0.w);
+  r0.z = cmp(r0.z < 1);
+  if (r0.z != 0) {
+    r2.z = dot(r1.xyzw, v6.xyzw);
+    r3.y = 0.5;
+    r0.z = t3.SampleLevel(s0_s, r3.xy, 0).w;
+    r0.z = r0.z * r0.z;
+    r0.z = r0.z * r0.z;
+    r3.yz = r2.xy / r3.xx;
+    r3.yz = r3.yz * float2(0.5, 0.5) + float2(0.5, 0.5);
+    r3.yzw = t3.SampleLevel(s0_s, r3.yz, 0).xyz;
+    r4.xyzw = t0.SampleLevel(s1_s, r0.xy, 0).xyzw;
+    r4.xyzw = r4.xyzw * float4(2, 2, 2, 2) + float4(-1, -1, -1, -1);
+    r0.w = dot(r4.xyz, r4.xyz);
+    r0.w = rsqrt(r0.w);
+    r4.xyz = r4.xyz * r0.www;
+    r5.xyz = v2.xyz + -r1.xyz;
+    r0.w = dot(r5.xyz, r5.xyz);
+    r0.w = rsqrt(r0.w);
+    r6.xyz = r5.xyz * r0.www;
+    r7.w = dot(r6.xyz, r4.xyz);
+    r1.w = saturate(r7.w);
+    r2.w = cmp(r4.w < 0);
+    r1.w = r2.w ? r7.w : r1.w;
+    r3.yzw = v3.xyz * r3.yzw;
+    r3.yzw = r3.yzw * r0.zzz;
+    r2.xyz = r2.xyz / r3.xxx;
+    r2.xy = r2.xy * v1.xy + v1.zw;
+    r0.z = cmp(r1.w < 0);
+    r8.xyz = r0.zzz ? -r4.xyz : r4.xyz;
+    r9.x = dot(r8.xyz, v4.xyz);
+    r9.y = dot(r8.xyz, v5.xyz);
+    r9.z = dot(r8.xyz, v6.xyz);
+    r0.z = dot(r9.xyz, r9.xyz);
+    r0.z = rsqrt(r0.z);
+    r8.xyz = r9.xyz * r0.zzz;
+    r0.z = dot(cb0[0].xy, cb0[0].xy);
+    r9.x = sqrt(r0.z);
+    r0.z = 262140 * abs(r3.x);
+    r9.z = 2.82842708 / r0.z;
+    r9.y = -r9.x;
+    r2.xyz = r8.xyz * r9.xyz + r2.xyz;
+    r8.xyzw = cb0[0].xyxy * float4(-0.5, -0.5, 0.5, -0.5) + r2.xyxy;
+    r0.z = cb0[1].x * r2.z + cb0[1].y;
+    r2.z = t4.SampleCmpLevelZero(s4_s, r8.xy, r0.z).x;
+    r2.z = cb0[1].x * r2.z + cb0[1].y;
+    r2.w = t4.SampleCmpLevelZero(s4_s, r8.zw, r0.z).x;
+    r2.w = cb0[1].x * r2.w + cb0[1].y;
+    r2.w = 0.25 * r2.w;
+    r2.z = r2.z * 0.25 + r2.w;
+    r8.xyzw = cb0[0].xyxy * float4(0.5, 0.5, -0.5, 0.5) + r2.xyxy;
+    r2.x = t4.SampleCmpLevelZero(s4_s, r8.xy, r0.z).x;
+    r2.x = cb0[1].x * r2.x + cb0[1].y;
+    r2.x = r2.x * 0.25 + r2.z;
+    r0.z = t4.SampleCmpLevelZero(s4_s, r8.zw, r0.z).x;
+    r0.z = cb0[1].x * r0.z + cb0[1].y;
+    r0.z = saturate(r0.z * 0.25 + r2.x);
+    r2.x = r0.z * -2 + 3;
+    r0.z = r0.z * r0.z;
+    r0.z = r2.x * r0.z;
+    r2.xyz = r3.yzw * r0.zzz;
+    r3.xyzw = t1.SampleLevel(s2_s, r0.xy, 0).xyzw;
+    r0.x = r3.w * r3.w;
+    r0.y = dot(-r1.xyz, -r1.xyz);
+    r0.y = rsqrt(r0.y);
+    r1.xyz = -r1.xyz * r0.yyy;
+    r7.z = saturate(dot(r4.xyz, r1.xyz));
+    r0.yzw = r5.xyz * r0.www + r1.xyz;
+    r1.x = dot(r0.yzw, r0.yzw);
+    r1.x = rsqrt(r1.x);
+    r0.yzw = r1.xxx * r0.yzw;
+    r7.x = dot(r4.xyz, r0.yzw);
+    r7.y = dot(r6.xyz, r0.yzw);
+    r5.xyzw = max(float4(0.00999999978, 0.00999999978, 0.00999999978, 0.00999999978), r7.xyzw);
+    r0.y = -8.65616989 * r5.y;
+    r0.y = exp2(r0.y);
+    r1.xyz = float3(1, 1, 1) + -r3.xyz;
+    r0.yzw = saturate(r1.xyz * r0.yyy + r3.xyz);
+    r1.x = cmp(-1 >= r4.w);
+    r0.yzw = r1.xxx ? float3(0, 0, 0) : r0.yzw;
+    r1.y = r0.x * 0.997500002 + 0.00249999994;
+    r1.z = r1.y * r1.y;
+    r2.w = r5.x * r5.x;
+    r3.x = r1.y * r1.y + -1;
+    r2.w = r2.w * r3.x + 1;
+    r2.w = r2.w * r2.w;
+    r2.w = 4 * r2.w;
+    r3.xy = r1.yy * float2(0.797884583, -0.797884583) + float2(0, 1);
+    r3.xy = r5.zw * r3.yy + r3.xx;
+    r1.y = r3.x * r3.y;
+    r1.y = r2.w * r1.y;
+    r1.y = r1.z / r1.y;
+    r3.xyz = r1.yyy * r0.yzw;
+    r1.y = cmp(0 < r1.w);
+    r0.yzw = r1.yyy ? r0.yzw : 0;
+    r3.xyz = ApplyCustomClampSpecular(r3.xyz * r1.www);
+    o0.xyz = r3.xyz * r2.xyz;
+    r1.y = saturate(r1.w * 0.5 + 0.5);
+    r1.y = r1.y * r1.y;
+    r1.z = sqrt(abs(r1.w));
+    r1.z = r1.z + -abs(r1.w);
+    r0.x = r0.x * r1.z + abs(r1.w);
+    r0.x = r1.x ? r1.y : r0.x;
+    r0.xyz = -r0.yzw * r0.xxx + r0.xxx;
+    o1.xyz = r0.xyz * r2.xyz;
+  } else {
+    o0.xyz = float3(0, 0, 0);
+    o1.xyz = float3(0, 0, 0);
+  }
+  return;
+}

--- a/src/games/dyinglight/lighting/0x6ECA8248.ps_5_0.hlsl
+++ b/src/games/dyinglight/lighting/0x6ECA8248.ps_5_0.hlsl
@@ -1,0 +1,173 @@
+#include "./lighting.hlsli"
+
+// ---- Created with 3Dmigoto v1.4.1 on Wed Jul  2 02:44:52 2025
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerComparisonState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb2 : register(b2) {
+  float4 cb2[10];
+}
+
+cbuffer cb0 : register(b0) {
+  float4 cb0[2];
+}
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(
+    float4 v0: SV_POSITION0,
+    float4 v1: TEXCOORD0,
+    float4 v2: TEXCOORD1,
+    float4 v3: TEXCOORD2,
+    float4 v4: TEXCOORD3,
+    float4 v5: TEXCOORD4,
+    float4 v6: TEXCOORD5,
+    float4 v7: TEXCOORD6,
+    out float3 o0: SV_TARGET0,
+    out float3 o1: SV_TARGET1) {
+  float4 r0, r1, r2, r3, r4, r5, r6, r7, r8, r9;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = v0.xy * cb2[7].xy + cb2[7].zw;
+  r0.z = t2.SampleLevel(s3_s, r0.xy, 0).x;
+  r0.zw = r0.zz * cb2[8].xy + cb2[8].zw;
+  r0.z = r0.z / -r0.w;
+  r1.xy = v0.xy * cb2[9].xy + cb2[9].zw;
+  r1.xy = r1.xy * abs(r0.zz);
+  r1.z = -abs(r0.z);
+  r1.w = 1;
+  r2.x = dot(r1.xyzw, v4.xyzw);
+  r2.y = dot(r1.xyzw, v5.xyzw);
+  r3.x = dot(r1.xyzw, v7.xyzw);
+  r3.y = 0.5;
+  r0.z = t3.SampleLevel(s0_s, r3.xy, 0).w;
+  r0.z = r0.z * r0.z;
+  r0.z = r0.z * r0.z;
+  r3.yz = r2.xy / r3.xx;
+  r3.yz = r3.yz * float2(0.5, 0.5) + float2(0.5, 0.5);
+  r3.yzw = t3.SampleLevel(s0_s, r3.yz, 0).xyz;
+  r4.xyzw = t0.SampleLevel(s1_s, r0.xy, 0).xyzw;
+  r4.xyzw = r4.xyzw * float4(2, 2, 2, 2) + float4(-1, -1, -1, -1);
+  r0.w = dot(r4.xyz, r4.xyz);
+  r0.w = rsqrt(r0.w);
+  r4.xyz = r4.xyz * r0.www;
+  r5.xyz = v2.xyz + -r1.xyz;
+  r0.w = dot(r5.xyz, r5.xyz);
+  r0.w = rsqrt(r0.w);
+  r6.xyz = r5.xyz * r0.www;
+  r7.w = dot(r6.xyz, r4.xyz);
+  r2.w = saturate(r7.w);
+  r5.w = cmp(r4.w < 0);
+  r2.w = r5.w ? r7.w : r2.w;
+  r5.w = abs(r2.w) * r0.z;
+  r5.w = min(1, r5.w);
+  r5.w = saturate(dot(r3.yzw, r5.www));
+  r5.w = cmp(0 < r5.w);
+  if (r5.w != 0) {
+    r2.z = dot(r1.xyzw, v6.xyzw);
+    r3.yzw = v3.xyz * r3.yzw;
+    r3.yzw = r3.yzw * r0.zzz;
+    r2.xyz = r2.xyz / r3.xxx;
+    r2.xy = r2.xy * v1.xy + v1.zw;
+    r0.z = cmp(r2.w < 0);
+    r8.xyz = r0.zzz ? -r4.xyz : r4.xyz;
+    r9.x = dot(r8.xyz, v4.xyz);
+    r9.y = dot(r8.xyz, v5.xyz);
+    r9.z = dot(r8.xyz, v6.xyz);
+    r0.z = dot(r9.xyz, r9.xyz);
+    r0.z = rsqrt(r0.z);
+    r8.xyz = r9.xyz * r0.zzz;
+    r0.z = dot(cb0[0].xy, cb0[0].xy);
+    r9.x = sqrt(r0.z);
+    r0.z = 262140 * abs(r3.x);
+    r9.z = 2.82842708 / r0.z;
+    r9.y = -r9.x;
+    r2.xyz = r8.xyz * r9.xyz + r2.xyz;
+    r8.xyzw = cb0[0].xyxy * float4(-0.5, -0.5, 0.5, -0.5) + r2.xyxy;
+    r0.z = cb0[1].x * r2.z + cb0[1].y;
+    r1.w = t4.SampleCmpLevelZero(s4_s, r8.xy, r0.z).x;
+    r1.w = cb0[1].x * r1.w + cb0[1].y;
+    r2.z = t4.SampleCmpLevelZero(s4_s, r8.zw, r0.z).x;
+    r2.z = cb0[1].x * r2.z + cb0[1].y;
+    r2.z = 0.25 * r2.z;
+    r1.w = r1.w * 0.25 + r2.z;
+    r8.xyzw = cb0[0].xyxy * float4(0.5, 0.5, -0.5, 0.5) + r2.xyxy;
+    r2.x = t4.SampleCmpLevelZero(s4_s, r8.xy, r0.z).x;
+    r2.x = cb0[1].x * r2.x + cb0[1].y;
+    r1.w = r2.x * 0.25 + r1.w;
+    r0.z = t4.SampleCmpLevelZero(s4_s, r8.zw, r0.z).x;
+    r0.z = cb0[1].x * r0.z + cb0[1].y;
+    r0.z = saturate(r0.z * 0.25 + r1.w);
+    r1.w = r0.z * -2 + 3;
+    r0.z = r0.z * r0.z;
+    r0.z = r1.w * r0.z;
+    r2.xyz = r3.yzw * r0.zzz;
+    r3.xyzw = t1.SampleLevel(s2_s, r0.xy, 0).xyzw;
+    r0.x = r3.w * r3.w;
+    r0.y = dot(-r1.xyz, -r1.xyz);
+    r0.y = rsqrt(r0.y);
+    r1.xyz = -r1.xyz * r0.yyy;
+    r7.z = saturate(dot(r4.xyz, r1.xyz));
+    r0.yzw = r5.xyz * r0.www + r1.xyz;
+    r1.x = dot(r0.yzw, r0.yzw);
+    r1.x = rsqrt(r1.x);
+    r0.yzw = r1.xxx * r0.yzw;
+    r7.x = dot(r4.xyz, r0.yzw);
+    r7.y = dot(r6.xyz, r0.yzw);
+    r1.xyzw = max(float4(0.00999999978, 0.00999999978, 0.00999999978, 0.00999999978), r7.xyzw);
+    r0.y = -8.65616989 * r1.y;
+    r0.y = exp2(r0.y);
+    r4.xyz = float3(1, 1, 1) + -r3.xyz;
+    r0.yzw = saturate(r4.xyz * r0.yyy + r3.xyz);
+    r1.y = cmp(-1 >= r4.w);
+    r0.yzw = r1.yyy ? float3(0, 0, 0) : r0.yzw;
+    r3.x = r0.x * 0.997500002 + 0.00249999994;
+    r3.y = r3.x * r3.x;
+    r1.x = r1.x * r1.x;
+    r3.z = r3.x * r3.x + -1;
+    r1.x = r1.x * r3.z + 1;
+    r1.x = r1.x * r1.x;
+    r1.x = 4 * r1.x;
+    r3.xz = r3.xx * float2(0.797884583, -0.797884583) + float2(0, 1);
+    r1.zw = r1.zw * r3.zz + r3.xx;
+    r1.z = r1.z * r1.w;
+    r1.x = r1.x * r1.z;
+    r1.x = r3.y / r1.x;
+    r1.xzw = r1.xxx * r0.yzw;
+    r3.x = cmp(0 < r2.w);
+    r0.yzw = r3.xxx ? r0.yzw : 0;
+    r1.xzw = ApplyCustomClampSpecular(r1.xzw * r2.www);
+    o0.xyz = r1.xzw * r2.xyz;
+    r1.x = saturate(r2.w * 0.5 + 0.5);
+    r1.x = r1.x * r1.x;
+    r1.z = sqrt(abs(r2.w));
+    r1.z = r1.z + -abs(r2.w);
+    r0.x = r0.x * r1.z + abs(r2.w);
+    r0.x = r1.y ? r1.x : r0.x;
+    r0.xyz = -r0.yzw * r0.xxx + r0.xxx;
+    o1.xyz = r0.xyz * r2.xyz;
+  } else {
+    o0.xyz = float3(0, 0, 0);
+    o1.xyz = float3(0, 0, 0);
+  }
+  return;
+}

--- a/src/games/dyinglight/lighting/0x7BF499C3.ps_5_0.hlsl
+++ b/src/games/dyinglight/lighting/0x7BF499C3.ps_5_0.hlsl
@@ -1,0 +1,127 @@
+#include "./lighting.hlsli"
+
+// ---- Created with 3Dmigoto v1.4.1 on Wed Jul  2 02:45:00 2025
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb2 : register(b2) {
+  float4 cb2[10];
+}
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(
+    float4 v0: SV_POSITION0,
+    float4 v1: TEXCOORD0,
+    float4 v2: TEXCOORD1,
+    float4 v3: TEXCOORD2,
+    float4 v4: TEXCOORD3,
+    float4 v5: TEXCOORD4,
+    out float3 o0: SV_TARGET0,
+    out float3 o1: SV_TARGET1) {
+  float4 r0, r1, r2, r3, r4, r5, r6, r7;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = v0.xy * cb2[7].xy + cb2[7].zw;
+  r0.z = t2.SampleLevel(s3_s, r0.xy, 0).x;
+  r0.zw = r0.zz * cb2[8].xy + cb2[8].zw;
+  r0.z = r0.z / -r0.w;
+  r1.xy = v0.xy * cb2[9].xy + cb2[9].zw;
+  r1.xy = r1.xy * abs(r0.zz);
+  r1.z = -abs(r0.z);
+  r1.w = 1;
+  r2.x = dot(r1.xyzw, v3.xyzw);
+  r2.y = dot(r1.xyzw, v4.xyzw);
+  r3.x = dot(r1.xyzw, v5.xyzw);
+  r3.y = 0.5;
+  r0.z = t3.SampleLevel(s0_s, r3.xy, 0).w;
+  r0.z = r0.z * r0.z;
+  r0.z = r0.z * r0.z;
+  r2.xy = r2.xy / r3.xx;
+  r2.xy = r2.xy * float2(0.5, 0.5) + float2(0.5, 0.5);
+  r2.xyz = t3.SampleLevel(s0_s, r2.xy, 0).xyz;
+  r3.xyzw = t0.SampleLevel(s1_s, r0.xy, 0).xyzw;
+  r3.xyzw = r3.xyzw * float4(2, 2, 2, 2) + float4(-1, -1, -1, -1);
+  r0.w = dot(r3.xyz, r3.xyz);
+  r0.w = rsqrt(r0.w);
+  r3.xyz = r3.xyz * r0.www;
+  r4.xyz = v1.xyz + -r1.xyz;
+  r0.w = dot(r4.xyz, r4.xyz);
+  r0.w = rsqrt(r0.w);
+  r5.xyz = r4.xyz * r0.www;
+  r6.w = dot(r5.xyz, r3.xyz);
+  r1.w = saturate(r6.w);
+  r2.w = cmp(r3.w < 0);
+  r1.w = r2.w ? r6.w : r1.w;
+  r2.w = abs(r1.w) * r0.z;
+  r2.w = min(1, r2.w);
+  r2.w = saturate(dot(r2.xyz, r2.www));
+  r2.w = cmp(0 < r2.w);
+  if (r2.w != 0) {
+    r2.xyz = v2.xyz * r2.xyz;
+    r2.xyz = r2.xyz * r0.zzz;
+    r7.xyzw = t1.SampleLevel(s2_s, r0.xy, 0).xyzw;
+    r0.x = r7.w * r7.w;
+    r0.y = dot(-r1.xyz, -r1.xyz);
+    r0.y = rsqrt(r0.y);
+    r1.xyz = -r1.xyz * r0.yyy;
+    r6.z = saturate(dot(r3.xyz, r1.xyz));
+    r0.yzw = r4.xyz * r0.www + r1.xyz;
+    r1.x = dot(r0.yzw, r0.yzw);
+    r1.x = rsqrt(r1.x);
+    r0.yzw = r1.xxx * r0.yzw;
+    r6.x = dot(r3.xyz, r0.yzw);
+    r6.y = dot(r5.xyz, r0.yzw);
+    r4.xyzw = max(float4(0.00999999978, 0.00999999978, 0.00999999978, 0.00999999978), r6.xyzw);
+    r0.y = -8.65616989 * r4.y;
+    r0.y = exp2(r0.y);
+    r1.xyz = float3(1, 1, 1) + -r7.xyz;
+    r0.yzw = saturate(r1.xyz * r0.yyy + r7.xyz);
+    r1.x = cmp(-1 >= r3.w);
+    r0.yzw = r1.xxx ? float3(0, 0, 0) : r0.yzw;
+    r1.y = r0.x * 0.997500002 + 0.00249999994;
+    r1.z = r1.y * r1.y;
+    r2.w = r4.x * r4.x;
+    r3.x = r1.y * r1.y + -1;
+    r2.w = r2.w * r3.x + 1;
+    r2.w = r2.w * r2.w;
+    r2.w = 4 * r2.w;
+    r3.xy = r1.yy * float2(0.797884583, -0.797884583) + float2(0, 1);
+    r3.xy = r4.zw * r3.yy + r3.xx;
+    r1.y = r3.x * r3.y;
+    r1.y = r2.w * r1.y;
+    r1.y = r1.z / r1.y;
+    r3.xyz = r1.yyy * r0.yzw;
+    r1.y = cmp(0 < r1.w);
+    r0.yzw = r1.yyy ? r0.yzw : 0;
+    r3.xyz = ApplyCustomClampSpecular(r3.xyz * r1.www);
+    o0.xyz = r3.xyz * r2.xyz;
+    r1.y = saturate(r1.w * 0.5 + 0.5);
+    r1.y = r1.y * r1.y;
+    r1.z = sqrt(abs(r1.w));
+    r1.z = r1.z + -abs(r1.w);
+    r0.x = r0.x * r1.z + abs(r1.w);
+    r0.x = r1.x ? r1.y : r0.x;
+    r0.xyz = -r0.yzw * r0.xxx + r0.xxx;
+    o1.xyz = r0.xyz * r2.xyz;
+  } else {
+    o0.xyz = float3(0, 0, 0);
+    o1.xyz = float3(0, 0, 0);
+  }
+  return;
+}

--- a/src/games/dyinglight/lighting/0x7C58E7EE.ps_5_0.hlsl
+++ b/src/games/dyinglight/lighting/0x7C58E7EE.ps_5_0.hlsl
@@ -1,0 +1,134 @@
+#include "./lighting.hlsli"
+
+// ---- Created with 3Dmigoto v1.4.1 on Wed Jul  2 02:45:01 2025
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb2 : register(b2) {
+  float4 cb2[10];
+}
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(
+    float4 v0: SV_POSITION0,
+    float4 v1: TEXCOORD0,
+    float4 v2: TEXCOORD1,
+    float4 v3: TEXCOORD2,
+    float4 v4: TEXCOORD3,
+    float4 v5: TEXCOORD4,
+    float4 v6: TEXCOORD5,
+    float4 v7: TEXCOORD6,
+    float4 v8: TEXCOORD7,
+    out float3 o0: SV_TARGET0,
+    out float3 o1: SV_TARGET1) {
+  float4 r0, r1, r2, r3, r4, r5, r6;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = v0.xy * cb2[7].xy + cb2[7].zw;
+  r0.z = t2.SampleLevel(s3_s, r0.xy, 0).x;
+  r0.zw = r0.zz * cb2[8].xy + cb2[8].zw;
+  r0.z = r0.z / -r0.w;
+  r1.xy = v0.xy * cb2[9].xy + cb2[9].zw;
+  r1.xy = r1.xy * abs(r0.zz);
+  r1.z = -abs(r0.z);
+  r1.w = 1;
+  r2.x = dot(r1.xyzw, v3.xyzw);
+  r2.y = dot(r1.xyzw, v4.xyzw);
+  r0.z = dot(r1.xyzw, v5.xyzw);
+  r0.w = max(abs(r2.y), abs(r0.z));
+  r0.w = max(abs(r2.x), r0.w);
+  r2.z = dot(r1.xyzw, v6.xyzw);
+  r2.w = dot(r1.xyzw, v7.xyzw);
+  r1.w = dot(r1.xyzw, v8.xyzw);
+  r0.w = max(abs(r2.z), r0.w);
+  r1.w = max(abs(r2.w), abs(r1.w));
+  r0.w = max(r1.w, r0.w);
+  r0.w = cmp(r0.w < 1);
+  if (r0.w != 0) {
+    r3.x = abs(r0.z) * 0.5 + 0.5;
+    r3.y = 0.5;
+    r0.z = t3.SampleLevel(s0_s, r3.xy, 0).w;
+    r0.z = r0.z * r0.z;
+    r0.z = r0.z * r0.z;
+    r2.xy = r2.xy * float2(-0.5, -0.5) + float2(0.5, 0.5);
+    r2.xyz = t3.SampleLevel(s0_s, r2.xy, 0).xyz;
+    r3.xyzw = t0.SampleLevel(s1_s, r0.xy, 0).xyzw;
+    r3.xyzw = r3.xyzw * float4(2, 2, 2, 2) + float4(-1, -1, -1, -1);
+    r0.w = dot(r3.xyz, r3.xyz);
+    r0.w = rsqrt(r0.w);
+    r3.xyz = r3.xyz * r0.www;
+    r0.w = dot(v1.xyz, v1.xyz);
+    r0.w = rsqrt(r0.w);
+    r4.xyz = v1.xyz * r0.www;
+    r5.w = dot(r4.xyz, r3.xyz);
+    r1.w = saturate(r5.w);
+    r2.w = cmp(r3.w < 0);
+    r1.w = r2.w ? r5.w : r1.w;
+    r2.xyz = v2.xyz * r2.xyz;
+    r2.xyz = r2.xyz * r0.zzz;
+    r6.xyzw = t1.SampleLevel(s2_s, r0.xy, 0).xyzw;
+    r0.x = r6.w * r6.w;
+    r0.y = dot(-r1.xyz, -r1.xyz);
+    r0.y = rsqrt(r0.y);
+    r1.xyz = -r1.xyz * r0.yyy;
+    r5.z = saturate(dot(r3.xyz, r1.xyz));
+    r0.yzw = v1.xyz * r0.www + r1.xyz;
+    r1.x = dot(r0.yzw, r0.yzw);
+    r1.x = rsqrt(r1.x);
+    r0.yzw = r1.xxx * r0.yzw;
+    r5.x = dot(r3.xyz, r0.yzw);
+    r5.y = dot(r4.xyz, r0.yzw);
+    r4.xyzw = max(float4(0.00999999978, 0.00999999978, 0.00999999978, 0.00999999978), r5.xyzw);
+    r0.y = -8.65616989 * r4.y;
+    r0.y = exp2(r0.y);
+    r1.xyz = float3(1, 1, 1) + -r6.xyz;
+    r0.yzw = saturate(r1.xyz * r0.yyy + r6.xyz);
+    r1.x = cmp(-1 >= r3.w);
+    r0.yzw = r1.xxx ? float3(0, 0, 0) : r0.yzw;
+    r1.y = r0.x * 0.997500002 + 0.00249999994;
+    r1.z = r1.y * r1.y;
+    r2.w = r4.x * r4.x;
+    r3.x = r1.y * r1.y + -1;
+    r2.w = r2.w * r3.x + 1;
+    r2.w = r2.w * r2.w;
+    r2.w = 4 * r2.w;
+    r3.xy = r1.yy * float2(0.797884583, -0.797884583) + float2(0, 1);
+    r3.xy = r4.zw * r3.yy + r3.xx;
+    r1.y = r3.x * r3.y;
+    r1.y = r2.w * r1.y;
+    r1.y = r1.z / r1.y;
+    r3.xyz = r1.yyy * r0.yzw;
+    r1.y = cmp(0 < r1.w);
+    r0.yzw = r1.yyy ? r0.yzw : 0;
+    r3.xyz = ApplyCustomClampSpecular(r3.xyz * r1.www);
+    o0.xyz = r3.xyz * r2.xyz;
+    r1.y = saturate(r1.w * 0.5 + 0.5);
+    r1.y = r1.y * r1.y;
+    r1.z = sqrt(abs(r1.w));
+    r1.z = r1.z + -abs(r1.w);
+    r0.x = r0.x * r1.z + abs(r1.w);
+    r0.x = r1.x ? r1.y : r0.x;
+    r0.xyz = -r0.yzw * r0.xxx + r0.xxx;
+    o1.xyz = r0.xyz * r2.xyz;
+  } else {
+    o0.xyz = float3(0, 0, 0);
+    o1.xyz = float3(0, 0, 0);
+  }
+  return;
+}

--- a/src/games/dyinglight/lighting/0x9FAA56D4.ps_5_0.hlsl
+++ b/src/games/dyinglight/lighting/0x9FAA56D4.ps_5_0.hlsl
@@ -1,0 +1,136 @@
+#include "./lighting.hlsli"
+
+// ---- Created with 3Dmigoto v1.4.1 on Wed Jul  2 02:45:25 2025
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb2 : register(b2) {
+  float4 cb2[10];
+}
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(
+    float4 v0: SV_POSITION0,
+    float4 v1: TEXCOORD0,
+    float4 v2: TEXCOORD1,
+    float4 v3: TEXCOORD2,
+    float4 v4: TEXCOORD3,
+    float4 v5: TEXCOORD4,
+    float4 v6: TEXCOORD5,
+    float4 v7: TEXCOORD6,
+    float4 v8: TEXCOORD7,
+    out float3 o0: SV_TARGET0,
+    out float3 o1: SV_TARGET1) {
+  float4 r0, r1, r2, r3, r4, r5, r6, r7;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = v0.xy * cb2[7].xy + cb2[7].zw;
+  r0.z = t2.SampleLevel(s3_s, r0.xy, 0).x;
+  r0.zw = r0.zz * cb2[8].xy + cb2[8].zw;
+  r0.z = r0.z / -r0.w;
+  r1.xy = v0.xy * cb2[9].xy + cb2[9].zw;
+  r1.xy = r1.xy * abs(r0.zz);
+  r1.z = -abs(r0.z);
+  r1.w = 1;
+  r2.x = dot(r1.xyzw, v3.xyzw);
+  r2.y = dot(r1.xyzw, v4.xyzw);
+  r3.x = dot(r1.xyzw, v5.xyzw);
+  r0.z = max(abs(r2.x), abs(r2.y));
+  r0.z = cmp(r3.x < r0.z);
+  r0.w = dot(r1.xyzw, v6.xyzw);
+  r2.z = dot(r1.xyzw, v7.xyzw);
+  r1.w = dot(r1.xyzw, v8.xyzw);
+  r0.z = r0.z ? 2 : abs(r3.x);
+  r0.z = max(r0.z, abs(r0.w));
+  r0.w = max(abs(r2.z), abs(r1.w));
+  r0.z = max(r0.z, r0.w);
+  r0.z = cmp(r0.z < 1);
+  if (r0.z != 0) {
+    r3.y = 0.5;
+    r0.z = t3.SampleLevel(s0_s, r3.xy, 0).w;
+    r0.z = r0.z * r0.z;
+    r0.z = r0.z * r0.z;
+    r2.xy = r2.xy / r3.xx;
+    r2.xy = r2.xy * float2(0.5, 0.5) + float2(0.5, 0.5);
+    r2.xyz = t3.SampleLevel(s0_s, r2.xy, 0).xyz;
+    r3.xyzw = t0.SampleLevel(s1_s, r0.xy, 0).xyzw;
+    r3.xyzw = r3.xyzw * float4(2, 2, 2, 2) + float4(-1, -1, -1, -1);
+    r0.w = dot(r3.xyz, r3.xyz);
+    r0.w = rsqrt(r0.w);
+    r3.xyz = r3.xyz * r0.www;
+    r4.xyz = v1.xyz + -r1.xyz;
+    r0.w = dot(r4.xyz, r4.xyz);
+    r0.w = rsqrt(r0.w);
+    r5.xyz = r4.xyz * r0.www;
+    r6.w = dot(r5.xyz, r3.xyz);
+    r1.w = saturate(r6.w);
+    r2.w = cmp(r3.w < 0);
+    r1.w = r2.w ? r6.w : r1.w;
+    r2.xyz = v2.xyz * r2.xyz;
+    r2.xyz = r2.xyz * r0.zzz;
+    r7.xyzw = t1.SampleLevel(s2_s, r0.xy, 0).xyzw;
+    r0.x = r7.w * r7.w;
+    r0.y = dot(-r1.xyz, -r1.xyz);
+    r0.y = rsqrt(r0.y);
+    r1.xyz = -r1.xyz * r0.yyy;
+    r6.z = saturate(dot(r3.xyz, r1.xyz));
+    r0.yzw = r4.xyz * r0.www + r1.xyz;
+    r1.x = dot(r0.yzw, r0.yzw);
+    r1.x = rsqrt(r1.x);
+    r0.yzw = r1.xxx * r0.yzw;
+    r6.x = dot(r3.xyz, r0.yzw);
+    r6.y = dot(r5.xyz, r0.yzw);
+    r4.xyzw = max(float4(0.00999999978, 0.00999999978, 0.00999999978, 0.00999999978), r6.xyzw);
+    r0.y = -8.65616989 * r4.y;
+    r0.y = exp2(r0.y);
+    r1.xyz = float3(1, 1, 1) + -r7.xyz;
+    r0.yzw = saturate(r1.xyz * r0.yyy + r7.xyz);
+    r1.x = cmp(-1 >= r3.w);
+    r0.yzw = r1.xxx ? float3(0, 0, 0) : r0.yzw;
+    r1.y = r0.x * 0.997500002 + 0.00249999994;
+    r1.z = r1.y * r1.y;
+    r2.w = r4.x * r4.x;
+    r3.x = r1.y * r1.y + -1;
+    r2.w = r2.w * r3.x + 1;
+    r2.w = r2.w * r2.w;
+    r2.w = 4 * r2.w;
+    r3.xy = r1.yy * float2(0.797884583, -0.797884583) + float2(0, 1);
+    r3.xy = r4.zw * r3.yy + r3.xx;
+    r1.y = r3.x * r3.y;
+    r1.y = r2.w * r1.y;
+    r1.y = r1.z / r1.y;
+    r3.xyz = r1.yyy * r0.yzw;
+    r1.y = cmp(0 < r1.w);
+    r0.yzw = r1.yyy ? r0.yzw : 0;
+    r3.xyz = ApplyCustomClampSpecular(r3.xyz * r1.www);
+    o0.xyz = r3.xyz * r2.xyz;
+    r1.y = saturate(r1.w * 0.5 + 0.5);
+    r1.y = r1.y * r1.y;
+    r1.z = sqrt(abs(r1.w));
+    r1.z = r1.z + -abs(r1.w);
+    r0.x = r0.x * r1.z + abs(r1.w);
+    r0.x = r1.x ? r1.y : r0.x;
+    r0.xyz = -r0.yzw * r0.xxx + r0.xxx;
+    o1.xyz = r0.xyz * r2.xyz;
+  } else {
+    o0.xyz = float3(0, 0, 0);
+    o1.xyz = float3(0, 0, 0);
+  }
+  return;
+}

--- a/src/games/dyinglight/lighting/0xA12396FD.ps_5_0.hlsl
+++ b/src/games/dyinglight/lighting/0xA12396FD.ps_5_0.hlsl
@@ -1,0 +1,120 @@
+#include "./lighting.hlsli"
+
+// ---- Created with 3Dmigoto v1.4.1 on Wed Jul  2 01:51:43 2025
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+cbuffer cb2 : register(b2) {
+  float4 cb2[10];
+}
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(
+    float4 v0: SV_POSITION0,
+    float4 v1: TEXCOORD0,
+    float4 v2: TEXCOORD1,
+    float4 v3: TEXCOORD2,
+    float4 v4: TEXCOORD3,
+    float4 v5: TEXCOORD4,
+    out float3 o0: SV_TARGET0,
+    out float3 o1: SV_TARGET1) {
+  float4 r0, r1, r2, r3, r4, r5, r6, r7;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = v0.xy * cb2[7].xy + cb2[7].zw;
+  r0.z = t2.SampleLevel(s3_s, r0.xy, 0).x;
+  r0.zw = r0.zz * cb2[8].xy + cb2[8].zw;
+  r0.z = r0.z / -r0.w;
+  r1.xy = v0.xy * cb2[9].xy + cb2[9].zw;
+  r1.xy = r1.xy * abs(r0.zz);
+  r1.z = -abs(r0.z);
+  r1.w = 1;
+  r2.x = dot(r1.xyzw, v3.xyzw);
+  r2.y = dot(r1.xyzw, v4.xyzw);
+  r2.z = dot(r1.xyzw, v5.xyzw);
+  r0.z = dot(-r2.xyz, -r2.xyz);
+  r0.z = 1 + -r0.z;
+  r0.z = max(0, r0.z);
+  r0.z = r0.z * r0.z;
+  r2.xyzw = t0.SampleLevel(s1_s, r0.xy, 0).xyzw;
+  r2.xyzw = r2.xyzw * float4(2, 2, 2, 2) + float4(-1, -1, -1, -1);
+  r0.w = dot(r2.xyz, r2.xyz);
+  r0.w = rsqrt(r0.w);
+  r2.xyz = r2.xyz * r0.www;
+  r3.xyz = v1.xyz + -r1.xyz;
+  r0.w = dot(r3.xyz, r3.xyz);
+  r0.w = rsqrt(r0.w);
+  r4.xyz = r3.xyz * r0.www;
+  r5.w = dot(r4.xyz, r2.xyz);
+  r1.w = saturate(r5.w);
+  r3.w = cmp(r2.w < 0);
+  r1.w = r3.w ? r5.w : r1.w;
+  r3.w = abs(r1.w) * r0.z;
+  r3.w = min(1, r3.w);
+  r3.w = dot(float3(1, 1, 1), r3.www);
+  r3.w = min(1, r3.w);
+  r3.w = cmp(0 < r3.w);
+  if (r3.w != 0) {
+    r6.xyz = v2.xyz * r0.zzz;
+    r7.xyzw = t1.SampleLevel(s2_s, r0.xy, 0).xyzw;
+    r0.x = r7.w * r7.w;
+    r0.y = dot(-r1.xyz, -r1.xyz);
+    r0.y = rsqrt(r0.y);
+    r1.xyz = -r1.xyz * r0.yyy;
+    r5.z = saturate(dot(r2.xyz, r1.xyz));
+    r0.yzw = r3.xyz * r0.www + r1.xyz;
+    r1.x = dot(r0.yzw, r0.yzw);
+    r1.x = rsqrt(r1.x);
+    r0.yzw = r1.xxx * r0.yzw;
+    r5.x = dot(r2.xyz, r0.yzw);
+    r5.y = dot(r4.xyz, r0.yzw);
+    r3.xyzw = max(float4(0.00999999978, 0.00999999978, 0.00999999978, 0.00999999978), r5.xyzw);
+    r0.y = -8.65616989 * r3.y;
+    r0.y = exp2(r0.y);
+    r1.xyz = float3(1, 1, 1) + -r7.xyz;
+    r0.yzw = saturate(r1.xyz * r0.yyy + r7.xyz);
+    r1.x = cmp(-1 >= r2.w);
+    r0.yzw = r1.xxx ? float3(0, 0, 0) : r0.yzw;
+    r1.y = r0.x * 0.997500002 + 0.00249999994;
+    r1.z = r1.y * r1.y;
+    r2.x = r3.x * r3.x;
+    r2.y = r1.y * r1.y + -1;
+    r2.x = r2.x * r2.y + 1;
+    r2.x = r2.x * r2.x;
+    r2.x = 4 * r2.x;
+    r2.yz = r1.yy * float2(0.797884583, -0.797884583) + float2(0, 1);
+    r2.yz = r3.zw * r2.zz + r2.yy;
+    r1.y = r2.y * r2.z;
+    r1.y = r2.x * r1.y;
+    r1.y = r1.z / r1.y;
+    r2.xyz = r1.yyy * r0.yzw;
+    r1.y = cmp(0 < r1.w);
+    r0.yzw = r1.yyy ? r0.yzw : 0;
+    r2.xyz = ApplyCustomClampSpecular(r2.xyz * r1.www);
+    o0.xyz = r2.xyz * r6.xyz;
+    r1.y = saturate(r1.w * 0.5 + 0.5);
+    r1.y = r1.y * r1.y;
+    r1.z = sqrt(abs(r1.w));
+    r1.z = r1.z + -abs(r1.w);
+    r0.x = r0.x * r1.z + abs(r1.w);
+    r0.x = r1.x ? r1.y : r0.x;
+    r0.xyz = -r0.yzw * r0.xxx + r0.xxx;
+    o1.xyz = r0.xyz * r6.xyz;
+  } else {
+    o0.xyz = float3(0, 0, 0);
+    o1.xyz = float3(0, 0, 0);
+  }
+  return;
+}

--- a/src/games/dyinglight/lighting/0xD690FC1B.ps_5_0.hlsl
+++ b/src/games/dyinglight/lighting/0xD690FC1B.ps_5_0.hlsl
@@ -1,0 +1,101 @@
+#include "./lighting.hlsli"
+
+// ---- Created with 3Dmigoto v1.4.1 on Wed Jul  2 02:45:59 2025
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb2 : register(b2) {
+  float4 cb2[9];
+}
+
+cbuffer cb0 : register(b0) {
+  float4 cb0[2];
+}
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(
+    float4 v0: SV_POSITION0,
+    float4 v1: TEXCOORD0,
+    float2 v2: TEXCOORD1,
+    out float3 o0: SV_TARGET0,
+    out float3 o1: SV_TARGET1) {
+  float4 r0, r1, r2, r3, r4;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyzw = t0.SampleLevel(s0_s, v2.xy, 0).xyzw;
+  r0.xyzw = r0.xyzw * float4(2, 2, 2, 2) + float4(-1, -1, -1, -1);
+  r1.x = dot(r0.xyz, r0.xyz);
+  r1.x = rsqrt(r1.x);
+  r0.xyz = r1.xxx * r0.xyz;
+  r1.w = dot(cb0[1].xyz, r0.xyz);
+  r2.x = saturate(r1.w);
+  r2.y = cmp(r0.w < 0);
+  r2.x = r2.y ? r1.w : r2.x;
+  r2.y = cmp(0 < abs(r2.x));
+  if (r2.y != 0) {
+    r2.y = t2.SampleLevel(s2_s, v2.xy, 0).x;
+    r2.yz = r2.yy * cb2[8].xy + cb2[8].zw;
+    r2.y = r2.y / -r2.z;
+    r2.yzw = v1.xyz * abs(r2.yyy);
+    r3.x = dot(-r2.yzw, -r2.yzw);
+    r3.x = rsqrt(r3.x);
+    r3.yzw = r3.xxx * -r2.yzw;
+    r1.z = saturate(dot(r0.xyz, r3.yzw));
+    r4.xyzw = t1.SampleLevel(s1_s, v2.xy, 0).xyzw;
+    r3.y = r4.w * r4.w;
+    r2.yzw = -r2.yzw * r3.xxx + cb0[1].xyz;
+    r3.x = dot(r2.yzw, r2.yzw);
+    r3.x = rsqrt(r3.x);
+    r2.yzw = r3.xxx * r2.yzw;
+    r1.x = dot(r0.xyz, r2.yzw);
+    r1.y = dot(cb0[1].xyz, r2.yzw);
+    r1.xyzw = max(float4(0.00999999978, 0.00999999978, 0.00999999978, 0.00999999978), r1.xyzw);
+    r0.x = -8.65616989 * r1.y;
+    r0.x = exp2(r0.x);
+    r2.yzw = float3(1, 1, 1) + -r4.xyz;
+    r0.xyz = saturate(r2.yzw * r0.xxx + r4.xyz);
+    r0.w = cmp(-1 >= r0.w);
+    r0.xyz = r0.www ? float3(0, 0, 0) : r0.xyz;
+    r1.y = r3.y * 0.997500002 + 0.00249999994;
+    r2.y = r1.y * r1.y;
+    r1.x = r1.x * r1.x;
+    r2.z = r1.y * r1.y + -1;
+    r1.x = r1.x * r2.z + 1;
+    r1.x = r1.x * r1.x;
+    r1.x = 4 * r1.x;
+    r2.zw = r1.yy * float2(0.797884583, -0.797884583) + float2(0, 1);
+    r1.yz = r1.zw * r2.ww + r2.zz;
+    r1.y = r1.y * r1.z;
+    r1.x = r1.x * r1.y;
+    r1.x = r2.y / r1.x;
+    r1.xyz = r1.xxx * r0.xyz;
+    r1.w = cmp(0 < r2.x);
+    r0.xyz = r1.www ? r0.xyz : 0;
+    r1.xyz = ApplyCustomClampSpecular(r1.xyz * r2.xxx);
+    r1.w = saturate(r2.x * 0.5 + 0.5);
+    r1.w = r1.w * r1.w;
+    r2.y = sqrt(abs(r2.x));
+    r2.y = r2.y + -abs(r2.x);
+    r2.x = r3.y * r2.y + abs(r2.x);
+    r0.w = r0.w ? r1.w : r2.x;
+    r0.xyz = -r0.xyz * r0.www + r0.www;
+    o0.xyz = cb0[0].xyz * r1.xyz;
+    o1.xyz = cb0[0].xyz * r0.xyz;
+  } else {
+    o0.xyz = float3(0, 0, 0);
+    o1.xyz = float3(0, 0, 0);
+  }
+  return;
+}

--- a/src/games/dyinglight/lighting/fire_0xAB16B3F7.ps_5_0.hlsl
+++ b/src/games/dyinglight/lighting/fire_0xAB16B3F7.ps_5_0.hlsl
@@ -1,0 +1,43 @@
+#include "./lighting.hlsli"
+
+// ---- Created with 3Dmigoto v1.4.1 on Wed Jul  2 02:45:32 2025
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb2 : register(b2) {
+  float4 cb2[9];
+}
+
+cbuffer cb0 : register(b0) {
+  float4 cb0[1];
+}
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(
+    float4 v0: SV_POSITION0,
+    float4 v1: TEXCOORD0,
+    float3 v2: TEXCOORD1,
+    out float4 o0: SV_TARGET0) {
+  float4 r0, r1;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = v0.xy * cb2[7].xy + cb2[7].zw;
+  r0.x = t0.SampleLevel(s1_s, r0.xy, 0).x;
+  r0.xy = r0.xx * cb2[8].xy + cb2[8].zw;
+  r0.x = r0.x / -r0.y;
+  r0.x = ApplyCustomClampFire(abs(r0.x) * cb0[0].y + -v2.z);
+  r0.x = v1.w * r0.x;
+  r1.xyzw = t1.Sample(s0_s, v2.xy).xyzw;
+  r0.yzw = v1.xyz * r1.xyz;
+  o0.w = r1.w * r0.x;
+  o0.xyz = r0.yzw * r0.xxx;
+  return;
+}

--- a/src/games/dyinglight/lighting/lighting.hlsli
+++ b/src/games/dyinglight/lighting/lighting.hlsli
@@ -40,7 +40,7 @@ float ApplyCustomClampFire(float unclamped_value) {
   clamped_value = min(100.f, unclamped_value);
   clamped_value = renodx::tonemap::ExponentialRollOff(unclamped_value, 1.f, 5.f);
 #else
-  clamped_value = min(5.f, clamped_value);
+  clamped_value = min(7.5f, clamped_value);
 #endif
 
   return clamped_value;

--- a/src/games/dyinglight/lighting/lighting.hlsli
+++ b/src/games/dyinglight/lighting/lighting.hlsli
@@ -1,0 +1,47 @@
+#include "../shared.h"
+
+float3 ApplyCustomClampSpecular(float3 unclamped_color) {
+  if (CUSTOM_UNCLAMP_LIGHTING == 0) return saturate(unclamped_color);
+
+  unclamped_color = max(0, unclamped_color);
+
+  float3 clamped_color = unclamped_color;
+#if 1
+  clamped_color = renodx::tonemap::ExponentialRollOff(unclamped_color, 1.f, 10.f);
+#else
+  clamped_color = min(10.f, clamped_color);
+#endif
+
+  return clamped_color;
+}
+
+float ApplyCustomClampWaterSpecular(float unclamped_value) {
+  if (CUSTOM_UNCLAMP_LIGHTING == 0) return saturate(unclamped_value);
+
+  unclamped_value = max(0, unclamped_value);
+
+  float clamped_value = unclamped_value;
+#if 1
+  clamped_value = renodx::tonemap::ExponentialRollOff(clamped_value, 1.f, 10.f);
+#else
+  clamped_value = min(10.f, clamped_value);
+#endif
+
+  return clamped_value;
+}
+
+float ApplyCustomClampFire(float unclamped_value) {
+  if (CUSTOM_UNCLAMP_LIGHTING == 0) return saturate(unclamped_value);
+
+  unclamped_value = max(0, unclamped_value);
+
+  float clamped_value = unclamped_value;
+#if 0
+  clamped_value = min(100.f, unclamped_value);
+  clamped_value = renodx::tonemap::ExponentialRollOff(unclamped_value, 1.f, 5.f);
+#else
+  clamped_value = min(5.f, clamped_value);
+#endif
+
+  return clamped_value;
+}

--- a/src/games/dyinglight/lighting/lighting_0x45B99B2D.ps_5_0.hlsl
+++ b/src/games/dyinglight/lighting/lighting_0x45B99B2D.ps_5_0.hlsl
@@ -1,0 +1,108 @@
+#include "./lighting.hlsli"
+// ---- Created with 3Dmigoto v1.4.1 on Wed Jul  2 01:36:17 2025
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb2 : register(b2) {
+  float4 cb2[9];
+}
+
+cbuffer cb0 : register(b0) {
+  float4 cb0[2];
+}
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(
+    float4 v0: SV_POSITION0,
+    float4 v1: TEXCOORD0,
+    float2 v2: TEXCOORD1,
+    out float3 o0: SV_TARGET0,
+    out float3 o1: SV_TARGET1) {
+  float4 r0, r1, r2, r3, r4, r5;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.x = t3.SampleLevel(s0_s, v2.xy, 0).x;
+  r1.xyzw = t0.SampleLevel(s1_s, v2.xy, 0).xyzw;
+  r1.xyzw = r1.xyzw * float4(2, 2, 2, 2) + float4(-1, -1, -1, -1);
+  r0.y = dot(r1.xyz, r1.xyz);
+  r0.y = rsqrt(r0.y);
+  r0.yzw = r1.xyz * r0.yyy;
+  r2.w = dot(cb0[1].xyz, r0.yzw);
+  r1.x = saturate(r2.w);
+  r1.y = cmp(r1.w < 0);
+  r1.x = r1.y ? r2.w : r1.x;
+  r1.y = abs(r1.x) * r0.x;
+  r1.y = cmp(0 < r1.y);
+  if (r1.y != 0) {
+    r1.y = t2.SampleLevel(s3_s, v2.xy, 0).x;
+    r1.yz = r1.yy * cb2[8].xy + cb2[8].zw;
+    r1.y = r1.y / -r1.z;
+    r3.xyz = v1.xyz * abs(r1.yyy);
+    r1.y = dot(-r3.xyz, -r3.xyz);
+    r1.y = rsqrt(r1.y);
+    r4.xyz = -r3.xyz * r1.yyy;
+    r2.z = saturate(dot(r0.yzw, r4.xyz));
+    r4.xyz = cb0[0].xyz * r0.xxx;
+    r5.xyzw = t1.SampleLevel(s2_s, v2.xy, 0).xyzw;
+    r0.x = r5.w * r5.w;
+    r3.xyz = -r3.xyz * r1.yyy + cb0[1].xyz;
+    r1.y = dot(r3.xyz, r3.xyz);
+    r1.y = rsqrt(r1.y);
+    r3.xyz = r3.xyz * r1.yyy;
+    r2.x = dot(r0.yzw, r3.xyz);
+    r2.y = dot(cb0[1].xyz, r3.xyz);
+    r2.xyzw = max(float4(0.00999999978, 0.00999999978, 0.00999999978, 0.00999999978), r2.xyzw);
+    r0.y = -8.65616989 * r2.y;
+    r0.y = exp2(r0.y);
+    r3.xyz = float3(1, 1, 1) + -r5.xyz;
+    r0.yzw = saturate(r3.xyz * r0.yyy + r5.xyz);
+    r1.y = cmp(-1 >= r1.w);
+    r0.yzw = r1.yyy ? float3(0, 0, 0) : r0.yzw;
+    r1.z = r0.x * 0.997500002 + 0.00249999994;
+    r1.w = r1.z * r1.z;
+    r2.x = r2.x * r2.x;
+    r2.y = r1.z * r1.z + -1;
+    r2.x = r2.x * r2.y + 1;
+    r2.x = r2.x * r2.x;
+    r2.x = 4 * r2.x;
+    r3.xy = r1.zz * float2(0.797884583, -0.797884583) + float2(0, 1);
+    r2.yz = r2.zw * r3.yy + r3.xx;
+    r1.z = r2.y * r2.z;
+    r1.z = r2.x * r1.z;
+    r1.z = r1.w / r1.z;
+    r2.xyz = r1.zzz * r0.yzw;
+    r1.z = cmp(0 < r1.x);
+    r0.yzw = r1.zzz ? r0.yzw : 0;
+    r2.xyz = ApplyCustomClampSpecular(r2.xyz * r1.xxx);  // removing this saturate unclamps specular
+
+    r1.z = saturate(r1.x * 0.5 + 0.5);
+    r1.z = r1.z * r1.z;
+    r1.w = sqrt(abs(r1.x));
+    r1.w = r1.w + -abs(r1.x);
+    r0.x = r0.x * r1.w + abs(r1.x);
+    r0.x = r1.y ? r1.z : r0.x;
+    r0.xyz = -r0.yzw * r0.xxx + r0.xxx;
+    o0.xyz = r2.xyz * r4.xyz;
+    o1.xyz = r0.xyz * r4.xyz;
+  } else {
+    o0.xyz = float3(0, 0, 0);
+    o1.xyz = float3(0, 0, 0);
+  }
+  return;
+}

--- a/src/games/dyinglight/lighting/water_0x36E3A838.ps_5_0.hlsl
+++ b/src/games/dyinglight/lighting/water_0x36E3A838.ps_5_0.hlsl
@@ -1,0 +1,249 @@
+#include "./lighting.hlsli"
+
+// ---- Created with 3Dmigoto v1.4.1 on Wed Jul  2 02:44:16 2025
+Texture2D<float4> t10 : register(t10);
+
+Texture2D<float4> t9 : register(t9);
+
+Texture2D<float4> t8 : register(t8);
+
+Texture2D<float4> t7 : register(t7);
+
+Texture2D<float4> t6 : register(t6);
+
+Texture2D<float4> t5 : register(t5);
+
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s11_s : register(s11);
+
+SamplerState s10_s : register(s10);
+
+SamplerState s9_s : register(s9);
+
+SamplerState s8_s : register(s8);
+
+SamplerState s7_s : register(s7);
+
+SamplerState s6_s : register(s6);
+
+SamplerState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb2 : register(b2) {
+  float4 cb2[13];
+}
+
+cbuffer cb0 : register(b0) {
+  float4 cb0[28];
+}
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(
+    float4 v0: SV_POSITION0,
+    float4 v1: TEXCOORD0,
+    float4 v2: TEXCOORD1,
+    float4 v3: TEXCOORD2,
+    float4 v4: TEXCOORD3,
+    float4 v5: TEXCOORD4,
+    float4 v6: TEXCOORD5,
+    float2 v7: TEXCOORD6,
+    out float4 o0: SV_TARGET0) {
+  float4 r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = t6.Sample(s6_s, v5.zw).yw;
+  r0.xy = r0.yx * float2(2, 2) + float2(-1, -1);
+  r1.x = dot(r0.xy, cb0[12].xy);
+  r1.z = dot(r0.yx, cb0[12].xz);
+  r0.xy = t7.Sample(s7_s, v4.xy).yw;
+  r0.xy = r0.yx * float2(2, 2) + float2(-1, -1);
+  r2.x = dot(r0.xy, cb0[13].xy);
+  r2.z = dot(r0.yx, cb0[13].xz);
+  r0.xy = r2.xz + r1.xz;
+  r0.zw = t8.Sample(s8_s, v4.zw).yw;
+  r0.zw = r0.wz * float2(2, 2) + float2(-1, -1);
+  r1.x = dot(r0.zw, cb0[14].xy);
+  r1.z = dot(r0.wz, cb0[14].xz);
+  r0.xy = r1.xz + r0.xy;
+  r0.zw = t9.Sample(s9_s, v5.xy).yw;
+  r0.zw = r0.wz * float2(2, 2) + float2(-1, -1);
+  r1.x = dot(r0.zw, cb0[15].xy);
+  r1.z = dot(r0.wz, cb0[15].xz);
+  r0.xy = r1.xz + r0.xy;
+  r0.zw = v0.xy * cb2[7].xy + cb2[7].zw;
+  r1.xy = t10.SampleLevel(s10_s, r0.zw, 0).xy;
+  r0.xy = r1.xy * float2(2, 2) + r0.xy;
+  r0.xy = float2(-1, -1) + r0.xy;
+  r1.x = t0.SampleLevel(s11_s, r0.zw, 0).x;
+  r1.xy = r1.xx * cb2[8].xy + cb2[8].zw;
+  r1.x = r1.x / -r1.y;
+  r2.x = -abs(r1.x);
+  r1.yz = v0.xy * cb2[9].xy + cb2[9].zw;
+  r2.yz = r1.yz * abs(r1.xx);
+  r3.xyz = ddx_coarse(r2.zxy);
+  r4.xyz = ddy_coarse(r2.xyz);
+  r1.x = dot(r2.xyz, r2.xyz);
+  r1.x = sqrt(r1.x);
+  r2.xyz = r4.xyz * r3.xyz;
+  r2.xyz = r4.zxy * r3.yzx + -r2.xyz;
+  r1.w = dot(r2.xyz, r2.xyz);
+  r1.w = rsqrt(r1.w);
+  r2.xyz = r2.xyz * r1.www;
+  r3.y = dot(r2.xyz, cb2[11].xyz);
+  r3.x = dot(r2.xyz, cb2[10].xyz);
+  r3.z = dot(r2.xyz, cb2[12].xyz);
+  r1.w = dot(r3.xyz, r3.xyz);
+  r1.w = rsqrt(r1.w);
+  r2.xy = r3.xz * r1.ww;
+  r1.w = dot(v7.xy, cb0[10].xy);
+  r2.z = t4.Sample(s3_s, v6.zw).y;
+  r2.w = t4.Sample(s3_s, v6.xy).y;
+  r3.x = dot(v2.xyz, v2.xyz);
+  r3.y = sqrt(r3.x);
+  r1.x = -r3.y + r1.x;
+  r3.z = saturate(cb0[11].z * r1.x);
+  r1.x = saturate(cb0[5].w * r1.x);
+  r3.w = r3.z * cb0[11].y + cb0[11].x;
+  r2.w = r2.w * cb0[6].w + r3.w;
+  r2.z = r2.z * cb0[6].w + r2.w;
+  r1.w = -r1.w * cb0[8].w + r2.z;
+  r2.zw = t5.Sample(s4_s, r1.ww).yw;
+  r2.zw = r2.zw * float2(2, 2) + float2(-1, -1);
+  r1.w = 1 + -r3.z;
+  r1.w = r2.z * r1.w;
+  r2.zw = float2(1, 2) * r2.ww;
+  r1.w = cb0[9].w * r1.w;
+  r0.xy = r2.xy * r1.ww + r0.xy;
+  r2.xy = r2.xy * r1.ww;
+  r4.xz = r3.zz * r0.xy + -r2.xy;
+  r0.x = cb0[11].y * r3.z;
+  r0.xy = r0.xx * float2(2, 15) + r2.zw;
+  r0.xy = saturate(float2(-1, -2) + r0.xy);
+  r4.y = 1;
+  r1.w = dot(r4.xyz, r4.xyz);
+  r1.w = rsqrt(r1.w);
+  r2.xyz = r4.xyz * r1.www;
+  r4.x = dot(r2.xyz, cb2[0].xyz);
+  r4.y = dot(r2.xyz, cb2[1].xyz);
+  r5.x = cb2[0].y;
+  r5.y = cb2[1].y;
+  r3.zw = -r5.xy + r4.xy;
+  r1.w = cb0[5].z / r3.y;
+  r1.x = r1.w * r1.x;
+  r1.xw = r3.zw * r1.xx;
+  r1.xw = r1.xw * r0.xx + r0.zw;
+  r0.z = t2.SampleLevel(s1_s, r0.zw, 0).x;
+  r0.w = t0.SampleLevel(s11_s, r1.xw, 0).x;
+  r4.xyzw = t1.Sample(s0_s, r1.xw).xyzw;
+  r1.xw = r0.ww * cb2[8].xy + cb2[8].zw;
+  r0.w = r1.x / -r1.w;
+  r1.xy = r1.yz * abs(r0.ww);
+  r1.z = -abs(r0.w);
+  r0.w = dot(r1.xyz, r1.xyz);
+  r0.w = sqrt(r0.w);
+  r0.w = r0.w + -r3.y;
+  r1.xyz = cb0[24].xyz * r3.yyy;
+  r1.xyz = exp2(r1.xyz);
+  r0.w = max(0, r0.w);
+  r3.yzw = cb0[3].xyz * -r0.www;
+  r5.xyz = cb0[2].xyz * -r0.www;
+  r5.xyz = exp2(r5.xyz);
+  r3.yzw = exp2(r3.yzw);
+  r6.w = 1;
+  r0.w = rsqrt(r3.x);
+  r7.xy = r2.xz * r3.xx;
+  r7.xz = r7.xy * cb0[5].yy + v3.xz;
+  r6.xyz = v2.xyz * r0.www;
+  r8.xyz = -v2.xyz * r0.www + cb0[7].xyz;
+  r9.x = dot(cb0[16].xyzw, r6.xyzw);
+  r9.y = dot(cb0[17].xyzw, r6.xyzw);
+  r9.z = dot(cb0[18].xyzw, r6.xyzw);
+  r10.xyzw = r6.xyzz * r6.yzzx;
+  r11.x = dot(cb0[19].xyzw, r10.xyzw);
+  r11.y = dot(cb0[20].xyzw, r10.xyzw);
+  r11.z = dot(cb0[21].xyzw, r10.xyzw);
+  r9.xyz = r11.xyz + r9.xyz;
+  r0.w = r6.y * r6.y;
+  r0.w = r6.x * r6.x + -r0.w;
+  r9.xyz = cb0[22].xyz * r0.www + r9.xyz;
+  r9.xyz = cb0[1].xyz + r9.xyz;
+  r9.xyz = cb0[0].xyz * r9.xyz;
+  r3.xyz = -r9.xyz * r3.yzw + r9.xyz;
+  r3.xyz = r4.xyz * r5.xyz + r3.xyz;
+  o0.w = r4.w;
+  r7.y = v3.y;
+  r7.w = 1;
+  r4.x = dot(r7.xyzw, cb2[0].xyzw);
+  r4.y = dot(r7.xyzw, cb2[1].xyzw);
+  r0.w = dot(r7.xyzw, cb2[3].xyzw);
+  r4.xy = r4.xy / r0.ww;
+  r4.xy = r4.xy * float2(0.5, -0.5) + float2(0.5, 0.5);
+  r4.xyz = t3.SampleLevel(s2_s, r4.xy, 0).xyz;
+  r4.xyz = r4.xyz + -r3.xyz;
+  r5.z = dot(-r6.xyz, r2.xyz);
+  r0.w = saturate(dot(r6.xyz, cb0[6].xyz));
+  r1.w = saturate(r5.z);
+  r1.w = -8.65616989 * r1.w;
+  r1.w = exp2(r1.w);
+  r1.w = saturate(cb0[4].w * r1.w + cb0[3].w);
+  r1.w = r1.w * r0.x;
+  r3.xyz = r1.www * r4.xyz + r3.xyz;
+  r1.w = dot(r8.xyz, r8.xyz);
+  r1.w = rsqrt(r1.w);
+  r4.xyz = r8.xyz * r1.www;
+  r5.x = dot(r2.xyz, r4.xyz);
+  r5.y = dot(cb0[7].xyz, r4.xyz);
+  r5.w = dot(cb0[7].xyz, r2.xyz);
+  r2.xyzw = max(float4(0.00999999978, 0.00999999978, 0.00999999978, 0.00999999978), r5.xyzw);
+  r2.zw = r2.zw * cb0[4].yy + cb0[4].xx;
+  r1.w = r2.z * r2.w;
+  r2.x = r2.x * r2.x;
+  r2.y = -8.65616989 * r2.y;
+  r2.y = exp2(r2.y);
+  r2.y = saturate(cb0[4].z * r2.y + cb0[3].w);
+  r2.x = r2.x * cb0[0].w + 1;
+  r2.x = r2.x * r2.x;
+  r2.x = 4 * r2.x;
+  r1.w = r2.x * r1.w;
+  r1.w = cb0[1].w / r1.w;
+  r1.w = r2.y * r1.w;
+  r1.w = ApplyCustomClampWaterSpecular(r1.w * r5.w);  // remove clamp on specular intensity
+  r1.w = r1.w * r0.x;
+  r0.x = r0.x + r0.y;
+  r0.x = min(1, r0.x);
+  r0.y = r1.w * r0.z;
+  r2.xyz = r0.yyy * cb0[8].xyz + r3.xyz;
+  r3.xyz = saturate(r2.xyz * cb0[23].xyz + r1.xyz);
+  r0.y = cb0[26].w * r0.w + cb0[27].x;
+  r0.z = r0.w * r0.w;
+  r0.z = r0.z * 0.238732412 + 0.238732412;
+  r0.y = sqrt(r0.y);
+  r0.w = r0.y * r0.y;
+  r0.y = r0.w * r0.y;
+  r4.xyz = cb0[26].xyz / r0.yyy;
+  r0.yzw = cb0[25].xyz * r0.zzz + r4.xyz;
+  r0.yzw = -r0.yzw * r1.xyz + r0.yzw;
+  r0.yzw = r2.xyz * r3.xyz + r0.yzw;
+  r0.yzw = r0.yzw + -r2.xyz;
+  o0.xyz = r0.xxx * r0.yzw + r2.xyz;
+  return;
+}

--- a/src/games/dyinglight/lighting/water_other_0xC24E43EF.ps_5_0.hlsl
+++ b/src/games/dyinglight/lighting/water_other_0xC24E43EF.ps_5_0.hlsl
@@ -1,0 +1,253 @@
+#include "./lighting.hlsli"
+
+// ---- Created with 3Dmigoto v1.4.1 on Wed Jul  2 02:45:45 2025
+Texture2D<float4> t10 : register(t10);
+
+Texture2D<float4> t9 : register(t9);
+
+Texture2D<float4> t8 : register(t8);
+
+Texture2D<float4> t7 : register(t7);
+
+Texture2D<float4> t6 : register(t6);
+
+Texture2D<float4> t5 : register(t5);
+
+Texture2D<float4> t4 : register(t4);
+
+Texture2D<float4> t3 : register(t3);
+
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s12_s : register(s12);
+
+SamplerState s11_s : register(s11);
+
+SamplerState s10_s : register(s10);
+
+SamplerState s9_s : register(s9);
+
+SamplerState s8_s : register(s8);
+
+SamplerState s7_s : register(s7);
+
+SamplerState s5_s : register(s5);
+
+SamplerState s4_s : register(s4);
+
+SamplerState s3_s : register(s3);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb2 : register(b2) {
+  float4 cb2[13];
+}
+
+cbuffer cb0 : register(b0) {
+  float4 cb0[28];
+}
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(
+    float4 v0: SV_POSITION0,
+    float4 v1: TEXCOORD0,
+    float4 v2: TEXCOORD1,
+    float4 v3: TEXCOORD2,
+    float4 v4: TEXCOORD3,
+    float4 v5: TEXCOORD4,
+    float4 v6: TEXCOORD5,
+    float4 v7: TEXCOORD6,
+    float4 v8: TEXCOORD7,
+    float4 v9: TEXCOORD8,
+    float4 v10: TEXCOORD9,
+    float4 v11: TEXCOORD10,
+    out float4 o0: SV_TARGET0) {
+  float4 r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = t6.Sample(s7_s, v6.zw).yw;
+  r0.xy = r0.yx * float2(2, 2) + float2(-1, -1);
+  r1.x = dot(r0.xy, cb0[12].xy);
+  r1.z = dot(r0.yx, cb0[12].xz);
+  r0.xy = t7.Sample(s8_s, v5.xy).yw;
+  r0.xy = r0.yx * float2(2, 2) + float2(-1, -1);
+  r2.x = dot(r0.xy, cb0[13].xy);
+  r2.z = dot(r0.yx, cb0[13].xz);
+  r0.xy = r2.xz + r1.xz;
+  r0.zw = t8.Sample(s9_s, v5.zw).yw;
+  r0.zw = r0.wz * float2(2, 2) + float2(-1, -1);
+  r1.x = dot(r0.zw, cb0[14].xy);
+  r1.z = dot(r0.wz, cb0[14].xz);
+  r0.xy = r1.xz + r0.xy;
+  r0.zw = t9.Sample(s10_s, v6.xy).yw;
+  r0.zw = r0.wz * float2(2, 2) + float2(-1, -1);
+  r1.x = dot(r0.zw, cb0[15].xy);
+  r1.z = dot(r0.wz, cb0[15].xz);
+  r0.xy = r1.xz + r0.xy;
+  r0.zw = v0.xy * cb2[7].xy + cb2[7].zw;
+  r1.xy = t10.SampleLevel(s11_s, r0.zw, 0).xy;
+  r0.xy = r1.xy * float2(2, 2) + r0.xy;
+  r0.xy = float2(-1, -1) + r0.xy;
+  r1.x = t0.SampleLevel(s12_s, r0.zw, 0).x;
+  r1.xy = r1.xx * cb2[8].xy + cb2[8].zw;
+  r1.x = r1.x / -r1.y;
+  r2.x = -abs(r1.x);
+  r1.yz = v0.xy * cb2[9].xy + cb2[9].zw;
+  r2.yz = r1.yz * abs(r1.xx);
+  r3.xyz = ddx_coarse(r2.zxy);
+  r4.xyz = ddy_coarse(r2.xyz);
+  r1.x = dot(r2.xyz, r2.xyz);
+  r1.x = sqrt(r1.x);
+  r2.xyz = r4.xyz * r3.xyz;
+  r2.xyz = r4.zxy * r3.yzx + -r2.xyz;
+  r1.w = dot(r2.xyz, r2.xyz);
+  r1.w = rsqrt(r1.w);
+  r2.xyz = r2.xyz * r1.www;
+  r3.y = dot(r2.xyz, cb2[11].xyz);
+  r3.x = dot(r2.xyz, cb2[10].xyz);
+  r3.z = dot(r2.xyz, cb2[12].xyz);
+  r1.w = dot(r3.xyz, r3.xyz);
+  r1.w = rsqrt(r1.w);
+  r2.xy = r3.xz * r1.ww;
+  r1.w = dot(v8.xy, cb0[10].xy);
+  r2.z = t4.Sample(s4_s, v7.zw).y;
+  r2.w = t4.Sample(s4_s, v7.xy).y;
+  r3.x = dot(v2.xyz, v2.xyz);
+  r3.y = sqrt(r3.x);
+  r1.x = -r3.y + r1.x;
+  r3.z = saturate(cb0[11].z * r1.x);
+  r1.x = saturate(cb0[5].w * r1.x);
+  r3.w = r3.z * cb0[11].y + cb0[11].x;
+  r2.w = r2.w * cb0[6].w + r3.w;
+  r2.z = r2.z * cb0[6].w + r2.w;
+  r1.w = -r1.w * cb0[8].w + r2.z;
+  r2.zw = t5.Sample(s5_s, r1.ww).yw;
+  r2.zw = r2.zw * float2(2, 2) + float2(-1, -1);
+  r1.w = 1 + -r3.z;
+  r1.w = r2.z * r1.w;
+  r2.zw = float2(1, 2) * r2.ww;
+  r1.w = cb0[9].w * r1.w;
+  r0.xy = r2.xy * r1.ww + r0.xy;
+  r2.xy = r2.xy * r1.ww;
+  r4.xz = r3.zz * r0.xy + -r2.xy;
+  r0.x = cb0[11].y * r3.z;
+  r0.xy = r0.xx * float2(2, 15) + r2.zw;
+  r0.xy = saturate(float2(-1, -2) + r0.xy);
+  r4.y = 1;
+  r1.w = dot(r4.xyz, r4.xyz);
+  r1.w = rsqrt(r1.w);
+  r2.xyz = r4.xyz * r1.www;
+  r4.x = dot(r2.xyz, cb2[0].xyz);
+  r4.y = dot(r2.xyz, cb2[1].xyz);
+  r5.x = cb2[0].y;
+  r5.y = cb2[1].y;
+  r3.zw = -r5.xy + r4.xy;
+  r1.w = cb0[5].z / r3.y;
+  r1.x = r1.w * r1.x;
+  r1.xw = r3.zw * r1.xx;
+  r1.xw = r1.xw * r0.xx + r0.zw;
+  r0.z = t2.SampleLevel(s1_s, r0.zw, 0).x;
+  r0.w = t0.SampleLevel(s12_s, r1.xw, 0).x;
+  r4.xyzw = t1.Sample(s0_s, r1.xw).xyzw;
+  r1.xw = r0.ww * cb2[8].xy + cb2[8].zw;
+  r0.w = r1.x / -r1.w;
+  r1.xy = r1.yz * abs(r0.ww);
+  r1.z = -abs(r0.w);
+  r0.w = dot(r1.xyz, r1.xyz);
+  r0.w = sqrt(r0.w);
+  r0.w = r0.w + -r3.y;
+  r1.xyz = cb0[24].xyz * r3.yyy;
+  r1.xyz = exp2(r1.xyz);
+  r0.w = max(0, r0.w);
+  r3.yzw = cb0[3].xyz * -r0.www;
+  r5.xyz = cb0[2].xyz * -r0.www;
+  r5.xyz = exp2(r5.xyz);
+  r3.yzw = exp2(r3.yzw);
+  r6.w = 1;
+  r0.w = rsqrt(r3.x);
+  r7.xy = r2.xz * r3.xx;
+  r7.xz = r7.xy * cb0[5].yy + v4.xz;
+  r6.xyz = v2.xyz * r0.www;
+  r8.xyz = -v2.xyz * r0.www + cb0[7].xyz;
+  r9.x = dot(cb0[16].xyzw, r6.xyzw);
+  r9.y = dot(cb0[17].xyzw, r6.xyzw);
+  r9.z = dot(cb0[18].xyzw, r6.xyzw);
+  r10.xyzw = r6.xyzz * r6.yzzx;
+  r11.x = dot(cb0[19].xyzw, r10.xyzw);
+  r11.y = dot(cb0[20].xyzw, r10.xyzw);
+  r11.z = dot(cb0[21].xyzw, r10.xyzw);
+  r9.xyz = r11.xyz + r9.xyz;
+  r0.w = r6.y * r6.y;
+  r0.w = r6.x * r6.x + -r0.w;
+  r9.xyz = cb0[22].xyz * r0.www + r9.xyz;
+  r9.xyz = cb0[1].xyz + r9.xyz;
+  r9.xyz = cb0[0].xyz * r9.xyz;
+  r3.xyz = -r9.xyz * r3.yzw + r9.xyz;
+  r3.xyz = r4.xyz * r5.xyz + r3.xyz;
+  o0.w = r4.w;
+  r7.y = v4.y;
+  r7.w = 1;
+  r4.x = dot(r7.xyzw, cb2[0].xyzw);
+  r4.y = dot(r7.xyzw, cb2[1].xyzw);
+  r0.w = dot(r7.xyzw, cb2[3].xyzw);
+  r4.xy = r4.xy / r0.ww;
+  r4.xy = r4.xy * float2(0.5, -0.5) + float2(0.5, 0.5);
+  r4.xyz = t3.SampleLevel(s3_s, r4.xy, 0).xyz;
+  r4.xyz = r4.xyz + -r3.xyz;
+  r5.z = dot(-r6.xyz, r2.xyz);
+  r0.w = saturate(dot(r6.xyz, cb0[6].xyz));
+  r1.w = saturate(r5.z);
+  r1.w = -8.65616989 * r1.w;
+  r1.w = exp2(r1.w);
+  r1.w = saturate(cb0[4].w * r1.w + cb0[3].w);
+  r1.w = r1.w * r0.x;
+  r3.xyz = r1.www * r4.xyz + r3.xyz;
+  r1.w = dot(r8.xyz, r8.xyz);
+  r1.w = rsqrt(r1.w);
+  r4.xyz = r8.xyz * r1.www;
+  r5.x = dot(r2.xyz, r4.xyz);
+  r5.y = dot(cb0[7].xyz, r4.xyz);
+  r5.w = dot(cb0[7].xyz, r2.xyz);
+  r2.xyzw = max(float4(0.00999999978, 0.00999999978, 0.00999999978, 0.00999999978), r5.xyzw);
+  r2.zw = r2.zw * cb0[4].yy + cb0[4].xx;
+  r1.w = r2.z * r2.w;
+  r2.x = r2.x * r2.x;
+  r2.y = -8.65616989 * r2.y;
+  r2.y = exp2(r2.y);
+  r2.y = saturate(cb0[4].z * r2.y + cb0[3].w);
+  r2.x = r2.x * cb0[0].w + 1;
+  r2.x = r2.x * r2.x;
+  r2.x = 4 * r2.x;
+  r1.w = r2.x * r1.w;
+  r1.w = cb0[1].w / r1.w;
+  r1.w = r2.y * r1.w;
+  r1.w = ApplyCustomClampWaterSpecular(r1.w * r5.w);  // remove clamp on specular intensity
+  r1.w = r1.w * r0.x;
+  r0.x = r0.x + r0.y;
+  r0.x = min(1, r0.x);
+  r0.y = r1.w * r0.z;
+  r2.xyz = r0.yyy * cb0[8].xyz + r3.xyz;
+  r3.xyz = saturate(r2.xyz * cb0[23].xyz + r1.xyz);
+  r0.y = cb0[26].w * r0.w + cb0[27].x;
+  r0.z = r0.w * r0.w;
+  r0.z = r0.z * 0.238732412 + 0.238732412;
+  r0.y = sqrt(r0.y);
+  r0.w = r0.y * r0.y;
+  r0.y = r0.w * r0.y;
+  r4.xyz = cb0[26].xyz / r0.yyy;
+  r0.yzw = cb0[25].xyz * r0.zzz + r4.xyz;
+  r0.yzw = -r0.yzw * r1.xyz + r0.yzw;
+  r0.yzw = r2.xyz * r3.xyz + r0.yzw;
+  r0.yzw = r0.yzw + -r2.xyz;
+  o0.xyz = r0.xxx * r0.yzw + r2.xyz;
+  return;
+}

--- a/src/games/dyinglight/shared.h
+++ b/src/games/dyinglight/shared.h
@@ -21,6 +21,15 @@
 // #define CUSTOM_LENS_FLARE                    0.f
 // #define CUSTOM_GRAIN_STRENGTH                1.f
 
+#define ORIGINAL_THRESHOLD    0.999985337
+#define SUN_SIZE              5.5
+#define SUN_THRESHOLD         (cos(acos(ORIGINAL_THRESHOLD) * SUN_SIZE))
+#define SUN_SHIFT_X           -0.01
+#define SUNSTAR_UV_OFFSET_X   -0.00385f
+#define SUNSTAR_BOOST         15.f
+#define SUNSTAR_BRIGHT_RADIUS .0275
+#define SUNSTAR_SHARPNESS     1.75
+
 // Must be 32bit aligned
 // Should be 4x32
 struct ShaderInjectData {
@@ -42,7 +51,11 @@ struct ShaderInjectData {
   float color_grade_gamut_expansion;
   float custom_bloom;
   float custom_lens_flare;
+  float custom_lens_flare_2;
   float custom_grain_strength;
+
+  float unclamp_lighting;
+  float improved_sun;
 };
 
 #ifndef __cplusplus
@@ -68,7 +81,10 @@ cbuffer cb13 : register(b13) {
 #define RENODX_COLOR_GRADE_GAMUT_EXPANSION   shader_injection.color_grade_gamut_expansion
 #define CUSTOM_BLOOM                         shader_injection.custom_bloom
 #define CUSTOM_LENS_FLARE                    shader_injection.custom_lens_flare
+#define CUSTOM_LENS_FLARE_2                  shader_injection.custom_lens_flare_2
 #define CUSTOM_GRAIN_STRENGTH                shader_injection.custom_grain_strength
+#define CUSTOM_UNCLAMP_LIGHTING              shader_injection.unclamp_lighting
+#define CUSTOM_IMPROVED_SUN                  shader_injection.improved_sun
 
 #include "../../shaders/renodx.hlsl"
 

--- a/src/games/dyinglight/shared.h
+++ b/src/games/dyinglight/shared.h
@@ -1,34 +1,12 @@
 #ifndef SRC_DYING_LIGHT_SHARED_H_
 #define SRC_DYING_LIGHT_SHARED_H_
 
-// #define RENODX_TONE_MAP_TYPE                 2.f
-// #define RENODX_PEAK_WHITE_NITS               400.f
-// #define RENODX_DIFFUSE_WHITE_NITS            100.f
-// #define RENODX_GRAPHICS_WHITE_NITS           100.f
-// #define RENODX_GAMMA_CORRECTION              1.f
-// #define RENODX_TONE_MAP_HUE_CORRECTION       1.f
-// #define RENODX_TONE_MAP_EXPOSURE             1.f
-// #define RENODX_TONE_MAP_HIGHLIGHTS           1.f
-// #define RENODX_TONE_MAP_SHADOWS              1.f
-// #define RENODX_TONE_MAP_CONTRAST             1.f
-// #define RENODX_TONE_MAP_SATURATION           1.f
-// #define RENODX_TONE_MAP_HIGHLIGHT_SATURATION 1.1f
-// #define RENODX_TONE_MAP_BLOWOUT              0.f
-// #define RENODX_TONE_MAP_FLARE                0.f
-// #define RENODX_COLOR_GRADE_STRENGTH          1.f
-// #define RENODX_COLOR_GRADE_GAMUT_EXPANSION   0.f
-// #define CUSTOM_BLOOM                         0.f
-// #define CUSTOM_LENS_FLARE                    0.f
-// #define CUSTOM_GRAIN_STRENGTH                1.f
-
-#define ORIGINAL_THRESHOLD    0.999985337
-#define SUN_SIZE              5.5
-#define SUN_THRESHOLD         (cos(acos(ORIGINAL_THRESHOLD) * SUN_SIZE))
-#define SUN_SHIFT_X           -0.01
-#define SUNSTAR_UV_OFFSET_X   -0.00385f
-#define SUNSTAR_BOOST         15.f
-#define SUNSTAR_BRIGHT_RADIUS .0275
-#define SUNSTAR_SHARPNESS     1.75
+#define ORIGINAL_THRESHOLD   0.999985337
+#define SUN_SIZE             5.5
+#define SUN_THRESHOLD        (cos(acos(ORIGINAL_THRESHOLD) * SUN_SIZE))
+#define SUN_SHIFT_X          0.0185
+#define SUN_SHIFT_Y          -0.0125
+#define SUN_BRIGHTNESS_BOOST 3.0  // 3x brighter sun
 
 // Must be 32bit aligned
 // Should be 4x32

--- a/src/games/dyinglight/sky/godrays_0xA6EC1DEC.ps_5_0.hlsl
+++ b/src/games/dyinglight/sky/godrays_0xA6EC1DEC.ps_5_0.hlsl
@@ -28,10 +28,10 @@ void main(
   uint4 bitmask, uiDest;
   float4 fDest;
 
-  r0.xyz = t2.SampleLevel(s2_s, v1.xy, 0).xyz;
+  r0.xyz = t2.SampleLevel(s2_s, v1.xy, 0).xyz;  // lens flare
   r0.xyz = cb0[0].yyy * r0.xyz;
   r0.w = t1.SampleLevel(s1_s, float2(0, 0), 0).x;
-  r1.xyzw = t0.SampleLevel(s0_s, v1.xy, 0).xyzw;
+  r1.xyzw = t0.SampleLevel(s0_s, v1.xy, 0).xyzw;  // main game render
   r1.xyz = r1.xyz * r0.www;
   o0.w = r1.w;
   r0.w = dot(float3(0.212500006, 0.715399981, 0.0720999986), r1.xyz);

--- a/src/games/dyinglight/sky/godrays_0xA6EC1DEC.ps_5_0.hlsl
+++ b/src/games/dyinglight/sky/godrays_0xA6EC1DEC.ps_5_0.hlsl
@@ -1,4 +1,4 @@
-#include "./shared.h"
+#include "../shared.h"
 
 // ---- Created with 3Dmigoto v1.3.16 on Sat May 25 22:39:30 2024
 Texture2D<float4> t2 : register(t2);
@@ -38,5 +38,8 @@ void main(
   r2.xy = r0.ww * cb0[0].xz + cb0[0].zz;
   r0.w = r2.x / r2.y;
   o0.xyz = r1.xyz * r0.www + r0.xyz;  //  o0.xyz = saturate(r1.xyz * r0.www + r0.xyz);
+  if (RENODX_TONE_MAP_TYPE == 0.f) {
+    o0.rgb = saturate(o0.rgb);
+  }
   return;
 }

--- a/src/games/dyinglight/sky/sky_0x975AA892.ps_5_0.hlsl
+++ b/src/games/dyinglight/sky/sky_0x975AA892.ps_5_0.hlsl
@@ -1,0 +1,81 @@
+#include "../shared.h"
+// ---- Created with 3Dmigoto v1.4.1 on Wed Jul  2 02:45:18 2025
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0) {
+  float4 cb0[7];
+}
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(
+    float4 v0: SV_POSITION0,
+    float4 v1: TEXCOORD0,
+    float2 v2: TEXCOORD1,
+    out float4 o0: SV_TARGET0,
+    out float4 o1: SV_TARGET1) {
+  float4 r0, r1, r2, r3;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.x = dot(v1.xyz, v1.xyz);
+  r0.x = rsqrt(r0.x);
+  r0.xyz = v1.xyz * r0.xxx;
+
+  float3 offset;
+  if (CUSTOM_IMPROVED_SUN == 0.f) {
+    offset = float3(0.0, 0.0, 0.0);
+  } else {
+    offset = float3(0.0, 0.0, SUN_SHIFT_X);
+  }
+
+  float3 sun_dir = normalize(cb0[0].xyz + offset);
+
+  r0.x = dot(r0.xyz, sun_dir);
+
+  // r0.x = dot(r0.xyz, cb0[0].xyz);
+  r0.z = saturate(r0.x);
+
+  float threshold;
+  if (CUSTOM_IMPROVED_SUN == 0.f) {
+    threshold = ORIGINAL_THRESHOLD;
+  } else {
+    threshold = SUN_THRESHOLD;
+  }
+  r0.x = cmp(threshold < r0.x);  // SUN_THRESHOLD originally 0.999985337
+  r0.x = r0.x ? cb0[0].w : 0;
+  r0.w = cb0[5].w * r0.z + cb0[6].x;
+  r0.z = r0.z * r0.z;
+  r0.z = r0.z * 0.238732412 + 0.238732412;
+  r0.w = sqrt(r0.w);
+  r1.x = r0.w * r0.w;
+  r0.w = r1.x * r0.w;
+  r1.xyz = cb0[5].xyz / r0.www;
+  r1.xyz = cb0[4].xyz * r0.zzz + r1.xyz;
+  r0.z = 12742000 * r0.y;
+  r0.zw = r0.zz * r0.zz + float2(2.34537435e+11, 1.17247558e+11);
+  r0.zw = sqrt(r0.zw);
+  r0.yz = -r0.yy * float2(12742000, 12742000) + r0.zw;
+  r0.y = 0.5 * r0.y;
+  r0.z = r0.z * 0.5 + -r0.y;
+  r2.xyzw = t0.Sample(s0_s, v2.xy).xyzw;
+  r3.xyzw = cb0[1].xyzw * r2.xyzw;
+  r2.xyzw = -r2.wwww * cb0[1].wwww + float4(1, 1, 1, 1);
+  r0.y = r3.w * r0.z + r0.y;
+  r3.xyz = r3.xyz * r3.www;
+  r0.yzw = cb0[3].xyz * r0.yyy;
+  r0.yzw = exp2(r0.yzw);
+  r1.xyz = -r1.xyz * r0.yzw + r1.xyz;
+  r0.yzw = saturate(r3.xyz * cb0[2].xyz + r0.yzw);
+  r0.yzw = r3.xyz * r0.yzw + r1.xyz;
+  r1.x = r2.w * r2.w;
+  o1.xyzw = r2.xyzw;
+  r0.x = r1.x * r0.x;
+  r0.xyz = r0.yzw * r0.xxx + r0.yzw;
+  o0.xyz = cb0[2].www * r0.xyz;
+  o0.w = 0;
+  return;
+}

--- a/src/games/dyinglight/sky/sky_0x975AA892.ps_5_0.hlsl
+++ b/src/games/dyinglight/sky/sky_0x975AA892.ps_5_0.hlsl
@@ -29,7 +29,7 @@ void main(
   if (CUSTOM_IMPROVED_SUN == 0.f) {
     offset = float3(0.0, 0.0, 0.0);
   } else {
-    offset = float3(0.0, 0.0, SUN_SHIFT_X);
+    offset = float3(0.0, SUN_SHIFT_Y, SUN_SHIFT_X);
   }
 
   float3 sun_dir = normalize(cb0[0].xyz + offset);
@@ -40,13 +40,16 @@ void main(
   r0.z = saturate(r0.x);
 
   float threshold;
+  float sun_brightness;
   if (CUSTOM_IMPROVED_SUN == 0.f) {
     threshold = ORIGINAL_THRESHOLD;
+    sun_brightness = 1.f;
   } else {
     threshold = SUN_THRESHOLD;
+    sun_brightness = SUN_BRIGHTNESS_BOOST;
   }
   r0.x = cmp(threshold < r0.x);  // SUN_THRESHOLD originally 0.999985337
-  r0.x = r0.x ? cb0[0].w : 0;
+  r0.x = r0.x ? cb0[0].w * sun_brightness: 0;
   r0.w = cb0[5].w * r0.z + cb0[6].x;
   r0.z = r0.z * r0.z;
   r0.z = r0.z * 0.238732412 + 0.238732412;
@@ -61,7 +64,7 @@ void main(
   r0.yz = -r0.yy * float2(12742000, 12742000) + r0.zw;
   r0.y = 0.5 * r0.y;
   r0.z = r0.z * 0.5 + -r0.y;
-  r2.xyzw = t0.Sample(s0_s, v2.xy).xyzw;
+  r2.xyzw = t0.Sample(s0_s, v2.xy).xyzw; // clouds
   r3.xyzw = cb0[1].xyzw * r2.xyzw;
   r2.xyzw = -r2.wwww * cb0[1].wwww + float4(1, 1, 1, 1);
   r0.y = r3.w * r0.z + r0.y;

--- a/src/games/dyinglight/sky/sunstar_0xBA89E3AC.ps_5_0.hlsl
+++ b/src/games/dyinglight/sky/sunstar_0xBA89E3AC.ps_5_0.hlsl
@@ -1,0 +1,40 @@
+// ---- Created with 3Dmigoto v1.4.1 on Wed Jul  2 02:45:41 2025
+Texture2D<float4> t2 : register(t2);
+
+Texture2D<float4> t1 : register(t1);
+
+Texture2D<float4> t0 : register(t0);
+
+SamplerState s2_s : register(s2);
+
+SamplerState s1_s : register(s1);
+
+SamplerState s0_s : register(s0);
+
+cbuffer cb0 : register(b0) {
+  float4 cb0[1];
+}
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(
+    float4 v0: SV_POSITION0,
+    float4 v1: TEXCOORD0,
+    float4 v2: TEXCOORD1,
+    out float4 o0: SV_TARGET0) {
+  float4 r0, r1;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xyz = t0.Sample(s0_s, v2.zw).xyz;
+  r0.xyz = v1.xyz * r0.xyz;
+
+  r0.w = t1.SampleLevel(s1_s, v2.xy, 0).x;
+  r0.xyz = r0.xyz * r0.www;
+  r1.xy = t2.SampleLevel(s2_s, v2.xy, 0).zw;
+  r1.x = saturate(cb0[0].z * r1.x + r1.y);
+  r0.w = v1.w;
+  o0.xyzw = -r0.xyzw * r1.xxxx + r0.xyzw;
+  return;
+}

--- a/src/shaders/math.hlsl
+++ b/src/shaders/math.hlsl
@@ -99,6 +99,13 @@ float3 DivideSafe(float3 dividend, float3 divisor, float3 fallback) {
                 DivideSafe(dividend.z, divisor.z, fallback.z));
 }
 
+float4 DivideSafe(float4 dividend, float4 divisor, float4 fallback) {
+  return float4(DivideSafe(dividend.x, divisor.x, fallback.x),
+                DivideSafe(dividend.y, divisor.y, fallback.y),
+                DivideSafe(dividend.z, divisor.z, fallback.z),
+                DivideSafe(dividend.w, divisor.w, fallback.w));
+}
+
 float Max(float x, float y, float z) {
   return max(x, max(y, z));
 }


### PR DESCRIPTION
Dying Light:
- unclamp specular lighting
- unclamp fire brightness
- add luminance gamma correction
- adjust shadow and highlight slider behavior
- add new recommended settings
- brighten and increase sun size
Math:
- add float4 `DivideSafe()`