### PR TITLE
resources.cpp aspect_ratio_tolerance

### DIFF
--- a/src/utils/resource.hpp
+++ b/src/utils/resource.hpp
@@ -96,6 +96,7 @@ struct ResourceUpgradeInfo {
   static const int16_t BACK_BUFFER = -1;
   static const int16_t ANY = -2;
   float aspect_ratio = ANY;
+  float aspect_ratio_tolerance = 0.0001f;
 
   uint32_t usage_set = 0;
   uint32_t usage_unset = 0;
@@ -165,9 +166,8 @@ struct ResourceUpgradeInfo {
         } else {
           target_ratio = this->aspect_ratio;
         }
-        static const float TOLERANCE = 0.0001f;
         const float diff = std::abs(view_ratio - target_ratio);
-        if (diff > TOLERANCE) return false;
+        if (diff > this->aspect_ratio_tolerance) return false;
       }
     }
     return true;


### PR DESCRIPTION
### Texture Upgrade: Exposing aspect_ratio check's TOLERANCE value as a ResourceUpgradeInfo struct field.

- I need it for Project Diva Mega Mix that requires the texture upgrade to do an aspect_ratio check, but the texture sometimes isn't exactly 16:9 (i.e. main color texture is 1920x1088 but can also be 2560x1440 if game resolution is switched).
- Having the tolerance value exposed means I won't have to hot swap or do other more complicated methods.