### PR TITLE
Tone Mapping improvements for Baldur's Gate 3

### DIFF
--- a/src/games/baldursgate3/shared.h
+++ b/src/games/baldursgate3/shared.h
@@ -13,7 +13,8 @@
 // #define RENODX_TONE_MAP_BLOWOUT     0.f
 // #define RENODX_COLOR_GRADE_STRENGTH 1.f
 
-#define RENODX_TONE_MAP_TYPE 1u
+#define RENODX_TONE_MAP_TYPE            1u
+#define GAMMA_CORRECTION_HUE_PRESERVING 1u
 
 // Must be 32bit aligned
 // Should be 4x32

--- a/src/games/baldursgate3/tonemap_lutbuilder_alternate_0x1B418D49.cs_5_0.hlsl
+++ b/src/games/baldursgate3/tonemap_lutbuilder_alternate_0x1B418D49.cs_5_0.hlsl
@@ -41,7 +41,7 @@ void main(uint3 vThreadID: SV_DispatchThreadID)  // unknown dcl_: dcl_thread_gro
 
   float3 untonemapped_bt709 = renodx::color::bt709::from::AP1(untonemapped_ap1);
   r0.rgb = ApplyUserToneMap(untonemapped_bt709, 0.18);
-  r0.rgb = renodx::color::correct::GammaSafe(r0.rgb);
+  r0.rgb = ApplyGammaCorrection(r0.rgb);
   r0.rgb = renodx::color::bt2020::from::BT709(r0.rgb);
 
   r0.rgb = renodx::color::pq::EncodeSafe(r0.rgb, 100.f);

--- a/src/games/baldursgate3/tonemap_lutbuilder_main_0x48E37C1E.cs_5_0.hlsl
+++ b/src/games/baldursgate3/tonemap_lutbuilder_main_0x48E37C1E.cs_5_0.hlsl
@@ -1826,7 +1826,7 @@ void main(uint3 vThreadID: SV_DispatchThreadID) {
 
     float3 untonemapped_bt709 = renodx::color::bt709::from::AP1(untonemapped_ap1);
     r0.rgb = ApplyUserToneMap(untonemapped_bt709, 0.18);
-    r0.rgb = renodx::color::correct::GammaSafe(r0.rgb);
+    r0.rgb = ApplyGammaCorrection(r0.rgb);
     r0.rgb = renodx::color::bt2020::from::BT709(r0.rgb);
 
     r1.rgb = renodx::color::pq::EncodeSafe(r0.rgb, 100.f);


### PR DESCRIPTION
- blend between RenoDRT for midtones and shadows and ACES for highlights
- use luminance gamma correction