### PR TITLE
feat(utils::resource): add VIEW_UPGRADES_R9G9B9E5

### DIFF
--- a/src/utils/resource.hpp
+++ b/src/utils/resource.hpp
@@ -78,6 +78,28 @@ const std::unordered_map<
         ViewUpgradeAll(b8g8r8a8_unorm_srgb, r11g11b10_float),
 };
 
+const std::unordered_map<
+    std::pair<reshade::api::resource_usage, reshade::api::format>,
+    reshade::api::format, utils::hash::HashPair>
+    VIEW_UPGRADES_R9G9B9E5 = {
+        ViewUpgradeAll(r16g16b16a16_typeless, r9g9b9e5),
+        ViewUpgradeAll(r10g10b10a2_typeless, r9g9b9e5),
+        ViewUpgradeAll(r8g8b8a8_typeless, r9g9b9e5),
+        ViewUpgradeAll(r16g16b16a16_float, r9g9b9e5),
+        ViewUpgradeAll(r16g16b16a16_unorm, r9g9b9e5),
+        ViewUpgradeAll(r16g16b16a16_snorm, r9g9b9e5),
+        ViewUpgradeAll(r10g10b10a2_unorm, r9g9b9e5),
+        ViewUpgradeAll(b10g10r10a2_unorm, r9g9b9e5),
+        ViewUpgradeAll(r8g8b8a8_unorm, r9g9b9e5),
+        ViewUpgradeAll(b8g8r8a8_unorm, r9g9b9e5),
+        ViewUpgradeAll(r8g8b8a8_snorm, r9g9b9e5),
+        ViewUpgradeAll(r8g8b8a8_unorm_srgb, r9g9b9e5),
+        ViewUpgradeAll(b8g8r8a8_unorm_srgb, r9g9b9e5),
+        ViewUpgradeAll(r11g11b10_float, r9g9b9e5),
+        ViewUpgradeAll(r9g9b9e5, r9g9b9e5),
+};
+
+
 #undef ViewUpgrade
 #undef ViewUpgradeAll
 


### PR DESCRIPTION
Tested to be functional on modern AMD hardware (RDNA2+, which is the only hardware that currently supports this format.)

The RGBA16 "upgrades" are there just to see if there was any performance advantages to be had by downgrading RGBA16 to R9G9B9E5 on hardware that is bandwidth constrained like the Steam Deck, though on most games it only breaks things. (Worked on some games though! With some minor performance gains too.)

Though in reality, the most practical use case for this, is that this is a safe, drop in upgrade for r11g11b10_float, from my testing on many games on both D3D11 and D3D12 (However, do keep in mind that D3D11 on Windows does not support R9G9B9E5 yet, even though the spec said support was coming, it does, however, work just fine on dxvk.), this doesn't introduce any issues, even on games that tend to crash when upgrading r11g11b10_float, like NieR:Automata, and it does produce appreciably less degraded colors, even in SDR. 
Here's a NieR: Automata example, with just unconditional r11g11b10_float -> r9g9b9e5 upgrades.
r9g9b9e5:
<img width="2550" height="1587" alt="image" src="https://github.com/user-attachments/assets/bb637ba0-3961-4c0d-9db0-d18b5450012b" />
r11g11b10_float:
<img width="2564" height="1494" alt="image" src="https://github.com/user-attachments/assets/ec391d2b-782d-43f4-ab40-5a3008570ed3" />
(Images courtesy of Lilium)

This is not currently exposed on any addon, though on supported hardware, adding:
```cpp
renodx::mods::swapchain::swap_chain_upgrade_targets.push_back({
            .old_format = reshade::api::format::r11g11b10_float,
            .new_format = reshade::api::format::r9g9b9e5,
            .ignore_size = true,
            .view_upgrades = renodx::utils::resource::VIEW_UPGRADES_R9G9B9E5
        });
```
Should be a free banding fix with no performance downsides.

(On Unreal Engine games, using this for upgrading the RGB10A2 32x32x32 LUT is also viable, though it does come at a cost of losing negatives, so BT.2020 colors, it was, however, a minor performance uplift on the Steam Deck OLED, relative to upgrading the LUT to RGBA16_F, so your millage may vary.)