### PR TITLE
Full RenoDX mod for Clive Barker's Jericho

### DIFF
--- a/src/games/clivebarkersjericho/Bloom_Threshold_0xDADCF8C0.ps_3_0.hlsl
+++ b/src/games/clivebarkersjericho/Bloom_Threshold_0xDADCF8C0.ps_3_0.hlsl
@@ -1,0 +1,47 @@
+#include "./shared.h"
+
+// HDR Bright-pass
+float g_fMiddleGray            : register(c0);
+float g_BRIGHT_PASS_THRESHOLD  : register(c1);
+float g_BRIGHT_PASS_OFFSET     : register(c2);
+
+sampler2D s0 : register(s0); // input HDR texture
+sampler2D s1 : register(s1); // exposure / luminance texture
+
+float4 main(float2 texcoord : TEXCOORD) : COLOR
+{
+    float4 o;
+    float4 r0;
+    float4 r1;
+
+    // sample luminance/exposure at fixed UV 0.5 (center)
+    r0 = tex2D(s1, float2(0.5, 0.5));
+
+    // compute scaling factor
+    r0.w = r0.x + 0.001;          // avoid division by zero
+    r0.w = 1.0 / r0.w;
+    r0.w *= g_fMiddleGray;        // scale by middle gray
+
+    // sample HDR color
+    r1 = tex2D(s0, texcoord);
+
+    // apply threshold and scaling
+    r1.xyz = r1.xyz * r0.w - g_BRIGHT_PASS_THRESHOLD * lerp(1.f, 4.f, Custom_BrightPass_Thresholding);
+
+    // clamp negative values
+    r0 = max(r1, float4(0.0, 0.0, 0.0, 0.0));
+
+    // add offset
+    r1.xyz = r0.xyz + g_BRIGHT_PASS_OFFSET * lerp(1.f, 4.f, Custom_BrightPass_Thresholding);
+
+    // reciprocal per channel
+    r1.x = 1.0 / r1.x;
+    r1.y = 1.0 / r1.y;
+    r1.z = 1.0 / r1.z;
+
+    // final color = scaled color
+    o.xyz = r0.xyz * r1.xyz;
+    o.w   = r0.w; // preserve alpha (if any)
+
+    return o;
+}

--- a/src/games/clivebarkersjericho/Damage_0x1BEF7A1F.ps_3_0.hlsl
+++ b/src/games/clivebarkersjericho/Damage_0x1BEF7A1F.ps_3_0.hlsl
@@ -1,0 +1,90 @@
+#include "./shared.h"
+
+// Damage red vingetting overlay and color tint
+sampler2D ActualFrameSampler : register(s0);
+float g_Value : register(c0); // scaling factor for hit effect
+float g_FX    : register(c1); // X offset
+float g_FY    : register(c2); // Y offset
+
+// ASM constants
+static const float4 OFFSET = float4(0.5, -1.5, 2.0, 1.0);        // C3
+static const float4 LUMA   = float4(0.299, 0.587, 0.114, 0.33); // C4
+static const float4 SCALE  = float4(0.6, 0.2, 4.0, 0.0);        // C5
+static const float4 TINT   = float4(0.8, 0.1, 0.0, 0.0);        // C6
+
+float4 main(float2 uv : TEXCOORD0) : COLOR0
+{
+    // intermediate registers
+    float4 r0 = 0;
+    float4 r1 = 0;
+    float4 r2 = 0;
+
+    // --- UV offsets, absolute differences, and axis maxima
+    r1.w = uv.x - g_FX;                       // r1.w = v0.x - g_FX
+    r0 = float4(uv.x, uv.x, uv.y, uv.y) + float4(OFFSET.x, OFFSET.y, OFFSET.x, OFFSET.y);
+    r1.w += OFFSET.z;                          // add 2
+    r0 = abs(r0) * OFFSET.x;                   // multiply by 0.5
+    r1.w = abs(r1.w) * OFFSET.x;
+    r1.x = max(r0.x, r0.y);                    // x-axis max
+    r1.y = max(r0.z, r0.w);                    // y-axis max
+
+    // --- conditional selection
+    r0.z = (-g_FX >= 0.0) ? r1.x : r1.w;
+
+    // --- Y-axis processing
+    r0.w = uv.y - g_FY;
+    r0.y = r0.z * r0.z;
+    r0.w += OFFSET.z;                          // add 2
+    r0.y = r0.y * r0.y;
+    r0.w = abs(r0.w) * OFFSET.x;
+    r1.x = saturate(r0.z * r0.y);
+    r1.z = (-g_FY >= 0.0) ? r1.y : r0.w;
+
+    // --- sample frame and compute luminance
+    r0 = tex2D(ActualFrameSampler, uv);
+    r1.w = dot(r0.rgb, LUMA.xyz);             // luminance
+    r1.y = r1.z * r1.z;
+    r1.w = saturate(r1.w * LUMA.w);
+    r1.y = r1.y * r1.y;
+    r1.w = 1.0 - r1.w;
+    r1.y = saturate(r1.z * r1.y);
+    r1.z = r1.w * r1.w;
+
+    // --- combine max and scaling
+    r2.w = saturate(max(r1.x, r1.y));
+    r1.w *= r1.z;
+    r1.z = OFFSET.x;
+    r1.y = saturate(g_Value * r2.w + r1.z);
+
+    // --- mask scaling and radial adjustments
+    r1.x = r1.w * SCALE.x;
+    r1.w = SCALE.y;
+    r1.z = r2.w * g_Value;
+    float tmpX = r1.y * r1.x;
+    float tmpW = r1.y * r1.w;
+    r1.x = tmpX;
+    r1.w = tmpW;
+
+    r1.y = rsqrt(r1.z);                        // 1 / sqrt(r1.z)
+    r2.w = r2.w * SCALE.z;
+    r1.y = 1.0 / r1.y;                         // sqrt(r1.z)
+    r1.z = r1.z * -OFFSET.x + 1.0;
+
+    r1.x = saturate(r1.x * r1.y);
+    r1.w = saturate(r1.w * r1.y);
+
+    r1.x = r0.x * r1.z + r1.x;
+    r1.w = r0.w * r1.z + r1.w;
+    r1.y = r0.y * r1.z;
+    r1.z = r0.z * r1.z;
+
+    // --- final tint blend
+    r0.w = r2.w * r2.w;
+    r2.w = saturate(r0.w * r0.w);
+    r2.z = saturate(g_Value);
+    r0 = -r1 + float4(TINT.x, TINT.y, TINT.y, TINT.z);
+    r2.w *= r2.z;
+
+    float4 outCol = (r2.w * r0 + r1);
+    return outCol;
+}

--- a/src/games/clivebarkersjericho/Damage_0x5503F1C7.ps_3_0.hlsl
+++ b/src/games/clivebarkersjericho/Damage_0x5503F1C7.ps_3_0.hlsl
@@ -1,0 +1,103 @@
+#include "./shared.h"
+
+// Damage Vignette, tint and Venas overlay
+sampler2D ActualFrameSampler : register(s0);
+sampler2D VenasSampler       : register(s1);
+
+float g_Value  : register(c0); // red vignette intensity
+float g_Closed : register(c1); // base mask control
+float g_Power  : register(c2); // mask exponent factor
+float g_Hit    : register(c3); // hit/additional mask modulation
+
+// Constants controlling radial falloff and tint
+static const float4 VIGNETTE_TWEAKS    = float4(0.0, 0.263157904, -50.0, 1.0); // small radial shaping tweaks
+static const float4 VIGNETTE_PARAMS    = float4(-0.5, 3.8, 4.0, 0.2);           // uv offset and base scaling
+static const float4 TINT_FACTORS       = float4(0.6, 0.3, 0.4, 0.1);             // tint multipliers
+
+float4 main(float2 uv : TEXCOORD0) : COLOR0
+{
+    // -----------------------
+    // Working registers / samples
+    // -----------------------
+    float4 venasSample       = 0.0;  // Venas texture sample + modulation
+    float4 frameSample       = 0.0;  // Actual frame color sample
+    float4 radialWork        = 0.0;  // UV offsets, squared values, and intermediate mask values
+    float4 auxValues         = 0.0;  // auxiliary temporaries
+
+    // -----------------------
+    // Base mask computation
+    // -----------------------
+    float baseMask = g_Closed * (-VIGNETTE_PARAMS.y) + VIGNETTE_PARAMS.z;
+    baseMask = g_Power * (-VIGNETTE_PARAMS.w) + baseMask;
+
+    radialWork.z = max(baseMask, VIGNETTE_TWEAKS.x); // keep original data-flow
+    auxValues.xy = VIGNETTE_TWEAKS.xy;
+
+    float maskMod = saturate(radialWork.z * auxValues.y - g_Hit);
+
+    // -----------------------
+    // Venas sample & UV radial offset
+    // -----------------------
+    venasSample = tex2D(VenasSampler, uv);
+    maskMod = -maskMod + venasSample.w; // modulate mask by Venas alpha
+
+    float2 uvOffset = uv + VIGNETTE_PARAMS.x;
+    uvOffset = abs(uvOffset);
+    uvOffset *= uvOffset;           // square each component
+    radialWork.xy = uvOffset;       // store squared offsets
+
+    // -----------------------
+    // Radial shaping (non-linear curve) & inverse sqrt
+    // -----------------------
+    float shapedMask = saturate(maskMod * VIGNETTE_TWEAKS.z);
+    shapedMask = shapedMask * (-shapedMask) + VIGNETTE_TWEAKS.w;
+
+    float invSqrtDist = rsqrt(radialWork.x + radialWork.y);
+    venasSample *= shapedMask;
+
+    radialWork.w = 1.0 / invSqrtDist;
+    float powMask = pow(radialWork.w, radialWork.z);
+
+    // -----------------------
+    // Auxiliary factors for final mask
+    // -----------------------
+    auxValues.w = g_Power * (-VIGNETTE_PARAMS.x) - VIGNETTE_PARAMS.x;
+    auxValues.z = radialWork.w * (-VIGNETTE_PARAMS.x) - VIGNETTE_PARAMS.x;
+
+    float maskScalar = powMask * auxValues.w;
+    radialWork.w = maskScalar; // preserve placement for logic consistency
+
+    // -----------------------
+    // Sample frame and compute tint delta
+    // -----------------------
+    frameSample = tex2D(ActualFrameSampler, uv);
+    float3 tintColor = frameSample.rgb * float3(TINT_FACTORS.x, TINT_FACTORS.y, TINT_FACTORS.y)
+                       + float3(TINT_FACTORS.z, TINT_FACTORS.w, TINT_FACTORS.w);  
+    float frameLum = dot(frameSample.rgb, float3(0.2126, 0.7152, 0.0722));
+    float tintLum = dot(tintColor, float3(0.2126, 0.7152, 0.0722));
+    float lumScale = (tintLum > 0) ? (frameLum / tintLum) : 1.0;
+    float3 tintDelta = tintColor - frameSample.rgb;
+    if (RENODX_TONE_MAP_TYPE > 0.f) {
+            tintDelta *= lumScale;
+            // Compute a scaling factor that **limits the change so bright channels don’t exceed original peak**
+            float3 safeDelta = tintDelta;
+            // Prevent tint from lowering any channel:
+            safeDelta = max(safeDelta, float3(0.0, 0.0, 0.0));
+            // Apply mask:
+            safeDelta *= saturate(radialWork.w * g_Value * 2.0 + VIGNETTE_TWEAKS.x);
+            frameSample.rgb += safeDelta;
+        } else {
+            frameSample.rgb += tintDelta;
+        }
+    // -----------------------
+    // Combine Venas contribution
+    // -----------------------
+    venasSample *= auxValues.z;
+    auxValues.w += g_Hit;
+
+    // -----------------------
+    // Final output
+    // -----------------------
+    float4 finalColor = venasSample * auxValues.w + float4(frameSample.rgb, 1.0);
+    return finalColor;
+}

--- a/src/games/clivebarkersjericho/DoF_Fog_0x88EF5970.ps_3_0.hlsl
+++ b/src/games/clivebarkersjericho/DoF_Fog_0x88EF5970.ps_3_0.hlsl
@@ -1,0 +1,88 @@
+#include "./shared.h"
+
+// DoF and Fog
+float DOFFogDesaturate : register(c15);
+float DOFFogDist : register(c10);
+float DOFFogFactorBlur : register(c14);
+float DOFFogFactorGray : register(c13);
+float DOFFogFactorScene : register(c12);
+float DOFFogRange : register(c11);
+float4 FogColor : register(c8);
+float FogDensity : register(c9);
+float FogDistance : register(c6);
+float FogRange : register(c7);
+float RenderMult : register(c16);
+float g_Value : register(c0);
+float g_ZDistFar : register(c1);
+float g_ZRangeFar : register(c2);
+float g_ZDistNear : register(c3);
+float g_ZRangeNear : register(c4);
+float g_ZNullDist : register(c5);
+
+sampler2D s0 : register(s0);
+sampler2D s1 : register(s1);
+sampler2D s2 : register(s2);
+
+float4 main(float2 v0 : TEXCOORD) : COLOR
+{
+    float4 r0 = tex2D(s2, v0);
+    float r2_z = (-r0.x >= 0) ? g_ZNullDist : r0.x;
+
+    float r0_x = 1.0 / g_ZRangeFar;
+    float r1_w = r2_z - g_ZDistFar;
+    float r0_y = max(r1_w, 0.0);
+
+    float r0_w = r2_z - g_ZDistNear;
+    float r0_z = 1.0 / g_ZRangeNear;
+    r0_w = (r0_w >= 0.0) ? 0.0 : -r0_w;
+
+    float r1_z = r0_x * r0_y;
+    float r1_w2 = r0_z * r0_w;
+
+    r0_x = min(r1_z, 1.0);
+    r0_z = min(r1_w2, 1.0);
+
+    r1_z = (-r0_y >= 0.0) ? r0_y : r0_x;
+    r1_w2 = (-r0_w >= 0.0) ? r0_w : r0_z;
+
+    r0_w = max(r1_z, r1_w2);
+
+    float r2_x = r0_w * g_Value;
+
+    float4 r0_tex = tex2D(s0, v0);
+    float4 r3_tex = tex2D(s1, v0);
+
+    r1_w = r2_z - FogDistance;
+    float r2_w = max(r1_w, 0.0);
+    float r2_y = 1.0 / FogRange;
+
+    float4 r1 = lerp(r0_tex, r3_tex, r2_x);
+    r2_w = saturate(r2_w * r2_y);
+
+    r0 = FogColor * RenderMult - r1;
+    r2_w *= FogDensity;
+    r1 = r2_w * r0 + r1;
+
+    float r2_luma = dot(r1.rgb, float3(0.2126, 0.7152, 0.0722));
+
+    float r4_w = r2_z - DOFFogDist;
+    float3 r0_rgb = lerp(r1.rgb, r2_luma.xxx, DOFFogDesaturate);
+
+    r2_w = max(r4_w, 0.0);
+    r0_z = 1.0 / DOFFogRange;
+    r4_w = saturate(r2_w * r0_z);
+
+    float r4_luma = dot(r3_tex.rgb, float3(0.2126, 0.7152, 0.0722));
+    float3 r2_rgb = r0_rgb * r4_w;
+    float3 r0b = (-r3_tex.rgb + r4_luma) * DOFFogDesaturate;
+    r2_rgb *= DOFFogFactorGray;
+
+    float r4_z = r4_w * (-DOFFogFactorScene) + 1.0;
+    float3 r0c = r4_w * r0b + r3_tex.rgb;
+    float3 r1_rgb = r1.rgb * r4_z + r2_rgb;
+
+    r0c *= r4_w;
+    float3 final = r0c * DOFFogFactorBlur + r1_rgb;
+
+    return float4(final, r1.a);
+}

--- a/src/games/clivebarkersjericho/DoF_Fog_0x88EF5970.ps_3_0.hlsl
+++ b/src/games/clivebarkersjericho/DoF_Fog_0x88EF5970.ps_3_0.hlsl
@@ -1,6 +1,6 @@
 #include "./shared.h"
 
-// DoF and Fog
+// DoF, Water and Fog
 float DOFFogDesaturate : register(c15);
 float DOFFogDist : register(c10);
 float DOFFogFactorBlur : register(c14);

--- a/src/games/clivebarkersjericho/Emissives_0xF0E16BB7.ps_3_0.hlsl
+++ b/src/games/clivebarkersjericho/Emissives_0xF0E16BB7.ps_3_0.hlsl
@@ -1,0 +1,16 @@
+#include "./shared.h"
+
+// Emissives
+sampler2D GlowMapSampler : register( s3 );
+float4 LightColor : register( c0 );
+
+float4 main(float2 texcoord : TEXCOORD) : COLOR
+{
+	float4 o;
+
+	float4 r0;
+	r0 = tex2D(GlowMapSampler, texcoord);
+	o = r0 * LightColor.w * Custom_Emissives_Intensity;
+
+	return o;
+}

--- a/src/games/clivebarkersjericho/Emissives_0xF0E16BB7.ps_3_0.hlsl
+++ b/src/games/clivebarkersjericho/Emissives_0xF0E16BB7.ps_3_0.hlsl
@@ -10,7 +10,7 @@ float4 main(float2 texcoord : TEXCOORD) : COLOR
 
 	float4 r0;
 	r0 = tex2D(GlowMapSampler, texcoord);
-	o = r0 * LightColor.w * Custom_Emissives_Intensity;
+	o = r0 * LightColor.w * pow(Custom_Emissives_Intensity, 2.3);
 
 	return o;
 }

--- a/src/games/clivebarkersjericho/MenuBlur_0x5D32B50A.ps_3_0.hlsl
+++ b/src/games/clivebarkersjericho/MenuBlur_0x5D32B50A.ps_3_0.hlsl
@@ -2,9 +2,9 @@
 
 // Menu Blur Shader
 sampler2D ActualFrameSampler : register(s0);
-float g_Value : register(c15);        // Blend factor
-float g_Scale : register(c16);        // Scale for sample offsets
-float2 g_avSampleOffsets[15] : register(c0); // Predefined blur offsets, exactly 15
+float g_Value : register(c15);                  // Blend factor
+float g_Scale : register(c16);                  // Scale for sample offsets
+float2 g_avSampleOffsets[15] : register(c0);    // Predefined blur offsets
 
 float4 main(float2 texcoord : TEXCOORD) : COLOR
 {
@@ -21,7 +21,7 @@ float4 main(float2 texcoord : TEXCOORD) : COLOR
         accumulated += tex2D(ActualFrameSampler, sampleUV);
     }
 
-    // Add the 16th sample (original) manually to match ASM
+    // Add the 16th sample
     float4 lastSample = tex2D(ActualFrameSampler, texcoord);
     accumulated += lastSample;
 
@@ -32,6 +32,5 @@ float4 main(float2 texcoord : TEXCOORD) : COLOR
     // Blend with original
     float4 outputColor = (g_Value.x * Custom_UI_Menu_Blur_Intensity) * blur + lastSample;
 
-    // return outputColor;
     return outputColor;
 }

--- a/src/games/clivebarkersjericho/MenuBlur_0x5D32B50A.ps_3_0.hlsl
+++ b/src/games/clivebarkersjericho/MenuBlur_0x5D32B50A.ps_3_0.hlsl
@@ -1,0 +1,37 @@
+#include "./shared.h"
+
+// Menu Blur Shader
+sampler2D ActualFrameSampler : register(s0);
+float g_Value : register(c15);        // Blend factor
+float g_Scale : register(c16);        // Scale for sample offsets
+float2 g_avSampleOffsets[15] : register(c0); // Predefined blur offsets, exactly 15
+
+float4 main(float2 texcoord : TEXCOORD) : COLOR
+{
+    float4 accumulated = float4(0,0,0,0);
+    float4 originalSample = tex2D(ActualFrameSampler, texcoord);
+
+    float scale = g_Scale.x;
+
+    // Accumulate the 15 samples
+    [unroll]
+    for (int i = 0; i < 15; i++)
+    {
+        float2 sampleUV = texcoord + g_avSampleOffsets[i] * scale;
+        accumulated += tex2D(ActualFrameSampler, sampleUV);
+    }
+
+    // Add the 16th sample (original) manually to match ASM
+    float4 lastSample = tex2D(ActualFrameSampler, texcoord);
+    accumulated += lastSample;
+
+    // Apply 1/16 factor and subtract original
+    float blurFactor = 0.0625;
+    float4 blur = accumulated * blurFactor - lastSample;
+
+    // Blend with original
+    float4 outputColor = (g_Value.x * Custom_UI_Menu_Blur_Intensity) * blur + lastSample;
+
+    // return outputColor;
+    return outputColor;
+}

--- a/src/games/clivebarkersjericho/MotionBlur_0xFB9052E6.ps_3_0.hlsl
+++ b/src/games/clivebarkersjericho/MotionBlur_0xFB9052E6.ps_3_0.hlsl
@@ -1,0 +1,73 @@
+#include "./shared.h"
+
+// Motion Blur
+// It's here mostly to increase the sampling count and increase HDR highlights.
+sampler2D FillSampler : register( s0 );
+sampler2D SceneSampler : register( s1 );
+float gBlurPower : register( c0 );
+
+float4 main(float2 texcoord : TEXCOORD) : COLOR
+{
+	float4 o;
+
+	float4 r2;
+	float4 r0;
+	float4 r1;
+	float2 r5;
+	float4 r3;
+	float4 r4;
+	r2 = tex2D(SceneSampler, texcoord);
+	r0 = tex2D(FillSampler, texcoord);
+	r1.xy = -r0.yw + r0.xz;
+	r1.xy = r1.xy * gBlurPower.x;
+	r0.w = dot(r0, r0);
+	r5.xy = r1.xy * float2(0.25, -0.25);
+	r1.w = (-r0.w >= 0) ? 0 : 1;
+	r1.xyz = r2.xyz;
+	r0.z = 1;
+	r0.w = -6;
+	for (int i0 = 0; i0 < 24; i0++) {
+		r0.xy = r0.w * r5.xy + texcoord.xy;
+		r3 = tex2D(FillSampler, r0);
+		r3.xz = -r3.y + r3.xy;
+		r3.y = -r3.z;
+		r2.w = dot(r5.x, r3.x) + 0;
+		r2.w = (-r2.w >= 0) ? 0 : 1;
+		r3 = tex2D(SceneSampler, r0);
+		if (r2.w != -r2.w) {
+			r1.xyz = r1.xyz + r3.xyz;
+			r0.z = r0.z + 1;
+		}
+		r0.w = r0.w + 1;
+	}
+	r4.xyz = r1.xyz;
+	r4.w = r0.z;
+	r1.xyz = r4.xyz;
+	r0.z = r4.w;
+	r0.w = 1;
+	for (int i0 = 0; i0 < 24; i0++) {
+		r0.xy = r0.w * r5.xy + texcoord.xy;
+		r3 = tex2D(FillSampler, r0);
+		r3.xz = -r3.y + r3.xy;
+		r3.y = -r3.z;
+		r2.w = dot(r5.x, r3.x) + 0;
+		r2.w = (-r2.w >= 0) ? 0 : 1;
+		r3 = tex2D(SceneSampler, r0);
+		if (r2.w != -r2.w) {
+			r1.xyz = r1.xyz + r3.xyz;
+			r0.z = r0.z + 1;
+		}
+		r0.w = r0.w + 1;
+	}
+	r0.w = r0.z;
+	if (r1.w != -r1.w) {
+		r0.w = 1 / r0.w;
+		r0.xyz = r1.xyz * r0.w;
+	} else {
+		r0.xyz = r2.xyz;
+	}
+	r0.w = 1;
+	o = r0;
+
+	return o;
+}

--- a/src/games/clivebarkersjericho/Output_0x43D12A2B.ps_3_0.hlsl
+++ b/src/games/clivebarkersjericho/Output_0x43D12A2B.ps_3_0.hlsl
@@ -1,0 +1,85 @@
+#include "./shared.h"
+
+// Tonemapper variant
+float4 g_LevelsInMax   : register(c5);
+float4 g_LevelsInMin   : register(c4);
+float4 g_LevelsOutMax  : register(c7);
+float4 g_LevelsOutMin  : register(c6);
+float  g_LevelsPow     : register(c8);
+
+float  g_fBloomScale   : register(c0);
+float  g_fBrightness   : register(c2);
+float  g_fContrast     : register(c3);
+float  g_fStarScale    : register(c1);
+
+sampler2D s0 : register(s0);    // main input
+sampler2D s1 : register(s1);    // bloom tex
+sampler2D s2 : register(s2);    // star streak tex
+
+float4 main(float2 texcoord : TEXCOORD) : COLOR
+{
+    float4 r0, r1;
+    float4 o;
+    //----------------------------------------------------------
+    // BASE COLOR
+    //----------------------------------------------------------
+    r1 = tex2D(s0, texcoord);   // base input color
+    //----------------------------------------------------------
+    // ADD STAR STREAK
+    //----------------------------------------------------------
+    r0 = tex2D(s2, texcoord);
+    r1 = r1 + (r0 * g_fStarScale * Custom_Star_Dispersion);
+    //----------------------------------------------------------
+    // ADD BLOOM
+    //----------------------------------------------------------
+    r0 = tex2D(s1, texcoord);
+    r0 = r1 + (r0 * g_fBloomScale * Custom_Bloom);
+    //----------------------------------------------------------
+    // LEVELS: Input normalization
+    //----------------------------------------------------------
+    float4 inRange = g_LevelsInMax - g_LevelsInMin; // denominator
+    r0 = r0 - g_LevelsInMin;
+    r1.x = 1.0 / inRange.x;
+    r1.y = 1.0 / inRange.y;
+    r1.z = 1.0 / inRange.z;
+    r1.w = 1.0 / inRange.w;
+    r0 = r0 * r1;
+    //----------------------------------------------------------
+    // LEVELS: Output mapping
+    //----------------------------------------------------------
+    float4 outRange = g_LevelsOutMax - g_LevelsOutMin;
+    r0 = lerp(r0, r0 * outRange + g_LevelsOutMin, Custom_Color_Tint2_Intensity);  // apply output range
+    //----------------------------------------------------------
+    // BRIGHTNESS & CONTRAST
+    //----------------------------------------------------------
+    r0 = lerp(r0, r0 + g_fBrightness.x, saturate(Custom_Contrast_Intensity));
+    r0 = r0 + (-0.5 * Custom_Contrast_Intensity);  // shift around 0.5 before contrast
+    r1.w = (0.5 * Custom_Contrast_Intensity);      // 0.5 constant
+    float4 unclamped = g_fContrast.x * r0 + r1.w;
+    r0 = saturate(g_fContrast.x * r0 + r1.w);      // apply contrast and shift back
+
+    r0.x = log2(r0.x);
+    r0.y = log2(r0.y);
+    r0.z = log2(r0.z);
+    r0.w = log2(r0.w);
+    r0 = r0 * g_LevelsPow.x;
+    o.x = exp2(r0.x);
+    o.y = exp2(r0.y);
+    o.z = exp2(r0.z);
+    o.w = exp2(r0.w);
+    float4 saturated = o;
+
+    float4 untonemapped_sRGB = max(0, unclamped);
+    float4 untonemapped = renodx::color::srgba::Decode(untonemapped_sRGB);
+    float3 tonemapped = renodx::tonemap::renodrt::NeutralSDR(untonemapped.rgb);
+    float4 tonemapped_sRGB = renodx::color::srgba::Encode(float4(tonemapped.rgb, 1));
+    if (RENODX_TONE_MAP_TYPE > 0.f) {
+        o.rgb = renodx::draw::ToneMapPass(untonemapped.rgb);
+    } else {
+        o = renodx::color::srgba::Decode(float4(saturated));
+    }
+    o.a = renodx::color::y::from::BT709(o.rgb);
+    o.rgb = renodx::draw::RenderIntermediatePass(o.rgb);
+
+    return o;
+}

--- a/src/games/clivebarkersjericho/Output_0x7E9BCFC6.ps_3_0.hlsl
+++ b/src/games/clivebarkersjericho/Output_0x7E9BCFC6.ps_3_0.hlsl
@@ -1,0 +1,100 @@
+#include "./shared.h"
+
+// Tonemapper variant
+float4 g_LevelsInMax   : register(c6);
+float4 g_LevelsInMin   : register(c5);
+float4 g_LevelsOutMax  : register(c8);
+float4 g_LevelsOutMin  : register(c7);
+float  g_LevelsPow     : register(c9);
+
+float  g_fBloomScale   : register(c1);
+float  g_fBrightness   : register(c3);
+float  g_fContrast     : register(c4);
+float  g_fMiddleGray   : register(c0);
+float  g_fStarScale    : register(c2);
+
+sampler2D s0 : register(s0);    // main input
+sampler2D s1 : register(s1);    // bloom tex
+sampler2D s2 : register(s2);    // star streak tex
+sampler2D s3 : register(s3);    // auto exposure 1x1
+
+float4 main(float2 texcoord : TEXCOORD) : COLOR
+{
+    float4 r0, r1;
+    float4 o;
+    //----------------------------------------------------------
+    // AUTO-EXPOSURE
+    //----------------------------------------------------------
+    // Sample the 1×1 exposure map at UV = 0.5 (center pixel)
+    r0 = tex2D(s3, float2(0.5, 0.5));
+    r0.w = r0.x + 0.001;
+    r0.w = 1.0 / r0.w;
+    r0.w *= g_fMiddleGray;
+    //----------------------------------------------------------
+    // MAIN INPUT * exposure
+    //----------------------------------------------------------
+    r1 = tex2D(s0, texcoord);   // input color
+    r1.xyz = r1.xyz * r0.w;     // exposure applied
+    //----------------------------------------------------------
+    // ADD STAR STREAK
+    //----------------------------------------------------------
+    float4 star = tex2D(s2, texcoord);
+    r1 = r1 + (star * g_fStarScale * Custom_Star_Dispersion);
+    //----------------------------------------------------------
+    // ADD BLOOM
+    //----------------------------------------------------------
+    float4 bloom = tex2D(s1, texcoord);
+    r0 = r1 + (bloom * g_fBloomScale * Custom_Bloom);
+    //----------------------------------------------------------
+    // LEVELS: Input normalization
+    //----------------------------------------------------------
+    float4 inRange = g_LevelsInMax - g_LevelsInMin;  // denominator
+    float4 invInRange = float4(
+        1.0 / inRange.x,
+        1.0 / inRange.y,
+        1.0 / inRange.z,
+        1.0 / inRange.w
+    );
+
+    r0 = (r0 - g_LevelsInMin) * invInRange;
+    //----------------------------------------------------------
+    // LEVELS: Output mapping
+    //----------------------------------------------------------
+    float4 outRange = g_LevelsOutMax - g_LevelsOutMin;
+    r0 = lerp(r0, r0 * outRange + g_LevelsOutMin, Custom_Color_Tint2_Intensity);  // apply output range
+    //----------------------------------------------------------
+    // BRIGHTNESS & CONTRAST
+    //----------------------------------------------------------
+    r0 = lerp(r0, r0 + g_fBrightness.x, saturate(Custom_Contrast_Intensity));
+    r0 = r0 + (-0.5 * Custom_Contrast_Intensity);  // shift around 0.5 before contrast
+    r1.w = (0.5 * Custom_Contrast_Intensity);      // 0.5 constant
+    float4 unclamped = g_fContrast.x * r0 + r1.w;
+    r0 = saturate(g_fContrast.x * r0 + r1.w);  // apply contrast and shift back
+
+    r0.x = log2(r0.x);
+    r0.y = log2(r0.y);
+    r0.z = log2(r0.z);
+    r0.w = log2(r0.w);
+
+    r0 *= g_LevelsPow;
+
+    o.x = exp2(r0.x);
+    o.y = exp2(r0.y);
+    o.z = exp2(r0.z);
+    o.w = exp2(r0.w);
+    float4 saturated = o;
+
+    float4 untonemapped_sRGB = max(0, unclamped);
+    float4 untonemapped = renodx::color::srgba::Decode(untonemapped_sRGB);
+    float3 tonemapped = renodx::tonemap::renodrt::NeutralSDR(untonemapped.rgb);
+    float4 tonemapped_sRGB = renodx::color::srgba::Encode(float4(tonemapped.rgb, 1));
+    if (RENODX_TONE_MAP_TYPE > 0.f) {
+      o.rgb = renodx::draw::ToneMapPass(untonemapped.rgb);
+    } else {
+      o = renodx::color::srgba::Decode(float4(saturated));
+    }
+    o.a = renodx::color::y::from::BT709(o.rgb);
+    o.rgb = renodx::draw::RenderIntermediatePass(o.rgb);
+
+    return o;
+}

--- a/src/games/clivebarkersjericho/Output_0xDBBB4C25.ps_3_0.hlsl
+++ b/src/games/clivebarkersjericho/Output_0xDBBB4C25.ps_3_0.hlsl
@@ -1,0 +1,101 @@
+#include "./shared.h"
+
+// Inside tonemapper
+float4 g_LevelsInMax : register(c6);
+float4 g_LevelsInMin : register(c5);
+float4 g_LevelsOutMax : register(c8);
+float4 g_LevelsOutMin : register(c7);
+float g_LevelsPow : register(c9);
+float g_fBloomScale : register(c1);
+float g_fBrightness : register(c3);
+float g_fContrast : register(c4);
+float g_fMiddleGray : register(c0);
+float g_fStarScale : register(c2);
+sampler2D s0 : register(s0);  // main input color
+sampler2D s1 : register(s1);  // bloom buffer
+sampler2D s2 : register(s2);  // star streak buffer
+sampler2D s3 : register(s3);  // auto-exposure 1x1 buffer
+
+float4 main(float2 texcoord: TEXCOORD) : COLOR
+{
+  float4 o;  // final output
+  float4 r0;  // temp register
+  float4 r1;  // temp register
+  float4 r2;  // temp register
+  // =====================================================
+  // Exposure
+  // =====================================================
+  r0 = tex2D(s3, 0.5);                // exposure buffer at center (single pixel)
+  r0.xy = r0.x + float2(1.5, 0.001);  // added constants to the exposure value
+  r2.w = r0.x * -0.24390244 + 1;      // exposure scale (1 - 0.2439 * exposure)
+  r1 = tex2D(s0, texcoord);
+  r0.z = dot(r1.xyz, float3(0.2126, 0.7152, 0.0722));  // Fixed vanilla Bt.601 to Rev.709
+  r0.w = 1 / r0.y;                                     // inverse of the modified exposure value (r0.y)
+  // =====================================================
+  // Color shift
+  // =====================================================
+  r0.xyz = r0.z * float3(1.05, 0.97, 1.27) + -r1.xyz;
+  r0.xyz = ((r2.w * r0.xyz) * Custom_Color_Tint_Intensity ) + r1.xyz;
+  r0.w = r0.w * g_fMiddleGray.x;
+  r1.xyz = r0.xyz * r0.w;
+  // =====================================================
+  // Star streak texture
+  // =====================================================
+  r0 = tex2D(s2, texcoord);
+  r1 = (g_fStarScale.x * Custom_Star_Dispersion) * r0 + r1;
+  // =====================================================
+  // Bloom texture
+  // =====================================================
+  r0 = tex2D(s1, texcoord);
+  r0 = (g_fBloomScale.x * Custom_Bloom) * r0 + r1;
+  // =====================================================
+  // Levels input normalization
+  // =====================================================
+  r1 = g_LevelsInMin;
+  r1 = -r1 + g_LevelsInMax;  // r1 = (InMax - InMin)
+  r0 = r0 + -g_LevelsInMin;  // subtract input min
+  r1.x = 1 / r1.x;           // invert (InMax - InMin) per channel
+  r1.y = 1 / r1.y;
+  r1.z = 1 / r1.z;
+  r1.w = 1 / r1.w;
+  r0 = r0 * r1;              // normalize input to 0–1 range
+  // =====================================================
+  // Levels output mapping
+  // =====================================================
+  r1 = g_LevelsOutMin;
+  r1 = -r1 + g_LevelsOutMax;      // r1 = (OutMax - OutMin)
+  r0 = r0 * r1 + g_LevelsOutMin;  // scale to output levels
+  // =====================================================
+  // Brightness & Contrast
+  // =====================================================
+  r0 = r0 + g_fBrightness.x;
+  r0 = r0 + (-0.5 * Custom_Contrast_Intensity);  // shift around 0.5 before contrast
+  r1.w = 0.5;                                    // 0.5 constant
+  float4 unclamped = g_fContrast.x * r0 + (r1.w * Custom_Contrast_Intensity);
+  r0 = saturate(g_fContrast.x * r0 + (r1.w * Custom_Contrast_Intensity));  // apply contrast and shift back
+
+  r0.x = log2(r0.x);
+  r0.y = log2(r0.y);
+  r0.z = log2(r0.z);
+  r0.w = log2(r0.w);
+  r0 = r0 * g_LevelsPow.x;
+  o.x = exp2(r0.x);
+  o.y = exp2(r0.y);
+  o.z = exp2(r0.z);
+  o.w = exp2(r0.w);
+  float4 saturated = o;
+
+  float4 untonemapped_sRGB = max(0, unclamped);
+  float4 untonemapped = renodx::color::srgba::Decode(untonemapped_sRGB);
+  float3 tonemapped = renodx::tonemap::renodrt::NeutralSDR(untonemapped.rgb);
+  float4 tonemapped_sRGB = renodx::color::srgba::Encode(float4(tonemapped.rgb, 1));
+  if (RENODX_TONE_MAP_TYPE > 0.f) {
+    o.rgb = renodx::draw::ToneMapPass(untonemapped.rgb);
+  } else {
+    o = renodx::color::srgba::Decode(float4(saturated));
+  }
+  o.a = renodx::color::y::from::BT709(o.rgb);
+  o.rgb = renodx::draw::RenderIntermediatePass(o.rgb);
+
+  return o;
+}

--- a/src/games/clivebarkersjericho/Output_0xEF22B21C.ps_3_0.hlsl
+++ b/src/games/clivebarkersjericho/Output_0xEF22B21C.ps_3_0.hlsl
@@ -1,0 +1,104 @@
+#include "./shared.h"
+
+// Outside tonemapper
+float4 g_LevelsInMax : register(c5);
+float4 g_LevelsInMin : register(c4);
+float4 g_LevelsOutMax : register(c7);
+float4 g_LevelsOutMin : register(c6);
+float g_LevelsPow : register(c8);
+float g_fBloomScale : register(c0);
+float g_fBrightness : register(c2);
+float g_fContrast : register(c3);
+float g_fStarScale : register(c1);
+
+sampler2D s0 : register(s0);  // main scene color
+sampler2D s1 : register(s1);  // bloom buffer
+sampler2D s2 : register(s2);  // star/streak buffer
+sampler2D s3 : register(s3);  // auto-exposure 1×1 buffer
+
+float4 main(float2 texcoord: TEXCOORD) : COLOR
+{
+  float4 o;   // output color
+  float4 r0;  // temp
+  float4 r1;  // temp
+
+  // =======================================================
+  // Read exposure buffer
+  // =======================================================
+  r0 = tex2D(s3, 0.5);  // sample 1×1 auto-exposure texture
+  r0.w = r0.x + 1.5;    // add constant to exposure value
+  // =======================================================
+  // Load main scene color
+  // =======================================================
+  r1 = tex2D(s0, texcoord);  // original pixel color
+  // Compute luminance using BT.709 coefficients
+  r0.z = dot(r1.xyz, float3(0.2126, 0.7152, 0.0722));
+  // Compute exposure scale: (1 - 0.24390244 * (exposure + 1.5))
+  r0.w = r0.w * -0.24390244 + 1;
+  // =======================================================
+  // Exposure-dependent color shift
+  // =======================================================
+  r0.xyz = r0.z * float3(1.05, 0.97, 1.27) + -r1.xyz;
+  r1.xyz = r0.w * r0.xyz + r1.xyz;
+  // =======================================================
+  // Add star/streak buffer
+  // =======================================================
+  r0 = tex2D(s2, texcoord);
+  r1 = (g_fStarScale.x * Custom_Star_Dispersion) * r0 + r1;
+  // =======================================================
+  // Add bloom buffer
+  // =======================================================
+  r0 = tex2D(s1, texcoord);
+  r0 = (g_fBloomScale.x * Custom_Bloom) * r0 + r1;
+  // =======================================================
+  // Levels: Input normalization
+  // =======================================================
+  r1 = g_LevelsInMin;
+  r1 = -r1 + g_LevelsInMax;  // r1 = (InMax - InMin)
+  r0 = r0 + -g_LevelsInMin;  // subtract InMin
+  r1.x = 1 / r1.x;  		// invert (InMax - InMin)
+  r1.y = 1 / r1.y;
+  r1.z = 1 / r1.z;
+  r1.w = 1 / r1.w;
+  r0 = r0 * r1;  			// scale into [0..1] range
+  // =======================================================
+  // Levels: Output remapping
+  // =======================================================
+  r1 = g_LevelsOutMin;
+  r1 = -r1 + g_LevelsOutMax;  		// r1 = (OutMax - OutMin)
+  r0 = r0 * r1 + g_LevelsOutMin;  	// apply output range
+  // =======================================================
+  // Brightness & contrast
+  // =======================================================
+  r0 = r0 + g_fBrightness.x;  		// apply brightness
+
+  r0 = r0 + (-0.5 * Custom_Contrast_Intensity );                  // shift around 0.5 before contrast
+  r1.w = 0.5;                                                     // 0.5 constant
+  float4 unclamped = g_fContrast.x * r0 + (r1.w * Custom_Contrast_Intensity);
+  r0 = saturate(g_fContrast.x * r0 + (r1.w * Custom_Contrast_Intensity));  // apply contrast and shift back
+
+  r0.x = log2(r0.x);
+  r0.y = log2(r0.y);
+  r0.z = log2(r0.z);
+  r0.w = log2(r0.w);
+  r0 = r0 * g_LevelsPow.x;
+  o.x = exp2(r0.x);
+  o.y = exp2(r0.y);
+  o.z = exp2(r0.z);
+  o.w = exp2(r0.w);
+  float4 saturated = o;
+
+  float4 untonemapped_sRGB = max(0, unclamped);
+  float4 untonemapped = renodx::color::srgba::Decode(untonemapped_sRGB);
+  float3 tonemapped = renodx::tonemap::renodrt::NeutralSDR(untonemapped.rgb);
+  float4 tonemapped_sRGB = renodx::color::srgba::Encode(float4(tonemapped.rgb, 1));
+  if (RENODX_TONE_MAP_TYPE > 0.f) {
+    o.rgb = renodx::draw::ToneMapPass(untonemapped.rgb);
+  } else {
+    o = renodx::color::srgba::Decode(float4(saturated));
+  }
+  o.a = renodx::color::y::from::BT709(o.rgb);
+  o.rgb = renodx::draw::RenderIntermediatePass(o.rgb);
+
+  return o;
+}

--- a/src/games/clivebarkersjericho/Overlay_0xE055A254.ps_3_0.hlsl
+++ b/src/games/clivebarkersjericho/Overlay_0xE055A254.ps_3_0.hlsl
@@ -1,0 +1,137 @@
+#include "./shared.h"
+
+// TV Noise overlay effect (shows up later in the game)
+sampler2D ActualFrameSampler : register(s0);
+sampler2D Sampler0           : register(s1);
+sampler2D Sampler1           : register(s2);
+sampler2D Sampler2           : register(s3);
+
+float g_Value   : register(c0);
+float FrameTime : register(c1);
+float FramePhase: register(c2);
+
+float4 main(float2 uv : TEXCOORD) : COLOR
+{
+    float4 A, B, C, D;   // renamed r0–r3 for structure
+    float3 M;            // renamed r4
+    float4 OUT;          // output
+
+    // -------------------------------------------------------------------------
+    // RANDOMIZED TIME / VERTICAL FALLOFF SETUP
+    // -------------------------------------------------------------------------
+
+    // Base constants (0.1, 17.5, 26.4, 0.5)
+    A = float4(0.1, 17.5, 26.4, 0.5);
+
+    // Temporal seeds
+    B.xyz = FrameTime * A.xyz + A.w;
+    C.xyz = frac(B.xyz);
+    B.xyz = B.xyz - C.xyz;
+
+    // Temporal offset corrected with integer part
+    A.xyz = FrameTime * A.xyz - B.xyz;
+
+    // Vertical gradient influence
+    A.xyz = A.xyz * 3.0 - float3(uv.y, uv.y, uv.y);
+
+    // Falloff shape
+    A.xyz = saturate(-abs(A.xyz) + float3(0.8, 0.6, 0.3));
+    A.xyz = A.xyz * float3(1.25, 1.66666663, 3.33333325);
+
+    // Shape squaring
+    A.xyz = A.xyz * A.xyz;
+    D.xyz = A.xyz * A.xyz;
+
+    // Additional shape mixing
+    A.w  = A.y * D.y;
+    D.w  = A.w * 0.3 + 0.85;
+    D.y  = saturate(D.x * 0.6 + 0.8);
+
+    // -------------------------------------------------------------------------
+    // TILE NOISE SAMPLING
+    // -------------------------------------------------------------------------
+
+    float2 tileUV = uv * 15.0;
+
+    float4 T0 = tex2D(Sampler0, tileUV);
+    float4 T1 = tex2D(Sampler1, tileUV);
+    float4 T2 = tex2D(Sampler2, tileUV);
+    float4 T2Inverted = 1.0 - T2;
+    // Mix-in high-frequency noise
+    if (RENODX_TONE_MAP_TYPE > 0.f) {
+      A = (T2 * 1.0) + (T2Inverted * 0.75);
+    } else {
+      A = T2 * 0.1 + 0.9;
+    }
+
+    // Blend between two tile textures
+    M = lerp(T0.xyz, T1.xyz, FramePhase);
+
+    // Add blended noise color tint
+    A *= 0.8;
+    A.xyz = M * float3(0.2, 0.12, 0.06) + A.xyz;
+
+    // -------------------------------------------------------------------------
+    // EDGE MASKING / SHAPE MODULATION
+    // -------------------------------------------------------------------------
+
+    C.z = D.z * D.z;      // squared falloff
+
+    // Local modulation
+    B = A - 0.3;
+    B = saturate(B * 1.5);
+    B *= D.y;
+
+    // Top-left region mask
+    C.xy = saturate(float2(0.02, 0.02) - uv);
+    C.xy *= 50.0;
+
+    float edgeAccum = C.x + C.y;
+
+    // Bottom-right region mask
+    C.xy = saturate(uv + (-0.98));
+    B *= D.w;
+
+    edgeAccum = C.x * 50.0 + edgeAccum;
+    C.z = C.z * 0.2 + 0.9;
+
+    edgeAccum = C.y * 50.0 + edgeAccum;
+    B *= C.z;
+
+    D.w = edgeAccum * edgeAccum;
+
+    // -------------------------------------------------------------------------
+    // FINAL COMPOSITION
+    // -------------------------------------------------------------------------
+
+    C = tex2D(ActualFrameSampler, uv);
+
+    A = A * g_Value + C;       // blend noise onto frame
+    float mask = saturate(D.w * D.w);
+    if (RENODX_TONE_MAP_TYPE > 0.f) {
+      A -= 0.10;
+    } else {
+      A += 0.025;
+    }
+
+    OUT = A * B - mask;  // final combine
+    if (RENODX_TONE_MAP_TYPE > 0.f) {
+        // REMOVE GREY CAST
+        float3 original = C.rgb;          // original frame
+        float3 effected = OUT.rgb;        // effect result
+
+        // Estimate grey offset by comparing average luminance drift
+        float l_orig = dot(original, float3(0.2126, 0.7152, 0.0722));
+        float l_eff  = dot(effected, float3(0.2126, 0.7152, 0.0722));
+
+        // Offset produced by the effect
+        float greyBias = l_eff - l_orig;
+
+        // Remove the uniform grey bias
+        effected -= greyBias;
+
+        effected = max(effected, 0.0);
+        OUT.rgb = lerp(OUT.rgb, effected, effected);
+    }	
+    return OUT;
+}

--- a/src/games/clivebarkersjericho/Particles_0x1D8C8AC9.ps_3_0.hlsl
+++ b/src/games/clivebarkersjericho/Particles_0x1D8C8AC9.ps_3_0.hlsl
@@ -1,7 +1,7 @@
 #include "./shared.h"
 
 // Particles
-sampler2D DiffuseMapSampler : register( s0 );
+sampler2D DiffuseMapSampler : register(s0);
 
 struct PS_IN
 {
@@ -15,15 +15,20 @@ float4 main(PS_IN i) : COLOR
 
 	float4 r0;
 	r0 = tex2D(DiffuseMapSampler, i.texcoord);
+	r0 = r0 * i.color;
+	r0 = r0 * float4(2, 2, 2, 1);
+
+	float Y = dot(r0.xyz, float3(0.2126, 0.7152, 0.0722));
+	// Chromatic component
+	float3 C = r0.xyz - float3(Y, Y, Y);
+	float Ch = length(C);
+	float YScale = length(r0.xyz);  // overall magnitude
+	float chromaWeight = saturate(Ch / (Ch + Y + 1e-6));
+	float perceptualWeight = saturate(pow(chromaWeight * YScale, 4.0));
+	// Boosting luminance based on chroma and luma
+	float HDRBoost = lerp(1.f, pow(Custom_Particles_Intensity, 4.f), perceptualWeight);
+	r0.xyz *= HDRBoost;
+
 	o = r0;
-	float r0_luma = dot(o.xyz, float3(0.2126, 0.7152, 0.0722));
-	if (r0_luma > 0.7f) {
-            // o = r0;
-            // o = pow(r0, 2.2) * float4(10, 10, 10, 1);            
-            o.xyz = dot((r0_luma) / 1.5f / Custom_Particles_Intensity, 0.5f) * r0.xyz;
-            o.xyz += (r0.xyz * (max(r0.x, max(r0.y, r0.z))) * (Custom_Particles_Intensity - 2.0f));
-        }
-	o = o * i.color;
-	o = o * float4(2, 2, 2, 1);
 	return o;
 }

--- a/src/games/clivebarkersjericho/Particles_0x1D8C8AC9.ps_3_0.hlsl
+++ b/src/games/clivebarkersjericho/Particles_0x1D8C8AC9.ps_3_0.hlsl
@@ -1,0 +1,29 @@
+#include "./shared.h"
+
+// Particles
+sampler2D DiffuseMapSampler : register( s0 );
+
+struct PS_IN
+{
+	float4 color : COLOR;
+	float2 texcoord : TEXCOORD;
+};
+
+float4 main(PS_IN i) : COLOR
+{
+	float4 o;
+
+	float4 r0;
+	r0 = tex2D(DiffuseMapSampler, i.texcoord);
+	o = r0;
+	float r0_luma = dot(o.xyz, float3(0.2126, 0.7152, 0.0722));
+	if (r0_luma > 0.7f) {
+            // o = r0;
+            // o = pow(r0, 2.2) * float4(10, 10, 10, 1);            
+            o.xyz = dot((r0_luma) / 1.5f / Custom_Particles_Intensity, 0.5f) * r0.xyz;
+            o.xyz += (r0.xyz * (max(r0.x, max(r0.y, r0.z))) * (Custom_Particles_Intensity - 2.0f));
+        }
+	o = o * i.color;
+	o = o * float4(2, 2, 2, 1);
+	return o;
+}

--- a/src/games/clivebarkersjericho/RadialBlur_0x58F1B3D3.ps_3_0.hlsl
+++ b/src/games/clivebarkersjericho/RadialBlur_0x58F1B3D3.ps_3_0.hlsl
@@ -1,0 +1,105 @@
+#include "./shared.h"
+
+// Radial Blur
+sampler2D ActualFrameSampler : register(s0);
+
+float g_Value : register(c0);   // Intensity of blur mix
+float g_Off   : register(c1);   // Vignette offset
+float g_Scale : register(c2);   // Radial sampling scale
+
+// Constants baked into the original shader
+static const float4 C3 = float4(-0.5, 0.8, 0.2, -0.1);
+static const float4 C4 = float4(0, 0, 1, 0.0625);
+static const float4 C5 = float4(0.2126, 0.7152, 0.0722, 1.5);
+static const float4 C6 = float4(0.33, 0, 0, 0);
+
+static const int SAMPLE_REP = 15;
+
+float4 main(float2 uv : TEXCOORD) : COLOR
+{
+    //--------------------------------------------------------------------
+    // 1. Compute position relative to screen center
+    //    (used both for blur direction and vignette strength)
+    //--------------------------------------------------------------------
+    float2 offsetFromCenter = uv + C3.x;   // uv - 0.5
+
+    //--------------------------------------------------------------------
+    // 2. Radial sample accumulation
+    //    We sample along the ray from the center toward uv, repeatedly.
+    //    Each iteration moves further outward.
+    //--------------------------------------------------------------------
+    float4 accum = 0.0;
+
+    [unroll]
+    for (int i = 0; i < SAMPLE_REP; ++i)
+    {
+        // Sample position moves outward each iteration
+        float2 sampleUV = offsetFromCenter * accum.w;
+        sampleUV = sampleUV * -g_Scale + uv;
+
+        float3 s = tex2D(ActualFrameSampler, sampleUV).xyz;
+
+        accum.xyz += s;
+        accum.w   += 1.0;  // track sample index (count)
+    }
+
+    //--------------------------------------------------------------------
+    // 3. Compute distance from the center (radial magnitude)
+    //--------------------------------------------------------------------
+    float2 sq = abs(offsetFromCenter);
+    sq *= sq;
+    float distSq = sq.x + sq.y;
+
+    // True radial distance
+    float dist = sqrt(distSq);
+
+    //--------------------------------------------------------------------
+    // 4. Compute vignette shaping based on distance
+    //    This produces two values:
+    //        vignetteXY.x → determines blur mix amount
+    //        vignetteXY.y → controls edge tint boost
+    //--------------------------------------------------------------------
+    float2 vignetteXY = dist * C3.y + C3.zw; // *0.8 + (0.2, -0.1)
+
+    //--------------------------------------------------------------------
+    // 5. Blur intensity: how much blurred image replaces the original
+    //--------------------------------------------------------------------
+    float blendBase = vignetteXY.x - g_Off;
+    float blendFactor = saturate(blendBase * g_Value);
+
+    //--------------------------------------------------------------------
+    // 6. Scale accumulated samples (their total sum) into a usable blur color
+    //--------------------------------------------------------------------
+    float3 blurColor = accum.xyz * C4.w; // multiply by 1/16
+
+    //--------------------------------------------------------------------
+    // 7. Fetch center pixel and blur-lerp
+    //--------------------------------------------------------------------
+    float3 centerCol = tex2D(ActualFrameSampler, uv).xyz;
+    float3 blended = lerp(centerCol, blurColor, blendFactor);
+
+    //--------------------------------------------------------------------
+    // 8. Edge tint modulation (makes outer region darker/stronger)
+    //--------------------------------------------------------------------
+    float edgeStrength = (vignetteXY.y * blendFactor) * C5.w; // *1.5
+
+    //--------------------------------------------------------------------
+    // 9. Local luminance (for tinting effect)
+    //--------------------------------------------------------------------
+    float lum = dot(blended, C5.xyz); // Rec709-ish weighting
+
+    //--------------------------------------------------------------------
+    // 10. Compute edge tint direction:
+    //     (lum*0.33 - blended) → pushes colors toward darkened neutral
+    //--------------------------------------------------------------------
+    float3 edgeTint = lum * C6.x - blended;
+
+    //--------------------------------------------------------------------
+    // 11. Final mix:
+    //     blended → main result
+    //     edgeTint * edgeStrength → outer vignette effect
+    //--------------------------------------------------------------------
+    float3 finalRGB = blended + edgeTint * edgeStrength;
+
+    return float4(finalRGB, 0.0);
+}

--- a/src/games/clivebarkersjericho/ScopeAndMagicOverlay_0x9C28BBBA.ps_3_0.hlsl
+++ b/src/games/clivebarkersjericho/ScopeAndMagicOverlay_0x9C28BBBA.ps_3_0.hlsl
@@ -1,0 +1,81 @@
+#include "./shared.h"
+
+// Scope and Magic Overlay
+sampler2D ActualFrameSampler : register(s0);
+float4    g_Color             : register(c1);
+float     g_Value             : register(c0);
+
+float4 main(float2 texcoord : TEXCOORD) : COLOR
+{
+    // --- centered UV ---
+    float2 centeredUV = texcoord - 0.5;
+
+    // --- doubled UV (for log) ---
+    float2 doubleUV = texcoord + texcoord;
+
+    // --- inverted offset ---
+    float2 invOffset = -centeredUV + 0.5;
+
+    // --- log values ---
+    float2 logDouble = log2(doubleUV);
+    float2 logOffset = log2(invOffset * 2.0);
+
+    // --- scale with g_Value ---
+    float2 scaledCenter = g_Value * float2(0.6, 0.2) + 1.0;
+
+    logDouble *= scaledCenter.x;
+    logOffset *= scaledCenter.x;
+
+    // --- exp ---
+    float2 expDouble = exp2(logDouble);
+    float2 expOffset = exp2(logOffset);
+
+    // --- saturate multiply/add ---
+    expDouble = saturate(expDouble * 0.5);
+    expOffset = saturate(expOffset * -0.5 + 1.0);
+
+    // --- quadrant select ---
+    float2 sampleUV;
+    sampleUV.x = (centeredUV.x >= 0.0) ? expOffset.x : expDouble.x;
+    sampleUV.y = (centeredUV.y >= 0.0) ? expOffset.y : expDouble.y;
+
+    // --- squared distance for vignette ---
+    float2 sq = abs(centeredUV);
+    sq = sq * sq;
+    float dist = sq.x + sq.y;
+    dist = 1.0 / sqrt(dist);
+    dist = 1.0 / dist;
+    dist = -dist + 1.0;
+    dist *= 1.2;
+
+    // --- sample texture ---
+    float4 texSample = tex2D(ActualFrameSampler, sampleUV);
+
+    // --- luminance ---
+    float lum = dot(texSample.rgb, float3(0.2126, 0.7152, 0.0722));
+
+    // --- vignette scaled ---
+    float vignette = dist * dist;
+    float blend = -vignette + 1.0;
+    blend *= g_Value;
+
+    // --- lerp texture with luminance ---
+    float4 lerpSample = lerp(texSample, float4(lum, lum, lum, 0), -g_Value * 0.5);
+
+    float4 final = 0.f;
+    // --- lerp final with scope color ---
+    if (RENODX_TONE_MAP_TYPE == 0.f) {
+      final = lerp(lerpSample, g_Color, blend);
+    } else {
+      final = lerp(texSample, g_Color, blend);
+    }
+	
+    // --- apply minor scale/offset ---
+    float scale = g_Value * -0.1 + 1.0;
+    final = final * scale;
+    //final += float4(0.0, 0.0, 0.0, 0.0);
+    //final += -0.5;
+    //final = final * 1.0 + 0.5;
+
+    return final;
+}

--- a/src/games/clivebarkersjericho/Sharpening_0x23614FA0.ps_3_0.hlsl
+++ b/src/games/clivebarkersjericho/Sharpening_0x23614FA0.ps_3_0.hlsl
@@ -1,13 +1,13 @@
 #include "./shared.h"
 
-// Some weird sharpening
+// Sharpening
 float4 CopySharpenValues : register( c0 );
 sampler2D s0 : register( s0 );
 
 float4 main(float2 texcoord : TEXCOORD) : COLOR
 {
     float4 r0, r1;
-	CopySharpenValues.xy *= Custom_Sharpening_Amount;
+	CopySharpenValues.xy *= pow(Custom_Sharpening_Amount, 2.3);
     // Sample left
     r0 = tex2D(s0, texcoord + float2(-CopySharpenValues.x, 0));
     r1 = r0 * CopySharpenValues.w;
@@ -28,5 +28,5 @@ float4 main(float2 texcoord : TEXCOORD) : COLOR
     r0 = tex2D(s0, texcoord + float2(0, CopySharpenValues.y));
     r1 = r1 - r0 * CopySharpenValues.w;
 
-    return r1; // final sharpened color
+    return r1;
 }

--- a/src/games/clivebarkersjericho/Sharpening_0x23614FA0.ps_3_0.hlsl
+++ b/src/games/clivebarkersjericho/Sharpening_0x23614FA0.ps_3_0.hlsl
@@ -1,0 +1,32 @@
+#include "./shared.h"
+
+// Some weird sharpening
+float4 CopySharpenValues : register( c0 );
+sampler2D s0 : register( s0 );
+
+float4 main(float2 texcoord : TEXCOORD) : COLOR
+{
+    float4 r0, r1;
+	CopySharpenValues.xy *= Custom_Sharpening_Amount;
+    // Sample left
+    r0 = tex2D(s0, texcoord + float2(-CopySharpenValues.x, 0));
+    r1 = r0 * CopySharpenValues.w;
+
+    // Sample center
+    r0 = tex2D(s0, texcoord);
+    r1 = r0 * CopySharpenValues.z - r1;
+
+    // Sample right
+    r0 = tex2D(s0, texcoord + float2(CopySharpenValues.x, 0));
+    r1 = r1 - r0 * CopySharpenValues.w;
+
+    // Sample top
+    r0 = tex2D(s0, texcoord + float2(0, -CopySharpenValues.y));
+    r1 = r1 - r0 * CopySharpenValues.w;
+
+    // Sample bottom
+    r0 = tex2D(s0, texcoord + float2(0, CopySharpenValues.y));
+    r1 = r1 - r0 * CopySharpenValues.w;
+
+    return r1; // final sharpened color
+}

--- a/src/games/clivebarkersjericho/Skybox_0x0B83B2B8.ps_3_0.hlsl
+++ b/src/games/clivebarkersjericho/Skybox_0x0B83B2B8.ps_3_0.hlsl
@@ -16,9 +16,9 @@ float4 main(PS_IN input) : COLOR
     float4 skySample = tex2D(DiffuseMapSampler, input.texcoord1);
 
     // --- Compute level adjustments ---
-    float4 levelFactor = input.texcoord * Levels.z;  // Scale by Levels.z
+    float4 levelFactor = input.texcoord * Levels.z;      // Scale by Levels.z
     levelFactor.w = levelFactor.w * Levels.x - Levels.x; // Apply offset
-    levelFactor.w = levelFactor.w + 1;                // Final adjustment for alpha
+    levelFactor.w = levelFactor.w + 1;                   // Final adjustment for alpha
 
     // --- Apply the level scaling to RGB and alpha ---
     float3 finalRGB = skySample.rgb * levelFactor.xyz * Custom_Skybox_Intensity;

--- a/src/games/clivebarkersjericho/Skybox_0x0B83B2B8.ps_3_0.hlsl
+++ b/src/games/clivebarkersjericho/Skybox_0x0B83B2B8.ps_3_0.hlsl
@@ -1,0 +1,28 @@
+#include "./shared.h"
+
+// Skybox shader
+sampler2D DiffuseMapSampler : register(s0);
+float4 Levels : register(c0); // x = offset, y/z/w = scaling factors
+
+struct PS_IN
+{
+    float4 texcoord : TEXCOORD;
+    float2 texcoord1 : TEXCOORD1;
+};
+
+float4 main(PS_IN input) : COLOR
+{
+    // --- Sample skybox texture ---
+    float4 skySample = tex2D(DiffuseMapSampler, input.texcoord1);
+
+    // --- Compute level adjustments ---
+    float4 levelFactor = input.texcoord * Levels.z;  // Scale by Levels.z
+    levelFactor.w = levelFactor.w * Levels.x - Levels.x; // Apply offset
+    levelFactor.w = levelFactor.w + 1;                // Final adjustment for alpha
+
+    // --- Apply the level scaling to RGB and alpha ---
+    float3 finalRGB = skySample.rgb * levelFactor.xyz * Custom_Skybox_Intensity;
+    float  finalA   = skySample.a * levelFactor.w;
+
+    return float4(finalRGB, finalA);
+}

--- a/src/games/clivebarkersjericho/UI_0x87D1670C.ps_3_0.hlsl
+++ b/src/games/clivebarkersjericho/UI_0x87D1670C.ps_3_0.hlsl
@@ -1,0 +1,31 @@
+#include "./shared.h"
+
+// UI
+sampler2D DiffuseMapSampler : register( s0 );
+float4 Levels : register( c0 );
+
+struct PS_IN
+{
+	float4 texcoord : TEXCOORD;
+	float2 texcoord1 : TEXCOORD1;
+};
+
+float4 main(PS_IN i) : COLOR
+{
+	float4 o;
+
+	float4 r0;
+	float4 r1;
+	r0 = tex2D(DiffuseMapSampler, i.texcoord1);
+	r1.w = i.texcoord.w * Levels.x + -Levels.x;
+	r1.w = r1.w + 1;
+	o.xyz = r0.xyz * i.texcoord.xyz;
+	o.w = r0.w * r1.w;
+	if (Custom_UI_Disable >= 0.001f) {
+		o.w = 0.f;
+		} else {
+		o.w = r0.w * r1.w;
+	}
+
+	return o;
+}

--- a/src/games/clivebarkersjericho/addon.cpp
+++ b/src/games/clivebarkersjericho/addon.cpp
@@ -711,6 +711,11 @@ BOOL APIENTRY DllMain(HMODULE h_module, DWORD fdw_reason, LPVOID lpv_reserved) {
           renodx::mods::swapchain::use_resize_buffer = setting->GetValue() < 4;
           renodx::mods::swapchain::use_resize_buffer_on_demand = renodx::mods::swapchain::use_resize_buffer;
           renodx::mods::swapchain::set_color_space = !renodx::mods::swapchain::use_resize_buffer;
+          renodx::mods::swapchain::swap_chain_upgrade_targets.push_back({
+            .old_format = reshade::api::format::b8g8r8a8_unorm,
+            .new_format = reshade::api::format::r16g16b16a16_typeless,
+            .aspect_ratio = renodx::mods::swapchain::SwapChainUpgradeTarget::BACK_BUFFER,
+          });
           shader_injection.swap_chain_encoding_color_space = is_hdr10 ? 1.f : 0.f;
           settings.push_back(setting);
         }
@@ -719,7 +724,7 @@ BOOL APIENTRY DllMain(HMODULE h_module, DWORD fdw_reason, LPVOID lpv_reserved) {
           auto* setting = new renodx::utils::settings::Setting{
               .key = "Upgrade_" + key,
               .value_type = renodx::utils::settings::SettingValueType::INTEGER,
-              .default_value = 0.f,
+              .default_value = 1.f,
               .label = key,
               .section = "Resource Upgrades",
               .labels = {

--- a/src/games/clivebarkersjericho/addon.cpp
+++ b/src/games/clivebarkersjericho/addon.cpp
@@ -1,0 +1,656 @@
+/*
+ * Copyright (C) 2024 Carlos Lopez
+ * SPDX-License-Identifier: MIT
+ */
+
+#define ImTextureID ImU64
+
+#define DEBUG_LEVEL_0
+
+#include <deps/imgui/imgui.h>
+#include <include/reshade.hpp>
+
+#include <embed/shaders.h>
+
+#include "../../mods/shader.hpp"
+#include "../../mods/swapchain.hpp"
+#include "../../utils/settings.hpp"
+#include "./shared.h"
+
+namespace {
+
+renodx::mods::shader::CustomShaders custom_shaders = {
+    __ALL_CUSTOM_SHADERS,
+};
+
+ShaderInjectData shader_injection;
+
+float current_settings_mode = 0;
+
+renodx::utils::settings::Settings settings = {
+    new renodx::utils::settings::Setting{
+        .key = "SettingsMode",
+        .binding = &current_settings_mode,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 0.f,
+        .can_reset = false,
+        .label = "Settings Mode",
+        .labels = {"Simple", "Intermediate", "Advanced"},
+        .is_global = true,
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapType",
+        .binding = &shader_injection.tone_map_type,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 3.f,
+        .can_reset = true,
+        .label = "Tone Mapper",
+        .section = "Tone Mapping",
+        .tooltip = "Sets the tone mapper type",
+        .labels = {"Vanilla", "None", "ACES", "RenoDRT"},
+        .is_visible = []() { return current_settings_mode >= 1; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapPeakNits",
+        .binding = &shader_injection.peak_white_nits,
+        .default_value = 1000.f,
+        .can_reset = false,
+        .label = "Peak Brightness",
+        .section = "Tone Mapping",
+        .tooltip = "Sets the value of peak white in nits",
+        .min = 48.f,
+        .max = 4000.f,
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapGameNits",
+        .binding = &shader_injection.diffuse_white_nits,
+        .default_value = 203.f,
+        .label = "Game Brightness",
+        .section = "Tone Mapping",
+        .tooltip = "Sets the value of 100% white in nits",
+        .min = 48.f,
+        .max = 500.f,
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapUINits",
+        .binding = &shader_injection.graphics_white_nits,
+        .default_value = 203.f,
+        .label = "UI Brightness",
+        .section = "Tone Mapping",
+        .tooltip = "Sets the brightness of UI and HUD elements in nits",
+        .min = 48.f,
+        .max = 500.f,
+    },
+    new renodx::utils::settings::Setting{
+        .key = "GammaCorrection",
+        .binding = &shader_injection.gamma_correction,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 1.f,
+        .label = "Gamma Correction",
+        .section = "Tone Mapping",
+        .tooltip = "Emulates a display EOTF.",
+        .labels = {"Off", "2.2", "BT.1886"},
+        .is_visible = []() { return current_settings_mode >= 1; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapScaling",
+        .binding = &shader_injection.tone_map_per_channel,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 0.f,
+        .label = "Scaling",
+        .section = "Tone Mapping",
+        .tooltip = "Luminance scales colors consistently while per-channel saturates and blows out sooner",
+        .labels = {"Luminance", "Per Channel"},
+        .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+        .is_visible = []() { return current_settings_mode >= 2; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapWorkingColorSpace",
+        .binding = &shader_injection.tone_map_working_color_space,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 0.f,
+        .label = "Working Color Space",
+        .section = "Tone Mapping",
+        .labels = {"BT709", "BT2020", "AP1"},
+        .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+        .is_visible = []() { return current_settings_mode >= 2; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapHueProcessor",
+        .binding = &shader_injection.tone_map_hue_processor,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 0.f,
+        .label = "Hue Processor",
+        .section = "Tone Mapping",
+        .tooltip = "Selects hue processor",
+        .labels = {"OKLab", "ICtCp", "darkTable UCS"},
+        .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+        .is_visible = []() { return current_settings_mode >= 2; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapHueCorrection",
+        .binding = &shader_injection.tone_map_hue_correction,
+        .default_value = 100.f,
+        .label = "Hue Correction",
+        .section = "Tone Mapping",
+        .tooltip = "Hue retention strength.",
+        .min = 0.f,
+        .max = 100.f,
+        .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+        .parse = [](float value) { return value * 0.01f; },
+        .is_visible = []() { return current_settings_mode >= 2; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapHueShift",
+        .binding = &shader_injection.tone_map_hue_shift,
+        .default_value = 50.f,
+        .label = "Hue Shift",
+        .section = "Tone Mapping",
+        .tooltip = "Hue-shift emulation strength.",
+        .min = 0.f,
+        .max = 100.f,
+        .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+        .parse = [](float value) { return value * 0.01f; },
+        .is_visible = []() { return current_settings_mode >= 1; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapClampColorSpace",
+        .binding = &shader_injection.tone_map_clamp_color_space,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 1.f,
+        .label = "Clamp Color Space",
+        .section = "Tone Mapping",
+        .tooltip = "Hue-shift emulation strength.",
+        .labels = {"None", "BT709", "BT2020", "AP1"},
+        .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+        .parse = [](float value) { return value - 1.f; },
+        .is_visible = []() { return current_settings_mode >= 2; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapClampPeak",
+        .binding = &shader_injection.tone_map_clamp_peak,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 1.f,
+        .label = "Clamp Peak",
+        .section = "Tone Mapping",
+        .tooltip = "Hue-shift emulation strength.",
+        .labels = {"None", "BT709", "BT2020", "AP1"},
+        .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+        .parse = [](float value) { return value - 1.f; },
+        .is_visible = []() { return current_settings_mode >= 2; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeExposure",
+        .binding = &shader_injection.tone_map_exposure,
+        .default_value = 1.f,
+        .label = "Exposure",
+        .section = "Color Grading",
+        .max = 2.f,
+        .format = "%.2f",
+        .is_visible = []() { return current_settings_mode >= 1; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeHighlights",
+        .binding = &shader_injection.tone_map_highlights,
+        .default_value = 50.f,
+        .label = "Highlights",
+        .section = "Color Grading",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+        .is_visible = []() { return current_settings_mode >= 1; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeShadows",
+        .binding = &shader_injection.tone_map_shadows,
+        .default_value = 50.f,
+        .label = "Shadows",
+        .section = "Color Grading",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+        .is_visible = []() { return current_settings_mode >= 1; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeContrast",
+        .binding = &shader_injection.tone_map_contrast,
+        .default_value = 50.f,
+        .label = "Contrast",
+        .section = "Color Grading",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeSaturation",
+        .binding = &shader_injection.tone_map_saturation,
+        .default_value = 50.f,
+        .label = "Saturation",
+        .section = "Color Grading",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeHighlightSaturation",
+        .binding = &shader_injection.tone_map_highlight_saturation,
+        .default_value = 50.f,
+        .label = "Highlight Saturation",
+        .section = "Color Grading",
+        .tooltip = "Adds or removes highlight color.",
+        .max = 100.f,
+        .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+        .parse = [](float value) { return value * 0.02f; },
+        .is_visible = []() { return current_settings_mode >= 1; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeBlowout",
+        .binding = &shader_injection.tone_map_blowout,
+        .default_value = 0.f,
+        .label = "Blowout",
+        .section = "Color Grading",
+        .tooltip = "Controls highlight desaturation due to overexposure.",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.01f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeFlare",
+        .binding = &shader_injection.tone_map_flare,
+        .default_value = 0.f,
+        .label = "Flare",
+        .section = "Color Grading",
+        .tooltip = "Flare/Glare Compensation",
+        .max = 100.f,
+        .is_enabled = []() { return shader_injection.tone_map_type == 3; },
+        .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeScene",
+        .binding = &shader_injection.color_grade_strength,
+        .default_value = 100.f,
+        .label = "Scene Grading",
+        .section = "Color Grading",
+        .tooltip = "Scene grading as applied by the game",
+        .max = 100.f,
+        .is_enabled = []() { return shader_injection.tone_map_type > 0; },
+        .parse = [](float value) { return value * 0.01f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "SwapChainCustomColorSpace",
+        .binding = &shader_injection.swap_chain_custom_color_space,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 0.f,
+        .label = "Custom Color Space",
+        .section = "Display Output",
+        .tooltip = "Selects output color space"
+                   "\nUS Modern for BT.709 D65."
+                   "\nJPN Modern for BT.709 D93."
+                   "\nUS CRT for BT.601 (NTSC-U)."
+                   "\nJPN CRT for BT.601 ARIB-TR-B9 D93 (NTSC-J)."
+                   "\nDefault: US CRT",
+        .labels = {
+            "US Modern",
+            "JPN Modern",
+            "US CRT",
+            "JPN CRT",
+        },
+        .is_visible = []() { return settings[0]->GetValue() >= 1; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "IntermediateDecoding",
+        .binding = &shader_injection.intermediate_encoding,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 2.f,
+        .label = "Intermediate Encoding",
+        .section = "Display Output",
+        .labels = {"Auto", "None", "SRGB", "2.2", "2.4"},
+        .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+        .parse = [](float value) {
+            if (value == 0) return shader_injection.gamma_correction + 1.f;
+            return value - 1.f; },
+        .is_visible = []() { return current_settings_mode >= 2; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "SwapChainDecoding",
+        .binding = &shader_injection.swap_chain_decoding,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 2.f,
+        .label = "Swapchain Decoding",
+        .section = "Display Output",
+        .labels = {"Auto", "None", "SRGB", "2.2", "2.4"},
+        .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+        .parse = [](float value) {
+            if (value == 0) return shader_injection.intermediate_encoding;
+            return value - 1.f; },
+        .is_visible = []() { return current_settings_mode >= 2; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "SwapChainGammaCorrection",
+        .binding = &shader_injection.swap_chain_gamma_correction,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 0.f,
+        .label = "Gamma Correction",
+        .section = "Display Output",
+        .labels = {"None", "2.2", "2.4"},
+        .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+        .is_visible = []() { return current_settings_mode >= 2; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "SwapChainClampColorSpace",
+        .binding = &shader_injection.swap_chain_clamp_color_space,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 2.f,
+        .label = "Clamp Color Space",
+        .section = "Display Output",
+        .labels = {"None", "BT709", "BT2020", "AP1"},
+        .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+        .parse = [](float value) { return value - 1.f; },
+        .is_visible = []() { return current_settings_mode >= 2; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "FxBloom",
+        .binding = &shader_injection.Custom_Bloom,
+        .default_value = 50.f,
+        .label = "Bloom Amount",
+        .section = "Effects",
+        .tooltip = "Vanila bloom. Very old-gen style, highly suggested to turn it off completely and user a third party ReShade bloom instead.",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "FxStarDispersion",
+        .binding = &shader_injection.Custom_Star_Dispersion,
+        .default_value = 50.f,
+        .label = "Star Dispersion Intensity",
+        .section = "Effects",
+        .tooltip = "Star Dispersion Intensity. Also give the image a bit softer look, similar to bloom.",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "FxEmissivesIntensity",
+        .binding = &shader_injection.Custom_Emissives_Intensity,
+        .default_value = 20.f,
+        .label = "Emissives Intensity",
+        .section = "Effects",
+        .tooltip = "All in game emissive materials intensity multiplier.",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.05f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "FxSkyboxIntensity",
+        .binding = &shader_injection.Custom_Skybox_Intensity,
+        .default_value = 8.f,
+        .label = "Skybox Intensity",
+        .section = "Effects",
+        .tooltip = "HDR skybox intensity multiplier. Scales pretty nicely, until you go very high, then you'll start noticing compression artifacts.",
+        .max = 10.f,
+        .parse = [](float value) { return value; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "FxParticlesIntensity",
+        .binding = &shader_injection.Custom_Particles_Intensity,
+        .default_value = 50.f,
+        .label = "Particles Intensity",
+        .section = "Effects",
+        .tooltip = "All in game particle effects intensity multiplier, that go above 0.7 luminance.",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "FxSharpeningAmount",
+        .binding = &shader_injection.Custom_Sharpening_Amount,
+        .default_value = 20.f,
+        .label = "Sharpening Amount",
+        .section = "Effects",
+        .tooltip = "Image sharpening amount. 20 is default vanilla amount.",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.05f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "FxUIDisable",
+        .binding = &shader_injection.Custom_UI_Disable,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 0.f,
+        .label = "Disable UI",
+        .section = "Effects",
+        .tooltip = "Disables UI completely",
+        .labels = {"Enabled UI", "Disabled UI"},    
+        .max = 1.f,
+        .parse = [](float value) { return value; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "FxUIMenuBlurIntensity",
+        .binding = &shader_injection.Custom_UI_Menu_Blur_Intensity,
+        .default_value = 50.f,
+        .label = "UI Menu Blur Intensity",
+                .section = "Effects",
+        .tooltip = "Disables UI menu blur. Can give an impression of clamped HDR, so I decided to unclude the option to turn it off.",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+    },
+        new renodx::utils::settings::Setting{
+        .key = "FxColotTintIntensity",
+        .binding = &shader_injection.Custom_Color_Tint_Intensity,
+        .default_value = 50.f,
+        .label = "Color Tint Intensity",
+        .section = "Effects",
+        .tooltip = "There is not LUT color grading in this game, just this funny float3 color shift.",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "FxContrastIntensity",
+        .binding = &shader_injection.Custom_Contrast_Intensity,
+        .default_value = 0.f,
+        .label = "Contrast Intensity",
+        .section = "Effects",
+        .tooltip = "Vanilla game does some cursed contrast adjustment in post processing. It's better to just disable it by default. Set to 50 for vanilla amount.",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+    },
+};
+
+const std::unordered_map<std::string, reshade::api::format> UPGRADE_TARGETS = {
+    {"R8G8B8A8_TYPELESS", reshade::api::format::r8g8b8a8_typeless},
+    {"B8G8R8A8_TYPELESS", reshade::api::format::b8g8r8a8_typeless},
+    {"R8G8B8A8_UNORM", reshade::api::format::r8g8b8a8_unorm},
+    {"B8G8R8A8_UNORM", reshade::api::format::b8g8r8a8_unorm},
+    {"R8G8B8A8_SNORM", reshade::api::format::r8g8b8a8_snorm},
+    {"R8G8B8A8_UNORM_SRGB", reshade::api::format::r8g8b8a8_unorm_srgb},
+    {"B8G8R8A8_UNORM_SRGB", reshade::api::format::b8g8r8a8_unorm_srgb},
+    {"R10G10B10A2_TYPELESS", reshade::api::format::r10g10b10a2_typeless},
+    {"R10G10B10A2_UNORM", reshade::api::format::r10g10b10a2_unorm},
+    {"B10G10R10A2_UNORM", reshade::api::format::b10g10r10a2_unorm},
+    {"R11G11B10_FLOAT", reshade::api::format::r11g11b10_float},
+    {"R16G16B16A16_TYPELESS", reshade::api::format::r16g16b16a16_typeless},
+};
+
+void OnPresetOff() {
+     renodx::utils::settings::UpdateSetting("toneMapType", 0.f);
+     renodx::utils::settings::UpdateSetting("toneMapPeakNits", 203.f);
+     renodx::utils::settings::UpdateSetting("toneMapGameNits", 203.f);
+     renodx::utils::settings::UpdateSetting("toneMapUINits", 203.f);
+     renodx::utils::settings::UpdateSetting("toneMapGammaCorrection", 0);
+     renodx::utils::settings::UpdateSetting("colorGradeExposure", 1.f);
+     renodx::utils::settings::UpdateSetting("colorGradeHighlights", 50.f);
+     renodx::utils::settings::UpdateSetting("colorGradeShadows", 50.f);
+     renodx::utils::settings::UpdateSetting("colorGradeContrast", 50.f);
+     renodx::utils::settings::UpdateSetting("colorGradeSaturation", 50.f);
+     renodx::utils::settings::UpdateSetting("colorGradeLUTStrength", 100.f);
+}
+
+const auto UPGRADE_TYPE_NONE = 0.f;
+const auto UPGRADE_TYPE_OUTPUT_SIZE = 1.f;
+const auto UPGRADE_TYPE_OUTPUT_RATIO = 2.f;
+const auto UPGRADE_TYPE_ANY = 3.f;
+
+bool initialized = false;
+
+}  // namespace
+
+extern "C" __declspec(dllexport) constexpr const char* NAME = "RenoDX";
+extern "C" __declspec(dllexport) constexpr const char* DESCRIPTION = "RenoDX (Generic)";
+
+BOOL APIENTRY DllMain(HMODULE h_module, DWORD fdw_reason, LPVOID lpv_reserved) {
+  switch (fdw_reason) {
+    case DLL_PROCESS_ATTACH:
+      if (!reshade::register_addon(h_module)) return FALSE;
+
+      if (!initialized) {
+        // while (!IsDebuggerPresent()) Sleep(100);
+
+        renodx::mods::shader::force_pipeline_cloning = true;
+        renodx::mods::shader::expected_constant_buffer_space = 50;
+        renodx::mods::shader::expected_constant_buffer_index = 13;
+        renodx::mods::shader::allow_multiple_push_constants = true;
+        renodx::mods::shader::constant_buffer_offset = 50 * 4;
+
+        renodx::mods::swapchain::expected_constant_buffer_index = 13;
+        renodx::mods::swapchain::expected_constant_buffer_space = 50;
+        // renodx::mods::swapchain::target_format = reshade::api::format::b8g8r8a8_unorm;
+        // renodx::mods::swapchain::target_color_space = reshade::api::color_space::srgb_nonlinear;
+        renodx::mods::swapchain::prevent_full_screen = false;
+        renodx::mods::swapchain::force_screen_tearing = false;
+        renodx::mods::swapchain::use_resource_cloning = true;
+        renodx::mods::swapchain::set_color_space = false;
+        renodx::mods::swapchain::use_device_proxy = true;
+        renodx::mods::swapchain::ignored_window_class_names = {
+            "SplashScreenClass",
+        };
+        renodx::mods::swapchain::swap_chain_proxy_shaders = {
+            {
+                reshade::api::device_api::d3d11,
+                {
+                    .vertex_shader = __swap_chain_proxy_vertex_shader_dx11,
+                    .pixel_shader = __swap_chain_proxy_pixel_shader_dx11,
+                },
+            },
+            {
+                reshade::api::device_api::d3d12,
+                {
+                    .vertex_shader = __swap_chain_proxy_vertex_shader_dx12,
+                    .pixel_shader = __swap_chain_proxy_pixel_shader_dx12,
+                },
+            },
+        };
+
+        {
+          auto* setting = new renodx::utils::settings::Setting{
+              .key = "SwapChainForceBorderless",
+              .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+              .default_value = 0.f,
+              .label = "Force Borderless",
+              .section = "Display Output",
+              .tooltip = "Forces fullscreen to be borderless for proper HDR",
+              .labels = {
+                  "Disabled",
+                  "Enabled",
+              },
+              .on_change_value = [](float previous, float current) { renodx::mods::swapchain::force_borderless = (current == 1.f); },
+              .is_global = true,
+              .is_visible = []() { return current_settings_mode >= 2; },
+          };
+          renodx::utils::settings::LoadSetting(renodx::utils::settings::global_name, setting);
+          renodx::mods::swapchain::force_borderless = (setting->GetValue() == 1.f);
+          settings.push_back(setting);
+        }
+
+        {
+          auto* setting = new renodx::utils::settings::Setting{
+              .key = "SwapChainPreventFullscreen",
+              .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+              .default_value = 0.f,
+              .label = "Prevent Fullscreen",
+              .section = "Display Output",
+              .tooltip = "Prevent exclusive fullscreen for proper HDR",
+              .labels = {
+                  "Disabled",
+                  "Enabled",
+              },
+              .on_change_value = [](float previous, float current) { renodx::mods::swapchain::prevent_full_screen = (current == 1.f); },
+              .is_global = true,
+              .is_visible = []() { return current_settings_mode >= 2; },
+          };
+          renodx::utils::settings::LoadSetting(renodx::utils::settings::global_name, setting);
+          renodx::mods::swapchain::prevent_full_screen = (setting->GetValue() == 1.f);
+          settings.push_back(setting);
+        }
+
+        {
+          auto* setting = new renodx::utils::settings::Setting{
+              .key = "SwapChainEncoding",
+              .binding = &shader_injection.swap_chain_encoding,
+              .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+              .default_value = 5.f,
+              .label = "Encoding",
+              .section = "Display Output",
+              .labels = {"None", "SRGB", "2.2", "2.4", "HDR10", "scRGB"},
+              .is_enabled = []() { return shader_injection.tone_map_type >= 1; },
+              .on_change_value = [](float previous, float current) {
+                bool is_hdr10 = current == 4;
+                shader_injection.swap_chain_encoding_color_space = (is_hdr10 ? 1.f : 0.f);
+                // return void
+              },
+              .is_global = true,
+              .is_visible = []() { return current_settings_mode >= 2; },
+          };
+          renodx::utils::settings::LoadSetting(renodx::utils::settings::global_name, setting);
+          bool is_hdr10 = setting->GetValue() == 4;
+          renodx::mods::swapchain::SetUseHDR10(is_hdr10);
+          renodx::mods::swapchain::use_resize_buffer = setting->GetValue() < 4;
+          renodx::mods::swapchain::use_resize_buffer_on_demand = renodx::mods::swapchain::use_resize_buffer;
+          renodx::mods::swapchain::set_color_space = !renodx::mods::swapchain::use_resize_buffer;
+          shader_injection.swap_chain_encoding_color_space = is_hdr10 ? 1.f : 0.f;
+          settings.push_back(setting);
+        }
+
+        for (const auto& [key, format] : UPGRADE_TARGETS) {
+          auto* setting = new renodx::utils::settings::Setting{
+              .key = "Upgrade_" + key,
+              .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+              .default_value = 0.f,
+              .label = key,
+              .section = "Resource Upgrades",
+              .labels = {
+                  "Off",
+                  "Output size",
+                  "Output ratio",
+                  "Any size",
+              },
+              .is_global = true,
+              .is_visible = []() { return settings[0]->GetValue() >= 2; },
+          };
+          renodx::utils::settings::LoadSetting(renodx::utils::settings::global_name, setting);
+          settings.push_back(setting);
+
+          auto value = setting->GetValue();
+          if (value > 0) {
+            renodx::mods::swapchain::swap_chain_upgrade_targets.push_back({
+                .old_format = format,
+                .new_format = reshade::api::format::r16g16b16a16_float,
+                .ignore_size = (value == UPGRADE_TYPE_ANY),
+                .use_resource_view_cloning = true,
+                .aspect_ratio = static_cast<float>((value == UPGRADE_TYPE_OUTPUT_RATIO)
+                                                       ? renodx::mods::swapchain::SwapChainUpgradeTarget::BACK_BUFFER
+                                                       : renodx::mods::swapchain::SwapChainUpgradeTarget::ANY),
+                .usage_include = reshade::api::resource_usage::render_target,
+            });
+            std::stringstream s;
+            s << "Applying user resource upgrade for ";
+            s << format << ": " << value;
+            reshade::log::message(reshade::log::level::info, s.str().c_str());
+          }
+        }
+
+        initialized = true;
+      }
+
+      break;
+    case DLL_PROCESS_DETACH:
+      reshade::unregister_addon(h_module);
+      break;
+  }
+
+  renodx::utils::settings::Use(fdw_reason, &settings, &OnPresetOff);
+  renodx::mods::swapchain::Use(fdw_reason, &shader_injection);
+  renodx::mods::shader::Use(fdw_reason, custom_shaders, &shader_injection);
+
+  return TRUE;
+}

--- a/src/games/clivebarkersjericho/addon.cpp
+++ b/src/games/clivebarkersjericho/addon.cpp
@@ -366,22 +366,22 @@ renodx::utils::settings::Settings settings = {
     new renodx::utils::settings::Setting{
         .key = "FxEmissivesIntensity",
         .binding = &shader_injection.Custom_Emissives_Intensity,
-        .default_value = 20.f,
+        .default_value = 50.f,
         .label = "Emissives Intensity",
         .section = "Effects",
         .tooltip = "All in game emissive materials intensity multiplier.",
         .max = 100.f,
-        .parse = [](float value) { return value * 0.05f; },
+        .parse = [](float value) { return value * 0.02f; },
     },
     new renodx::utils::settings::Setting{
         .key = "FxSkyboxIntensity",
         .binding = &shader_injection.Custom_Skybox_Intensity,
-        .default_value = 8.f,
+        .default_value = 50.f,
         .label = "Skybox Intensity",
         .section = "Effects",
-        .tooltip = "HDR skybox intensity multiplier. Scales pretty nicely, until you go very high, then you'll start noticing compression artifacts.",
-        .max = 10.f,
-        .parse = [](float value) { return value; },
+        .tooltip = "HDR skybox intensity multiplier. Scales pretty nicely, until you go very high, then you'll start noticing compression artifacts. Set to 6.25 for vanilla look.",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.16f; },
     },
     new renodx::utils::settings::Setting{
         .key = "FxParticlesIntensity",
@@ -389,19 +389,19 @@ renodx::utils::settings::Settings settings = {
         .default_value = 50.f,
         .label = "Particles Intensity",
         .section = "Effects",
-        .tooltip = "All in game particle effects intensity multiplier, that go above 0.7 luminance.",
+        .tooltip = "All in game particle effects HDR Boost multiplier.",
         .max = 100.f,
         .parse = [](float value) { return value * 0.02f; },
     },
     new renodx::utils::settings::Setting{
         .key = "FxSharpeningAmount",
         .binding = &shader_injection.Custom_Sharpening_Amount,
-        .default_value = 20.f,
+        .default_value = 50.f,
         .label = "Sharpening Amount",
         .section = "Effects",
-        .tooltip = "Image sharpening amount. 20 is default vanilla amount.",
+        .tooltip = "Image sharpening amount. 50 is default vanilla amount.",
         .max = 100.f,
-        .parse = [](float value) { return value * 0.05f; },
+        .parse = [](float value) { return value * 0.02f; },
     },
     new renodx::utils::settings::Setting{
         .key = "FxUIDisable",
@@ -426,12 +426,22 @@ renodx::utils::settings::Settings settings = {
         .parse = [](float value) { return value * 0.02f; },
     },
         new renodx::utils::settings::Setting{
-        .key = "FxColotTintIntensity",
+        .key = "FxColorTintIntensity",
         .binding = &shader_injection.Custom_Color_Tint_Intensity,
         .default_value = 50.f,
         .label = "Color Tint Intensity",
         .section = "Effects",
-        .tooltip = "There is not LUT color grading in this game, just this funny float3 color shift.",
+        .tooltip = "There is not LUT color grading in this game, just some funky math.",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "FxColorTint2Intensity",
+        .binding = &shader_injection.Custom_Color_Tint2_Intensity,
+        .default_value = 50.f,
+        .label = "Color Tint 2 Intensity",
+        .section = "Effects",
+        .tooltip = "There is not LUT color grading in this game, just some funky math.",
         .max = 100.f,
         .parse = [](float value) { return value * 0.02f; },
     },
@@ -441,9 +451,99 @@ renodx::utils::settings::Settings settings = {
         .default_value = 0.f,
         .label = "Contrast Intensity",
         .section = "Effects",
-        .tooltip = "Vanilla game does some cursed contrast adjustment in post processing. It's better to just disable it by default. Set to 50 for vanilla amount.",
+        .tooltip = "Vanilla game does contrast so strong, that it actually clips. It's disabled by default here to avoid that. Set to 50 for vanilla look.", 
         .max = 100.f,
         .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "FxMotionBlurAmount",
+        .binding = &shader_injection.Custom_MotionBlur_Amount,
+        .default_value = 50.f,
+        .label = "Motion Blur Amount",
+        .section = "Effects",
+        .tooltip = "Amount of motion blur applied.",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "FxMotionBlurHDRBoost",
+        .binding = &shader_injection.Custom_MotionBlur_HDRBoost,
+        .default_value = 50.f,
+        .label = "Motion Blur Intensity",
+        .section = "Effects",
+        .tooltip = "Boosts motion blur sampling brightness. Set to 0 to disable for vanilla look.",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+    .key = "FxBrightPassThresholding",
+    .binding = &shader_injection.Custom_BrightPass_Thresholding,
+    .default_value = 20.f,
+    .label = "Bright Pass Thresholding",
+    .section = "Effects",
+    .tooltip = "Controls the threshold for bright pass filtering used in bloom and star dispersion effects. Set to 0 for vanilla look.",
+    .max = 100.f,
+    .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+    .value_type = renodx::utils::settings::SettingValueType::BUTTON,
+    .label = "Reset",
+    .section = "Color Grading Templates",
+    .group = "button-line-1",
+    .tint = 0xE50067,
+    .on_change = []() {
+        renodx::utils::settings::UpdateSetting("toneMapType", 0.f);
+        renodx::utils::settings::UpdateSetting("toneMapGammaCorrection", 1);
+        renodx::utils::settings::UpdateSetting("colorGradeExposure", 1.f);
+        renodx::utils::settings::UpdateSetting("colorGradeHighlights", 50.f);
+        renodx::utils::settings::UpdateSetting("colorGradeShadows", 50.f);
+        renodx::utils::settings::UpdateSetting("colorGradeContrast", 50.f);
+        renodx::utils::settings::UpdateSetting("colorGradeSaturation", 50.f);
+        renodx::utils::settings::UpdateSetting("colorGradeLUTStrength", 100.f);
+        renodx::utils::settings::UpdateSetting("FxBloom", 50.f);
+        renodx::utils::settings::UpdateSetting("FxStarDispersion", 50.f);
+        renodx::utils::settings::UpdateSetting("FxEmissivesIntensity", 50.f);
+        renodx::utils::settings::UpdateSetting("FxSkyboxIntensity", 6.25f);
+        renodx::utils::settings::UpdateSetting("FxParticlesIntensity", 50.f);
+        renodx::utils::settings::UpdateSetting("FxSharpeningAmount", 50.f);
+        renodx::utils::settings::UpdateSetting("FxUIDisable", 0);
+        renodx::utils::settings::UpdateSetting("FxUIMenuBlurIntensity", 50.f);
+        renodx::utils::settings::UpdateSetting("FxColorTintIntensity", 50.f);
+        renodx::utils::settings::UpdateSetting("FxColorTint2Intensity", 50.f);
+        renodx::utils::settings::UpdateSetting("FxContrastIntensity", 50.f);
+        renodx::utils::settings::UpdateSetting("FxMotionBlurAmount", 50.f);
+        renodx::utils::settings::UpdateSetting("FxMotionBlurHDRBoost", 0.f);
+        renodx::utils::settings::UpdateSetting("FxBrightPassThresholding", 0.f); },
+    },
+    new renodx::utils::settings::Setting{
+    .value_type = renodx::utils::settings::SettingValueType::BUTTON,
+    .label = "HDR Look",
+    .section = "Color Grading Templates",
+    .group = "button-line-1",
+    .tint = 0x3FD9B9,
+    .on_change = []() {
+        renodx::utils::settings::UpdateSetting("toneMapType", 0.f);
+        renodx::utils::settings::UpdateSetting("toneMapGammaCorrection", 1);
+        renodx::utils::settings::UpdateSetting("colorGradeExposure", 1.f);
+        renodx::utils::settings::UpdateSetting("colorGradeHighlights", 50.f);
+        renodx::utils::settings::UpdateSetting("colorGradeShadows", 50.f);
+        renodx::utils::settings::UpdateSetting("colorGradeContrast", 50.f);
+        renodx::utils::settings::UpdateSetting("colorGradeSaturation", 50.f);
+        renodx::utils::settings::UpdateSetting("colorGradeLUTStrength", 100.f);
+        renodx::utils::settings::UpdateSetting("FxBloom", 50.f);
+        renodx::utils::settings::UpdateSetting("FxStarDispersion", 50.f);
+        renodx::utils::settings::UpdateSetting("FxEmissivesIntensity", 100.f);
+        renodx::utils::settings::UpdateSetting("FxSkyboxIntensity", 50.f);
+        renodx::utils::settings::UpdateSetting("FxParticlesIntensity", 100.f);
+        renodx::utils::settings::UpdateSetting("FxSharpeningAmount", 25.f);
+        renodx::utils::settings::UpdateSetting("FxUIDisable", 0);
+        renodx::utils::settings::UpdateSetting("FxUIMenuBlurIntensity", 0.f);
+        renodx::utils::settings::UpdateSetting("FxColorTintIntensity", 0.f);
+        renodx::utils::settings::UpdateSetting("FxColorTint2Intensity", 0.f);
+        renodx::utils::settings::UpdateSetting("FxContrastIntensity", 0.f);
+        renodx::utils::settings::UpdateSetting("FxMotionBlurAmount", 50.f);
+        renodx::utils::settings::UpdateSetting("FxMotionBlurHDRBoost", 100.f);
+        renodx::utils::settings::UpdateSetting("FxBrightPassThresholding", 20.f); },
     },
 };
 
@@ -474,6 +574,20 @@ void OnPresetOff() {
      renodx::utils::settings::UpdateSetting("colorGradeContrast", 50.f);
      renodx::utils::settings::UpdateSetting("colorGradeSaturation", 50.f);
      renodx::utils::settings::UpdateSetting("colorGradeLUTStrength", 100.f);
+     renodx::utils::settings::UpdateSetting("FxBloom", 50.f);
+     renodx::utils::settings::UpdateSetting("FxStarDispersion", 50.f);
+     renodx::utils::settings::UpdateSetting("FxEmissivesIntensity", 50.f);
+     renodx::utils::settings::UpdateSetting("FxSkyboxIntensity", 6.25f);
+     renodx::utils::settings::UpdateSetting("FxParticlesIntensity", 50.f);
+     renodx::utils::settings::UpdateSetting("FxSharpeningAmount", 50.f);
+     renodx::utils::settings::UpdateSetting("FxUIDisable", 0);
+     renodx::utils::settings::UpdateSetting("FxUIMenuBlurIntensity", 50.f);
+     renodx::utils::settings::UpdateSetting("FxColorTintIntensity", 50.f);
+     renodx::utils::settings::UpdateSetting("FxColorTint2Intensity", 50.f);
+     renodx::utils::settings::UpdateSetting("FxContrastIntensity", 50.f);
+     renodx::utils::settings::UpdateSetting("FxMotionBlurAmount", 50.f);
+     renodx::utils::settings::UpdateSetting("FxMotionBlurHDRBoost", 0.f);
+     renodx::utils::settings::UpdateSetting("FxBrightPassThresholding", 0.f);     
 }
 
 const auto UPGRADE_TYPE_NONE = 0.f;

--- a/src/games/clivebarkersjericho/shared.h
+++ b/src/games/clivebarkersjericho/shared.h
@@ -85,14 +85,18 @@ struct ShaderInjectData {
   float Custom_UI_Disable;
   float Custom_UI_Menu_Blur_Intensity;
   float Custom_Color_Tint_Intensity;
-  float Custom_Contrast_Intensity;
+  float Custom_Color_Tint2_Intensity;
 
+  float Custom_Contrast_Intensity;
+  float Custom_MotionBlur_Amount;
+  float Custom_MotionBlur_HDRBoost;
+  float Custom_BrightPass_Thresholding;
 };
 
 #ifndef __cplusplus
 #if (__SHADER_TARGET_MAJOR == 3)
 
-float4 shader_injection[10] : register(c50);
+float4 shader_injection[11] : register(c50);
 
 #define RENODX_PEAK_WHITE_NITS               shader_injection[0][0]
 #define RENODX_DIFFUSE_WHITE_NITS            shader_injection[0][1]
@@ -133,8 +137,11 @@ float4 shader_injection[10] : register(c50);
 #define Custom_UI_Disable                      shader_injection[9][0]
 #define Custom_UI_Menu_Blur_Intensity          shader_injection[9][1]
 #define Custom_Color_Tint_Intensity            shader_injection[9][2]
-#define Custom_Contrast_Intensity              shader_injection[9][3]
-
+#define Custom_Color_Tint2_Intensity           shader_injection[9][3]
+#define Custom_Contrast_Intensity              shader_injection[10][0]
+#define Custom_MotionBlur_Amount               shader_injection[10][1]
+#define Custom_MotionBlur_HDRBoost             shader_injection[10][2]
+#define Custom_BrightPass_Thresholding         shader_injection[10][3]
 
 
 #define RENODX_RENO_DRT_TONE_MAP_METHOD renodx::tonemap::renodrt::config::tone_map_method::REINHARD
@@ -186,7 +193,11 @@ cbuffer shader_injection : register(b13) {
 #define Custom_UI_Disable                      shader_injection.Custom_UI_Disable
 #define Custom_UI_Menu_Blur_Intensity          shader_injection.Custom_UI_Menu_Blur_Intensity
 #define Custom_Color_Tint_Intensity            shader_injection.Custom_Color_Tint_Intensity
+#define Custom_Color_Tint2_Intensity           shader_injection.Custom_Color_Tint_Intensity
 #define Custom_Contrast_Intensity              shader_injection.Custom_Contrast_Intensity
+#define Custom_MotionBlur_Amount               shader_injection.Custom_MotionBlur_Amount
+#define Custom_MotionBlur_HDRBoost             shader_injection.Custom_MotionBlur_HDRBoost
+#define Custom_BrightPass_Thresholding         shader_injection.Custom_BrightPass_Thresholding
 
 #endif
 

--- a/src/games/clivebarkersjericho/shared.h
+++ b/src/games/clivebarkersjericho/shared.h
@@ -1,0 +1,199 @@
+#ifndef SRC_TEMPLATE_SHARED_H_
+#define SRC_TEMPLATE_SHARED_H_
+
+// #define RENODX_PEAK_WHITE_NITS                 1000.f
+// #define RENODX_DIFFUSE_WHITE_NITS              renodx::color::bt2408::REFERENCE_WHITE
+// #define RENODX_GRAPHICS_WHITE_NITS             renodx::color::bt2408::GRAPHICS_WHITE
+// #define RENODX_COLOR_GRADE_STRENGTH            1.f
+// #define RENODX_TONE_MAP_TYPE                   TONE_MAP_TYPE_RENO_DRT
+// #define RENODX_TONE_MAP_EXPOSURE               1.f
+// #define RENODX_TONE_MAP_HIGHLIGHTS             1.f
+// #define RENODX_TONE_MAP_SHADOWS                1.f
+// #define RENODX_TONE_MAP_CONTRAST               1.f
+// #define RENODX_TONE_MAP_SATURATION             1.f
+// #define RENODX_TONE_MAP_HIGHLIGHT_SATURATION   1.f
+// #define RENODX_TONE_MAP_BLOWOUT                0
+// #define RENODX_TONE_MAP_FLARE                  0
+// #define RENODX_TONE_MAP_HUE_CORRECTION         1.f
+// #define RENODX_TONE_MAP_HUE_SHIFT              0
+// #define RENODX_TONE_MAP_WORKING_COLOR_SPACE    color::convert::COLOR_SPACE_BT709
+// #define RENODX_TONE_MAP_CLAMP_COLOR_SPACE      color::convert::COLOR_SPACE_NONE
+// #define RENODX_TONE_MAP_CLAMP_PEAK             color::convert::COLOR_SPACE_BT709
+// #define RENODX_TONE_MAP_HUE_PROCESSOR          HUE_PROCESSOR_OKLAB
+// #define RENODX_TONE_MAP_PER_CHANNEL            0
+// #define RENODX_GAMMA_CORRECTION                GAMMA_CORRECTION_GAMMA_2_2
+// #define RENODX_INTERMEDIATE_SCALING            (RENODX_DIFFUSE_WHITE_NITS / RENODX_GRAPHICS_WHITE_NITS)
+// #define RENODX_INTERMEDIATE_ENCODING           (RENODX_GAMMA_CORRECTION + 1.f)
+// #define RENODX_INTERMEDIATE_COLOR_SPACE        color::convert::COLOR_SPACE_BT709
+// #define RENODX_SWAP_CHAIN_DECODING             RENODX_INTERMEDIATE_ENCODING
+// #define RENODX_SWAP_CHAIN_DECODING_COLOR_SPACE RENODX_INTERMEDIATE_COLOR_SPACE
+// #define RENODX_SWAP_CHAIN_CUSTOM_COLOR_SPACE   COLOR_SPACE_CUSTOM_BT709D65
+// #define RENODX_SWAP_CHAIN_SCALING_NITS         RENODX_GRAPHICS_WHITE_NITS
+// #define RENODX_SWAP_CHAIN_CLAMP_NITS           RENODX_PEAK_WHITE_NITS
+// #define RENODX_SWAP_CHAIN_CLAMP_COLOR_SPACE    color::convert::COLOR_SPACE_UNKNOWN
+// #define RENODX_SWAP_CHAIN_ENCODING             ENCODING_SCRGB
+// #define RENODX_SWAP_CHAIN_ENCODING_COLOR_SPACE color::convert::COLOR_SPACE_BT709
+
+// Must be 32bit aligned
+// Should be 4x32
+struct ShaderInjectData {
+  float peak_white_nits;
+  float diffuse_white_nits;
+  float graphics_white_nits;
+  float color_grade_strength;
+
+  float tone_map_type;
+  float tone_map_exposure;
+  float tone_map_highlights;
+  float tone_map_shadows;
+
+  float tone_map_contrast;
+  float tone_map_saturation;
+  float tone_map_highlight_saturation;
+  float tone_map_blowout;
+
+  float tone_map_flare;
+  float tone_map_hue_correction;
+  float tone_map_hue_shift;
+  float tone_map_working_color_space;
+
+  float tone_map_clamp_color_space;
+  float tone_map_clamp_peak;
+  float tone_map_hue_processor;
+  float tone_map_per_channel;
+
+  float gamma_correction;
+  float intermediate_scaling;
+  float intermediate_encoding;
+  float intermediate_color_space;
+
+  float swap_chain_decoding;
+  float swap_chain_gamma_correction;
+  float swap_chain_custom_color_space;
+  float swap_chain_clamp_color_space;
+
+  float swap_chain_encoding;
+  float swap_chain_encoding_color_space;
+  float Custom_Bloom;
+  float Custom_Star_Dispersion;
+
+  float Custom_Emissives_Intensity;
+  float Custom_Skybox_Intensity;
+  float Custom_Particles_Intensity;
+  float Custom_Sharpening_Amount;
+
+  float Custom_UI_Disable;
+  float Custom_UI_Menu_Blur_Intensity;
+  float Custom_Color_Tint_Intensity;
+  float Custom_Contrast_Intensity;
+
+};
+
+#ifndef __cplusplus
+#if (__SHADER_TARGET_MAJOR == 3)
+
+float4 shader_injection[10] : register(c50);
+
+#define RENODX_PEAK_WHITE_NITS               shader_injection[0][0]
+#define RENODX_DIFFUSE_WHITE_NITS            shader_injection[0][1]
+#define RENODX_GRAPHICS_WHITE_NITS           shader_injection[0][2]
+#define RENODX_COLOR_GRADE_STRENGTH          shader_injection[0][3]
+#define RENODX_TONE_MAP_TYPE                 shader_injection[1][0]
+#define RENODX_TONE_MAP_EXPOSURE             shader_injection[1][1]
+#define RENODX_TONE_MAP_HIGHLIGHTS           shader_injection[1][2]
+#define RENODX_TONE_MAP_SHADOWS              shader_injection[1][3]
+#define RENODX_TONE_MAP_CONTRAST             shader_injection[2][0]
+#define RENODX_TONE_MAP_SATURATION           shader_injection[2][1]
+#define RENODX_TONE_MAP_HIGHLIGHT_SATURATION shader_injection[2][2]
+#define RENODX_TONE_MAP_BLOWOUT              shader_injection[2][3]
+#define RENODX_TONE_MAP_FLARE                shader_injection[3][0]
+#define RENODX_TONE_MAP_HUE_CORRECTION       shader_injection[3][1]
+#define RENODX_TONE_MAP_HUE_SHIFT            shader_injection[3][2]
+#define RENODX_TONE_MAP_WORKING_COLOR_SPACE  shader_injection[3][3]
+#define RENODX_TONE_MAP_CLAMP_COLOR_SPACE    shader_injection[4][0]
+#define RENODX_TONE_MAP_CLAMP_PEAK           shader_injection[4][1]
+#define RENODX_TONE_MAP_HUE_PROCESSOR        shader_injection[4][2]
+#define RENODX_TONE_MAP_PER_CHANNEL          shader_injection[4][3]
+#define RENODX_GAMMA_CORRECTION              shader_injection[5][0]
+// #define RENODX_INTERMEDIATE_SCALING            shader_injection[5][1]
+#define RENODX_INTERMEDIATE_ENCODING           shader_injection[5][2]
+#define RENODX_INTERMEDIATE_COLOR_SPACE        shader_injection[5][3]
+#define RENODX_SWAP_CHAIN_DECODING             shader_injection[6][0]
+#define RENODX_SWAP_CHAIN_GAMMA_CORRECTION     shader_injection[6][1]
+#define RENODX_SWAP_CHAIN_CLAMP_COLOR_SPACE    shader_injection[6][2]
+#define RENODX_SWAP_CHAIN_CUSTOM_COLOR_SPACE   shader_injection[6][3]
+#define RENODX_SWAP_CHAIN_ENCODING             shader_injection[7][0]
+#define RENODX_SWAP_CHAIN_ENCODING_COLOR_SPACE shader_injection[7][1]
+#define Custom_Bloom                           shader_injection[7][2]
+#define Custom_Star_Dispersion                 shader_injection[7][3]
+#define Custom_Emissives_Intensity             shader_injection[8][0]
+#define Custom_Skybox_Intensity                shader_injection[8][1]
+#define Custom_Particles_Intensity             shader_injection[8][2]
+#define Custom_Sharpening_Amount               shader_injection[8][3]
+#define Custom_UI_Disable                      shader_injection[9][0]
+#define Custom_UI_Menu_Blur_Intensity          shader_injection[9][1]
+#define Custom_Color_Tint_Intensity            shader_injection[9][2]
+#define Custom_Contrast_Intensity              shader_injection[9][3]
+
+
+
+#define RENODX_RENO_DRT_TONE_MAP_METHOD renodx::tonemap::renodrt::config::tone_map_method::REINHARD
+#else
+#if ((__SHADER_TARGET_MAJOR == 5 && __SHADER_TARGET_MINOR >= 1) || __SHADER_TARGET_MAJOR >= 6)
+cbuffer shader_injection : register(b13, space50) {
+  ShaderInjectData shader_injection : packoffset(c0);
+}
+#elif (__SHADER_TARGET_MAJOR < 5) || ((__SHADER_TARGET_MAJOR == 5) && (__SHADER_TARGET_MINOR < 1))
+cbuffer shader_injection : register(b13) {
+  ShaderInjectData shader_injection : packoffset(c0);
+}
+
+#define RENODX_PEAK_WHITE_NITS                 shader_injection.peak_white_nits
+#define RENODX_DIFFUSE_WHITE_NITS              shader_injection.diffuse_white_nits
+#define RENODX_GRAPHICS_WHITE_NITS             shader_injection.graphics_white_nits
+#define RENODX_COLOR_GRADE_STRENGTH            shader_injection.color_grade_strength
+#define RENODX_TONE_MAP_TYPE                   shader_injection.tone_map_type
+#define RENODX_GAMMA_CORRECTION                shader_injection.gamma_correction
+#define RENODX_TONE_MAP_PER_CHANNEL            shader_injection.tone_map_per_channel
+#define RENODX_TONE_MAP_WORKING_COLOR_SPACE    shader_injection.tone_map_working_color_space
+#define RENODX_TONE_MAP_HUE_PROCESSOR          shader_injection.tone_map_hue_processor
+#define RENODX_TONE_MAP_HUE_CORRECTION         shader_injection.tone_map_hue_correction
+#define RENODX_TONE_MAP_HUE_SHIFT              shader_injection.tone_map_hue_shift
+#define RENODX_TONE_MAP_CLAMP_COLOR_SPACE      shader_injection.tone_map_clamp_color_space
+#define RENODX_TONE_MAP_CLAMP_PEAK             shader_injection.tone_map_clamp_peak
+#define RENODX_TONE_MAP_EXPOSURE               shader_injection.tone_map_exposure
+#define RENODX_TONE_MAP_HIGHLIGHTS             shader_injection.tone_map_highlights
+#define RENODX_TONE_MAP_SHADOWS                shader_injection.tone_map_shadows
+#define RENODX_TONE_MAP_CONTRAST               shader_injection.tone_map_contrast
+#define RENODX_TONE_MAP_SATURATION             shader_injection.tone_map_saturation
+#define RENODX_TONE_MAP_HIGHLIGHT_SATURATION   shader_injection.tone_map_highlight_saturation
+#define RENODX_TONE_MAP_BLOWOUT                shader_injection.tone_map_blowout
+#define RENODX_TONE_MAP_FLARE                  shader_injection.tone_map_flare
+#define RENODX_INTERMEDIATE_ENCODING           shader_injection.intermediate_encoding
+#define RENODX_SWAP_CHAIN_DECODING             shader_injection.swap_chain_decoding
+#define RENODX_SWAP_CHAIN_GAMMA_CORRECTION     shader_injection.swap_chain_gamma_correction
+#define RENODX_SWAP_CHAIN_CUSTOM_COLOR_SPACE   shader_injection.swap_chain_custom_color_space
+#define RENODX_SWAP_CHAIN_CLAMP_COLOR_SPACE    shader_injection.swap_chain_clamp_color_space
+#define RENODX_SWAP_CHAIN_ENCODING             shader_injection.swap_chain_encoding
+#define RENODX_SWAP_CHAIN_ENCODING_COLOR_SPACE shader_injection.swap_chain_encoding_color_space
+#define RENODX_RENO_DRT_TONE_MAP_METHOD        renodx::tonemap::renodrt::config::tone_map_method::REINHARD
+#define Custom_Bloom                           shader_injection.Custom_Bloom
+#define Custom_Star_Dispersion                 shader_injection.Custom_Star_Dispersion
+#define Custom_Emissives_Intensity             shader_injection.Custom_Emissives_Intensity
+#define Custom_Skybox_Intensity                shader_injection.Custom_Skybox_Intensity
+#define Custom_Particles_Intensity             shader_injection.Custom_Particles_Intensity
+#define Custom_Sharpening_Amount               shader_injection.Custom_Sharpening_Amount
+#define Custom_UI_Disable                      shader_injection.Custom_UI_Disable
+#define Custom_UI_Menu_Blur_Intensity          shader_injection.Custom_UI_Menu_Blur_Intensity
+#define Custom_Color_Tint_Intensity            shader_injection.Custom_Color_Tint_Intensity
+#define Custom_Contrast_Intensity              shader_injection.Custom_Contrast_Intensity
+
+#endif
+
+#endif
+
+#include "../../shaders/renodx.hlsl"
+
+#endif
+
+#endif  // SRC_TEMPLATE_SHARED_H_

--- a/src/games/clivebarkersjericho/swap_chain_proxy_pixel_shader.ps_5_x.hlsl
+++ b/src/games/clivebarkersjericho/swap_chain_proxy_pixel_shader.ps_5_x.hlsl
@@ -1,0 +1,8 @@
+#include "./shared.h"
+
+Texture2D t0 : register(t0);
+SamplerState s0 : register(s0);
+float4 main(float4 vpos: SV_POSITION, float2 uv: TEXCOORD0)
+    : SV_TARGET {
+  return renodx::draw::SwapChainPass(t0.Sample(s0, uv));
+}

--- a/src/games/clivebarkersjericho/swap_chain_proxy_vertex_shader.vs_5_x.hlsl
+++ b/src/games/clivebarkersjericho/swap_chain_proxy_vertex_shader.vs_5_x.hlsl
@@ -1,0 +1,6 @@
+void main(uint id: SV_VERTEXID, out float4 pos: SV_POSITION,
+          out float2 uv: TEXCOORD0) {
+  uv.x = (id == 1) ? 2.0 : 0.0;
+  uv.y = (id == 2) ? 2.0 : 0.0;
+  pos = float4(uv * float2(2.0, -2.0) + float2(-1.0, 1.0), 0.0, 1.0);
+}


### PR DESCRIPTION
Images from top to bottom: **SDR\HDR\SDR Look\HDR Look\**
<img width="1776" height="998" alt="SDR" src="https://github.com/user-attachments/assets/cf3808b1-0241-4522-b67e-4b45297702df" />
<img width="1775" height="1001" alt="HDR" src="https://github.com/user-attachments/assets/6d132c6b-701a-49cd-86a6-51b59c76c1f9" />
<img width="1777" height="1000" alt="SDR_Look" src="https://github.com/user-attachments/assets/1b69828a-a5b0-47e3-9d7e-613035eec6cf" />
<img width="1775" height="1002" alt="HDR_Look" src="https://github.com/user-attachments/assets/b0fbc6be-dc25-4db6-aec1-a776d1b67cc4" />

**Features:**
- Bloom slider
- Star dispersion slider
- Emissive texture HDR boost slider
- Skybox HDR boost slider
- Particles HDR boost slider
- Sharpening amount slider
- UI toggle
- UI menu blur slider
- Color tint slider (no lut grading in this game, just some basic color grading in shaders)
- Contrast slider (vanilla game is clipped pretty badly because of this)
- HDR look button that sets all of the above to my own personal taste
- Reworked some of the FX to work better in HDR (hit\damage overlay and "TV" overlay no longer raise black level some much, and highlights don't get clipped)

**Notes:**
- Do **NOT** run the game with MSAA, swapchain proxy creation will fail
- It's highly advised to run the game first, setup a resolution, and then run with [Display Commander Addon](https://github.com/pmnoxx/reshade-display-commander/releases) to fix issues with fullscreen