### PR TITLE
fix(unrealengine): fix ACE7 bugged text and auto upgrade

### DIFF
--- a/src/games/unrealengine/addon.cpp
+++ b/src/games/unrealengine/addon.cpp
@@ -499,6 +499,8 @@ void AddGamePatches() {
     AddSonicRacingCrossWorldsUpgrades();
   } else if (product_name == "Lost Soul Aside") {
     AddLostSoulAsideUpgrades();
+  } else if (filename == "Ace7Game.exe") {
+    renodx::mods::swapchain::swapchain_proxy_revert_state = true;
   } else {
     return;
   }
@@ -639,6 +641,12 @@ const std::unordered_map<
             "EM-Win64-Shipping.exe",
             {
                 {"Upgrade_R10G10B10A2_UNORM", UPGRADE_TYPE_OUTPUT_SIZE},
+                {"Upgrade_B8G8R8A8_TYPELESS", UPGRADE_TYPE_OUTPUT_SIZE},
+            },
+        },
+		{
+            "Ace7Game.exe",
+            {
                 {"Upgrade_B8G8R8A8_TYPELESS", UPGRADE_TYPE_OUTPUT_SIZE},
             },
         },


### PR DESCRIPTION
Fixes bugged text in Ace Combat 7 and auto upgrades necessary resources for HDR output.