### PR TITLE
Silksong - Adapt shader code from Gaussian blur with linear sampling source

### DIFF
--- a/src/games/hollowknight-silksong/render/light_blur_0x4E2F49B3.ps_4_0.hlsl
+++ b/src/games/hollowknight-silksong/render/light_blur_0x4E2F49B3.ps_4_0.hlsl
@@ -12,29 +12,21 @@ cbuffer cb0 : register(b0) {
 // 3Dmigoto declarations
 #define cmp -
 
+static float offsets[3] = { 0.0, 1.3846153846, 3.2307692308 };
+static float weights[3] = { 0.2270270270, 0.3162162162, 0.0702702703 };
+
 void main(
     float4 v0: SV_POSITION0,
     float2 v1: TEXCOORD0,
     out float4 o0: SV_Target0) {
-  float4 r0, r1, r2;
-  uint4 bitmask, uiDest;
-  float4 fDest;
+  float texScale = cb0[2].y;
 
-  r0.xz = v1.xx;
-  r1.xyzw = cb0[2].yyyy * float4(1.38461494, 3.23076892, -0.615384996, -2.76923108) + v1.yyyy;
-  r0.yw = r1.xz;
-  r2.xyzw = t0.Sample(s0_s, r0.xy).xyzw;
-  r0.xyzw = t0.Sample(s0_s, r0.zw).xyzw;
-  r0.xyz = r2.xyz + r0.xyz;
-  r0.xyz = float3(0.316260993, 0.316260993, 0.316260993) * r0.xyz;
-  r2.xyzw = t0.Sample(s0_s, v1.xy).xyzw;
-  r0.xyz = r2.xyz * float3(0.227026999, 0.227026999, 0.227026999) + r0.xyz;
-  r1.xz = v1.xx;
-  r2.xyzw = t0.Sample(s0_s, r1.xy).xyzw;
-  r1.xyzw = t0.Sample(s0_s, r1.zw).xyzw;
-  r1.xyz = r2.xyz + r1.xyz;
-  o0.xyz = r1.xyz * float3(0.0702700019, 0.0702700019, 0.0702700019) + r0.xyz;
-  o0.w = 1;
+  o0 = t0.Sample(s0_s, v1) * weights[0];
+
+  for (int i = 1; i < 3; i++) {
+    o0 += t0.Sample(s0_s, v1 + float2(0.0, offsets[i]) * texScale) * weights[i];
+    o0 += t0.Sample(s0_s, v1 - float2(0.0, offsets[i]) * texScale) * weights[i];
+  }
 
   [branch]
   if (RENODX_TONE_MAP_TYPE == 0.f) {
@@ -42,5 +34,4 @@ void main(
   } else {
     o0 = max(0, o0);
   }
-  return;
 }

--- a/src/games/hollowknight-silksong/render/light_blur_0xC7659A76.ps_4_0.hlsl
+++ b/src/games/hollowknight-silksong/render/light_blur_0xC7659A76.ps_4_0.hlsl
@@ -11,29 +11,21 @@ cbuffer cb0 : register(b0) {
 // 3Dmigoto declarations
 #define cmp -
 
+static float offsets[3] = { 0.0, 1.3846153846, 3.2307692308 };
+static float weights[3] = { 0.2270270270, 0.3162162162, 0.0702702703 };
+
 void main(
     float4 v0: SV_POSITION0,
     float2 v1: TEXCOORD0,
     out float4 o0: SV_Target0) {
-  float4 r0, r1, r2;
-  uint4 bitmask, uiDest;
-  float4 fDest;
+  float texScale = cb0[2].x;
 
-  r0.xyzw = cb0[2].xxxx * float4(3.23076892, 1.38461494, -2.76923108, -0.615384996) + v1.xxxx;
-  r1.xz = r0.yw;
-  r1.yw = v1.yy;
-  r2.xyzw = t0.Sample(s0_s, r1.xy).xyzw;
-  r1.xyzw = t0.Sample(s0_s, r1.zw).xyzw;
-  r1.xyz = r2.xyz + r1.xyz;
-  r1.xyz = float3(0.316260993, 0.316260993, 0.316260993) * r1.xyz;
-  r2.xyzw = t0.Sample(s0_s, v1.xy).xyzw;
-  r1.xyz = r2.xyz * float3(0.227026999, 0.227026999, 0.227026999) + r1.xyz;
-  r0.yw = v1.yy;
-  r2.xyzw = t0.Sample(s0_s, r0.xy).xyzw;
-  r0.xyzw = t0.Sample(s0_s, r0.zw).xyzw;
-  r0.xyz = r2.xyz + r0.xyz;
-  o0.xyz = r0.xyz * float3(0.0702700019, 0.0702700019, 0.0702700019) + r1.xyz;
-  o0.w = 1;
+  o0 = t0.Sample(s0_s, v1) * weights[0];
+
+  for (int i = 1; i < 3; i++) {
+    o0 += t0.Sample(s0_s, v1 + float2(offsets[i], 0.0) * texScale) * weights[i];
+    o0 += t0.Sample(s0_s, v1 - float2(offsets[i], 0.0) * texScale) * weights[i];
+  }
 
   [branch]
   if (RENODX_TONE_MAP_TYPE == 0.f) {
@@ -41,5 +33,4 @@ void main(
   } else {
     o0 = max(0, o0);
   }
-  return;
 }


### PR DESCRIPTION
Adapt shader code from Gaussian blur with linear sampling source, mentioned here:
https://www.rastergrid.com/blog/2010/09/efficient-gaussian-blur-with-linear-sampling/

Fixes issue where the shader slightly offsets the background, when using mods to increase the number of passes

Comparison:
https://imgsli.com/NDIzNzQ0