### PR TITLE
HITMAN WoA: New Tone Mapping, SDR EOTF Emulation, Gamut Compression, and More

### DIFF
--- a/src/games/hitmanwoa/shared.h
+++ b/src/games/hitmanwoa/shared.h
@@ -9,7 +9,7 @@
 #define RENODX_DIFFUSE_WHITE_NITS              100.f
 #define RENODX_GRAPHICS_WHITE_NITS             100.f
 #define RENODX_TONE_MAP_HUE_SHIFT              0.f
-#define RENODX_GAMMA_CORRECTION                3.f
+#define RENODX_GAMMA_CORRECTION                2.f
 #define RENODX_PER_CHANNEL_BLOWOUT_RESTORATION 0.35f
 #define RENODX_TONE_MAP_EXPOSURE               1.f
 #define RENODX_TONE_MAP_HIGHLIGHTS             1.16f
@@ -28,7 +28,6 @@
 #define CUSTOM_SHARPENING                      2.f
 #define CUSTOM_DITHERING                       0.f
 
-#define LUT_SCALING_MAX   ((RENODX_GAMMA_CORRECTION == 0.f) ? 1.f : 0.71f)
 #define BLOOM_SCALING_MAX 0.33f
 
 // Must be 32bit aligned


### PR DESCRIPTION
- use new grading
- boost highlights
- lower blowout restoration
- use hermite spline maxcll
- use reinhardsmoothclamp for lut
- disable dithering
- adjust lut scaling
- add gamut compress
- use gamma correction with hue correction (type 2)