### PR TITLE
Decompiler Overhaul

### DIFF
--- a/src/decompiler/cli.cpp
+++ b/src/decompiler/cli.cpp
@@ -9,6 +9,7 @@
 #include "../utils/path.hpp"
 #include "../utils/shader_compiler_directx.hpp"
 #include "../utils/shader_decompiler_dxc.hpp"
+#include "../utils/shader_decompiler/semantic_labels.hpp"
 
 int main(int argc, char** argv) {
   std::span<char*> arguments = {argv, argv + argc};
@@ -20,8 +21,20 @@ int main(int argc, char** argv) {
   }
 
   if (paths.size() < 1) {
-    std::cerr << "USAGE: decomp.exe {cso} [{hlsl}] [--flatten] [-f] [--skip-existing] [-s] [--use-do-while]\n";
+    std::cerr << "USAGE: decomp.exe {cso} [{hlsl}] [options]\n";
     std::cerr << "  Creates {hlsl} from the contents of {cso}\n";
+    std::cerr << "\n";
+    std::cerr << "Options:\n";
+    std::cerr << "  --flatten, -f        Optimize/inline expressions\n";
+    std::cerr << "  --use-do-while       Use do-while convergence wrappers\n";
+    std::cerr << "  --stackify           Recursive if/else nesting with phi_sel\n";
+    std::cerr << "  --structural         ShortFuse structural analysis (RECOMMENDED)\n";
+    std::cerr << "  --mermaid-decompile  Condition-based flat guarded emission\n";
+    std::cerr << "  --mermaid            Output Mermaid flowchart instead of HLSL\n";
+    std::cerr << "  --annotate           Add block boundary and condition comments to output\n";
+    std::cerr << "  --annotate-mermaid   Add full graph IR dump (nodes, edges, phi assignments)\n";
+    std::cerr << "  --semantic-labels    Add semantic labels as inline comments\n";
+    std::cerr << "  --skip-existing, -s  Skip if output file exists\n";
     return EXIT_FAILURE;
   }
 
@@ -49,13 +62,49 @@ int main(int argc, char** argv) {
     bool use_do_while = std::ranges::any_of(arguments, [](const std::string& argument) {
       return (argument == "--use-do-while");
     });
+    bool stackify = std::ranges::any_of(arguments, [](const std::string& argument) {
+      return (argument == "--stackify");
+    });
+    bool structural = std::ranges::any_of(arguments, [](const std::string& argument) {
+      return (argument == "--structural");
+    });
+    bool annotate = std::ranges::any_of(arguments, [](const std::string& argument) {
+      return (argument == "--annotate");
+    });
+    bool annotate_mermaid = std::ranges::any_of(arguments, [](const std::string& argument) {
+      return (argument == "--annotate-mermaid");
+    });
+    bool mermaid = std::ranges::any_of(arguments, [](const std::string& argument) {
+      return (argument == "--mermaid");
+    });
+    bool mermaid_decompile = std::ranges::any_of(arguments, [](const std::string& argument) {
+      return (argument == "--mermaid-decompile");
+    });
+    bool no_single_use_inline = std::ranges::any_of(arguments, [](const std::string& argument) {
+      return (argument == "--no-inline");
+    });
+    bool semantic_labels = std::ranges::any_of(arguments, [](const std::string& argument) {
+      return (argument == "--semantic-labels");
+    });
     std::string decompilation = decompiler.Decompile(disassembly, {
                                                                       .flatten = flatten,
                                                                       .use_do_while = use_do_while,
+                                                                      .stackify = stackify,
+                                                                      .structural = structural,
+                                                                      .mermaid = mermaid,
+                                                                      .annotate = annotate,
+                                                                      .annotate_mermaid = annotate_mermaid,
+                                                                      .mermaid_decompile = mermaid_decompile,
+                                                                      .no_single_use_inline = no_single_use_inline,
                                                                   });
 
     if (decompilation.empty()) {
       return EXIT_FAILURE;
+    }
+
+    // Apply semantic labeling post-pass if requested
+    if (semantic_labels) {
+      decompilation = renodx::utils::shader::decompiler::SemanticLabeler::Label(decompilation);
     }
 
     std::string output;

--- a/src/utils/shader_compiler_directx.hpp
+++ b/src/utils/shader_compiler_directx.hpp
@@ -26,11 +26,15 @@
 #include "./path.hpp"
 
 _COM_SMARTPTR_TYPEDEF(IDxcCompiler, __uuidof(IDxcCompiler));
+_COM_SMARTPTR_TYPEDEF(IDxcCompiler3, __uuidof(IDxcCompiler3));
 _COM_SMARTPTR_TYPEDEF(IDxcLibrary, __uuidof(IDxcLibrary));
 _COM_SMARTPTR_TYPEDEF(IDxcBlobEncoding, __uuidof(IDxcBlobEncoding));
+_COM_SMARTPTR_TYPEDEF(IDxcBlobUtf8, __uuidof(IDxcBlobUtf8));
+_COM_SMARTPTR_TYPEDEF(IDxcBlobWide, __uuidof(IDxcBlobWide));
 _COM_SMARTPTR_TYPEDEF(IDxcIncludeHandler, __uuidof(IDxcIncludeHandler));
 _COM_SMARTPTR_TYPEDEF(ID3DBlob, __uuidof(ID3DBlob));
 _COM_SMARTPTR_TYPEDEF(IDxcOperationResult, __uuidof(IDxcOperationResult));
+_COM_SMARTPTR_TYPEDEF(IDxcResult, __uuidof(IDxcResult));
 
 namespace renodx::utils::shader::compiler::directx {
 
@@ -174,6 +178,20 @@ inline HRESULT CreateCompiler(IDxcCompiler** dxc_compiler) {
   auto dxc_create_instance = DxcCreateInstanceProc(GetProcAddress(dxc_compiler_library, "DxcCreateInstance"));
   if (dxc_create_instance == nullptr) return -1;
   return dxc_create_instance(CLSID_DxcCompiler, __uuidof(IDxcCompiler), reinterpret_cast<void**>(dxc_compiler));
+}
+
+inline HRESULT CreateCompiler3(IDxcCompiler3** dxc_compiler) {
+  // HMODULE dxil_loader = LoadLibraryW(L"dxil.dll");
+  if (dxc_compiler_library == nullptr) {
+    dxc_compiler_library = LoadDXCompiler();
+  }
+  if (dxc_compiler_library == nullptr) {
+    return -1;
+  }
+  // NOLINTNEXTLINE(google-readability-casting)
+  auto dxc_create_instance = DxcCreateInstanceProc(GetProcAddress(dxc_compiler_library, "DxcCreateInstance"));
+  if (dxc_create_instance == nullptr) return -1;
+  return dxc_create_instance(CLSID_DxcCompiler, __uuidof(IDxcCompiler3), reinterpret_cast<void**>(dxc_compiler));
 }
 
 #define IFR(x)                \
@@ -478,6 +496,30 @@ inline std::string DisassembleShaderFXC(std::span<uint8_t> blob) {
       out_blob->GetBufferSize()};
 }
 
+inline bool TryDisassembleShaderDXC3(std::span<uint8_t> blob, std::string& output) {
+  IDxcCompiler3Ptr compiler;
+  IDxcResultPtr result;
+  IDxcBlobUtf8Ptr disassembly_text;
+  IDxcBlobWidePtr output_name;
+
+  if (FAILED(internal::CreateCompiler3(&compiler))) return false;
+
+  const DxcBuffer source = {
+      .Ptr = blob.data(),
+      .Size = blob.size(),
+      .Encoding = 0,
+  };
+  if (FAILED(compiler->Disassemble(&source, __uuidof(IDxcResult), reinterpret_cast<void**>(&result))) || result == nullptr) return false;
+
+  HRESULT status = S_OK;
+  if (FAILED(result->GetStatus(&status)) || FAILED(status)) return false;
+
+  if (FAILED(result->GetOutput(DXC_OUT_DISASSEMBLY, __uuidof(IDxcBlobUtf8), reinterpret_cast<void**>(&disassembly_text), &output_name)) || disassembly_text == nullptr) return false;
+
+  output.assign(disassembly_text->GetStringPointer(), disassembly_text->GetStringLength());
+  return !output.empty();
+}
+
 inline std::string DisassembleShaderDXC(std::span<uint8_t> blob) {
   IDxcLibraryPtr library;
   IDxcCompilerPtr compiler;
@@ -486,6 +528,15 @@ inline std::string DisassembleShaderDXC(std::span<uint8_t> blob) {
   ID3DBlobPtr disassembly;
 
   std::unique_lock lock(mutex_dxc_compiler);
+  std::string compiler3_disassembly;
+  try {
+    if (TryDisassembleShaderDXC3(blob, compiler3_disassembly)) {
+      return compiler3_disassembly;
+    }
+  } catch (...) {
+    // Fall back to the legacy disassembler path below.
+  }
+
   if (FAILED(internal::CreateLibrary(&library))) throw std::exception("Could not create library.");
   if (FAILED(library->CreateBlobWithEncodingFromPinned(blob.data(), blob.size(), CP_ACP, &source))) throw std::exception("Could not prepare blob.");
   if (FAILED(internal::CreateCompiler(&compiler))) throw std::exception("Could not create compiler object.");

--- a/src/utils/shader_decompiler/mermaid.hpp
+++ b/src/utils/shader_decompiler/mermaid.hpp
@@ -1,0 +1,897 @@
+// ===== MERMAID DIAGRAM OUTPUT =====
+// Generates Mermaid flowchart diagrams from CodeFunction's control flow graph.
+// These are methods on the CodeFunction class, #included inside the class body.
+//
+// Usage: decomp.exe shader.cso output.md --mermaid
+// The output is a Mermaid flowchart that can be rendered in any Mermaid viewer.
+    static std::string EscapeMermaidLabel(std::string_view input) {
+      std::string output;
+      output.reserve(input.size());
+      for (const auto character : input) {
+        switch (character) {
+          case '&':
+            output += "&amp;";
+            break;
+          case '"':
+            output += "&quot;";
+            break;
+          case '<':
+            output += "&lt;";
+            break;
+          case '>':
+            output += "&gt;";
+            break;
+          default:
+            output.push_back(character);
+            break;
+        }
+      }
+      return output;
+    }
+
+    static std::string MermaidNodeId(std::string_view prefix, int line_number) {
+      return std::format("{}_bb{}", prefix, line_number);
+    }
+
+    static std::string MermaidOrderNodeId(std::string_view prefix, size_t index) {
+      return std::format("{}_ord{}", prefix, index);
+    }
+
+    static std::string MermaidPlanNodeId(std::string_view prefix, std::string_view kind, int line_number) {
+      return std::format("{}_{}_{}", prefix, kind, line_number);
+    }
+
+    std::string BuildMermaid(std::string_view prefix) const {
+      try {
+        std::stringstream string_stream;
+        auto predecessors = ListPredecessorsVec();
+        auto postdominators = ListPostDominators();
+        auto immediate_postdominators = ListImmediatePostDominators(postdominators);
+        auto recursions = ListRecursions();
+        size_t edge_index = 0;
+        std::vector<std::string> branch_nodes;
+        std::vector<std::string> join_nodes;
+        std::vector<std::string> loop_nodes;
+
+      auto summarize_ints = [](const auto& values, size_t max_items = 4) {
+        std::stringstream summary;
+        size_t index = 0;
+        for (const auto value : values) {
+          if (index != 0) {
+            summary << ", ";
+          }
+          if (index >= max_items) {
+            summary << "+" << (values.size() - max_items);
+            break;
+          }
+          summary << value;
+          ++index;
+        }
+        return summary.str();
+      };
+
+      auto summarize_strings = [](const auto& values, size_t max_items = 4) {
+        std::stringstream summary;
+        size_t index = 0;
+        for (const auto& value : values) {
+          if (index != 0) {
+            summary << ", ";
+          }
+          if (index >= max_items) {
+            summary << "+" << (values.size() - max_items);
+            break;
+          }
+          summary << value;
+          ++index;
+        }
+        return summary.str();
+      };
+
+      auto summarize_phi_variables = [&](const CodeBlock& code_block) {
+        std::set<std::string> phi_variables;
+        for (const auto& phi_data : code_block.phi_lines) {
+          phi_variables.emplace(std::format("_{}", phi_data.variable));
+        }
+        return summarize_strings(phi_variables);
+      };
+
+      auto truncate_label = [](std::string_view label, size_t max_size = 96) {
+        if (label.size() <= max_size) {
+          return std::string(label);
+        }
+        return std::format("{}...", label.substr(0, max_size - 3));
+      };
+
+      auto debug_parse_variable = [&](std::string_view input, std::string_view expected_type) {
+        return std::format("_{}",  input.substr(1));
+      };
+
+      auto format_debug_phi_value = [&](std::string_view value, std::string_view type) {
+        auto debug_type = [&]() -> std::string_view {
+          if (type == "i1") return "bool";
+          if (type == "i32" || type == "int") return "int";
+          if (type == "i16" || type == "int16_t") return "int16_t";
+          if (type == "uint" || type == "uint16_t") return "uint";
+          if (type == "f16" || type == "half" || type == "min16float") return "half";
+          return "float";
+        }();
+
+        if (value.empty()) {
+          return std::string{};
+        }
+        if (value.starts_with('%')) {
+          return debug_parse_variable(value, debug_type);
+        }
+        if (type == "i1") return ParseBoolString(value);
+        if (type == "i32" || type == "int" || type == "i16" || type == "int16_t") return ParseIntString(value);
+        if (type == "uint" || type == "uint16_t") return ParseUintString(value);
+        if (type == "f16" || type == "half" || type == "min16float") return ParseSuffixedString(value, 'h');
+        return ParseSuffixedString(value, 'f');
+      };
+
+      auto summarize_edge_phi_assignments = [&](int predecessor, int target) {
+        std::vector<std::string> phi_assignments;
+        std::unordered_set<std::string> seen_assignments;
+        auto predecessor_it = code_blocks.find(predecessor);
+        if (predecessor_it == code_blocks.end()) {
+          return std::string{};
+        }
+        for (const auto& phi_data : predecessor_it->second.phi_lines) {
+          if (phi_data.code_function == target && phi_data.is_assign) {
+            auto formatted_value = OptimizeString(format_debug_phi_value(phi_data.value, phi_data.type));
+            auto assignment = std::format("_{}={}", phi_data.variable, formatted_value);
+            if (seen_assignments.emplace(assignment).second) {
+              phi_assignments.push_back(assignment);
+            }
+          }
+        }
+        if (phi_assignments.empty()) {
+          return std::string{};
+        }
+
+        std::stringstream assignment_stream;
+        size_t emitted_count = 0;
+        constexpr size_t MAX_ASSIGNMENTS = 3;
+        for (size_t i = 0; i < phi_assignments.size() && emitted_count < MAX_ASSIGNMENTS; ++i, ++emitted_count) {
+          if (emitted_count != 0) {
+            assignment_stream << ", ";
+          }
+          assignment_stream << phi_assignments[i];
+        }
+        if (phi_assignments.size() > MAX_ASSIGNMENTS) {
+          assignment_stream << ", +" << (phi_assignments.size() - MAX_ASSIGNMENTS);
+        }
+        return truncate_label(assignment_stream.str(), 72);
+      };
+
+      auto entry_block = code_blocks.empty() ? -1 : code_blocks.begin()->first;
+
+      auto is_loop_header = [&](int line_number) {
+        auto recursion_it = recursions.find(line_number);
+        return recursion_it != recursions.end() && !recursion_it->second.empty();
+      };
+
+      auto is_anchor_block = [&](int line_number) {
+        auto code_block_it = code_blocks.find(line_number);
+        if (code_block_it == code_blocks.end()) {
+          return false;
+        }
+        const auto& code_block = code_block_it->second;
+        auto successors = ListNormalizedSuccessors(code_block);
+        auto predecessor_it = predecessors.find(line_number);
+        const auto predecessor_count = predecessor_it == predecessors.end() ? 0u : predecessor_it->second.size();
+        return line_number == entry_block
+            || successors.empty()
+            || !code_block.code_switch.switch_condition.empty()
+            || !code_block.code_branch.branch_condition.empty()
+            || predecessor_count > 1
+            || !code_block.phi_lines.empty()
+            || is_loop_header(line_number);
+      };
+
+      auto ladder_index = BuildBranchLadderIndex(predecessors, immediate_postdominators);
+
+      auto function_name = name.empty() ? std::string("anonymous") : std::string(name);
+      string_stream << "  subgraph " << prefix << "[\"" << EscapeMermaidLabel(function_name) << "\"]\n";
+      string_stream << "    direction TB\n";
+
+      std::vector<int> ordered_blocks;
+      ordered_blocks.reserve(code_blocks.size());
+
+      for (const auto& [line_number, code_block] : code_blocks) {
+        ordered_blocks.push_back(line_number);
+        std::vector<std::string> label_lines = {
+            EscapeMermaidLabel(std::format("bb {}", line_number))};
+
+        auto predecessor_it = predecessors.find(line_number);
+        if (predecessor_it != predecessors.end() && !predecessor_it->second.empty()) {
+          label_lines.push_back(EscapeMermaidLabel(std::format("preds: {}", predecessor_it->second.size())));
+          if (predecessor_it->second.size() > 1) {
+            label_lines.push_back(EscapeMermaidLabel(std::format("join: {}", summarize_ints(predecessor_it->second))));
+          }
+        }
+
+        auto immediate_postdominator_it = immediate_postdominators.find(line_number);
+        if (immediate_postdominator_it != immediate_postdominators.end()) {
+          label_lines.push_back(EscapeMermaidLabel(std::format("ipdom: {}", immediate_postdominator_it->second)));
+        }
+
+        if (!code_block.phi_lines.empty()) {
+          label_lines.push_back(EscapeMermaidLabel(std::format("phi: {}", code_block.phi_lines.size())));
+          auto phi_summary = summarize_phi_variables(code_block);
+          if (!phi_summary.empty()) {
+            label_lines.push_back(EscapeMermaidLabel(std::format("phi vars: {}", phi_summary)));
+          }
+        }
+
+        if (!code_block.code_switch.switch_condition.empty()) {
+          label_lines.push_back(EscapeMermaidLabel(std::format("switch {}", truncate_label(code_block.code_switch.switch_condition))));
+        } else if (!code_block.code_branch.branch_condition.empty()) {
+          label_lines.push_back(EscapeMermaidLabel(std::format("if {}", truncate_label(code_block.code_branch.branch_condition))));
+        } else if (code_block.code_branch.branch_condition_true != -1) {
+          label_lines.push_back(EscapeMermaidLabel(std::format("goto {}", code_block.code_branch.branch_condition_true)));
+        } else {
+          label_lines.push_back("terminal");
+        }
+
+        std::stringstream label_stream;
+        for (size_t label_index = 0; label_index < label_lines.size(); ++label_index) {
+          if (label_index != 0) {
+            label_stream << "<br/>";
+          }
+          label_stream << label_lines[label_index];
+        }
+
+        string_stream << "    " << MermaidNodeId(prefix, line_number)
+                      << "[\"" << label_stream.str() << "\"]\n";
+
+        if (!code_block.code_switch.switch_condition.empty() || !code_block.code_branch.branch_condition.empty()) {
+          branch_nodes.push_back(MermaidNodeId(prefix, line_number));
+        }
+        if ((predecessor_it != predecessors.end() && predecessor_it->second.size() > 1) || !code_block.phi_lines.empty()) {
+          join_nodes.push_back(MermaidNodeId(prefix, line_number));
+        }
+        if (auto recursion_it = recursions.find(line_number);
+            recursion_it != recursions.end() && !recursion_it->second.empty()) {
+          loop_nodes.push_back(MermaidNodeId(prefix, line_number));
+        }
+      }
+
+      const bool use_ordering_scaffold = ordered_blocks.size() <= 24;
+      if (use_ordering_scaffold) {
+        for (size_t block_index = 0; block_index < ordered_blocks.size(); ++block_index) {
+          string_stream << "    " << MermaidOrderNodeId(prefix, block_index) << "[\" \"]\n";
+        }
+      }
+
+      string_stream << "  end\n";
+
+      if (use_ordering_scaffold) {
+        std::stringstream hidden_class_stream;
+        hidden_class_stream << "  class ";
+        for (size_t block_index = 0; block_index < ordered_blocks.size(); ++block_index) {
+          if (block_index != 0) {
+            hidden_class_stream << ",";
+          }
+          hidden_class_stream << MermaidOrderNodeId(prefix, block_index);
+        }
+        hidden_class_stream << " hidden\n";
+        string_stream << hidden_class_stream.str();
+      }
+
+      for (const auto& [line_number, code_block] : code_blocks) {
+        auto edge_operator = [&](int target) {
+          auto recursion_it = recursions.find(target);
+          if (recursion_it != recursions.end() && recursion_it->second.contains(line_number)) {
+            return "-.->";
+          }
+          return "-->";
+        };
+
+        auto write_edge = [&](int target, std::string_view label) {
+          if (target < 0 || !code_blocks.contains(target)) {
+            return;
+          }
+
+          std::string full_label = std::string(label);
+          auto phi_summary = summarize_edge_phi_assignments(line_number, target);
+          if (!phi_summary.empty()) {
+            if (!full_label.empty()) {
+              full_label += " ";
+            }
+            full_label += std::format("phi {}", phi_summary);
+          }
+
+          string_stream << "  " << MermaidNodeId(prefix, line_number)
+                        << " " << edge_operator(target);
+          if (!full_label.empty()) {
+            string_stream << "|"
+                          << EscapeMermaidLabel(full_label)
+                          << "|";
+          }
+          string_stream << " " << MermaidNodeId(prefix, target) << "\n";
+          ++edge_index;
+        };
+
+        if (!code_block.code_switch.switch_condition.empty()) {
+          std::map<int, std::vector<std::string>> labeled_targets;
+          labeled_targets[code_block.code_switch.case_default].push_back("default");
+          for (const auto& [case_value, case_function] : code_block.code_switch.case_values) {
+            labeled_targets[case_function].push_back(std::format("case {}", case_value));
+          }
+
+          for (const auto& [target, labels] : labeled_targets) {
+            std::stringstream label_stream;
+            for (size_t label_index = 0; label_index < labels.size(); ++label_index) {
+              if (label_index != 0) {
+                label_stream << ", ";
+              }
+              label_stream << labels[label_index];
+            }
+            write_edge(target, label_stream.str());
+          }
+          continue;
+        }
+
+        if (!code_block.code_branch.branch_condition.empty()) {
+          write_edge(code_block.code_branch.branch_condition_true, "T");
+          write_edge(code_block.code_branch.branch_condition_false, "F");
+        } else {
+          write_edge(code_block.code_branch.branch_condition_true, "");
+        }
+
+        if ((!code_block.code_switch.switch_condition.empty() || !code_block.code_branch.branch_condition.empty())) {
+          auto immediate_postdominator_it = immediate_postdominators.find(line_number);
+          if (immediate_postdominator_it != immediate_postdominators.end()) {
+            auto join_target = immediate_postdominator_it->second;
+            if (join_target >= 0 && code_blocks.contains(join_target)
+                && join_target != code_block.code_branch.branch_condition_true
+                && join_target != code_block.code_branch.branch_condition_false) {
+              std::string join_label = "join";
+              if (auto target_it = code_blocks.find(join_target);
+                  target_it != code_blocks.end() && !target_it->second.phi_lines.empty()) {
+                join_label = "join phi";
+              }
+              string_stream << "  " << MermaidNodeId(prefix, line_number)
+                            << " -.->|" << EscapeMermaidLabel(join_label) << "| "
+                            << MermaidNodeId(prefix, join_target) << "\n";
+              ++edge_index;
+            }
+          }
+        }
+      }
+
+      if (use_ordering_scaffold) {
+        for (size_t block_index = 0; block_index < ordered_blocks.size(); ++block_index) {
+          string_stream << "  " << MermaidOrderNodeId(prefix, block_index)
+                        << " --> " << MermaidNodeId(prefix, ordered_blocks[block_index]) << "\n";
+          string_stream << "  linkStyle " << edge_index++
+                        << " stroke:transparent,fill:none,color:transparent;\n";
+        }
+        for (size_t block_index = 0; block_index + 1 < ordered_blocks.size(); ++block_index) {
+          string_stream << "  " << MermaidOrderNodeId(prefix, block_index)
+                        << " --> " << MermaidOrderNodeId(prefix, block_index + 1) << "\n";
+          string_stream << "  linkStyle " << edge_index++
+                        << " stroke:transparent,fill:none,color:transparent;\n";
+        }
+      }
+
+      if (entry_block != -1) {
+        string_stream << "  class " << MermaidNodeId(prefix, entry_block) << " entry\n";
+      }
+      for (const auto& branch_node : branch_nodes) {
+        string_stream << "  class " << branch_node << " branch\n";
+      }
+      for (const auto& join_node : join_nodes) {
+        string_stream << "  class " << join_node << " join\n";
+      }
+      for (const auto& loop_node : loop_nodes) {
+        string_stream << "  class " << loop_node << " loop\n";
+      }
+
+        const auto plan_prefix = std::format("{}_plan", prefix);
+        try {
+          string_stream << BuildMermaidPlan(plan_prefix);
+        } catch (const std::exception& ex) {
+          throw std::runtime_error(std::format("BuildMermaidPlan({}): {}", prefix, ex.what()));
+        }
+        if (entry_block != -1) {
+          string_stream << "  " << MermaidNodeId(prefix, entry_block)
+                        << " -.->|plan| "
+                        << MermaidPlanNodeId(plan_prefix, "bb", entry_block)
+                        << "\n";
+        }
+        for (const auto& [line_number, code_block] : code_blocks) {
+          std::string plan_node_id;
+          if (auto ladder_it = ladder_index.owner.find(line_number); ladder_it != ladder_index.owner.end()) {
+            if (ladder_it->second != line_number) {
+              continue;
+            }
+            plan_node_id = MermaidPlanNodeId(plan_prefix, "ladder", line_number);
+          } else if (is_anchor_block(line_number)) {
+            plan_node_id = MermaidPlanNodeId(plan_prefix, "bb", line_number);
+          } else {
+            continue;
+          }
+          string_stream << "  " << MermaidNodeId(prefix, line_number)
+                        << " ~~~ " << plan_node_id << "\n";
+        }
+
+        return string_stream.str();
+      } catch (const std::exception& ex) {
+        throw std::runtime_error(std::format("BuildMermaid({}): {}", prefix, ex.what()));
+      }
+    }
+
+    std::string BuildMermaidPlan(std::string_view prefix) const {
+      std::stringstream string_stream;
+      auto predecessors = ListPredecessorsVec();
+      auto postdominators = ListPostDominators();
+      auto immediate_postdominators = ListImmediatePostDominators(postdominators);
+      auto recursions = ListRecursions();
+
+      auto summarize_ints = [](const auto& values, size_t max_items = 4) {
+        std::stringstream summary;
+        size_t index = 0;
+        for (const auto value : values) {
+          if (index != 0) {
+            summary << ", ";
+          }
+          if (index >= max_items) {
+            summary << "+" << (values.size() - max_items);
+            break;
+          }
+          summary << value;
+          ++index;
+        }
+        return summary.str();
+      };
+
+      auto summarize_strings = [](const auto& values, size_t max_items = 4) {
+        std::stringstream summary;
+        size_t index = 0;
+        for (const auto& value : values) {
+          if (index != 0) {
+            summary << ", ";
+          }
+          if (index >= max_items) {
+            summary << "+" << (values.size() - max_items);
+            break;
+          }
+          summary << value;
+          ++index;
+        }
+        return summary.str();
+      };
+
+      auto truncate_label = [](std::string_view label, size_t max_size = 72) {
+        if (label.size() <= max_size) {
+          return std::string(label);
+        }
+        return std::format("{}...", label.substr(0, max_size - 3));
+      };
+
+      auto debug_parse_variable = [&](std::string_view input, std::string_view expected_type) {
+        return std::format("_{}",  input.substr(1));
+      };
+
+      auto format_debug_phi_value = [&](std::string_view value, std::string_view type) {
+        auto debug_type = [&]() -> std::string_view {
+          if (type == "i1") return "bool";
+          if (type == "i32" || type == "int") return "int";
+          if (type == "i16" || type == "int16_t") return "int16_t";
+          if (type == "uint" || type == "uint16_t") return "uint";
+          if (type == "f16" || type == "half" || type == "min16float") return "half";
+          return "float";
+        }();
+
+        if (value.empty()) {
+          return std::string{};
+        }
+        if (value.starts_with('%')) {
+          return debug_parse_variable(value, debug_type);
+        }
+        if (type == "i1") return ParseBoolString(value);
+        if (type == "i32" || type == "int" || type == "i16" || type == "int16_t") return ParseIntString(value);
+        if (type == "uint" || type == "uint16_t") return ParseUintString(value);
+        if (type == "f16" || type == "half" || type == "min16float") return ParseSuffixedString(value, 'h');
+        return ParseSuffixedString(value, 'f');
+      };
+
+      auto summarize_edge_phi_assignments = [&](int predecessor, int target) {
+        std::vector<std::string> phi_assignments;
+        std::unordered_set<std::string> seen_assignments;
+        auto predecessor_it = code_blocks.find(predecessor);
+        if (predecessor_it == code_blocks.end()) {
+          return std::string{};
+        }
+        for (const auto& phi_data : predecessor_it->second.phi_lines) {
+          if (phi_data.code_function == target && phi_data.is_assign) {
+            auto formatted_value = OptimizeString(format_debug_phi_value(phi_data.value, phi_data.type));
+            auto assignment = std::format("_{}={}", phi_data.variable, formatted_value);
+            if (seen_assignments.emplace(assignment).second) {
+              phi_assignments.push_back(assignment);
+            }
+          }
+        }
+        if (phi_assignments.empty()) {
+          return std::string{};
+        }
+
+        std::stringstream assignment_stream;
+        size_t emitted_count = 0;
+        constexpr size_t MAX_ASSIGNMENTS = 3;
+        for (size_t i = 0; i < phi_assignments.size() && emitted_count < MAX_ASSIGNMENTS; ++i, ++emitted_count) {
+          if (emitted_count != 0) {
+            assignment_stream << ", ";
+          }
+          assignment_stream << phi_assignments[i];
+        }
+        if (phi_assignments.size() > MAX_ASSIGNMENTS) {
+          assignment_stream << ", +" << (phi_assignments.size() - MAX_ASSIGNMENTS);
+        }
+        return truncate_label(assignment_stream.str(), 72);
+      };
+
+      auto summarize_phi_variables = [&](const CodeBlock& code_block) {
+        std::set<std::string> phi_variables;
+        for (const auto& phi_data : code_block.phi_lines) {
+          phi_variables.emplace(std::format("_{}", phi_data.variable));
+        }
+        return summarize_strings(phi_variables);
+      };
+
+      auto summarize_join_carriers = [&](int target) {
+        auto predecessor_it = predecessors.find(target);
+        if (predecessor_it == predecessors.end() || predecessor_it->second.empty()) {
+          return std::string{};
+        }
+
+        std::vector<std::pair<std::vector<int>, std::string>> grouped;
+        std::unordered_map<std::string, size_t> group_index;
+        for (const auto predecessor : predecessor_it->second) {
+          auto summary = summarize_edge_phi_assignments(predecessor, target);
+          if (summary.empty()) {
+            continue;
+          }
+          auto [it, inserted] = group_index.emplace(summary, grouped.size());
+          if (inserted) {
+            grouped.push_back({{predecessor}, summary});
+          } else {
+            grouped[it->second].first.push_back(predecessor);
+          }
+        }
+
+        if (grouped.empty()) {
+          return std::string{};
+        }
+
+        std::stringstream carrier_stream;
+        constexpr size_t MAX_GROUPS = 3;
+        for (size_t i = 0; i < grouped.size() && i < MAX_GROUPS; ++i) {
+          if (i != 0) {
+            carrier_stream << "; ";
+          }
+          carrier_stream << summarize_ints(grouped[i].first) << "=>" << grouped[i].second;
+        }
+        if (grouped.size() > MAX_GROUPS) {
+          carrier_stream << "; +" << (grouped.size() - MAX_GROUPS);
+        }
+        return truncate_label(carrier_stream.str(), 120);
+      };
+
+      auto entry_block = code_blocks.empty() ? -1 : code_blocks.begin()->first;
+      auto is_loop_header = [&](int line_number) {
+        auto recursion_it = recursions.find(line_number);
+        return recursion_it != recursions.end() && !recursion_it->second.empty();
+      };
+
+      auto is_anchor_block = [&](int line_number) {
+        auto code_block_it = code_blocks.find(line_number);
+        if (code_block_it == code_blocks.end()) {
+          return false;
+        }
+        const auto& code_block = code_block_it->second;
+        auto successors = ListNormalizedSuccessors(code_block);
+        auto predecessor_it = predecessors.find(line_number);
+        const auto predecessor_count = predecessor_it == predecessors.end() ? 0u : predecessor_it->second.size();
+        return line_number == entry_block
+            || successors.empty()
+            || !code_block.code_switch.switch_condition.empty()
+            || !code_block.code_branch.branch_condition.empty()
+            || predecessor_count > 1
+            || !code_block.phi_lines.empty()
+            || is_loop_header(line_number);
+      };
+
+      auto ladder_index = BuildBranchLadderIndex(predecessors, immediate_postdominators);
+
+      struct PlanNode {
+        std::string id;
+        std::string class_name;
+        std::vector<int> members;
+      };
+
+      std::vector<PlanNode> plan_nodes;
+      std::unordered_map<int, size_t> block_to_plan_node;
+
+      auto add_plan_node = [&](std::string id, std::string class_name, std::vector<int> members, std::vector<std::string> label_lines) {
+        std::stringstream label_stream;
+        for (size_t label_index = 0; label_index < label_lines.size(); ++label_index) {
+          if (label_index != 0) {
+            label_stream << "<br/>";
+          }
+          label_stream << EscapeMermaidLabel(label_lines[label_index]);
+        }
+
+        string_stream << "  " << id << "[\"" << label_stream.str() << "\"]\n";
+
+        auto index = plan_nodes.size();
+        plan_nodes.push_back({
+            .id = std::move(id),
+            .class_name = std::move(class_name),
+            .members = std::move(members),
+        });
+        for (const auto member : plan_nodes.back().members) {
+          block_to_plan_node[member] = index;
+        }
+      };
+
+      auto function_name = name.empty() ? std::string("anonymous") : std::string(name);
+      string_stream << "  subgraph " << prefix << "[\"" << EscapeMermaidLabel(std::format("{} plan", function_name)) << "\"]\n";
+      string_stream << "    direction TB\n";
+
+      for (const auto& [root, ladder] : ladder_index.ladders) {
+        std::set<int> member_blocks(ladder.blocks.begin(), ladder.blocks.end());
+        std::set<int> unique_exits;
+        std::map<int, std::vector<std::string>> exit_phi_summaries;
+        for (const auto block : ladder.blocks) {
+          for (const auto successor : ListNormalizedSuccessors(code_blocks.at(block))) {
+            if (!member_blocks.contains(successor)) {
+              unique_exits.emplace(successor);
+              if (auto phi_summary = summarize_edge_phi_assignments(block, successor); !phi_summary.empty()) {
+                exit_phi_summaries[successor].push_back(std::format("{}=>{}", block, phi_summary));
+              }
+            }
+          }
+        }
+
+        std::vector<std::string> label_lines = {
+            std::format("ladder {}..{}", ladder.blocks.front(), ladder.blocks.back()),
+            std::format("shape: if / else-if x{}", ladder.blocks.size() - 1),
+            std::format("tests: {}", ladder.blocks.size()),
+        };
+        auto branch_plan = AnalyzeBranchStructure(root, immediate_postdominators, ladder_index);
+        if (branch_plan.has_value()) {
+          label_lines.push_back(std::format("arms: {}", branch_plan->arm_count));
+          label_lines.push_back(std::format("else: {}", branch_plan->has_else ? "yes" : "no"));
+          if (branch_plan->convergence != -1) {
+            label_lines.push_back(std::format("join: {}", branch_plan->convergence));
+          }
+        }
+        if (!unique_exits.empty()) {
+          label_lines.push_back(std::format("exits: {}", summarize_ints(unique_exits)));
+          for (const auto& exit_target : unique_exits) {
+            auto exit_phi_it = exit_phi_summaries.find(exit_target);
+            if (exit_phi_it == exit_phi_summaries.end() || exit_phi_it->second.empty()) {
+              continue;
+            }
+            label_lines.push_back(std::format(
+                "exit phi {}: {}",
+                exit_target,
+                summarize_strings(exit_phi_it->second, 2)));
+          }
+        }
+
+        add_plan_node(
+            MermaidPlanNodeId(prefix, "ladder", root),
+            "planladder",
+            ladder.blocks,
+            label_lines);
+      }
+
+      for (const auto& [line_number, code_block] : code_blocks) {
+        if (block_to_plan_node.contains(line_number)) {
+          continue;
+        }
+        if (!is_anchor_block(line_number)) {
+          continue;
+        }
+
+        auto successors = ListNormalizedSuccessors(code_block);
+        auto predecessor_it = predecessors.find(line_number);
+        auto predecessor_count = predecessor_it == predecessors.end() ? 0u : predecessor_it->second.size();
+        auto phi_summary = summarize_phi_variables(code_block);
+        auto branch_plan = AnalyzeBranchStructure(line_number, immediate_postdominators, ladder_index);
+
+        std::string class_name = "planseq";
+        std::vector<std::string> label_lines;
+        if (line_number == entry_block) {
+          class_name = "planentry";
+          label_lines.push_back(std::format("entry bb {}", line_number));
+        } else if (successors.empty()) {
+          class_name = "planexit";
+          label_lines.push_back(std::format("exit bb {}", line_number));
+        } else if (is_loop_header(line_number)) {
+          class_name = "planloop";
+          label_lines.push_back(std::format("loop bb {}", line_number));
+        } else if (predecessor_count > 1 || !code_block.phi_lines.empty()) {
+          class_name = "planjoin";
+          label_lines.push_back(std::format("join bb {}", line_number));
+        } else if (!code_block.code_switch.switch_condition.empty()) {
+          class_name = "planbranch";
+          label_lines.push_back(std::format("switch bb {}", line_number));
+        } else if (!code_block.code_branch.branch_condition.empty()) {
+          class_name = "planbranch";
+          label_lines.push_back(std::format("if bb {}", line_number));
+        } else {
+          class_name = "planseq";
+          label_lines.push_back(std::format("seq bb {}", line_number));
+        }
+
+        if (!phi_summary.empty()) {
+          label_lines.push_back(std::format("phi {}", phi_summary));
+        }
+        if (auto carrier_summary = summarize_join_carriers(line_number); !carrier_summary.empty()) {
+          label_lines.push_back(std::format("incoming {}", carrier_summary));
+        }
+        if (branch_plan.has_value()) {
+          label_lines.push_back(std::format("shape: {}", branch_plan->shape));
+          if (branch_plan->test_count > 0) {
+            label_lines.push_back(std::format("tests: {}", branch_plan->test_count));
+          }
+          if (branch_plan->arm_count > 0) {
+            label_lines.push_back(std::format("arms: {}", branch_plan->arm_count));
+          }
+          if (branch_plan->shape == "if/else") {
+            label_lines.push_back("else: yes");
+          } else if (branch_plan->shape == "if") {
+            label_lines.push_back("else: no");
+          }
+          if (branch_plan->convergence != -1) {
+            label_lines.push_back(std::format("join: {}", branch_plan->convergence));
+          }
+        }
+        if (!code_block.code_switch.switch_condition.empty()) {
+          label_lines.push_back(std::format("switch {}", truncate_label(code_block.code_switch.switch_condition)));
+        } else if (!code_block.code_branch.branch_condition.empty()) {
+          label_lines.push_back(std::format("if {}", truncate_label(code_block.code_branch.branch_condition)));
+        } else if (code_block.code_branch.branch_condition_true != -1) {
+          label_lines.push_back(std::format("goto {}", code_block.code_branch.branch_condition_true));
+        }
+
+        add_plan_node(
+            MermaidPlanNodeId(prefix, "bb", line_number),
+            class_name,
+            {line_number},
+            label_lines);
+      }
+
+      auto resolve_plan_target = [&](int start) -> std::pair<size_t, size_t> {
+        std::set<int> visited;
+        int current = start;
+        size_t collapsed = 0;
+        while (current >= 0) {
+          if (auto plan_it = block_to_plan_node.find(current);
+              plan_it != block_to_plan_node.end()) {
+            return {plan_it->second, collapsed};
+          }
+          if (!visited.emplace(current).second) {
+            break;
+          }
+          auto block_it = code_blocks.find(current);
+          if (block_it == code_blocks.end()) {
+            break;
+          }
+          auto successors = ListNormalizedSuccessors(block_it->second);
+          if (successors.size() != 1) {
+            break;
+          }
+          current = successors.front();
+          ++collapsed;
+        }
+        return {static_cast<size_t>(-1), collapsed};
+      };
+
+      struct PlanEdge {
+        size_t from = static_cast<size_t>(-1);
+        size_t to = static_cast<size_t>(-1);
+        std::string label;
+        bool dashed = false;
+
+        auto operator<=>(const PlanEdge&) const = default;
+      };
+
+      std::set<PlanEdge> plan_edges;
+
+      auto add_plan_edge = [&](size_t from, int successor, std::string label, bool dashed = false) {
+        auto [target, collapsed] = resolve_plan_target(successor);
+        if (target == static_cast<size_t>(-1) || target == from) {
+          return;
+        }
+        if (plan_nodes[from].members.size() == 1) {
+          auto phi_summary = summarize_edge_phi_assignments(plan_nodes[from].members.front(), successor);
+          if (!phi_summary.empty()) {
+            if (!label.empty()) {
+              label += " ";
+            }
+            label += std::format("phi {}", phi_summary);
+          }
+        }
+        if (collapsed > 0) {
+          if (!label.empty()) {
+            label += " ";
+          }
+          label += std::format("+{}", collapsed);
+        }
+        plan_edges.emplace(PlanEdge{
+            .from = from,
+            .to = target,
+            .label = std::move(label),
+            .dashed = dashed,
+        });
+      };
+
+      for (size_t node_index = 0; node_index < plan_nodes.size(); ++node_index) {
+        const auto& plan_node = plan_nodes[node_index];
+        if (plan_node.class_name == "planladder") {
+          auto ladder_root = plan_node.members.front();
+          auto ladder_it = ladder_index.ladders.find(ladder_root);
+          if (ladder_it == ladder_index.ladders.end()) {
+            continue;
+          }
+
+          std::set<int> member_blocks(ladder_it->second.blocks.begin(), ladder_it->second.blocks.end());
+          std::map<int, size_t> exit_counts;
+          for (const auto block : ladder_it->second.blocks) {
+            for (const auto successor : ListNormalizedSuccessors(code_blocks.at(block))) {
+              if (!member_blocks.contains(successor)) {
+                ++exit_counts[successor];
+              }
+            }
+          }
+
+          for (const auto& [exit_target, count] : exit_counts) {
+            auto label = count > 1 ? "match" : "fallthrough";
+            add_plan_edge(node_index, exit_target, label);
+          }
+          continue;
+        }
+
+        const auto block = plan_node.members.front();
+        const auto& code_block = code_blocks.at(block);
+        if (!code_block.code_switch.switch_condition.empty()) {
+          add_plan_edge(node_index, code_block.code_switch.case_default, "default");
+          for (const auto& [case_value, case_function] : code_block.code_switch.case_values) {
+            add_plan_edge(node_index, case_function, std::format("case {}", case_value));
+          }
+          continue;
+        }
+        if (!code_block.code_branch.branch_condition.empty()) {
+          add_plan_edge(node_index, code_block.code_branch.branch_condition_true, "T");
+          add_plan_edge(node_index, code_block.code_branch.branch_condition_false, "F");
+          continue;
+        }
+        if (code_block.code_branch.branch_condition_true != -1) {
+          add_plan_edge(node_index, code_block.code_branch.branch_condition_true, "");
+        }
+      }
+
+      for (const auto& edge : plan_edges) {
+        string_stream << "  " << plan_nodes[edge.from].id
+                      << (edge.dashed ? " -.->" : " -->");
+        if (!edge.label.empty()) {
+          string_stream << "|" << EscapeMermaidLabel(edge.label) << "|";
+        }
+        string_stream << " " << plan_nodes[edge.to].id << "\n";
+      }
+
+      string_stream << "  end\n";
+
+      for (const auto& plan_node : plan_nodes) {
+        string_stream << "  class " << plan_node.id << " " << plan_node.class_name << "\n";
+      }
+
+      return string_stream.str();
+    }
+

--- a/src/utils/shader_decompiler/mermaid_decompile.hpp
+++ b/src/utils/shader_decompiler/mermaid_decompile.hpp
@@ -1,0 +1,3576 @@
+/*
+ * Copyright (C) 2024 Carlos Lopez
+ * SPDX-License-Identifier: MIT
+ *
+ * Mermaid Decompile Strategy — Condition-based HLSL emission via Graph IR
+ *
+ * This file is #included into the CodeFunction class body inside
+ * shader_decompiler_dxc.hpp, within the Decompile() method's strategy
+ * dispatch block. It has access to all CodeFunction members, PreprocessState,
+ * and the string_stream output.
+ *
+ * Strategy overview:
+ *   Phase 1: Build typed Graph IR from code_blocks
+ *   Loop Detection: Identify natural loops via back-edge validation
+ *   Condition-Based Emission: Compute reaching conditions, emit flat guarded blocks
+ */
+
+// ============================================================
+// Phase 1: Graph IR — Data Structures and Construction
+// ============================================================
+
+{
+  // Reference to the parent-scope stringstream for region helper functions.
+  // These are emitted BEFORE main() by the splice logic in shader_decompiler_dxc.hpp.
+  auto& mermaid_region_functions = mermaid_pre_main_functions;
+  int mermaid_region_counter = 0;
+
+  // Annotation prefix: "// [mermaid] " for --annotate-mermaid, "// --- " for --annotate
+  const bool use_mermaid_prefix = decompile_options.annotate_mermaid;
+  auto ann_block = [&](int block_id) { return use_mermaid_prefix ? std::format("// [mermaid] block {}", block_id) : std::format("// --- block {}", block_id); };
+  auto ann_loop_block = [&](int block_id) { return use_mermaid_prefix ? std::format("// [mermaid] loop block {}", block_id) : std::format("// --- loop block {}", block_id); };
+
+  // --- Graph IR data structures (Task 3.1) ---
+
+  enum class GraphNodeType {
+    Entry,
+    Branch,
+    LoopHeader,
+    Join,
+    Switch,
+    Sequence,
+    Terminal
+  };
+
+  enum class GraphEdgeType {
+    Unconditional,
+    TrueBranch,
+    FalseBranch,
+    BackEdge,
+    SwitchCase
+  };
+
+  struct PhiAssignment {
+    std::string variable;   // e.g., "_1234"
+    std::string type;       // LLVM IR type (e.g., "i32", "float")
+    std::string value;      // Raw LLVM IR value (e.g., "%42", "0.0", "undef")
+  };
+
+  struct GraphNode {
+    int block_id = -1;
+    GraphNodeType type = GraphNodeType::Sequence;
+    std::vector<int> successors;
+    std::vector<int> predecessors;
+    int ipdom = -1;
+  };
+
+  struct GraphEdge {
+    int source = -1;
+    int target = -1;
+    GraphEdgeType type = GraphEdgeType::Unconditional;
+    std::vector<PhiAssignment> phi_assignments;
+  };
+
+  // --- Graph IR construction (Task 3.2) ---
+
+  // Call existing analysis functions
+  auto mermaid_recursions = current_code_function->ListRecursions();
+  auto mermaid_predecessors = current_code_function->ListPredecessorsVec();
+  auto mermaid_idom = current_code_function->ComputeDominators();
+  auto mermaid_postdominators = current_code_function->ListPostDominators();
+  auto mermaid_ipdom = current_code_function->ListImmediatePostDominators(mermaid_postdominators);
+
+  // Build dominator sets for back-edge validation
+  auto mermaid_dom_sets = current_code_function->ListDominators();
+
+  // Storage for the Graph IR
+  std::map<int, GraphNode> graph_nodes;
+  std::vector<GraphEdge> graph_edges;
+
+  // Determine entry block (first block in sorted code_blocks)
+  // Edge case: empty code_blocks produces empty main function body (Task 8.2)
+  int mermaid_entry_block = -1;
+  if (!current_code_function->code_blocks.empty()) {
+    mermaid_entry_block = current_code_function->code_blocks.begin()->first;
+  }
+
+  // Walk code_blocks once, classify each block
+  for (const auto& [line_number, code_block] : current_code_function->code_blocks) {
+    GraphNode node;
+    node.block_id = line_number;
+
+    // Compute successors via existing ListNormalizedSuccessors
+    node.successors = current_code_function->ListNormalizedSuccessors(code_block);
+
+    // Predecessors from precomputed map
+    if (mermaid_predecessors.contains(line_number)) {
+      node.predecessors = mermaid_predecessors.at(line_number);
+    }
+
+    // Immediate post-dominator
+    if (mermaid_ipdom.contains(line_number)) {
+      node.ipdom = mermaid_ipdom.at(line_number);
+    }
+
+    // Classify node type using priority: Entry > Terminal > LoopHeader > Switch > Branch > Join > Sequence
+    if (line_number == mermaid_entry_block) {
+      node.type = GraphNodeType::Entry;
+    } else if (node.successors.empty()) {
+      node.type = GraphNodeType::Terminal;
+    } else if (mermaid_recursions.contains(line_number)) {
+      node.type = GraphNodeType::LoopHeader;
+    } else if (!code_block.code_switch.switch_condition.empty()) {
+      node.type = GraphNodeType::Switch;
+    } else if (!code_block.code_branch.branch_condition.empty()) {
+      node.type = GraphNodeType::Branch;
+    } else if (node.predecessors.size() > 1 || !code_block.phi_lines.empty()) {
+      node.type = GraphNodeType::Join;
+    } else {
+      node.type = GraphNodeType::Sequence;
+    }
+
+    graph_nodes[line_number] = std::move(node);
+  }
+
+  // Build a set of true back-edge targets using dominator-based detection.
+  // A block is a loop header only if it has an incoming edge where
+  // source >= target AND target dominates source.
+  // This is more precise than ListRecursions() which may include
+  // convergence edges that look like back-edges but aren't.
+  std::set<int> mermaid_backedge_targets;
+  for (const auto& [src_line, src_block] : current_code_function->code_blocks) {
+    auto succs = current_code_function->ListNormalizedSuccessors(src_block);
+    for (int tgt : succs) {
+      if (src_line >= tgt && mermaid_dom_sets.contains(src_line)
+          && mermaid_dom_sets.at(src_line).contains(tgt)) {
+        mermaid_backedge_targets.insert(tgt);
+      }
+    }
+  }
+
+  // Reclassify nodes: only mark as LoopHeader if they have a true back-edge
+  for (auto& [line_number, node] : graph_nodes) {
+    if (node.type == GraphNodeType::LoopHeader && !mermaid_backedge_targets.contains(line_number)) {
+      // Reclassify: this was marked as LoopHeader by ListRecursions but
+      // has no true back-edge. Reclassify based on its properties.
+      const auto& code_block = current_code_function->code_blocks.at(line_number);
+      if (!code_block.code_switch.switch_condition.empty()) {
+        node.type = GraphNodeType::Switch;
+      } else if (!code_block.code_branch.branch_condition.empty()) {
+        node.type = GraphNodeType::Branch;
+      } else if (node.predecessors.size() > 1 || !code_block.phi_lines.empty()) {
+        node.type = GraphNodeType::Join;
+      } else {
+        node.type = GraphNodeType::Sequence;
+      }
+    }
+  }
+
+  // Build edges from branch conditions and classify edge types
+  for (const auto& [line_number, code_block] : current_code_function->code_blocks) {
+    bool has_branch_condition = !code_block.code_branch.branch_condition.empty();
+    bool has_switch = !code_block.code_switch.switch_condition.empty();
+
+    // Helper: detect back-edge (source line >= target line AND target dominates source)
+    auto is_back_edge = [&](int source, int target) -> bool {
+      if (source < target) return false;
+      // Check if target dominates source using dominator sets
+      if (mermaid_dom_sets.contains(source)) {
+        return mermaid_dom_sets.at(source).contains(target);
+      }
+      return false;
+    };
+
+    // Helper: extract phi assignments for an edge (source -> target)
+    // Stores raw LLVM IR types/values — parsing deferred to emission phase
+    auto extract_phi_assignments = [&](int source, int target) -> std::vector<PhiAssignment> {
+      std::vector<PhiAssignment> assignments;
+      // phi_lines are stored on the SOURCE block (the predecessor).
+      // Each PhiData entry has code_function = target block.
+      const auto& source_block = current_code_function->code_blocks.at(source);
+      for (const auto& phi : source_block.phi_lines) {
+        if (phi.is_assign && phi.code_function == target) {
+          PhiAssignment pa;
+          pa.variable = std::format("_{}", phi.variable);
+          pa.type = phi.type;      // Raw LLVM IR type
+          pa.value = phi.value;    // Raw LLVM IR value — parsed during emission
+          assignments.push_back(std::move(pa));
+        }
+      }
+      return assignments;
+    };
+
+    if (has_switch) {
+      // Switch edges
+      if (code_block.code_switch.case_default >= 0 &&
+          current_code_function->code_blocks.contains(code_block.code_switch.case_default)) {
+        GraphEdge edge;
+        edge.source = line_number;
+        edge.target = code_block.code_switch.case_default;
+        edge.type = is_back_edge(line_number, edge.target) ? GraphEdgeType::BackEdge : GraphEdgeType::SwitchCase;
+        edge.phi_assignments = extract_phi_assignments(line_number, edge.target);
+        graph_edges.push_back(std::move(edge));
+      }
+      for (const auto& [case_value, case_function] : code_block.code_switch.case_values) {
+        if (case_function >= 0 && current_code_function->code_blocks.contains(case_function)) {
+          GraphEdge edge;
+          edge.source = line_number;
+          edge.target = case_function;
+          edge.type = is_back_edge(line_number, case_function) ? GraphEdgeType::BackEdge : GraphEdgeType::SwitchCase;
+          edge.phi_assignments = extract_phi_assignments(line_number, case_function);
+          graph_edges.push_back(std::move(edge));
+        }
+      }
+    } else if (has_branch_condition) {
+      // Conditional branch — true and false edges
+      int true_target = code_block.code_branch.branch_condition_true;
+      int false_target = code_block.code_branch.branch_condition_false;
+
+      if (true_target >= 0 && current_code_function->code_blocks.contains(true_target)) {
+        GraphEdge edge;
+        edge.source = line_number;
+        edge.target = true_target;
+        edge.type = is_back_edge(line_number, true_target) ? GraphEdgeType::BackEdge : GraphEdgeType::TrueBranch;
+        edge.phi_assignments = extract_phi_assignments(line_number, true_target);
+        graph_edges.push_back(std::move(edge));
+      }
+      if (false_target >= 0 && current_code_function->code_blocks.contains(false_target)) {
+        GraphEdge edge;
+        edge.source = line_number;
+        edge.target = false_target;
+        edge.type = is_back_edge(line_number, false_target) ? GraphEdgeType::BackEdge : GraphEdgeType::FalseBranch;
+        edge.phi_assignments = extract_phi_assignments(line_number, false_target);
+        graph_edges.push_back(std::move(edge));
+      }
+    } else {
+      // Unconditional branch — single successor
+      // Could be branch_condition_true with no condition (goto), or fallthrough
+      int target = code_block.code_branch.branch_condition_true;
+      if (target >= 0 && current_code_function->code_blocks.contains(target)) {
+        GraphEdge edge;
+        edge.source = line_number;
+        edge.target = target;
+        edge.type = is_back_edge(line_number, target) ? GraphEdgeType::BackEdge : GraphEdgeType::Unconditional;
+        edge.phi_assignments = extract_phi_assignments(line_number, target);
+        graph_edges.push_back(std::move(edge));
+      }
+    }
+  }
+
+  // Full graph IR dump — only with --annotate-mermaid (verbose, for decompiler debugging)
+  if (decompile_options.annotate_mermaid) {
+    string_stream << spacing << "// [mermaid] Graph IR: " << graph_nodes.size() << " nodes, "
+                  << graph_edges.size() << " edges\n";
+    for (const auto& [block_id, node] : graph_nodes) {
+      const char* type_str = "Sequence";
+      switch (node.type) {
+        case GraphNodeType::Entry: type_str = "Entry"; break;
+        case GraphNodeType::Branch: type_str = "Branch"; break;
+        case GraphNodeType::LoopHeader: type_str = "LoopHeader"; break;
+        case GraphNodeType::Join: type_str = "Join"; break;
+        case GraphNodeType::Switch: type_str = "Switch"; break;
+        case GraphNodeType::Sequence: type_str = "Sequence"; break;
+        case GraphNodeType::Terminal: type_str = "Terminal"; break;
+      }
+      string_stream << spacing << "// [mermaid]   node " << block_id << ": " << type_str
+                    << " succ=[";
+      for (size_t i = 0; i < node.successors.size(); ++i) {
+        if (i > 0) string_stream << ",";
+        string_stream << node.successors[i];
+      }
+      string_stream << "] pred=[";
+      for (size_t i = 0; i < node.predecessors.size(); ++i) {
+        if (i > 0) string_stream << ",";
+        string_stream << node.predecessors[i];
+      }
+      string_stream << "] ipdom=" << node.ipdom << "\n";
+    }
+    for (const auto& edge : graph_edges) {
+      const char* edge_str = "Unconditional";
+      switch (edge.type) {
+        case GraphEdgeType::Unconditional: edge_str = "Unconditional"; break;
+        case GraphEdgeType::TrueBranch: edge_str = "TrueBranch"; break;
+        case GraphEdgeType::FalseBranch: edge_str = "FalseBranch"; break;
+        case GraphEdgeType::BackEdge: edge_str = "BackEdge"; break;
+        case GraphEdgeType::SwitchCase: edge_str = "SwitchCase"; break;
+      }
+      string_stream << spacing << "// [mermaid]   edge " << edge.source << " -> " << edge.target
+                    << " [" << edge_str << "]";
+      if (!edge.phi_assignments.empty()) {
+        string_stream << " phi={";
+        for (size_t i = 0; i < edge.phi_assignments.size(); ++i) {
+          if (i > 0) string_stream << ", ";
+          string_stream << edge.phi_assignments[i].variable << ":" << edge.phi_assignments[i].type;
+        }
+        string_stream << "}";
+      }
+      string_stream << "\n";
+    }
+  }
+
+  // ============================================================
+  // Phase 1.5: Graph Normalization
+  // ============================================================
+  std::set<int> synthetic_blocks;
+
+  // ============================================================
+  // CondExpr — Boolean expression tree for reaching conditions
+  // ============================================================
+
+  struct CondExpr {
+    enum class Kind { Const, Var, Not, And, Or };
+    Kind kind;
+    bool const_val = false;                              // for Kind::Const
+    std::string var_name;                                // for Kind::Var (e.g., "__cond_3612")
+    std::shared_ptr<CondExpr> child;                     // for Kind::Not
+    std::vector<std::shared_ptr<CondExpr>> children;     // for Kind::And, Kind::Or
+  };
+
+  using CondExprPtr = std::shared_ptr<CondExpr>;
+
+  // --- Factory functions ---
+
+  auto make_const = [](bool val) -> CondExprPtr {
+    auto e = std::make_shared<CondExpr>();
+    e->kind = CondExpr::Kind::Const;
+    e->const_val = val;
+    return e;
+  };
+
+  auto make_var = [](const std::string& name) -> CondExprPtr {
+    auto e = std::make_shared<CondExpr>();
+    e->kind = CondExpr::Kind::Var;
+    e->var_name = name;
+    return e;
+  };
+
+  auto make_not = [](CondExprPtr child) -> CondExprPtr {
+    auto e = std::make_shared<CondExpr>();
+    e->kind = CondExpr::Kind::Not;
+    e->child = std::move(child);
+    return e;
+  };
+
+  auto make_and = [](CondExprPtr a, CondExprPtr b) -> CondExprPtr {
+    auto e = std::make_shared<CondExpr>();
+    e->kind = CondExpr::Kind::And;
+    e->children.push_back(std::move(a));
+    e->children.push_back(std::move(b));
+    return e;
+  };
+
+  auto make_or = [](CondExprPtr a, CondExprPtr b) -> CondExprPtr {
+    auto e = std::make_shared<CondExpr>();
+    e->kind = CondExpr::Kind::Or;
+    e->children.push_back(std::move(a));
+    e->children.push_back(std::move(b));
+    return e;
+  };
+
+  // --- Helper predicates ---
+
+  auto is_const_true = [](const CondExprPtr& expr) -> bool {
+    return expr && expr->kind == CondExpr::Kind::Const && expr->const_val;
+  };
+
+  auto is_const_false = [](const CondExprPtr& expr) -> bool {
+    return expr && expr->kind == CondExpr::Kind::Const && !expr->const_val;
+  };
+
+  // Structural equality of two CondExpr trees
+  std::function<bool(const CondExprPtr&, const CondExprPtr&)> expr_equal;
+  expr_equal = [&expr_equal](const CondExprPtr& a, const CondExprPtr& b) -> bool {
+    if (!a && !b) return true;
+    if (!a || !b) return false;
+    if (a->kind != b->kind) return false;
+    switch (a->kind) {
+      case CondExpr::Kind::Const:
+        return a->const_val == b->const_val;
+      case CondExpr::Kind::Var:
+        return a->var_name == b->var_name;
+      case CondExpr::Kind::Not:
+        return expr_equal(a->child, b->child);
+      case CondExpr::Kind::And:
+      case CondExpr::Kind::Or:
+        if (a->children.size() != b->children.size()) return false;
+        for (size_t i = 0; i < a->children.size(); ++i) {
+          if (!expr_equal(a->children[i], b->children[i])) return false;
+        }
+        return true;
+    }
+    return false;
+  };
+
+  // Deep clone a CondExpr tree to avoid shared_ptr aliasing issues during simplification.
+  // simplify() uses std::move which corrupts shared subtrees if multiple RCs reference the same nodes.
+  std::function<CondExprPtr(const CondExprPtr&)> clone_expr;
+  clone_expr = [&clone_expr, &make_const, &make_var](const CondExprPtr& expr) -> CondExprPtr {
+    if (!expr) return nullptr;
+    switch (expr->kind) {
+      case CondExpr::Kind::Const:
+        return make_const(expr->const_val);
+      case CondExpr::Kind::Var:
+        return make_var(expr->var_name);
+      case CondExpr::Kind::Not: {
+        auto e = std::make_shared<CondExpr>();
+        e->kind = CondExpr::Kind::Not;
+        e->child = clone_expr(expr->child);
+        return e;
+      }
+      case CondExpr::Kind::And:
+      case CondExpr::Kind::Or: {
+        auto e = std::make_shared<CondExpr>();
+        e->kind = expr->kind;
+        e->children.reserve(expr->children.size());
+        for (const auto& c : expr->children) {
+          e->children.push_back(clone_expr(c));
+        }
+        return e;
+      }
+    }
+    return nullptr;
+  };
+
+  // --- Emit a CondExpr as an HLSL boolean expression string ---
+
+  std::function<std::string(const CondExprPtr&)> emit_expr;
+  emit_expr = [&emit_expr](const CondExprPtr& expr) -> std::string {
+    if (!expr) return "false";
+    switch (expr->kind) {
+      case CondExpr::Kind::Const:
+        return expr->const_val ? "true" : "false";
+      case CondExpr::Kind::Var:
+        return expr->var_name;
+      case CondExpr::Kind::Not: {
+        std::string inner = emit_expr(expr->child);
+        // If the child is a simple variable or const, no parens needed around it
+        if (expr->child && (expr->child->kind == CondExpr::Kind::Var
+            || expr->child->kind == CondExpr::Kind::Const)) {
+          return std::format("!{}", inner);
+        }
+        return std::format("!({})", inner);
+      }
+      case CondExpr::Kind::And: {
+        if (expr->children.empty()) return "true";
+        if (expr->children.size() == 1) return emit_expr(expr->children[0]);
+        std::string result;
+        for (size_t i = 0; i < expr->children.size(); ++i) {
+          if (i > 0) result += " && ";
+          const auto& c = expr->children[i];
+          if (!c) { result += "false"; continue; }
+          // Wrap OR children in parens for precedence
+          if (c->kind == CondExpr::Kind::Or) {
+            result += std::format("({})", emit_expr(c));
+          } else {
+            result += emit_expr(c);
+          }
+        }
+        return result;
+      }
+      case CondExpr::Kind::Or: {
+        if (expr->children.empty()) return "false";
+        if (expr->children.size() == 1) return emit_expr(expr->children[0]);
+        std::string result;
+        for (size_t i = 0; i < expr->children.size(); ++i) {
+          if (i > 0) result += " || ";
+          const auto& c = expr->children[i];
+          if (!c) { result += "false"; continue; }
+          // Wrap AND children in parens for precedence
+          if (c->kind == CondExpr::Kind::And) {
+            result += std::format("({})", emit_expr(c));
+          } else {
+            result += emit_expr(c);
+          }
+        }
+        return result;
+      }
+    }
+    return "false";
+  };
+
+  // --- Simplify a CondExpr tree using boolean algebra rules ---
+
+  std::function<CondExprPtr(CondExprPtr, int)> simplify;
+  simplify = [&](CondExprPtr expr, int depth) -> CondExprPtr {
+    if (!expr) return make_const(false);
+
+    // Depth guard: stop simplification if depth exceeds 100
+    if (depth > 100) return expr;
+
+    switch (expr->kind) {
+      case CondExpr::Kind::Const:
+      case CondExpr::Kind::Var:
+        return expr;
+
+      case CondExpr::Kind::Not: {
+        // Recursively simplify the child first
+        expr->child = simplify(expr->child, depth + 1);
+
+        // Double negation elimination: NOT(NOT(x)) → x
+        if (expr->child && expr->child->kind == CondExpr::Kind::Not) {
+          return expr->child->child;
+        }
+        // NOT(true) → false, NOT(false) → true
+        if (is_const_true(expr->child)) return make_const(false);
+        if (is_const_false(expr->child)) return make_const(true);
+
+        return expr;
+      }
+
+      case CondExpr::Kind::And: {
+        // Recursively simplify all children
+        for (auto& c : expr->children) {
+          c = simplify(c, depth + 1);
+        }
+
+        // Flatten nested AND: AND(AND(a,b), c) → AND(a,b,c)
+        {
+          std::vector<CondExprPtr> flattened;
+          for (auto& c : expr->children) {
+            if (c && c->kind == CondExpr::Kind::And) {
+              for (auto& gc : c->children) {
+                flattened.push_back(std::move(gc));
+              }
+            } else {
+              flattened.push_back(std::move(c));
+            }
+          }
+          expr->children = std::move(flattened);
+        }
+
+        // Annihilation: if any child is false → false
+        for (const auto& c : expr->children) {
+          if (is_const_false(c)) return make_const(false);
+        }
+
+        // Identity: remove true children (x AND true → x)
+        {
+          std::vector<CondExprPtr> filtered;
+          for (auto& c : expr->children) {
+            if (!is_const_true(c)) {
+              filtered.push_back(std::move(c));
+            }
+          }
+          expr->children = std::move(filtered);
+        }
+
+        // If empty after filtering, it was all true → true
+        if (expr->children.empty()) return make_const(true);
+        // Single child → return it directly
+        if (expr->children.size() == 1) return expr->children[0];
+
+        // Idempotence: remove duplicate children (x AND x → x)
+        {
+          std::vector<CondExprPtr> deduped;
+          for (auto& c : expr->children) {
+            bool found = false;
+            for (const auto& d : deduped) {
+              if (expr_equal(c, d)) {
+                found = true;
+                break;
+              }
+            }
+            if (!found) {
+              deduped.push_back(std::move(c));
+            }
+          }
+          expr->children = std::move(deduped);
+        }
+        if (expr->children.size() == 1) return expr->children[0];
+
+        // Complementation: x AND NOT(x) → false
+        for (size_t i = 0; i < expr->children.size(); ++i) {
+          for (size_t j = i + 1; j < expr->children.size(); ++j) {
+            const auto& ci = expr->children[i];
+            const auto& cj = expr->children[j];
+            // Check if ci == NOT(cj) or cj == NOT(ci)
+            if (ci->kind == CondExpr::Kind::Not && expr_equal(ci->child, cj)) {
+              return make_const(false);
+            }
+            if (cj->kind == CondExpr::Kind::Not && expr_equal(cj->child, ci)) {
+              return make_const(false);
+            }
+          }
+        }
+
+        // Absorption: x AND (x OR y) → x
+        // For each child ci, check if any other child cj is an OR containing ci
+        {
+          std::vector<bool> absorbed(expr->children.size(), false);
+          for (size_t i = 0; i < expr->children.size(); ++i) {
+            if (absorbed[i]) continue;
+            for (size_t j = 0; j < expr->children.size(); ++j) {
+              if (i == j || absorbed[j]) continue;
+              // If children[j] is OR and contains children[i], absorb children[j]
+              if (expr->children[j]->kind == CondExpr::Kind::Or) {
+                for (const auto& oc : expr->children[j]->children) {
+                  if (expr_equal(expr->children[i], oc)) {
+                    absorbed[j] = true;
+                    break;
+                  }
+                }
+              }
+            }
+          }
+          std::vector<CondExprPtr> result;
+          for (size_t i = 0; i < expr->children.size(); ++i) {
+            if (!absorbed[i]) {
+              result.push_back(std::move(expr->children[i]));
+            }
+          }
+          expr->children = std::move(result);
+        }
+        if (expr->children.empty()) return make_const(true);
+        if (expr->children.size() == 1) return expr->children[0];
+
+        return expr;
+      }
+
+      case CondExpr::Kind::Or: {
+        // Recursively simplify all children
+        for (auto& c : expr->children) {
+          c = simplify(c, depth + 1);
+        }
+
+        // Flatten nested OR: OR(OR(a,b), c) → OR(a,b,c)
+        {
+          std::vector<CondExprPtr> flattened;
+          for (auto& c : expr->children) {
+            if (c && c->kind == CondExpr::Kind::Or) {
+              for (auto& gc : c->children) {
+                flattened.push_back(std::move(gc));
+              }
+            } else {
+              flattened.push_back(std::move(c));
+            }
+          }
+          expr->children = std::move(flattened);
+        }
+
+        // Annihilation: if any child is true → true
+        for (const auto& c : expr->children) {
+          if (is_const_true(c)) return make_const(true);
+        }
+
+        // Identity: remove false children (x OR false → x)
+        {
+          std::vector<CondExprPtr> filtered;
+          for (auto& c : expr->children) {
+            if (!is_const_false(c)) {
+              filtered.push_back(std::move(c));
+            }
+          }
+          expr->children = std::move(filtered);
+        }
+
+        // If empty after filtering, it was all false → false
+        if (expr->children.empty()) return make_const(false);
+        // Single child → return it directly
+        if (expr->children.size() == 1) return expr->children[0];
+
+        // Idempotence: remove duplicate children (x OR x → x)
+        {
+          std::vector<CondExprPtr> deduped;
+          for (auto& c : expr->children) {
+            bool found = false;
+            for (const auto& d : deduped) {
+              if (expr_equal(c, d)) {
+                found = true;
+                break;
+              }
+            }
+            if (!found) {
+              deduped.push_back(std::move(c));
+            }
+          }
+          expr->children = std::move(deduped);
+        }
+        if (expr->children.size() == 1) return expr->children[0];
+
+        // Complementation: x OR NOT(x) → true
+        for (size_t i = 0; i < expr->children.size(); ++i) {
+          for (size_t j = i + 1; j < expr->children.size(); ++j) {
+            const auto& ci = expr->children[i];
+            const auto& cj = expr->children[j];
+            if (ci->kind == CondExpr::Kind::Not && expr_equal(ci->child, cj)) {
+              return make_const(true);
+            }
+            if (cj->kind == CondExpr::Kind::Not && expr_equal(cj->child, ci)) {
+              return make_const(true);
+            }
+          }
+        }
+
+        // Absorption: x OR (x AND y) → x
+        // For each child ci, check if any other child cj is an AND containing ci
+        {
+          std::vector<bool> absorbed(expr->children.size(), false);
+          for (size_t i = 0; i < expr->children.size(); ++i) {
+            if (absorbed[i]) continue;
+            for (size_t j = 0; j < expr->children.size(); ++j) {
+              if (i == j || absorbed[j]) continue;
+              // If children[j] is AND and contains children[i], absorb children[j]
+              if (expr->children[j]->kind == CondExpr::Kind::And) {
+                for (const auto& ac : expr->children[j]->children) {
+                  if (expr_equal(expr->children[i], ac)) {
+                    absorbed[j] = true;
+                    break;
+                  }
+                }
+              }
+            }
+          }
+          std::vector<CondExprPtr> result;
+          for (size_t i = 0; i < expr->children.size(); ++i) {
+            if (!absorbed[i]) {
+              result.push_back(std::move(expr->children[i]));
+            }
+          }
+          expr->children = std::move(result);
+        }
+        if (expr->children.empty()) return make_const(false);
+        if (expr->children.size() == 1) return expr->children[0];
+
+        return expr;
+      }
+    }
+
+    return expr;
+  };
+
+  // ============================================================
+  // EmitRegion — CFG partitioning into acyclic regions and loops
+  // ============================================================
+
+  struct EmitRegion {
+    enum class Kind { Acyclic, Loop };
+    Kind kind;
+    int entry;                             // entry block of this region
+    std::set<int> blocks;                  // blocks belonging to this region
+    int loop_header = -1;                  // for Loop regions: the loop header block
+    std::set<int> back_edge_sources;       // for Loop regions: blocks with back-edges to header
+    int loop_exit = -1;                    // for Loop regions: first block after the loop
+    std::vector<EmitRegion> nested_loops;  // loops nested inside this region
+  };
+
+  // ============================================================
+  // Loop Detection (kept from Phase 2)
+  // ============================================================
+
+  // Compute natural loops and loop bodies using existing infrastructure
+  auto mermaid_natural_loops = current_code_function->ListNaturalLoops();
+  auto mermaid_loop_bodies = current_code_function->ComputeLoopBodies(mermaid_natural_loops);
+
+  // Build a lookup: block -> innermost loop header it belongs to
+  std::map<int, int> block_to_loop_header;
+  for (const auto& [header, body] : mermaid_loop_bodies) {
+    for (int block : body) {
+      // If block is already assigned to a loop, keep the innermost (smallest body)
+      if (block_to_loop_header.contains(block)) {
+        int existing_header = block_to_loop_header[block];
+        if (mermaid_loop_bodies[existing_header].size() > body.size()) {
+          block_to_loop_header[block] = header;
+        }
+      } else {
+        block_to_loop_header[block] = header;
+      }
+    }
+  }
+
+  // ============================================================
+  // Heap resource declaration tracking (SM6.6 bindless)
+  // ============================================================
+  //
+  // Each SM6.6 heap resource (_HeapResource_N) is declared at the point where
+  // its descriptor-heap index is first computed, e.g.
+  //     ByteAddressBuffer _HeapResource_52 = ResourceDescriptorHeap[NonUniformResourceIndex(_404)];
+  //
+  // The index variable `_404` is an SSA local that is pre-declared at function
+  // scope and assigned inside the block that also declares _HeapResource_52.
+  //
+  // When other blocks USE _HeapResource_52, HLSL lexical scoping routes the
+  // identifier back to the function-scope pre-declaration (if present) where
+  // `_404` is still zero-init'd, producing a handle to descriptor heap slot 0.
+  // The fix: inject the canonical declaration at the top of every block that
+  // uses a heap resource without declaring it locally. The SSA index variable
+  // is guaranteed to hold the correct value by the block's reaching condition.
+  static const std::regex mermaid_heap_decl_re(
+      R"(^(ByteAddressBuffer|RWByteAddressBuffer|Texture\w+<[^>]+>|RaytracingAccelerationStructure)\s+(_HeapResource_\d+)\s*=\s*ResourceDescriptorHeap)");
+  static const std::regex mermaid_heap_use_re(R"(_HeapResource_\d+)");
+
+  std::map<std::string, std::string> heap_decl_by_var;
+  std::map<int, std::set<std::string>> heap_decls_in_block;
+  std::map<int, std::set<std::string>> heap_uses_in_block;
+
+  for (const auto& [blk_id, cb] : current_code_function->code_blocks) {
+    for (const auto& line : cb.hlsl_lines) {
+      std::smatch m;
+      if (std::regex_search(line, m, mermaid_heap_decl_re)) {
+        std::string var_name = m[2].str();
+        heap_decls_in_block[blk_id].insert(var_name);
+        if (!heap_decl_by_var.contains(var_name)) {
+          std::string decl = line;
+          size_t first = decl.find_first_not_of(" \t");
+          if (first != std::string::npos) decl = decl.substr(first);
+          heap_decl_by_var[var_name] = decl;
+        }
+      }
+      auto begin = std::sregex_iterator(line.begin(), line.end(), mermaid_heap_use_re);
+      auto end = std::sregex_iterator();
+      for (auto it = begin; it != end; ++it) {
+        heap_uses_in_block[blk_id].insert(it->str());
+      }
+    }
+  }
+
+  // Phi assignments may also materialize heap-resource references at emission
+  // time (via ParseByType inlining). Scan the expanded form to capture those.
+  for (const auto& edge : graph_edges) {
+    for (const auto& pa : edge.phi_assignments) {
+      if (pa.value == "undef") continue;
+      std::string parsed_value;
+      try {
+        parsed_value = current_code_function->ParseByType(pa.value, pa.type);
+      } catch (...) {
+        continue;
+      }
+      std::string optimized = OptimizeString(parsed_value);
+      if (optimized.find("_HeapResource_") == std::string::npos) continue;
+      auto begin = std::sregex_iterator(optimized.begin(), optimized.end(), mermaid_heap_use_re);
+      auto end = std::sregex_iterator();
+      for (auto it = begin; it != end; ++it) {
+        heap_uses_in_block[edge.source].insert(it->str());
+      }
+    }
+  }
+
+  auto heap_decls_to_inject = [&](int block_id) -> std::vector<std::string> {
+    std::vector<std::string> out;
+    if (!heap_uses_in_block.contains(block_id)) return out;
+    const auto& uses = heap_uses_in_block.at(block_id);
+    const auto& decls = heap_decls_in_block.contains(block_id)
+                        ? heap_decls_in_block.at(block_id)
+                        : std::set<std::string>{};
+    std::vector<std::string> to_inject;
+    for (const auto& var : uses) {
+      if (decls.contains(var)) continue;
+      if (!heap_decl_by_var.contains(var)) continue;
+      to_inject.push_back(var);
+    }
+    std::sort(to_inject.begin(), to_inject.end());
+    for (const auto& var : to_inject) {
+      out.push_back(heap_decl_by_var.at(var));
+    }
+    return out;
+  };
+
+  // Collect phi variables at a convergence/exit block from incoming edges
+  auto collect_phi_vars = [&](int target_block) -> std::pair<std::vector<std::string>, std::vector<std::string>> {
+    std::vector<std::string> phi_vars;
+    std::vector<std::string> phi_types_vec;
+    std::set<std::string> seen;
+    for (const auto& edge : graph_edges) {
+      if (edge.target == target_block) {
+        for (const auto& pa : edge.phi_assignments) {
+          if (!seen.contains(pa.variable)) {
+            seen.insert(pa.variable);
+            phi_vars.push_back(pa.variable);
+            phi_types_vec.push_back(pa.type);
+          }
+        }
+      }
+    }
+    return {phi_vars, phi_types_vec};
+  };
+
+  // Find the loop exit block for a given loop header.
+  // The exit is the first successor of any loop body block that is NOT in the loop body.
+  auto find_loop_exit = [&](int header, const std::set<int>& body) -> int {
+    // Prefer the ipdom of the header if it's outside the loop
+    if (graph_nodes.contains(header)) {
+      int ipdom = graph_nodes[header].ipdom;
+      if (ipdom >= 0 && !body.contains(ipdom)) {
+        return ipdom;
+      }
+    }
+    // Fallback: scan body blocks for successors outside the loop
+    for (int block : body) {
+      if (!graph_nodes.contains(block)) continue;
+      for (int succ : graph_nodes[block].successors) {
+        if (!body.contains(succ)) {
+          return succ;
+        }
+      }
+    }
+    return -1;
+  };
+
+  // ============================================================
+  // Reverse Post-Order Traversal (Task 4.1)
+  // ============================================================
+
+  // Compute reverse post-order of blocks in a region, ignoring back-edges.
+  // This gives topological order for acyclic graphs.
+  auto compute_rpo = [&graph_edges, &graph_nodes](
+      int entry,
+      const std::set<int>& block_set
+  ) -> std::vector<int> {
+    std::vector<int> post_order;
+    std::set<int> visited;
+
+    // Build a quick lookup: (source, target) -> edge type
+    std::map<std::pair<int,int>, GraphEdgeType> edge_type_map;
+    for (const auto& edge : graph_edges) {
+      edge_type_map[{edge.source, edge.target}] = edge.type;
+    }
+
+    std::function<void(int)> dfs = [&](int block) {
+      if (visited.contains(block) || !block_set.contains(block)) return;
+      visited.insert(block);
+      if (graph_nodes.contains(block)) {
+        for (int succ : graph_nodes[block].successors) {
+          if (!block_set.contains(succ)) continue;
+          auto it = edge_type_map.find({block, succ});
+          if (it != edge_type_map.end() && it->second == GraphEdgeType::BackEdge) continue;
+          dfs(succ);
+        }
+      }
+      post_order.push_back(block);
+    };
+
+    dfs(entry);
+    std::reverse(post_order.begin(), post_order.end());
+    return post_order;
+  };
+
+  // ============================================================
+  // Reaching Condition Computation (Task 4.2)
+  // ============================================================
+
+  // Inter-region RC propagation map.
+  // Records the reaching condition variable for each block that has outgoing
+  // cross-region edges. When a subsequent region computes RCs and encounters
+  // an external predecessor, it looks up the predecessor's actual RC here
+  // instead of assuming RC=true.
+  // Maps: block_id → RC variable name (e.g., "__rc_9436", "__cond_735", or "" for true)
+  std::map<int, std::string> block_exit_rc;
+
+  // Compute reaching conditions for all blocks in an acyclic region.
+  // Entry block gets RC = true. Other blocks get RC computed from predecessor
+  // contributions combined with OR (multiple preds) or directly (single pred).
+  // Back-edges and blocks outside the region are skipped.
+  // Each block's RC is simplified after computation.
+  // cond_vars is populated with block_id → "__cond_N" variable name for branch conditions.
+  // rc_vars_out is populated with block_id → "__rc_N" variable name for blocks with complex RCs.
+  auto compute_reaching_conditions = [&](
+      int entry,
+      const std::set<int>& block_set,
+      std::map<int, std::string>& cond_vars,
+      std::map<int, std::string>& rc_vars_out,
+      bool use_inter_region_rc = true  // false for loop body RC computation (header is always true)
+  ) -> std::map<int, CondExprPtr> {
+    std::map<int, CondExprPtr> rc;
+
+    // Entry block RC: for loop bodies (use_inter_region_rc=false), always true.
+    // For top-level regions, look up inter-region RC from external predecessors.
+    if (use_inter_region_rc) {
+      std::vector<CondExprPtr> entry_contributions;
+      for (const auto& edge : graph_edges) {
+        if (edge.target != entry) continue;
+        if (edge.type == GraphEdgeType::BackEdge) continue;
+        if (block_set.contains(edge.source)) continue;
+        // External predecessor of the entry block
+        if (block_exit_rc.contains(edge.source)) {
+          const std::string& pred_rc_var = block_exit_rc[edge.source];
+          CondExprPtr contrib;
+          if (pred_rc_var.empty()) {
+            contrib = make_const(true);
+          } else {
+            contrib = make_var(pred_rc_var);
+          }
+          // Apply edge condition
+          if (edge.type == GraphEdgeType::TrueBranch) {
+            std::string cond_name = std::format("__cond_{}", edge.source);
+            contrib = make_and(contrib, make_var(cond_name));
+          } else if (edge.type == GraphEdgeType::FalseBranch) {
+            std::string cond_name = std::format("__cond_{}", edge.source);
+            contrib = make_and(contrib, make_not(make_var(cond_name)));
+          }
+          entry_contributions.push_back(contrib);
+        }
+      }
+      if (!entry_contributions.empty()) {
+        if (entry_contributions.size() == 1) {
+          rc[entry] = entry_contributions[0];
+        } else {
+          CondExprPtr combined = entry_contributions[0];
+          for (size_t i = 1; i < entry_contributions.size(); ++i) {
+            combined = make_or(combined, entry_contributions[i]);
+          }
+          rc[entry] = combined;
+        }
+        rc[entry] = simplify(clone_expr(rc[entry]), 0);
+      } else {
+        rc[entry] = make_const(true);
+      }
+    } else {
+      rc[entry] = make_const(true);
+    }
+
+    // Build edge lookup: target → list of incoming edges (within block_set, non-back-edge)
+    std::map<int, std::vector<const GraphEdge*>> incoming_edges;
+    for (const auto& edge : graph_edges) {
+      if (edge.type == GraphEdgeType::BackEdge) continue;
+      if (!block_set.contains(edge.source)) continue;
+      if (!block_set.contains(edge.target)) continue;
+      incoming_edges[edge.target].push_back(&edge);
+    }
+
+    // Detect blocks in the region that have predecessors OUTSIDE the region.
+    // Instead of assuming RC=true, we look up the external predecessor's actual
+    // RC from block_exit_rc (inter-region propagation).
+    std::set<int> has_external_predecessor;
+    // Maps: target_block → list of external predecessor edges (for RC lookup)
+    std::map<int, std::vector<const GraphEdge*>> external_pred_edges;
+    for (const auto& edge : graph_edges) {
+      if (edge.type == GraphEdgeType::BackEdge) continue;
+      if (!block_set.contains(edge.target)) continue;
+      if (block_set.contains(edge.source)) continue;  // internal edge, already handled
+      if (edge.target == entry) continue;  // entry block already handled above
+      has_external_predecessor.insert(edge.target);
+      external_pred_edges[edge.target].push_back(&edge);
+    }
+
+    // rc_vars maps block_id → "__rc_N" variable name for blocks that have
+    // non-trivial reaching conditions. When building a successor's RC, we
+    // reference the variable name instead of inlining the full expression tree.
+    // This keeps expression trees O(1) depth per block instead of O(N) for cascades.
+    std::map<int, std::string> rc_vars;
+
+    // Helper: get the "reference" form of a block's RC for use in successor expressions.
+    // If the block has a simple RC (const true, single var), return it directly.
+    // Otherwise, return a Var node referencing the block's __rc_N variable.
+    auto get_rc_ref = [&](int block_id) -> CondExprPtr {
+      if (!rc.contains(block_id)) return make_const(false);
+      const auto& expr = rc[block_id];
+      // Const true/false — return a fresh copy (safe to share)
+      if (is_const_true(expr)) return make_const(true);
+      if (is_const_false(expr)) return make_const(false);
+      // Single variable — return a fresh Var copy (prevents simplify from corrupting rc map)
+      if (expr->kind == CondExpr::Kind::Var) return make_var(expr->var_name);
+      // Complex expression — reference via __rc_N variable
+      if (!rc_vars.contains(block_id)) {
+        rc_vars[block_id] = std::format("__rc_{}", block_id);
+      }
+      return make_var(rc_vars[block_id]);
+    };
+
+    // Compute reverse post-order for the region
+    auto rpo = compute_rpo(entry, block_set);
+
+    // Process blocks in RPO order
+    for (int block_id : rpo) {
+      if (block_id == entry) continue;  // Already set to true
+
+      // Collect contributions from each predecessor edge
+      std::vector<CondExprPtr> contributions;
+
+      if (incoming_edges.contains(block_id)) {
+        for (const auto* edge_ptr : incoming_edges.at(block_id)) {
+          const auto& edge = *edge_ptr;
+
+          // Skip predecessors whose RC hasn't been computed yet
+          // (shouldn't happen in RPO, but defensive)
+          if (!rc.contains(edge.source)) continue;
+
+          // Use the variable reference form of the predecessor's RC.
+          CondExprPtr pred_rc = get_rc_ref(edge.source);
+
+        switch (edge.type) {
+          case GraphEdgeType::TrueBranch: {
+            // Get or create condition variable for the predecessor's branch
+            if (!cond_vars.contains(edge.source)) {
+              // Use the branch condition expression from the code block to name the variable
+              cond_vars[edge.source] = std::format("__cond_{}", edge.source);
+            }
+            std::string cond_name = cond_vars[edge.source];
+            contributions.push_back(make_and(pred_rc, make_var(cond_name)));
+            break;
+          }
+          case GraphEdgeType::FalseBranch: {
+            // Get or create condition variable for the predecessor's branch
+            if (!cond_vars.contains(edge.source)) {
+              cond_vars[edge.source] = std::format("__cond_{}", edge.source);
+            }
+            std::string cond_name = cond_vars[edge.source];
+            contributions.push_back(make_and(pred_rc, make_not(make_var(cond_name))));
+            break;
+          }
+          case GraphEdgeType::Unconditional: {
+            contributions.push_back(pred_rc);
+            break;
+          }
+          case GraphEdgeType::SwitchCase: {
+            // Build case equality condition from the switch block's condition
+            // and the specific case value targeting this block
+            if (current_code_function->code_blocks.contains(edge.source)) {
+              const auto& src_block = current_code_function->code_blocks.at(edge.source);
+              const std::string& switch_cond = src_block.code_switch.switch_condition;
+
+              // Check if this is the default case
+              if (src_block.code_switch.case_default == edge.target) {
+                // Default case: negate all explicit case conditions
+                // For simplicity, use a synthetic variable representing the default path
+                std::string default_cond = std::format("__switch_{}_default", edge.source);
+                contributions.push_back(make_and(pred_rc, make_var(default_cond)));
+              } else {
+                // Find the case value(s) that target this block
+                for (const auto& [case_val, case_func] : src_block.code_switch.case_values) {
+                  if (case_func == edge.target) {
+                    std::string case_equality = std::format("({} == {})",
+                        switch_cond, std::string(case_val));
+                    contributions.push_back(make_and(pred_rc, make_var(case_equality)));
+                  }
+                }
+              }
+            }
+            break;
+          }
+          case GraphEdgeType::BackEdge:
+            // Already handled above, but satisfy the switch
+            break;
+        }
+      }
+      }  // end if (incoming_edges.contains(block_id))
+
+      // Add contribution from external predecessors.
+      // Instead of assuming RC=true, look up the actual RC of each external
+      // predecessor from block_exit_rc (inter-region propagation).
+      if (has_external_predecessor.contains(block_id)) {
+        if (external_pred_edges.contains(block_id)) {
+          for (const auto* edge_ptr : external_pred_edges.at(block_id)) {
+            const auto& edge = *edge_ptr;
+            CondExprPtr contrib;
+            if (block_exit_rc.contains(edge.source)) {
+              const std::string& pred_rc_var = block_exit_rc[edge.source];
+              if (pred_rc_var.empty()) {
+                contrib = make_const(true);
+              } else {
+                contrib = make_var(pred_rc_var);
+              }
+            } else {
+              // External predecessor's RC not yet recorded — conservative fallback
+              contrib = make_const(true);
+            }
+            // Apply edge condition for conditional edges — use variable name
+            // directly without adding to cond_vars (block is external)
+            if (edge.type == GraphEdgeType::TrueBranch) {
+              std::string cond_name = std::format("__cond_{}", edge.source);
+              contrib = make_and(contrib, make_var(cond_name));
+            } else if (edge.type == GraphEdgeType::FalseBranch) {
+              std::string cond_name = std::format("__cond_{}", edge.source);
+              contrib = make_and(contrib, make_not(make_var(cond_name)));
+            }
+            contributions.push_back(contrib);
+          }
+        } else {
+          // No edge info available — conservative fallback
+          contributions.push_back(make_const(true));
+        }
+      }
+
+      // Combine contributions
+      if (contributions.empty()) {
+        // No predecessors within the region (unreachable block)
+        rc[block_id] = make_const(false);
+      } else if (contributions.size() == 1) {
+        // Single predecessor contribution — use directly
+        rc[block_id] = contributions[0];
+      } else {
+        // Multiple predecessors — OR chain
+        CondExprPtr combined = contributions[0];
+        for (size_t i = 1; i < contributions.size(); ++i) {
+          combined = make_or(combined, contributions[i]);
+        }
+        rc[block_id] = combined;
+      }
+
+      // Simplify the reaching condition.
+      // Clone first to avoid corrupting shared subtrees — multiple blocks' RCs
+      // may reference the same CondExpr nodes via shared_ptr, and simplify()
+      // uses std::move which would leave dangling nulls in other blocks' trees.
+      rc[block_id] = simplify(clone_expr(rc[block_id]), 0);
+    }
+
+    // Handle blocks in block_set that weren't visited by RPO (unreachable from
+    // the region entry). These are blocks reached from external predecessors
+    // (e.g., loop exit targets). First, find the entry points of these disconnected
+    // sub-graphs (blocks with external predecessors), then compute their RPO and
+    // RCs using the same algorithm as the main pass.
+    {
+      std::set<int> unvisited;
+      for (int block_id : block_set) {
+        if (!rc.contains(block_id)) {
+          unvisited.insert(block_id);
+        }
+      }
+
+      if (!unvisited.empty()) {
+        // Find entry points: blocks with external predecessors
+        std::vector<int> sub_entries;
+        for (int block_id : unvisited) {
+          if (has_external_predecessor.contains(block_id)) {
+            sub_entries.push_back(block_id);
+          }
+        }
+
+        // For each sub-entry, set RC based on external predecessor's actual RC
+        for (int sub_entry : sub_entries) {
+          if (rc.contains(sub_entry)) continue;  // already processed
+          // Look up external predecessors' RCs
+          if (external_pred_edges.contains(sub_entry)) {
+            std::vector<CondExprPtr> entry_contribs;
+            for (const auto* edge_ptr : external_pred_edges.at(sub_entry)) {
+              const auto& edge = *edge_ptr;
+              CondExprPtr contrib;
+              if (block_exit_rc.contains(edge.source)) {
+                const std::string& pred_rc_var = block_exit_rc[edge.source];
+                if (pred_rc_var.empty()) {
+                  contrib = make_const(true);
+                } else {
+                  contrib = make_var(pred_rc_var);
+                }
+              } else {
+                contrib = make_const(true);
+              }
+              // Apply edge condition — use variable name directly (block is external)
+              if (edge.type == GraphEdgeType::TrueBranch) {
+                std::string cond_name = std::format("__cond_{}", edge.source);
+                contrib = make_and(contrib, make_var(cond_name));
+              } else if (edge.type == GraphEdgeType::FalseBranch) {
+                std::string cond_name = std::format("__cond_{}", edge.source);
+                contrib = make_and(contrib, make_not(make_var(cond_name)));
+              }
+              entry_contribs.push_back(contrib);
+            }
+            if (entry_contribs.size() == 1) {
+              rc[sub_entry] = entry_contribs[0];
+            } else if (entry_contribs.size() > 1) {
+              CondExprPtr combined = entry_contribs[0];
+              for (size_t i = 1; i < entry_contribs.size(); ++i) {
+                combined = make_or(combined, entry_contribs[i]);
+              }
+              rc[sub_entry] = combined;
+            } else {
+              rc[sub_entry] = make_const(true);
+            }
+            rc[sub_entry] = simplify(clone_expr(rc[sub_entry]), 0);
+          } else {
+            rc[sub_entry] = make_const(true);
+          }
+
+          // Compute RPO from this sub-entry within unvisited blocks
+          auto sub_rpo = compute_rpo(sub_entry, unvisited);
+
+          // Process sub-RPO blocks using the same RC computation logic
+          for (int block_id : sub_rpo) {
+            if (block_id == sub_entry) continue;
+            if (rc.contains(block_id)) continue;
+
+            std::vector<CondExprPtr> contributions;
+            if (incoming_edges.contains(block_id)) {
+              for (const auto* edge_ptr : incoming_edges.at(block_id)) {
+                const auto& edge = *edge_ptr;
+                if (!rc.contains(edge.source)) continue;
+                CondExprPtr pred_rc = get_rc_ref(edge.source);
+
+                switch (edge.type) {
+                  case GraphEdgeType::TrueBranch: {
+                    if (!cond_vars.contains(edge.source))
+                      cond_vars[edge.source] = std::format("__cond_{}", edge.source);
+                    contributions.push_back(make_and(pred_rc, make_var(cond_vars[edge.source])));
+                    break;
+                  }
+                  case GraphEdgeType::FalseBranch: {
+                    if (!cond_vars.contains(edge.source))
+                      cond_vars[edge.source] = std::format("__cond_{}", edge.source);
+                    contributions.push_back(make_and(pred_rc, make_not(make_var(cond_vars[edge.source]))));
+                    break;
+                  }
+                  case GraphEdgeType::Unconditional: {
+                    contributions.push_back(pred_rc);
+                    break;
+                  }
+                  default: break;
+                }
+              }
+            }
+
+            if (has_external_predecessor.contains(block_id)) {
+              if (external_pred_edges.contains(block_id)) {
+                for (const auto* ext_edge_ptr : external_pred_edges.at(block_id)) {
+                  const auto& ext_edge = *ext_edge_ptr;
+                  CondExprPtr contrib;
+                  if (block_exit_rc.contains(ext_edge.source)) {
+                    const std::string& pred_rc_var = block_exit_rc[ext_edge.source];
+                    if (pred_rc_var.empty()) {
+                      contrib = make_const(true);
+                    } else {
+                      contrib = make_var(pred_rc_var);
+                    }
+                  } else {
+                    contrib = make_const(true);
+                  }
+                  // Apply edge condition — use variable name directly (block is external)
+                  if (ext_edge.type == GraphEdgeType::TrueBranch) {
+                    std::string cond_name = std::format("__cond_{}", ext_edge.source);
+                    contrib = make_and(contrib, make_var(cond_name));
+                  } else if (ext_edge.type == GraphEdgeType::FalseBranch) {
+                    std::string cond_name = std::format("__cond_{}", ext_edge.source);
+                    contrib = make_and(contrib, make_not(make_var(cond_name)));
+                  }
+                  contributions.push_back(contrib);
+                }
+              } else {
+                contributions.push_back(make_const(true));
+              }
+            }
+
+            if (contributions.empty()) {
+              rc[block_id] = make_const(false);
+            } else if (contributions.size() == 1) {
+              rc[block_id] = contributions[0];
+            } else {
+              CondExprPtr combined = contributions[0];
+              for (size_t i = 1; i < contributions.size(); ++i) {
+                combined = make_or(combined, contributions[i]);
+              }
+              rc[block_id] = combined;
+            }
+            rc[block_id] = simplify(clone_expr(rc[block_id]), 0);
+          }
+        }
+
+        // Any remaining unvisited blocks get RC=false
+        for (int block_id : unvisited) {
+          if (!rc.contains(block_id)) {
+            rc[block_id] = make_const(false);
+          }
+        }
+      }
+    }
+
+    // Export rc_vars so the emitter knows which blocks need __rc_N declarations.
+    // Also ensure ALL blocks with complex RCs get an __rc_N variable, not just
+    // those referenced by successors via get_rc_ref. This is needed because
+    // post-region code (e.g., after a loop) may reference __rc_N for blocks
+    // that have no successors within the region (like loop latches).
+    for (const auto& [block_id, expr] : rc) {
+      if (is_const_true(expr) || is_const_false(expr)) continue;
+      if (expr->kind == CondExpr::Kind::Var) continue;
+      if (!rc_vars.contains(block_id)) {
+        rc_vars[block_id] = std::format("__rc_{}", block_id);
+      }
+    }
+    rc_vars_out = rc_vars;
+
+    return rc;
+  };
+
+  // ============================================================
+  // Irreducible Control Flow Detection (Task 4.3)
+  // ============================================================
+
+  // Detect irreducible control flow in an acyclic region.
+  // After removing back-edges, if any block in block_set is not visited
+  // by RPO from the entry, the region has irreducible control flow
+  // (a cycle exists in the acyclic portion).
+  auto has_irreducible_flow = [&compute_rpo](
+      int entry,
+      const std::set<int>& block_set
+  ) -> bool {
+    auto rpo = compute_rpo(entry, block_set);
+    return rpo.size() < block_set.size();
+  };
+
+  // ============================================================
+  // Phi Variable Pre-Declaration (Task 7.1)
+  // ============================================================
+
+  // Scan edges within a region for phi assignments, collect unique phi variable
+  // names and their LLVM IR types, and emit zero-initialized declarations at
+  // function scope before any guarded blocks.
+  // This ensures phi variables are in scope for all guarded assignments.
+  auto emit_phi_predeclarations = [&](const std::set<int>& block_set) {
+    // Collect unique phi variable names and their LLVM IR types.
+    // Use an ordered map for deterministic output ordering.
+    std::map<std::string, std::string> phi_var_types;  // variable_name -> LLVM IR type
+
+    for (const auto& edge : graph_edges) {
+      // Only consider edges where both source and target are in the region
+      if (!block_set.contains(edge.source) || !block_set.contains(edge.target)) continue;
+
+      for (const auto& pa : edge.phi_assignments) {
+        // Skip if we've already seen this variable
+        if (phi_var_types.contains(pa.variable)) continue;
+        phi_var_types[pa.variable] = pa.type;
+      }
+    }
+
+    // Also scan edges from outside the region targeting blocks inside the region
+    // (e.g., pre-header → loop header edges carry phi assignments too)
+    for (const auto& edge : graph_edges) {
+      if (!block_set.contains(edge.target)) continue;
+      for (const auto& pa : edge.phi_assignments) {
+        if (phi_var_types.contains(pa.variable)) continue;
+        phi_var_types[pa.variable] = pa.type;
+      }
+    }
+
+    if (phi_var_types.empty()) return;
+
+    // Emit a declaration for each unique phi variable with a zero-initialized default.
+    // Convert LLVM IR type to HLSL type and pick the appropriate zero literal.
+    for (const auto& [var_name, llvm_type] : phi_var_types) {
+      // Convert LLVM IR type to HLSL type
+      std::string hlsl_type;
+      try {
+        hlsl_type = ParseType(llvm_type);
+      } catch (...) {
+        // Fallback: if type cannot be parsed, default to float (most common SSA type)
+        hlsl_type = "float";
+      }
+
+      // Determine zero-initialized default based on HLSL type
+      std::string default_val;
+      if (hlsl_type == "bool") {
+        default_val = "false";
+      } else if (hlsl_type == "int" || hlsl_type == "int16_t" || hlsl_type == "int64_t") {
+        default_val = "0";
+      } else if (hlsl_type == "uint" || hlsl_type == "uint16_t" || hlsl_type == "uint64_t") {
+        default_val = "0u";
+      } else if (hlsl_type == "float") {
+        default_val = "0.0f";
+      } else if (hlsl_type == "half" || hlsl_type == "min16float") {
+        default_val = "0.0h";
+      } else if (hlsl_type == "double") {
+        default_val = "0.0";
+      } else {
+        // For any other type (structs, vectors, etc.), use HLSL's (Type)0 cast
+        default_val = std::format("({})0", hlsl_type);
+      }
+
+      string_stream << spacing << hlsl_type << " " << var_name << " = " << default_val << ";\n";
+    }
+  };
+
+  // ============================================================
+  // Zero-Init Phi Skip — skip phi assignments matching pre-declared default
+  // ============================================================
+
+  // Check if a parsed phi value is a zero-init literal that matches the
+  // pre-declared default for the given LLVM IR type. If so, the assignment
+  // is redundant and can be skipped.
+  // IMPORTANT: Only skip literal constants, NOT variable references.
+  // Variable references like "_42" could carry non-zero values at runtime.
+  auto is_redundant_zero_phi = [&](const std::string& optimized_value, const std::string& llvm_type) -> bool {
+    // Only skip in non-loop contexts to be safe (loop-carried variables need assignments)
+    // Actually, we check the value itself — if it's a literal zero, it's safe anywhere.
+    std::string hlsl_type;
+    try {
+      hlsl_type = ParseType(llvm_type);
+    } catch (...) {
+      return false;
+    }
+
+    // Check if the optimized value matches the zero-init default for this type
+    if (hlsl_type == "bool" && (optimized_value == "false" || optimized_value == "bool(false)")) return true;
+    if ((hlsl_type == "int" || hlsl_type == "int16_t" || hlsl_type == "int64_t") && optimized_value == "0") return true;
+    if ((hlsl_type == "uint" || hlsl_type == "uint16_t" || hlsl_type == "uint64_t") && optimized_value == "0u") return true;
+    if (hlsl_type == "float" && (optimized_value == "0.0f" || optimized_value == "0.000000f" || optimized_value == "0.0" || optimized_value == "0")) return true;
+    if ((hlsl_type == "half" || hlsl_type == "min16float") && (optimized_value == "0.0h" || optimized_value == "0.0" || optimized_value == "0")) return true;
+    if (hlsl_type == "double" && (optimized_value == "0.0" || optimized_value == "0")) return true;
+
+    // Vector/struct zero: (Type)0
+    if (optimized_value == std::format("({})0", hlsl_type)) return true;
+
+    return false;
+  };
+
+  // Helper: emit a single phi assignment, skipping if it matches the zero-init default.
+  // Returns true if the assignment was emitted, false if skipped.
+  auto emit_phi_assignment = [&](const PhiAssignment& pa) -> bool {
+    if (pa.value == "undef") return false;
+
+    std::string parsed_value;
+    try {
+      parsed_value = current_code_function->ParseByType(pa.value, pa.type);
+    } catch (...) {
+      if (pa.value.starts_with("%")) {
+        parsed_value = std::format("_{}", pa.value.substr(1));
+      } else if (pa.value.starts_with("_")) {
+        parsed_value = pa.value;
+      } else {
+        parsed_value = pa.value;
+      }
+    }
+
+    std::string optimized = OptimizeString(parsed_value);
+
+    // Skip if the value matches the zero-init default
+    if (is_redundant_zero_phi(optimized, pa.type)) return false;
+
+    string_stream << spacing << pa.variable << " = " << optimized << ";\n";
+    return true;
+  };
+
+  // ============================================================
+  // Condition Variable Emission (Task 7.2)
+  // ============================================================
+
+  // Track which __cond_N, __rc_N, and __switch_N_default variables have been declared
+  // to avoid redefinition errors when the same block appears in multiple regions
+  // (e.g., acyclic region before a loop AND inside the loop body).
+  std::set<std::string> emitted_bool_vars;
+
+  // Track which of those variables have received their real assignment (not
+  // just the zero-init pre-declaration). Used by the convergence bypass phi
+  // emission to suppress override writes that would reference a guard variable
+  // before it's meaningfully set (the zero-init default would wrongly trigger
+  // the bypass path on every edge reaching the convergence block).
+  std::set<std::string> assigned_bool_vars;
+
+  // Emit `bool __cond_N = (branch_condition);` for a branch block.
+  // The branch condition is already decompiled to HLSL by the instruction-level
+  // decompiler (stored in code_branch.branch_condition as e.g. "_42" or "(_x == _y)").
+  // cond_vars maps block_id → "__cond_N" variable name (populated by compute_reaching_conditions).
+  auto emit_cond_var = [&](int block_id, const std::map<int, std::string>& cond_vars, bool pre_declared = false) {
+    // Only emit if this block has a condition variable assigned
+    if (!cond_vars.contains(block_id)) return;
+
+    // Only emit for blocks that actually have a branch condition
+    if (!current_code_function->code_blocks.contains(block_id)) return;
+    const auto& code_block = current_code_function->code_blocks.at(block_id);
+    if (code_block.code_branch.branch_condition.empty()) return;
+
+    const std::string& var_name = cond_vars.at(block_id);
+    const std::string& branch_cond = code_block.code_branch.branch_condition;
+
+    // Check if this variable was already declared (by a previous region or pre-declaration)
+    bool already_declared = pre_declared || emitted_bool_vars.contains(var_name);
+
+    if (already_declared) {
+      string_stream << spacing << var_name << " = " << ParseWrapped(branch_cond) << ";";
+    } else {
+      string_stream << spacing << "bool " << var_name << " = " << ParseWrapped(branch_cond) << ";";
+      emitted_bool_vars.insert(var_name);
+    }
+    assigned_bool_vars.insert(var_name);
+    // Annotate with branch targets when --annotate is enabled
+    if (decompile_options.annotate) {
+      int true_target = code_block.code_branch.branch_condition_true;
+      int false_target = code_block.code_branch.branch_condition_false;
+      if (true_target > 0 && false_target > 0) {
+        string_stream << "  // true->" << true_target << ", false->" << false_target;
+      }
+    }
+    string_stream << "\n";
+  };
+
+  // Emit `bool __switch_N_default = !(cond == val1 || cond == val2 || ...);` for switch blocks.
+  // This is needed when the reaching condition computation uses __switch_N_default as a
+  // synthetic variable for the default case path.
+  std::set<int> emitted_switch_defaults;  // track which switch defaults we've already emitted
+  auto emit_switch_default_var = [&](int block_id) {
+    if (!current_code_function->code_blocks.contains(block_id)) return;
+    const auto& code_block = current_code_function->code_blocks.at(block_id);
+    if (code_block.code_switch.switch_condition.empty()) return;
+    if (code_block.code_switch.case_default < 0) return;
+
+    std::string var_name = std::format("__switch_{}_default", block_id);
+    if (emitted_switch_defaults.contains(block_id)) return;
+    emitted_switch_defaults.insert(block_id);
+
+    const std::string& switch_cond = code_block.code_switch.switch_condition;
+
+    // Build the negation of all explicit case conditions
+    std::string case_or;
+    for (const auto& [case_val, case_func] : code_block.code_switch.case_values) {
+      if (!case_or.empty()) case_or += " || ";
+      case_or += std::format("({} == {})", switch_cond, std::string(case_val));
+    }
+
+    // Check if already declared (by a previous region)
+    if (emitted_bool_vars.contains(var_name)) {
+      if (case_or.empty()) {
+        string_stream << spacing << var_name << " = true;\n";
+      } else {
+        string_stream << spacing << var_name << " = !(" << case_or << ");\n";
+      }
+    } else {
+      if (case_or.empty()) {
+        string_stream << spacing << "bool " << var_name << " = true;\n";
+      } else {
+        string_stream << spacing << "bool " << var_name << " = !(" << case_or << ");\n";
+      }
+      emitted_bool_vars.insert(var_name);
+    }
+  };
+
+  // Emit `bool __rc_N = (rc_expression);` for blocks with complex reaching conditions.
+  // Only emits if the block has an entry in rc_vars (meaning its RC is complex enough
+  // to need a named variable — not a single variable or constant).
+  // Uses emit_expr() to convert the CondExpr tree to an HLSL string.
+  auto emit_rc_var = [&](int block_id, const std::map<int, CondExprPtr>& rc, const std::map<int, std::string>& rc_vars) {
+    // Only emit if this block needs an __rc_N variable
+    if (!rc_vars.contains(block_id)) return;
+
+    // Must have a reaching condition computed
+    if (!rc.contains(block_id)) return;
+
+    const std::string& var_name = rc_vars.at(block_id);
+    const CondExprPtr& expr = rc.at(block_id);
+
+    // Skip emission for constant true (should not happen if rc_vars is populated correctly,
+    // but defensive)
+    if (is_const_true(expr)) return;
+
+    // Emit: bool __rc_N = (rc_expression); or assignment if already declared
+    std::string rc_str = emit_expr(expr);
+    if (emitted_bool_vars.contains(var_name)) {
+      string_stream << spacing << var_name << " = " << rc_str << ";\n";
+    } else {
+      string_stream << spacing << "bool " << var_name << " = " << rc_str << ";\n";
+      emitted_bool_vars.insert(var_name);
+    }
+    assigned_bool_vars.insert(var_name);
+  };
+
+  // ============================================================
+  // Flat Guarded Emission for Acyclic Regions (Task 7.3)
+  // ============================================================
+
+  // Emit an acyclic region as flat guarded blocks.
+  // For each block in topological order:
+  //   1. If RC is const true: emit block code directly (no guard)
+  //   2. If RC is const false: skip block entirely
+  //   3. Otherwise: emit "if (guard) { block code + phi assignments }"
+  // Phi assignments are emitted inside the PREDECESSOR's guarded block,
+  // not at the convergence point. This is the key to preventing DXC from
+  // merging paths — each predecessor's phi assignment is protected by that
+  // predecessor's unique reaching condition.
+  // Helper: expand __cond_N and __rc_N references in a guard expression to the actual
+  // branch conditions for developer-friendly annotations.
+  // Returns the expanded string, truncated to max_len characters.
+  auto expand_guard = [&](const std::string& guard, const std::map<int, std::string>& cvars,
+                          const std::map<int, CondExprPtr>& rc_map, const std::map<int, std::string>& rv_map,
+                          int max_len = 100) -> std::string {
+    if (!decompile_options.annotate) return guard;
+    std::string result = guard;
+
+    // First expand __rc_N to their CondExpr form (which contains __cond_N references)
+    for (const auto& [bid, vname] : rv_map) {
+      if (result.find(vname) == std::string::npos) continue;
+      if (!rc_map.contains(bid)) continue;
+      std::string rc_str = emit_expr(rc_map.at(bid));
+      if (rc_str.size() > 60) rc_str = rc_str.substr(0, 57) + "...";
+      size_t pos;
+      while ((pos = result.find(vname)) != std::string::npos) {
+        result.replace(pos, vname.size(), rc_str);
+      }
+    }
+
+    // Then expand __cond_N to the actual branch condition expressions
+    for (const auto& [bid, vname] : cvars) {
+      if (result.find(vname) == std::string::npos) continue;
+      if (!current_code_function->code_blocks.contains(bid)) continue;
+      const auto& cb = current_code_function->code_blocks.at(bid);
+      if (cb.code_branch.branch_condition.empty()) continue;
+      std::string cond = ParseWrapped(cb.code_branch.branch_condition);
+      if (cond.size() > 40) cond = cond.substr(0, 37) + "...";
+      size_t pos;
+      while ((pos = result.find(vname)) != std::string::npos) {
+        result.replace(pos, vname.size(), cond);
+      }
+    }
+    if ((int)result.size() > max_len) result = result.substr(0, max_len - 3) + "...";
+    return result;
+  };
+
+  // Convergence bypass phi info — populated during preprocessing, used during emission.
+  // Maps: target_block_id → (variable_name → {guard_var, skip_value, bypass_source})
+  //
+  // bypass_source identifies which source block's edge is the actual bypass
+  // edge. The override `if (!guard_var) { var = skip_value; }` must only be
+  // emitted on that edge, not on every edge reaching the convergence block —
+  // otherwise unrelated edges (e.g., intermediate paths that also assign the
+  // phi variable) would erroneously zero out their values when the bypass
+  // guard was not yet assigned in topological order (its assignment lives
+  // AFTER the offending edge's emission).
+  struct BypassPhiInfo {
+    std::string guard_var;
+    std::string skip_value;
+    int bypass_source = -1;
+  };
+  std::map<int, std::map<std::string, BypassPhiInfo>> convergence_bypass_phis;
+
+  auto emit_acyclic_region = [&](const EmitRegion& region) {
+    // Step 1: Compute reaching conditions for all blocks in this region
+    std::map<int, std::string> cond_vars;
+    std::map<int, std::string> rc_vars;
+    auto rc = compute_reaching_conditions(region.entry, region.blocks, cond_vars, rc_vars);
+
+    // Step 2: Compute topological order (RPO)
+    auto rpo = compute_rpo(region.entry, region.blocks);
+
+    // Step 3: Phi variables are already pre-declared at function scope by the
+    // existing infrastructure in shader_decompiler_dxc.hpp (which scans all
+    // code_blocks and phi_lines). No need to emit them again here.
+
+    // Step 4: Build edge lookup for phi assignments: source block → list of edges
+    // We need this to emit phi assignments inside the predecessor's guarded block.
+    // Include both intra-region edges AND cross-region edges (edges from blocks in
+    // this region to blocks outside it) since cross-region edges may carry phi
+    // assignments that need to be emitted inside the source block's guard.
+    std::map<int, std::vector<const GraphEdge*>> outgoing_edges;
+    for (const auto& edge : graph_edges) {
+      if (!region.blocks.contains(edge.source)) continue;
+      if (edge.type == GraphEdgeType::BackEdge) continue;
+      outgoing_edges[edge.source].push_back(&edge);
+    }
+
+    // Ensure cond_vars has entries for blocks with cross-region conditional edges
+    // that carry phi assignments. Without this, the edge guard logic can't apply
+    // branch condition guards to cross-region phi emissions.
+    for (const auto& edge : graph_edges) {
+      if (!region.blocks.contains(edge.source)) continue;
+      if (region.blocks.contains(edge.target)) continue;
+      if (edge.type == GraphEdgeType::BackEdge) continue;
+      if (edge.phi_assignments.empty()) continue;
+      if (edge.type == GraphEdgeType::TrueBranch || edge.type == GraphEdgeType::FalseBranch) {
+        if (!cond_vars.contains(edge.source)) {
+          cond_vars[edge.source] = std::format("__cond_{}", edge.source);
+        }
+      }
+    }
+
+    // Step 4.5: Pre-declare all __cond_N and __rc_N variables at the outer scope.
+    // These must be visible to all blocks in the region since successor blocks'
+    // __rc_N expressions reference predecessor blocks' __cond_N variables.
+    // The actual values are assigned inside each block's guard after the hlsl_lines.
+    for (const auto& [bid, vname] : cond_vars) {
+      if (!emitted_bool_vars.contains(vname)) {
+        string_stream << spacing << "bool " << vname << " = false;\n";
+        emitted_bool_vars.insert(vname);
+      }
+    }
+    for (const auto& [bid, vname] : rc_vars) {
+      if (!emitted_bool_vars.contains(vname)) {
+        string_stream << spacing << "bool " << vname << " = false;\n";
+        emitted_bool_vars.insert(vname);
+      }
+    }
+
+    // Also pre-declare __switch_N_default variables for any switch blocks in this region.
+    // These are referenced in RC expressions for blocks reachable from the default case.
+    for (int bid : region.blocks) {
+      if (!current_code_function->code_blocks.contains(bid)) continue;
+      const auto& cb = current_code_function->code_blocks.at(bid);
+      if (cb.code_switch.switch_condition.empty()) continue;
+      if (cb.code_switch.case_default < 0) continue;
+      std::string sw_var = std::format("__switch_{}_default", bid);
+      if (!emitted_bool_vars.contains(sw_var)) {
+        string_stream << spacing << "bool " << sw_var << " = false;\n";
+        emitted_bool_vars.insert(sw_var);
+      }
+    }
+
+    // Step 5: Walk blocks in RPO order and emit guarded code.
+    // Also build a set of visited blocks to detect unreachable blocks later.
+    std::set<int> rpo_set(rpo.begin(), rpo.end());
+
+    // Append any blocks in the region that aren't in the RPO (unreachable from
+    // the region entry but reachable from external predecessors like loop exits).
+    // These blocks need to be emitted too — they have RC=true from the external
+    // predecessor fix and contain code/branches that affect downstream blocks.
+    std::vector<int> full_walk = rpo;
+    for (int bid : region.blocks) {
+      if (!rpo_set.contains(bid)) {
+        full_walk.push_back(bid);
+      }
+    }
+
+    // Build position map for topological ordering violation detection.
+    // If a phi source block appears AFTER its target in full_walk, the phi
+    // assignment would arrive too late. We need to emit those early.
+    std::map<int, size_t> block_position;
+    for (size_t i = 0; i < full_walk.size(); ++i) {
+      block_position[full_walk[i]] = i;
+    }
+
+    if (decompile_options.annotate_mermaid) {
+      string_stream << spacing << "// [mermaid] acyclic region entry=" << region.entry
+                    << " blocks=" << region.blocks.size() << "\n";
+    }
+    for (int block_id : full_walk) {
+      // Emit "early" phi assignments for incoming edges from blocks that appear
+      // LATER in the walk order (topological ordering violations). Without this,
+      // the phi value arrives too late — the target block reads the variable before
+      // the source block writes it.
+      if (block_position.contains(block_id)) {
+        size_t my_pos = block_position[block_id];
+        for (const auto& edge : graph_edges) {
+          if (edge.target != block_id) continue;
+          if (edge.type == GraphEdgeType::BackEdge) continue;
+          if (edge.phi_assignments.empty()) continue;
+          if (!region.blocks.contains(edge.source)) continue;
+          // Check if source appears after target in the walk order
+          if (!block_position.contains(edge.source)) continue;
+          if (block_position[edge.source] <= my_pos) continue;
+          // Skip source blocks that are appended after RPO (external predecessor
+          // blocks). Their RC=true doesn't mean "always reached" — it means
+          // "reached when the external path is taken." Their phi assignments are
+          // emitted correctly when the block itself is processed later.
+          if (!rpo_set.contains(edge.source)) continue;
+          // Skip pre-header edges to loop headers — the loop region's
+          // emit_loop_region call will emit these phi assignments itself.
+          if (mermaid_loop_bodies.contains(edge.target)) {
+            const auto& loop_body = mermaid_loop_bodies.at(edge.target);
+            if (!loop_body.contains(edge.source)) continue;
+          }
+          // Source is later — emit its phi assignments early, guarded by source RC
+          CondExprPtr src_rc = rc.contains(edge.source) ? rc[edge.source] : make_const(false);
+          if (is_const_false(src_rc)) continue;
+
+          bool src_needs_guard = !is_const_true(src_rc);
+          std::string src_guard;
+          if (src_needs_guard) {
+            if (src_rc->kind == CondExpr::Kind::Var) {
+              src_guard = src_rc->var_name;
+            } else if (rc_vars.contains(edge.source)) {
+              src_guard = rc_vars[edge.source];
+            } else {
+              src_guard = emit_expr(src_rc);
+            }
+          }
+
+          // Also apply edge condition if it's a conditional branch
+          std::string full_guard;
+          if (edge.type == GraphEdgeType::TrueBranch && cond_vars.contains(edge.source)) {
+            full_guard = src_needs_guard
+              ? std::format("{} && {}", src_guard, cond_vars[edge.source])
+              : cond_vars[edge.source];
+          } else if (edge.type == GraphEdgeType::FalseBranch && cond_vars.contains(edge.source)) {
+            full_guard = src_needs_guard
+              ? std::format("{} && !{}", src_guard, cond_vars[edge.source])
+              : std::format("!{}", cond_vars[edge.source]);
+          } else if (src_needs_guard) {
+            full_guard = src_guard;
+          }
+
+          bool has_phis = false;
+          for (const auto& pa : edge.phi_assignments) {
+            if (pa.value != "undef") { has_phis = true; break; }
+          }
+          if (!has_phis) continue;
+
+          if (!full_guard.empty()) {
+            string_stream << spacing << "if (" << full_guard << ") {\n";
+            indent_spacing();
+          }
+          for (const auto& pa : edge.phi_assignments) {
+            emit_phi_assignment(pa);
+          }
+          if (!full_guard.empty()) {
+            unindent_spacing();
+            string_stream << spacing << "}\n";
+          }
+        }
+      }
+
+      // Check if this block has code_blocks entry (has HLSL instructions)
+      bool has_code_block = current_code_function->code_blocks.contains(block_id);
+
+      // Get this block's reaching condition
+      CondExprPtr block_rc = rc.contains(block_id) ? rc[block_id] : make_const(false);
+
+      // Skip blocks with RC = const false (unreachable)
+      if (is_const_false(block_rc)) {
+        if (decompile_options.annotate) {
+          string_stream << spacing << ann_block(block_id) << " skipped (RC = false)\n";
+        }
+        continue;
+      }
+
+      // Determine the guard expression for this block
+      bool needs_guard = !is_const_true(block_rc);
+      std::string guard_expr;
+
+      if (needs_guard) {
+        // Determine what to use as the if-guard:
+        // - If RC is a single Var, use that var name directly (Req 6.6)
+        // - If RC has an __rc_N variable, use that
+        // - Otherwise, inline the expression
+        if (block_rc->kind == CondExpr::Kind::Var) {
+          guard_expr = block_rc->var_name;
+        } else if (rc_vars.contains(block_id)) {
+          guard_expr = rc_vars[block_id];
+        } else {
+          guard_expr = emit_expr(block_rc);
+        }
+      }
+
+      // Annotate block in debug mode
+      if (decompile_options.annotate) {
+        string_stream << spacing << ann_block(block_id);
+        if (needs_guard) {
+          if (use_mermaid_prefix) {
+            string_stream << " (guard: " << guard_expr << ")";
+          } else {
+            string_stream << " (" << guard_expr << ": " << expand_guard(guard_expr, cond_vars, rc, rc_vars) << ")";
+          }
+        } else {
+          string_stream << (use_mermaid_prefix ? " (no guard, RC = true)" : " (no guard)");
+        }
+        string_stream << "\n";
+      }
+
+      // Emit __rc_N variable for blocks with complex RCs (before the guard — 
+      // this block's RC depends on predecessor conditions, not this block's code)
+      emit_rc_var(block_id, rc, rc_vars);
+
+      // Open the guard if needed
+      if (needs_guard) {
+        string_stream << spacing << "if (" << guard_expr << ") {\n";
+        indent_spacing();
+      }
+
+      // Inject heap resource declarations for blocks that use but don't declare
+      // them. Re-emits the canonical `ResourceDescriptorHeap[...]` lookup so
+      // the handle is reconstructed inside the current scope rather than
+      // falling back to an outer (possibly zero-initialized) binding.
+      for (const auto& decl : heap_decls_to_inject(block_id)) {
+        string_stream << spacing << decl << "\n";
+      }
+
+      // Emit the block's hlsl_lines (the already-decompiled HLSL body)
+      // When a line declares a variable that was already pre-declared at function
+      // scope (by the SSA pre-declaration infrastructure), strip the type prefix
+      // and emit just the assignment. This prevents redefinition errors when
+      // variables are used across guarded blocks.
+      // Also handles array declarations (e.g., "int _56[4]") by skipping them
+      // entirely when already pre-declared.
+      static const std::regex mermaid_decl_re(R"(^(float4|float3|float2|float|int64_t|uint64_t|int16_t[234]?|uint16_t[234]?|int|uint|bool|uint4|int4|int2|uint2|int3|uint3|double|half[234]?|min16float[234]?|min16int[234]?|min16uint[234]?)\s+(_\d+)\s*=)");
+      static const std::regex mermaid_array_decl_re(R"(^(float|int|uint)\s+(_\d+)\[(\d+)\];?\s*$)");
+      // Match "Type _NNN;" declarations without assignment (e.g., "int _259; InterlockedAdd(..., _259);")
+      static const std::regex mermaid_decl_noassign_re(R"(^(float4|float3|float2|float|int64_t|uint64_t|int16_t[234]?|uint16_t[234]?|int|uint|bool|uint4|int4|int2|uint2|int3|uint3|double|half[234]?|min16float[234]?|min16int[234]?|min16uint[234]?)\s+(_\d+)\s*;)");
+      if (has_code_block) {
+        const auto& code_block = current_code_function->code_blocks.at(block_id);
+        for (const auto& line : code_block.hlsl_lines) {
+          std::string emit_line = line;
+          std::smatch m;
+          // Check for array declarations first (e.g., "int _56[4]")
+          if (std::regex_search(emit_line, m, mermaid_array_decl_re)) {
+            std::string var_name = m[2].str();
+            if (declared_vars.contains(var_name)) {
+              // Already pre-declared at function scope — skip entirely
+              continue;
+            }
+          }
+          // Check for scalar/vector variable declarations with assignment
+          if (std::regex_search(emit_line, m, mermaid_decl_re)) {
+            std::string var_name = m[2].str();
+            if (declared_vars.contains(var_name)) {
+              // Already pre-declared at function scope — emit as assignment only
+              emit_line = var_name + " =" + m.suffix().str();
+            }
+          }
+          // Check for "Type _NNN; ..." declarations without assignment (atomic output params)
+          // Strip the entire "Type _NNN; " prefix, keeping only the function call part
+          else if (std::regex_search(emit_line, m, mermaid_decl_noassign_re)) {
+            std::string var_name = m[2].str();
+            if (declared_vars.contains(var_name)) {
+              // Strip "Type _NNN;" and any leading whitespace from the remainder
+              std::string remainder = m.suffix().str();
+              // Remove leading whitespace from remainder
+              size_t start = remainder.find_first_not_of(" \t");
+              if (start != std::string::npos) {
+                emit_line = remainder.substr(start);
+              } else {
+                // Nothing after the declaration — skip the line entirely
+                continue;
+              }
+            }
+          }
+          string_stream << spacing << emit_line << "\n";
+        }
+      }
+
+      // Emit __cond_N variable for branch blocks AFTER the block's hlsl_lines.
+      emit_cond_var(block_id, cond_vars);
+
+      // Emit __switch_N_default variable for switch blocks (also after hlsl_lines)
+      emit_switch_default_var(block_id);
+
+      // Emit phi assignments for all outgoing edges from this block.
+      // Each edge from this block to a target in the region carries phi assignments
+      // that must be emitted HERE (inside this block's guard), not at the target.
+      // For conditional edges (TrueBranch/FalseBranch), the phi assignments must be
+      // further guarded by the branch condition to prevent cross-arm contamination:
+      // without this, a FalseBranch phi overwrites the variable unconditionally,
+      // even when the TrueBranch is taken.
+      if (outgoing_edges.contains(block_id)) {
+        // Check if this block has both true and false outgoing edges (conditional branch)
+        bool has_true_edge = false, has_false_edge = false;
+        for (const auto* ep : outgoing_edges.at(block_id)) {
+          if (ep->type == GraphEdgeType::TrueBranch) has_true_edge = true;
+          if (ep->type == GraphEdgeType::FalseBranch) has_false_edge = true;
+        }
+        bool is_conditional = has_true_edge && has_false_edge;
+
+        for (const auto* edge_ptr : outgoing_edges.at(block_id)) {
+          const auto& edge = *edge_ptr;
+
+          // Skip back-edges (handled by loop emission)
+          if (edge.type == GraphEdgeType::BackEdge) continue;
+
+          // Skip pre-header edges to loop headers — emit_loop_region will emit
+          // these phi assignments as pre-header phis. Without this skip, the
+          // phi expression is emitted twice: once here (as the source block's
+          // outgoing edge phi) and again in emit_loop_region. For wave intrinsics
+          // this produces two distinct wave ops with potentially different lane
+          // masks, causing per-lane non-uniform values where the original shader
+          // expected uniform ones.
+          if (mermaid_loop_bodies.contains(edge.target)) {
+            const auto& loop_body = mermaid_loop_bodies.at(edge.target);
+            // Target is a loop header, and source is outside that loop body
+            // => this is a pre-header edge. Skip it.
+            if (!loop_body.contains(edge.source)) {
+              continue;
+            }
+          }
+
+          // Determine if this edge's phis need an edge-condition guard
+          bool needs_edge_guard = false;
+          std::string edge_guard;
+          if (is_conditional && !edge.phi_assignments.empty() && cond_vars.contains(block_id)) {
+            if (edge.type == GraphEdgeType::TrueBranch) {
+              needs_edge_guard = true;
+              edge_guard = cond_vars.at(block_id);
+            } else if (edge.type == GraphEdgeType::FalseBranch) {
+              needs_edge_guard = true;
+              edge_guard = std::format("!{}", cond_vars.at(block_id));
+            }
+          }
+
+          // Check if there are any non-undef phis to emit
+          bool has_phis = false;
+          for (const auto& pa : edge.phi_assignments) {
+            if (pa.value != "undef") { has_phis = true; break; }
+          }
+
+          if (needs_edge_guard && has_phis) {
+            string_stream << spacing << "if (" << edge_guard << ") {\n";
+            indent_spacing();
+          }
+
+          for (const auto& pa : edge.phi_assignments) {
+            emit_phi_assignment(pa);
+          }
+
+          // Inject convergence bypass phis immediately after phi assignments.
+          if (convergence_bypass_phis.contains(edge.target)) {
+            const auto& bypass_map = convergence_bypass_phis.at(edge.target);
+            std::string bp_guard;
+            std::vector<std::pair<std::string, std::string>> bp_overrides;
+            for (const auto& pa : edge.phi_assignments) {
+              if (bypass_map.contains(pa.variable)) {
+                const auto& info = bypass_map.at(pa.variable);
+                bp_guard = info.guard_var;
+                bp_overrides.push_back({pa.variable, info.skip_value});
+              }
+            }
+            // Only emit if the guard variable was actually declared
+            if (!bp_guard.empty() && !bp_overrides.empty() && emitted_bool_vars.contains(bp_guard)) {
+              string_stream << spacing << "if (!" << bp_guard << ") {\n";
+              indent_spacing();
+              for (const auto& [var, val] : bp_overrides) {
+                string_stream << spacing << var << " = " << val << ";\n";
+              }
+              unindent_spacing();
+              string_stream << spacing << "}\n";
+            }
+          }
+
+          if (needs_edge_guard && has_phis) {
+            unindent_spacing();
+            string_stream << spacing << "}\n";
+          }
+        }
+      }
+
+      // Close the guard if needed
+      if (needs_guard) {
+        unindent_spacing();
+        string_stream << spacing << "}\n";
+      }
+    }
+
+    // Record inter-region exit RCs for blocks with cross-region outgoing edges.
+    // This enables subsequent regions to look up the actual RC of their external
+    // predecessors instead of assuming RC=true.
+    for (int block_id : region.blocks) {
+      // Check if this block has any outgoing edge to a block outside this region
+      bool has_cross_region_edge = false;
+      for (const auto& edge : graph_edges) {
+        if (edge.source != block_id) continue;
+        if (edge.type == GraphEdgeType::BackEdge) continue;
+        if (region.blocks.contains(edge.target)) continue;
+        has_cross_region_edge = true;
+        break;
+      }
+      if (!has_cross_region_edge) continue;
+
+      // Record this block's RC variable
+      if (!rc.contains(block_id)) continue;
+      const auto& expr = rc[block_id];
+      if (is_const_true(expr)) {
+        block_exit_rc[block_id] = "";  // empty string means "true"
+      } else if (is_const_false(expr)) {
+        // Don't record — block is unreachable, shouldn't contribute
+        continue;
+      } else if (expr->kind == CondExpr::Kind::Var) {
+        block_exit_rc[block_id] = expr->var_name;
+      } else if (rc_vars.contains(block_id)) {
+        block_exit_rc[block_id] = rc_vars[block_id];
+      } else {
+        // Complex expression without an __rc_N variable — create one
+        std::string var_name = std::format("__rc_{}", block_id);
+        block_exit_rc[block_id] = var_name;
+      }
+    }
+  };
+
+  // ============================================================
+  // Loop Region Emission (Task 9.1)
+  // ============================================================
+
+  // Emit a loop region as [loop] for(;;) { ... break; } with guarded body blocks.
+  // Algorithm:
+  //   1. Emit pre-header phi assignments (edges from outside loop → header)
+  //   2. Emit [loop] for (;;) {
+  //   3. Compute reaching conditions for loop body blocks relative to header
+  //   4. Emit guarded blocks inside the loop body (same pattern as acyclic)
+  //   5. Emit guarded break for loop exit
+  //   6. Emit back-edge phi assignments (latch → header)
+  //   7. Emit closing }
+  std::function<void(const EmitRegion&)> emit_loop_region;
+  emit_loop_region = [&](const EmitRegion& region) {
+    int header = region.loop_header;
+    if (header < 0) return;
+
+
+    // --- Step 1: Emit pre-header phi assignments ---
+    // These are phi assignments on edges from OUTSIDE the loop body to the header.
+    // They represent the initial values of loop-carried variables before the loop starts.
+    if (decompile_options.annotate) {
+      string_stream << spacing << "// [mermaid] loop region entry=" << header
+                    << " exit=" << region.loop_exit
+                    << " body=[";
+      bool first = true;
+      for (int b : region.blocks) {
+        if (!first) string_stream << ",";
+        string_stream << b;
+        first = false;
+      }
+      string_stream << "] back_edges=[";
+      first = true;
+      for (int b : region.back_edge_sources) {
+        if (!first) string_stream << ",";
+        string_stream << b;
+        first = false;
+      }
+      string_stream << "]\n";
+    }
+
+    for (const auto& edge : graph_edges) {
+      // Edges targeting the header from blocks NOT in the loop body = pre-header edges
+      if (edge.target != header) continue;
+      if (region.blocks.contains(edge.source)) continue;  // skip intra-loop edges (back-edges)
+
+      for (const auto& pa : edge.phi_assignments) {
+        emit_phi_assignment(pa);
+      }
+    }
+
+    // --- Step 2: Emit [loop] for (;;) { ---
+    string_stream << spacing << "[loop] for (;;) {\n";
+    indent_spacing();
+
+    // --- Step 3: Compute reaching conditions for loop body blocks ---
+    // The header is the local entry point (RC = true within the loop).
+    std::map<int, std::string> loop_cond_vars;
+    std::map<int, std::string> loop_rc_vars;
+    auto loop_rc = compute_reaching_conditions(header, region.blocks, loop_cond_vars, loop_rc_vars, false);
+
+    // --- Step 4: Compute topological order (RPO) within the loop body ---
+    auto loop_rpo = compute_rpo(header, region.blocks);
+
+    // Build lookup structures for nested loops so we can emit them recursively
+    // instead of as flat guarded blocks.
+    std::map<int, const EmitRegion*> nested_loop_by_header;  // header → nested EmitRegion
+    std::set<int> blocks_in_nested_loops;  // all blocks belonging to any nested loop
+    for (const auto& nested : region.nested_loops) {
+      if (nested.kind == EmitRegion::Kind::Loop && nested.loop_header >= 0) {
+        nested_loop_by_header[nested.loop_header] = &nested;
+        for (int b : nested.blocks) {
+          if (b != nested.loop_header) {  // header is emitted by emit_loop_region
+            blocks_in_nested_loops.insert(b);
+          }
+        }
+      }
+    }
+
+    // Build edge lookup for phi assignments within the loop body
+    std::map<int, std::vector<const GraphEdge*>> loop_outgoing_edges;
+    for (const auto& edge : graph_edges) {
+      if (region.blocks.contains(edge.source) && region.blocks.contains(edge.target)) {
+        loop_outgoing_edges[edge.source].push_back(&edge);
+      }
+    }
+
+    // Determine the exit condition: find edges from loop body blocks to blocks OUTSIDE the loop.
+    // The exit condition is the reaching condition of the path that leads out of the loop.
+    // We collect all edges from body blocks to any block outside the loop body and build
+    // the exit condition from their contributions.
+    CondExprPtr exit_condition = nullptr;
+    {
+      std::vector<CondExprPtr> exit_contributions;
+      for (const auto& edge : graph_edges) {
+        if (!region.blocks.contains(edge.source)) continue;
+        if (region.blocks.contains(edge.target)) continue;  // skip intra-loop edges
+        if (edge.type == GraphEdgeType::BackEdge) continue;
+
+        // The exit contribution is the predecessor's RC combined with the edge condition.
+        // Clone to prevent simplify() from corrupting loop_rc entries via std::move.
+        CondExprPtr pred_rc = loop_rc.contains(edge.source) ? clone_expr(loop_rc[edge.source]) : make_const(false);
+
+        // Use the variable reference form if the RC has an __rc_N variable
+        if (!is_const_true(pred_rc) && !is_const_false(pred_rc)
+            && pred_rc->kind != CondExpr::Kind::Var
+            && loop_rc_vars.contains(edge.source)) {
+          pred_rc = make_var(loop_rc_vars[edge.source]);
+        }
+
+        switch (edge.type) {
+          case GraphEdgeType::TrueBranch: {
+            if (!loop_cond_vars.contains(edge.source)) {
+              loop_cond_vars[edge.source] = std::format("__cond_{}", edge.source);
+            }
+            exit_contributions.push_back(make_and(pred_rc, make_var(loop_cond_vars[edge.source])));
+            break;
+          }
+          case GraphEdgeType::FalseBranch: {
+            if (!loop_cond_vars.contains(edge.source)) {
+              loop_cond_vars[edge.source] = std::format("__cond_{}", edge.source);
+            }
+            exit_contributions.push_back(make_and(pred_rc, make_not(make_var(loop_cond_vars[edge.source]))));
+            break;
+          }
+          case GraphEdgeType::Unconditional: {
+            exit_contributions.push_back(pred_rc);
+            break;
+          }
+          default:
+            break;
+        }
+      }
+
+      if (exit_contributions.size() == 1) {
+        exit_condition = exit_contributions[0];
+      } else if (exit_contributions.size() > 1) {
+        exit_condition = exit_contributions[0];
+        for (size_t i = 1; i < exit_contributions.size(); ++i) {
+          exit_condition = make_or(exit_condition, exit_contributions[i]);
+        }
+      }
+      if (exit_condition) {
+        exit_condition = simplify(exit_condition, 0);
+      }
+    }
+
+    // --- Step 5: Walk blocks in RPO order and emit guarded code ---
+    // Same pattern as emit_acyclic_region, but within the loop body.
+    // Type-stripping regex for variable declarations (same as emit_acyclic_region)
+    static const std::regex loop_decl_re(R"(^(float4|float3|float2|float|int64_t|uint64_t|int16_t[234]?|uint16_t[234]?|int|uint|bool|uint4|int4|int2|uint2|int3|uint3|double|half[234]?|min16float[234]?|min16int[234]?|min16uint[234]?)\s+(_\d+)\s*=)");
+    static const std::regex loop_array_decl_re(R"(^(float|int|uint)\s+(_\d+)\[(\d+)\];?\s*$)");
+    // Match "Type _NNN;" declarations without assignment (e.g., atomic output params)
+    static const std::regex loop_decl_noassign_re(R"(^(float4|float3|float2|float|int64_t|uint64_t|int16_t[234]?|uint16_t[234]?|int|uint|bool|uint4|int4|int2|uint2|int3|uint3|double|half[234]?|min16float[234]?|min16int[234]?|min16uint[234]?)\s+(_\d+)\s*;)");
+
+    // Pre-declare all __cond_N and __rc_N variables at the outer loop scope.
+    // This ensures they're visible both inside nested loops (where they're assigned)
+    // and in the outer loop's exit/continuation conditions (where they're referenced).
+    for (const auto& [bid, vname] : loop_cond_vars) {
+      if (!emitted_bool_vars.contains(vname)) {
+        string_stream << spacing << "bool " << vname << " = false;\n";
+        emitted_bool_vars.insert(vname);
+      }
+    }
+    for (const auto& [bid, vname] : loop_rc_vars) {
+      if (!emitted_bool_vars.contains(vname)) {
+        string_stream << spacing << "bool " << vname << " = false;\n";
+        emitted_bool_vars.insert(vname);
+      }
+    }
+
+    // Also pre-declare __switch_N_default variables for any switch blocks in this loop.
+    for (int bid : region.blocks) {
+      if (!current_code_function->code_blocks.contains(bid)) continue;
+      const auto& cb = current_code_function->code_blocks.at(bid);
+      if (cb.code_switch.switch_condition.empty()) continue;
+      if (cb.code_switch.case_default < 0) continue;
+      std::string sw_var = std::format("__switch_{}_default", bid);
+      if (!emitted_bool_vars.contains(sw_var)) {
+        string_stream << spacing << "bool " << sw_var << " = false;\n";
+        emitted_bool_vars.insert(sw_var);
+      }
+    }
+
+    for (int block_id : loop_rpo) {
+      // If this block belongs to a nested loop (but is not the header), skip it —
+      // it will be emitted by the nested loop's recursive emit_loop_region call.
+      if (blocks_in_nested_loops.contains(block_id)) continue;
+
+      // If this block is a nested loop header, emit the nested loop recursively.
+      if (nested_loop_by_header.contains(block_id)) {
+        const auto& nested = *nested_loop_by_header[block_id];
+
+        emit_loop_region(nested);
+
+        // After emitting the nested loop, assign __rc_N variables for blocks
+        // inside the nested loop that have entries in the OUTER loop's rc_vars.
+        for (int nested_bid : nested.blocks) {
+          if (loop_rc_vars.contains(nested_bid) && loop_rc.contains(nested_bid)) {
+            emit_rc_var(nested_bid, loop_rc, loop_rc_vars);
+          }
+        }
+
+        continue;
+      }
+
+      if (!current_code_function->code_blocks.contains(block_id)) continue;
+
+      const auto& code_block = current_code_function->code_blocks.at(block_id);
+
+      // Get this block's reaching condition (relative to loop header)
+      CondExprPtr block_rc = loop_rc.contains(block_id) ? loop_rc[block_id] : make_const(false);
+
+      // Skip blocks with RC = const false (unreachable within loop)
+      if (is_const_false(block_rc)) {
+        if (decompile_options.annotate) {
+          string_stream << spacing << ann_loop_block(block_id) << " skipped (RC = false)\n";
+        }
+        continue;
+      }
+
+
+      // Determine the guard expression
+      bool needs_guard = !is_const_true(block_rc);
+      std::string guard_expr;
+
+      if (needs_guard) {
+        if (block_rc->kind == CondExpr::Kind::Var) {
+          guard_expr = block_rc->var_name;
+        } else if (loop_rc_vars.contains(block_id)) {
+          guard_expr = loop_rc_vars[block_id];
+        } else {
+          guard_expr = emit_expr(block_rc);
+        }
+      }
+
+      // Annotate block in debug mode
+      if (decompile_options.annotate) {
+        string_stream << spacing << ann_loop_block(block_id);
+        if (needs_guard) {
+          if (use_mermaid_prefix) {
+            string_stream << " (guard: " << guard_expr << ")";
+          } else {
+            string_stream << " (" << guard_expr << ": " << expand_guard(guard_expr, loop_cond_vars, loop_rc, loop_rc_vars) << ")";
+          }
+        } else {
+          string_stream << (use_mermaid_prefix ? " (no guard, RC = true)" : " (no guard)");
+        }
+        string_stream << "\n";
+      }
+
+      // Emit __rc_N variable for blocks with complex RCs (before the guard)
+      emit_rc_var(block_id, loop_rc, loop_rc_vars);
+
+      // Open the guard if needed
+      if (needs_guard) {
+        string_stream << spacing << "if (" << guard_expr << ") {\n";
+        indent_spacing();
+      }
+
+      // Inject heap resource declarations for blocks that use but don't declare
+      // them. See the acyclic emit site for rationale.
+      for (const auto& decl : heap_decls_to_inject(block_id)) {
+        string_stream << spacing << decl << "\n";
+      }
+
+      // Emit the block's hlsl_lines with type-stripping for pre-declared variables
+      for (const auto& line : code_block.hlsl_lines) {
+        std::string emit_line = line;
+        std::smatch m;
+        // Check for array declarations first
+        if (std::regex_search(emit_line, m, loop_array_decl_re)) {
+          std::string var_name = m[2].str();
+          if (declared_vars.contains(var_name)) {
+            continue;  // Already pre-declared — skip
+          }
+        }
+        // Check for scalar/vector variable declarations with assignment
+        if (std::regex_search(emit_line, m, loop_decl_re)) {
+          std::string var_name = m[2].str();
+          if (declared_vars.contains(var_name)) {
+            emit_line = var_name + " =" + m.suffix().str();
+          }
+        }
+        // Check for "Type _NNN; ..." declarations without assignment (atomic output params)
+        else if (std::regex_search(emit_line, m, loop_decl_noassign_re)) {
+          std::string var_name = m[2].str();
+          if (declared_vars.contains(var_name)) {
+            std::string remainder = m.suffix().str();
+            size_t start = remainder.find_first_not_of(" \t");
+            if (start != std::string::npos) {
+              emit_line = remainder.substr(start);
+            } else {
+              continue;
+            }
+          }
+        }
+        string_stream << spacing << emit_line << "\n";
+      }
+
+      // Emit __cond_N variable for branch blocks AFTER the block's hlsl_lines.
+      // The branch condition depends on values computed by the block's code.
+      emit_cond_var(block_id, loop_cond_vars);
+
+      // Emit __switch_N_default variable for switch blocks (also after hlsl_lines)
+      emit_switch_default_var(block_id);
+
+      // Emit phi assignments for outgoing edges within the loop body
+      // (skip back-edges — those are handled separately at the end)
+      // For conditional edges, guard phis by the branch condition to prevent cross-arm contamination.
+      if (loop_outgoing_edges.contains(block_id)) {
+        bool has_true_edge = false, has_false_edge = false;
+        for (const auto* ep : loop_outgoing_edges.at(block_id)) {
+          if (ep->type == GraphEdgeType::TrueBranch) has_true_edge = true;
+          if (ep->type == GraphEdgeType::FalseBranch) has_false_edge = true;
+        }
+        bool is_conditional = has_true_edge && has_false_edge;
+
+        for (const auto* edge_ptr : loop_outgoing_edges.at(block_id)) {
+          const auto& edge = *edge_ptr;
+
+          // Skip back-edges (handled in step 6)
+          if (edge.type == GraphEdgeType::BackEdge) continue;
+
+          // Skip edges to blocks outside the loop (phi assignments for exit are handled
+          // after the break statement)
+          if (!region.blocks.contains(edge.target)) continue;
+
+          // Skip pre-header edges to nested loop headers — the nested loop's
+          // emit_loop_region call will emit these phi assignments as pre-header
+          // phis. Without this skip, the phi expression is emitted twice: once
+          // here and again in the nested loop's pre-header.
+          if (nested_loop_by_header.contains(edge.target)) {
+            const auto& nested = *nested_loop_by_header.at(edge.target);
+            // Source is outside the nested loop's body => pre-header edge.
+            if (!nested.blocks.contains(edge.source)) {
+              continue;
+            }
+          }
+
+          // Determine if this edge's phis need an edge-condition guard
+          bool needs_edge_guard = false;
+          std::string edge_guard;
+          if (is_conditional && !edge.phi_assignments.empty() && loop_cond_vars.contains(block_id)) {
+            if (edge.type == GraphEdgeType::TrueBranch) {
+              needs_edge_guard = true;
+              edge_guard = loop_cond_vars.at(block_id);
+            } else if (edge.type == GraphEdgeType::FalseBranch) {
+              needs_edge_guard = true;
+              edge_guard = std::format("!{}", loop_cond_vars.at(block_id));
+            }
+          }
+
+          bool has_phis = false;
+          for (const auto& pa : edge.phi_assignments) {
+            if (pa.value != "undef") { has_phis = true; break; }
+          }
+
+          if (needs_edge_guard && has_phis) {
+            string_stream << spacing << "if (" << edge_guard << ") {\n";
+            indent_spacing();
+          }
+
+          for (const auto& pa : edge.phi_assignments) {
+            emit_phi_assignment(pa);
+          }
+
+          if (needs_edge_guard && has_phis) {
+            unindent_spacing();
+            string_stream << spacing << "}\n";
+          }
+        }
+      }
+
+      // Close the guard if needed
+      if (needs_guard) {
+        unindent_spacing();
+        string_stream << spacing << "}\n";
+      }
+    }
+
+    // --- Step 6: Emit guarded break for loop exit ---
+    if (exit_condition) {
+      std::string exit_expr;
+      if (is_const_true(exit_condition)) {
+        // Unconditional break (loop always exits after one iteration)
+        exit_expr = "true";
+      } else {
+        exit_expr = emit_expr(exit_condition);
+      }
+
+      if (decompile_options.annotate) {
+        string_stream << spacing << (use_mermaid_prefix ? "// [mermaid] loop exit condition\n" : "// --- loop exit ---\n");
+      }
+
+      // Emit phi assignments for the exit edge(s) inside the break guard
+      // These are phi assignments on edges from body blocks to blocks outside the loop
+      bool has_exit_phis = false;
+      for (const auto& edge : graph_edges) {
+        if (!region.blocks.contains(edge.source)) continue;
+        if (region.blocks.contains(edge.target)) continue;  // skip intra-loop edges
+        if (edge.type == GraphEdgeType::BackEdge) continue;
+        if (!edge.phi_assignments.empty()) {
+          has_exit_phis = true;
+          break;
+        }
+      }
+
+      if (has_exit_phis) {
+        // Emit exit phi assignments inside the exit guard
+        // Each exit edge gets its own guarded phi assignments
+        for (const auto& edge : graph_edges) {
+          if (!region.blocks.contains(edge.source)) continue;
+          if (region.blocks.contains(edge.target)) continue;  // skip intra-loop edges
+          if (edge.type == GraphEdgeType::BackEdge) continue;
+
+          // Compute the guard for this edge's phi assignments ONCE (outside the phi loop).
+          // Clone src_rc to prevent simplify() from corrupting loop_rc entries.
+          CondExprPtr src_rc = loop_rc.contains(edge.source) ? clone_expr(loop_rc[edge.source]) : make_const(false);
+
+          // Build the full guard: source RC AND edge condition
+          CondExprPtr phi_guard = src_rc;
+          if (edge.type == GraphEdgeType::TrueBranch && loop_cond_vars.contains(edge.source)) {
+            phi_guard = make_and(clone_expr(src_rc), make_var(loop_cond_vars[edge.source]));
+          } else if (edge.type == GraphEdgeType::FalseBranch && loop_cond_vars.contains(edge.source)) {
+            phi_guard = make_and(clone_expr(src_rc), make_not(make_var(loop_cond_vars[edge.source])));
+          }
+          phi_guard = simplify(clone_expr(phi_guard), 0);
+
+          std::string phi_guard_str;
+          bool phi_guard_is_true = is_const_true(phi_guard);
+          if (!phi_guard_is_true) {
+            phi_guard_str = emit_expr(phi_guard);
+          }
+
+          for (const auto& pa : edge.phi_assignments) {
+            if (pa.value == "undef") continue;
+
+            std::string parsed_value;
+            try {
+              parsed_value = current_code_function->ParseByType(pa.value, pa.type);
+            } catch (...) {
+              if (pa.value.starts_with("%")) {
+                parsed_value = std::format("_{}", pa.value.substr(1));
+              } else if (pa.value.starts_with("_")) {
+                parsed_value = pa.value;
+              } else {
+                parsed_value = pa.value;
+              }
+            }
+
+            std::string optimized = OptimizeString(parsed_value);
+
+            if (!phi_guard_is_true) {
+              string_stream << spacing << "if (" << phi_guard_str << ") " << pa.variable << " = " << optimized << ";\n";
+            } else {
+              string_stream << spacing << pa.variable << " = " << optimized << ";\n";
+            }
+          }
+        }
+      }
+
+      // Emit the break
+      if (is_const_true(exit_condition)) {
+        string_stream << spacing << "break;\n";
+      } else {
+        string_stream << spacing << "if (" << exit_expr << ") break;\n";
+      }
+    }
+
+    // --- Step 7: Emit back-edge phi assignments (latch → header) ---
+    // These are the loop-carried values: assignments from back-edge source blocks
+    // to the loop header's phi variables.
+    bool has_backedge_phis = false;
+    for (const auto& edge : graph_edges) {
+      if (edge.type != GraphEdgeType::BackEdge) continue;
+      if (edge.target != header) continue;
+      if (!region.blocks.contains(edge.source)) continue;
+      if (!edge.phi_assignments.empty()) {
+        has_backedge_phis = true;
+        break;
+      }
+    }
+
+    if (has_backedge_phis) {
+      if (decompile_options.annotate) {
+        string_stream << spacing << (use_mermaid_prefix ? "// [mermaid] back-edge phi assignments (latch -> header)\n" : "// --- back-edge phis ---\n");
+      }
+
+      // Collect all back-edge sources in the loop body
+      std::vector<const GraphEdge*> backedge_list;
+      for (const auto& edge : graph_edges) {
+        if (edge.type != GraphEdgeType::BackEdge) continue;
+        if (edge.target != header) continue;
+        if (!region.blocks.contains(edge.source)) continue;
+        backedge_list.push_back(&edge);
+      }
+
+      // If there's a single back-edge source, emit assignments directly.
+      // If multiple, guard each by the source block's RC.
+      for (const auto* edge_ptr : backedge_list) {
+        const auto& edge = *edge_ptr;
+        bool needs_latch_guard = backedge_list.size() > 1;
+        CondExprPtr latch_rc;
+
+        if (needs_latch_guard) {
+          latch_rc = loop_rc.contains(edge.source) ? loop_rc[edge.source] : make_const(false);
+          if (is_const_true(latch_rc)) {
+            needs_latch_guard = false;
+          }
+        }
+
+        if (needs_latch_guard && latch_rc) {
+          std::string latch_guard;
+          if (latch_rc->kind == CondExpr::Kind::Var) {
+            latch_guard = latch_rc->var_name;
+          } else if (loop_rc_vars.contains(edge.source)) {
+            latch_guard = loop_rc_vars[edge.source];
+          } else {
+            latch_guard = emit_expr(latch_rc);
+          }
+          string_stream << spacing << "if (" << latch_guard << ") {\n";
+          indent_spacing();
+        }
+
+        for (const auto& pa : edge.phi_assignments) {
+          if (pa.value == "undef") continue;
+
+          std::string parsed_value;
+          try {
+            parsed_value = current_code_function->ParseByType(pa.value, pa.type);
+          } catch (...) {
+            if (pa.value.starts_with("%")) {
+              parsed_value = std::format("_{}", pa.value.substr(1));
+            } else if (pa.value.starts_with("_")) {
+              parsed_value = pa.value;
+            } else {
+              parsed_value = pa.value;
+            }
+          }
+
+          std::string optimized = OptimizeString(parsed_value);
+          string_stream << spacing << pa.variable << " = " << optimized << ";\n";
+        }
+
+        if (needs_latch_guard && latch_rc) {
+          unindent_spacing();
+          string_stream << spacing << "}\n";
+        }
+      }
+    }
+
+    // --- Step 8: Emit guarded continue for non-last latch blocks ---
+    // When there are multiple back-edge sources and the latch is not the last
+    // block in the loop body RPO, emit a guarded continue to skip remaining code.
+    // (In practice, the back-edge phi assignments above handle the latch→header
+    // transition, and the for(;;) loop naturally continues. A guarded continue
+    // is only needed if there's code after the latch that shouldn't execute on
+    // the continue path. Since we emit all blocks in RPO and the break handles
+    // the exit, the natural loop continuation suffices for most cases.)
+
+    // --- Step 9: Close the loop ---
+    unindent_spacing();
+    string_stream << spacing << "}\n";
+
+    // Record inter-region exit RCs for loop body blocks with cross-region edges.
+    // This enables subsequent regions to look up the actual RC of blocks inside
+    // this loop that have outgoing edges to blocks outside the loop.
+    for (int block_id : region.blocks) {
+      bool has_cross_region_edge = false;
+      for (const auto& edge : graph_edges) {
+        if (edge.source != block_id) continue;
+        if (edge.type == GraphEdgeType::BackEdge) continue;
+        if (region.blocks.contains(edge.target)) continue;
+        has_cross_region_edge = true;
+        break;
+      }
+      if (!has_cross_region_edge) continue;
+
+      // Record this block's RC within the loop context
+      if (!loop_rc.contains(block_id)) continue;
+      const auto& expr = loop_rc[block_id];
+      if (is_const_true(expr)) {
+        block_exit_rc[block_id] = "";  // empty string means "true"
+      } else if (is_const_false(expr)) {
+        continue;  // unreachable, don't record
+      } else if (expr->kind == CondExpr::Kind::Var) {
+        block_exit_rc[block_id] = expr->var_name;
+      } else if (loop_rc_vars.contains(block_id)) {
+        block_exit_rc[block_id] = loop_rc_vars[block_id];
+      } else {
+        std::string var_name = std::format("__rc_{}", block_id);
+        block_exit_rc[block_id] = var_name;
+      }
+    }
+  };
+
+  // ============================================================
+  // Switch Region Emission (Task 10.1)
+  // ============================================================
+
+  // Emit a switch region as switch (switch_var) { case N: { ... } }
+  // Each case contains the target block's code and phi assignments for that edge.
+  // When multiple cases target the same block (fallthrough), they are combined
+  // with stacked case labels.
+  auto emit_switch_region = [&](int switch_block) {
+    if (!current_code_function->code_blocks.contains(switch_block)) return;
+
+    const auto& code_block = current_code_function->code_blocks.at(switch_block);
+    const auto& code_switch = code_block.code_switch;
+
+    // Must actually be a switch block
+    if (code_switch.switch_condition.empty()) return;
+
+    if (decompile_options.annotate) {
+      string_stream << spacing << "// [mermaid] switch region block=" << switch_block
+                    << " condition=" << code_switch.switch_condition
+                    << " cases=" << code_switch.case_values.size()
+                    << " default=" << code_switch.case_default << "\n";
+    }
+
+    // --- Step 1: Emit the switch block's hlsl_lines (code before the switch) ---
+    static const std::regex switch_decl_re(R"(^(float4|float3|float2|float|int64_t|uint64_t|int16_t[234]?|uint16_t[234]?|int|uint|bool|uint4|int4|int2|uint2|int3|uint3|double|half[234]?|min16float[234]?|min16int[234]?|min16uint[234]?)\s+(_\d+)\s*=)");
+    static const std::regex switch_array_decl_re(R"(^(float|int|uint)\s+(_\d+)\[(\d+)\];?\s*$)");
+    static const std::regex switch_decl_noassign_re(R"(^(float4|float3|float2|float|int64_t|uint64_t|int16_t[234]?|uint16_t[234]?|int|uint|bool|uint4|int4|int2|uint2|int3|uint3|double|half[234]?|min16float[234]?|min16int[234]?|min16uint[234]?)\s+(_\d+)\s*;)");
+    // Inject heap resource declarations for the switch block.
+    for (const auto& decl : heap_decls_to_inject(switch_block)) {
+      string_stream << spacing << decl << "\n";
+    }
+    for (const auto& line : code_block.hlsl_lines) {
+      std::string emit_line = line;
+      std::smatch m;
+      if (std::regex_search(emit_line, m, switch_array_decl_re)) {
+        std::string var_name = m[2].str();
+        if (declared_vars.contains(var_name)) {
+          continue;
+        }
+      }
+      if (std::regex_search(emit_line, m, switch_decl_re)) {
+        std::string var_name = m[2].str();
+        if (declared_vars.contains(var_name)) {
+          emit_line = var_name + " =" + m.suffix().str();
+        }
+      } else if (std::regex_search(emit_line, m, switch_decl_noassign_re)) {
+        std::string var_name = m[2].str();
+        if (declared_vars.contains(var_name)) {
+          std::string remainder = m.suffix().str();
+          size_t start = remainder.find_first_not_of(" \t");
+          if (start != std::string::npos) {
+            emit_line = remainder.substr(start);
+          } else {
+            continue;
+          }
+        }
+      }
+      string_stream << spacing << emit_line << "\n";
+    }
+
+    // --- Step 2: Build a map of target_block → list of case labels ---
+    // This handles fallthrough: multiple case values targeting the same block
+    // get stacked case labels.
+    struct CaseInfo {
+      std::vector<std::string> labels;  // case value strings (empty string = default)
+      bool is_default = false;
+    };
+    std::map<int, CaseInfo> target_cases;  // target_block_id → case info
+
+    for (const auto& [case_value, case_target] : code_switch.case_values) {
+      if (case_target < 0 || !current_code_function->code_blocks.contains(case_target)) continue;
+      target_cases[case_target].labels.push_back(std::string(case_value));
+    }
+
+    if (code_switch.case_default >= 0
+        && current_code_function->code_blocks.contains(code_switch.case_default)) {
+      target_cases[code_switch.case_default].is_default = true;
+    }
+
+    // --- Step 3: Emit switch (switch_condition) { ---
+    string_stream << spacing << "switch (" << code_switch.switch_condition << ") {\n";
+    indent_spacing();
+
+    // --- Step 4: Helper to emit a case body (target block code + phi assignments) ---
+    auto emit_case_body = [&](int target_block) {
+      if (!current_code_function->code_blocks.contains(target_block)) return;
+
+      const auto& target_code_block = current_code_function->code_blocks.at(target_block);
+
+      // Emit the target block's hlsl_lines with type-stripping
+      // Inject heap resource declarations for the case's target block.
+      for (const auto& decl : heap_decls_to_inject(target_block)) {
+        string_stream << spacing << decl << "\n";
+      }
+      for (const auto& line : target_code_block.hlsl_lines) {
+        std::string emit_line = line;
+        std::smatch m;
+        if (std::regex_search(emit_line, m, switch_array_decl_re)) {
+          std::string var_name = m[2].str();
+          if (declared_vars.contains(var_name)) {
+            continue;
+          }
+        }
+        if (std::regex_search(emit_line, m, switch_decl_re)) {
+          std::string var_name = m[2].str();
+          if (declared_vars.contains(var_name)) {
+            emit_line = var_name + " =" + m.suffix().str();
+          }
+        } else if (std::regex_search(emit_line, m, switch_decl_noassign_re)) {
+          std::string var_name = m[2].str();
+          if (declared_vars.contains(var_name)) {
+            std::string remainder = m.suffix().str();
+            size_t start = remainder.find_first_not_of(" \t");
+            if (start != std::string::npos) {
+              emit_line = remainder.substr(start);
+            } else {
+              continue;
+            }
+          }
+        }
+        string_stream << spacing << emit_line << "\n";
+      }
+
+      // Emit phi assignments for edges from switch_block to this target
+      for (const auto& edge : graph_edges) {
+        if (edge.source != switch_block) continue;
+        if (edge.target != target_block) continue;
+
+        for (const auto& pa : edge.phi_assignments) {
+          if (pa.value == "undef") continue;
+
+          std::string parsed_value;
+          try {
+            parsed_value = current_code_function->ParseByType(pa.value, pa.type);
+          } catch (...) {
+            if (pa.value.starts_with("%")) {
+              parsed_value = std::format("_{}", pa.value.substr(1));
+            } else if (pa.value.starts_with("_")) {
+              parsed_value = pa.value;
+            } else {
+              parsed_value = pa.value;
+            }
+          }
+
+          std::string optimized = OptimizeString(parsed_value);
+          string_stream << spacing << pa.variable << " = " << optimized << ";\n";
+        }
+      }
+    };
+
+    // --- Step 5: Emit each unique target block as a case group ---
+    // Process case values first, then default
+    std::set<int> emitted_targets;
+
+    for (const auto& [case_value, case_target] : code_switch.case_values) {
+      if (case_target < 0 || !current_code_function->code_blocks.contains(case_target)) continue;
+      if (emitted_targets.contains(case_target)) continue;
+      emitted_targets.insert(case_target);
+
+      const auto& info = target_cases[case_target];
+
+      // Emit all case labels for this target (stacked for fallthrough)
+      for (const auto& label : info.labels) {
+        string_stream << spacing << "case " << label << ":\n";
+      }
+      // If this target is also the default, emit default label too
+      if (info.is_default) {
+        string_stream << spacing << "default:\n";
+      }
+
+      // Open case body
+      string_stream << spacing << "{\n";
+      indent_spacing();
+
+      if (decompile_options.annotate) {
+        string_stream << spacing << "// --- case target block " << case_target << "\n";
+      }
+
+      emit_case_body(case_target);
+
+      string_stream << spacing << "break;\n";
+      unindent_spacing();
+      string_stream << spacing << "}\n";
+    }
+
+    // --- Step 6: Emit default case if not already emitted as part of a shared target ---
+    if (code_switch.case_default >= 0
+        && current_code_function->code_blocks.contains(code_switch.case_default)
+        && !emitted_targets.contains(code_switch.case_default)) {
+      string_stream << spacing << "default:\n";
+      string_stream << spacing << "{\n";
+      indent_spacing();
+
+      if (decompile_options.annotate) {
+        string_stream << spacing << "// --- default target block " << code_switch.case_default << "\n";
+      }
+
+      emit_case_body(code_switch.case_default);
+
+      string_stream << spacing << "break;\n";
+      unindent_spacing();
+      string_stream << spacing << "}\n";
+    }
+
+    // --- Step 7: Close the switch ---
+    unindent_spacing();
+    string_stream << spacing << "}\n";
+  };
+
+  // ============================================================
+  // Irreducible Control Flow Dispatcher Fallback (Task 10.2)
+  // ============================================================
+
+  // When an acyclic region contains irreducible control flow (a cycle that
+  // is not a natural loop), we fall back to a state-machine dispatcher:
+  //   int __state = entry_id;
+  //   [loop] for (;;) {
+  //       switch (__state) {
+  //           case block_N: { ... __state = next; break; }
+  //       }
+  //   }
+  // This is a rare fallback — most shader CFGs are reducible.
+  auto emit_dispatcher_fallback = [&](const std::set<int>& blocks, int entry) {
+    // Type-stripping regexes (same patterns used elsewhere in the emitter)
+    static const std::regex disp_decl_re(R"(^(float4|float3|float2|float|int64_t|uint64_t|int16_t[234]?|uint16_t[234]?|int|uint|bool|uint4|int4|int2|uint2|int3|uint3|double|half[234]?|min16float[234]?|min16int[234]?|min16uint[234]?)\s+(_\d+)\s*=)");
+    static const std::regex disp_array_decl_re(R"(^(float|int|uint)\s+(_\d+)\[(\d+)\];?\s*$)");
+    static const std::regex disp_decl_noassign_re(R"(^(float4|float3|float2|float|int64_t|uint64_t|int16_t[234]?|uint16_t[234]?|int|uint|bool|uint4|int4|int2|uint2|int3|uint3|double|half[234]?|min16float[234]?|min16int[234]?|min16uint[234]?)\s+(_\d+)\s*;)");
+
+    // Log warning
+    string_stream << spacing << "// [mermaid] WARNING: irreducible control flow detected, using dispatcher fallback\n";
+
+    if (decompile_options.annotate) {
+      string_stream << spacing << "// [mermaid] dispatcher blocks: {";
+      bool first = true;
+      for (int b : blocks) {
+        if (!first) string_stream << ", ";
+        string_stream << b;
+        first = false;
+      }
+      string_stream << "} entry=" << entry << "\n";
+    }
+
+    // Emit state variable and loop
+    string_stream << spacing << "int __state = " << entry << ";\n";
+    string_stream << spacing << "[loop] for (;;) {\n";
+    indent_spacing();
+    string_stream << spacing << "switch (__state) {\n";
+    indent_spacing();
+
+    // Emit a case for each block (sorted by block ID via std::set ordering)
+    for (int block_id : blocks) {
+      if (!current_code_function->code_blocks.contains(block_id)) continue;
+      const auto& code_block = current_code_function->code_blocks.at(block_id);
+
+      string_stream << spacing << "case " << block_id << ": {\n";
+      indent_spacing();
+
+      if (decompile_options.annotate) {
+        string_stream << spacing << "// --- dispatcher case block " << block_id << "\n";
+      }
+
+      // Emit the block's hlsl_lines with type-stripping for pre-declared vars
+      // Inject heap resource declarations for the dispatcher case block.
+      for (const auto& decl : heap_decls_to_inject(block_id)) {
+        string_stream << spacing << decl << "\n";
+      }
+      for (const auto& line : code_block.hlsl_lines) {
+        std::string emit_line = line;
+        std::smatch m;
+        if (std::regex_search(emit_line, m, disp_array_decl_re)) {
+          std::string var_name = m[2].str();
+          if (declared_vars.contains(var_name)) {
+            continue;  // Already pre-declared — skip
+          }
+        }
+        if (std::regex_search(emit_line, m, disp_decl_re)) {
+          std::string var_name = m[2].str();
+          if (declared_vars.contains(var_name)) {
+            emit_line = var_name + " =" + m.suffix().str();
+          }
+        } else if (std::regex_search(emit_line, m, disp_decl_noassign_re)) {
+          std::string var_name = m[2].str();
+          if (declared_vars.contains(var_name)) {
+            std::string remainder = m.suffix().str();
+            size_t start = remainder.find_first_not_of(" \t");
+            if (start != std::string::npos) {
+              emit_line = remainder.substr(start);
+            } else {
+              continue;
+            }
+          }
+        }
+        string_stream << spacing << emit_line << "\n";
+      }
+
+      // Determine the next state transition based on the block's branch structure
+      bool has_branch_condition = !code_block.code_branch.branch_condition.empty();
+      int true_target = code_block.code_branch.branch_condition_true;
+      int false_target = code_block.code_branch.branch_condition_false;
+
+      if (has_branch_condition && true_target >= 0 && false_target >= 0) {
+        // Conditional branch: emit if/else state transition
+        std::string cond = code_block.code_branch.branch_condition;
+        string_stream << spacing << "if (" << cond << ") __state = " << true_target
+                      << "; else __state = " << false_target << ";\n";
+      } else if (true_target >= 0) {
+        // Unconditional branch: set state to the single target
+        string_stream << spacing << "__state = " << true_target << ";\n";
+      } else {
+        // Terminal block (no successors): break out of the for loop
+        string_stream << spacing << "break;\n";
+      }
+
+      // Emit phi assignments for outgoing edges from this block
+      for (const auto& edge : graph_edges) {
+        if (edge.source != block_id) continue;
+        if (edge.type == GraphEdgeType::BackEdge) continue;
+        for (const auto& pa : edge.phi_assignments) {
+          if (pa.value == "undef") continue;
+
+          std::string parsed_value;
+          try {
+            parsed_value = current_code_function->ParseByType(pa.value, pa.type);
+          } catch (...) {
+            if (pa.value.starts_with("%")) {
+              parsed_value = std::format("_{}", pa.value.substr(1));
+            } else if (pa.value.starts_with("_")) {
+              parsed_value = pa.value;
+            } else {
+              parsed_value = pa.value;
+            }
+          }
+
+          std::string optimized = OptimizeString(parsed_value);
+          string_stream << spacing << pa.variable << " = " << optimized << ";\n";
+        }
+      }
+
+      // Break out of the switch case
+      string_stream << spacing << "break;\n";
+      unindent_spacing();
+      string_stream << spacing << "}\n";
+    }
+
+    // Close switch
+    unindent_spacing();
+    string_stream << spacing << "}\n";
+
+    // Close for loop
+    unindent_spacing();
+    string_stream << spacing << "}\n";
+  };
+
+  // ============================================================
+  // CFG Partitioning (Task 5.1)
+  // ============================================================
+
+  // Partition the CFG into a sequence of EmitRegions.
+  // Top-level loops become Loop regions; everything else is Acyclic.
+  // Nested loops are recursively partitioned within their parent loop body.
+  // Regions are ordered so that blocks are emitted in topological order.
+  std::function<std::vector<EmitRegion>(int, const std::set<int>&, int, int)> partition_cfg;
+  partition_cfg = [&](
+      int entry,
+      const std::set<int>& all_blocks,
+      int parent_loop_header,  // -1 at top level; set to the loop header when recursing into a loop body
+      int depth
+  ) -> std::vector<EmitRegion> {
+    std::vector<EmitRegion> regions;
+
+    if (all_blocks.empty()) return regions;
+
+    // Guard against infinite recursion — max nesting depth of 20 is more than enough
+    if (depth > 20) return regions;
+
+    // Step 1: Identify top-level loops within all_blocks.
+    // A loop is "top-level" relative to this partition call if:
+    //   - Its header is in all_blocks
+    //   - It is NOT the parent_loop_header (avoid infinite recursion — the parent
+    //     loop is already being handled by the caller)
+    //   - It is not nested inside another loop that is also top-level at this level
+    std::set<int> candidate_headers;
+    for (const auto& [header, body] : mermaid_loop_bodies) {
+      // Only consider loops whose header is in our block set
+      if (!all_blocks.contains(header)) continue;
+
+      // Skip the parent loop header — it's already being handled by the caller.
+      // Without this check, recursing into a loop body would re-discover the same
+      // loop and recurse infinitely.
+      if (header == parent_loop_header) continue;
+
+      candidate_headers.insert(header);
+    }
+
+    // Two-pass nesting detection: a candidate header H is nested if there exists
+    // another candidate header H2 (H2 != H) whose loop body contains H.
+    // This correctly handles self-loops (block_to_loop_header[H] == H) by checking
+    // against all other candidates' bodies rather than relying on the innermost-loop map.
+    std::set<int> top_level_headers;
+    for (int header : candidate_headers) {
+      bool is_nested = false;
+      for (int other_header : candidate_headers) {
+        if (other_header == header) continue;
+        if (mermaid_loop_bodies.contains(other_header)) {
+          const auto& other_body = mermaid_loop_bodies.at(other_header);
+          if (other_body.contains(header)) {
+            is_nested = true;
+            break;
+          }
+        }
+      }
+      if (!is_nested) {
+        top_level_headers.insert(header);
+      }
+    }
+
+    // Step 2: Collect all blocks that belong to top-level loops
+    std::set<int> blocks_in_loops;
+    for (int header : top_level_headers) {
+      if (mermaid_loop_bodies.contains(header)) {
+        const auto& body = mermaid_loop_bodies.at(header);
+        for (int block : body) {
+          if (all_blocks.contains(block)) {
+            blocks_in_loops.insert(block);
+          }
+        }
+      }
+    }
+
+    // Step 3: Compute RPO of all_blocks to determine region ordering
+    auto rpo = compute_rpo(entry, all_blocks);
+
+    // Step 4: Walk blocks in RPO order, grouping consecutive non-loop blocks
+    // into Acyclic regions and emitting Loop regions when we hit a loop header.
+    std::set<int> current_acyclic_blocks;
+    int current_acyclic_entry = -1;
+    std::set<int> emitted_loop_headers;
+
+    auto flush_acyclic = [&]() {
+      if (!current_acyclic_blocks.empty()) {
+        EmitRegion acyclic_region;
+        acyclic_region.kind = EmitRegion::Kind::Acyclic;
+        acyclic_region.entry = current_acyclic_entry;
+        acyclic_region.blocks = std::move(current_acyclic_blocks);
+        regions.push_back(std::move(acyclic_region));
+        current_acyclic_blocks.clear();
+        current_acyclic_entry = -1;
+      }
+    };
+
+    for (int block_id : rpo) {
+      if (top_level_headers.contains(block_id) && !emitted_loop_headers.contains(block_id)) {
+        flush_acyclic();
+
+        EmitRegion loop_region;
+        loop_region.kind = EmitRegion::Kind::Loop;
+        loop_region.entry = block_id;
+        loop_region.loop_header = block_id;
+
+        if (mermaid_loop_bodies.contains(block_id)) {
+          const auto& body = mermaid_loop_bodies.at(block_id);
+          for (int b : body) {
+            if (all_blocks.contains(b)) {
+              loop_region.blocks.insert(b);
+            }
+          }
+        }
+
+        if (mermaid_natural_loops.contains(block_id)) {
+          loop_region.back_edge_sources = mermaid_natural_loops.at(block_id);
+        }
+
+        loop_region.loop_exit = find_loop_exit(block_id, loop_region.blocks);
+        loop_region.nested_loops = partition_cfg(block_id, loop_region.blocks, block_id, depth + 1);
+
+        regions.push_back(std::move(loop_region));
+        emitted_loop_headers.insert(block_id);
+      } else if (!blocks_in_loops.contains(block_id)) {
+        if (current_acyclic_entry < 0) {
+          current_acyclic_entry = block_id;
+        }
+        current_acyclic_blocks.insert(block_id);
+      }
+    }
+
+    flush_acyclic();
+
+    return regions;
+  };
+
+  // ============================================================
+  // Condition-based emission — Wired emission (Task 8)
+  // ============================================================
+
+  // Partition the CFG into acyclic and loop regions
+  std::set<int> all_block_ids;
+  for (const auto& [id, _] : graph_nodes) {
+    all_block_ids.insert(id);
+  }
+  auto regions = partition_cfg(mermaid_entry_block, all_block_ids, -1, 0);
+
+  // ============================================================
+  // Preprocessing: Detect loop-bypass convergence phi patterns
+  // ============================================================
+  // For each guarded loop followed by an acyclic region, precompute which
+  // phi variables at the convergence point need bypass treatment.
+
+  for (size_t ri = 0; ri < regions.size(); ++ri) {
+    if (regions[ri].kind != EmitRegion::Kind::Loop) continue;
+    const auto& loop_region = regions[ri];
+    if (loop_region.loop_header < 0) continue;
+
+    // Check if this loop has a guarded entry (unconditional-branch predecessor)
+    std::vector<int> ext_preds;
+    for (const auto& edge : graph_edges) {
+      if (edge.target != loop_region.loop_header) continue;
+      if (edge.type == GraphEdgeType::BackEdge) continue;
+      if (loop_region.blocks.contains(edge.source)) continue;
+      ext_preds.push_back(edge.source);
+    }
+    if (ext_preds.size() != 1) continue;
+
+    int pred = ext_preds[0];
+    if (!current_code_function->code_blocks.contains(pred)) continue;
+    const auto& pred_block = current_code_function->code_blocks.at(pred);
+    if (!pred_block.code_branch.branch_condition.empty()) continue;  // must be unconditional
+
+    // Only proceed if the predecessor is conditionally reachable (has multiple
+    // predecessors or a predecessor with a conditional branch). If the predecessor
+    // is always reached (single unconditional predecessor chain from entry), its
+    // __rc_N won't be emitted and the bypass would reference an undeclared variable.
+    bool pred_is_conditional = false;
+    if (graph_nodes.contains(pred) && graph_nodes.at(pred).predecessors.size() >= 1) {
+      // Check if any predecessor of pred has a conditional branch
+      for (int pp : graph_nodes.at(pred).predecessors) {
+        if (current_code_function->code_blocks.contains(pp)) {
+          const auto& pp_block = current_code_function->code_blocks.at(pp);
+          if (!pp_block.code_branch.branch_condition.empty()) {
+            pred_is_conditional = true;
+            break;
+          }
+        }
+      }
+    }
+    if (!pred_is_conditional) continue;
+
+    std::string guard_var = std::format("__rc_{}", pred);
+
+    // Find the convergence region — the first region after the loop that contains
+    // a block reachable from outside the guarded scope (the convergence point).
+    // This may not be ri+1 if there are intermediate regions that are only
+    // reachable from the loop exit (extended guard regions).
+    const EmitRegion* convergence_region = nullptr;
+    std::set<int> guarded_scope;
+    guarded_scope.insert(loop_region.blocks.begin(), loop_region.blocks.end());
+    guarded_scope.insert(pred);
+
+    for (size_t search_ri = ri + 1; search_ri < regions.size(); ++search_ri) {
+      const auto& candidate = regions[search_ri];
+
+      // Check if this region contains a block with an external predecessor
+      // from outside the guarded scope (convergence point)
+      bool has_convergence = false;
+      for (const auto& edge : graph_edges) {
+        if (edge.type == GraphEdgeType::BackEdge) continue;
+        if (!candidate.blocks.contains(edge.target)) continue;
+        if (candidate.blocks.contains(edge.source)) continue;
+        if (guarded_scope.contains(edge.source)) continue;
+        // This block has a predecessor from outside the guarded scope
+        has_convergence = true;
+        break;
+      }
+
+      if (has_convergence) {
+        convergence_region = &candidate;
+        break;
+      }
+
+      // Check if this region's entry is only reachable from the guarded scope
+      int next_entry = candidate.entry;
+      bool all_preds_guarded = true;
+      bool has_any_pred = false;
+      for (const auto& edge : graph_edges) {
+        if (edge.target != next_entry) continue;
+        if (edge.type == GraphEdgeType::BackEdge) continue;
+        has_any_pred = true;
+        if (!guarded_scope.contains(edge.source)) {
+          all_preds_guarded = false;
+          break;
+        }
+      }
+      if (!all_preds_guarded || !has_any_pred) {
+        // Can't extend further — use this region as convergence
+        convergence_region = &candidate;
+        break;
+      }
+
+      // This region is part of the extended guard scope
+      guarded_scope.insert(candidate.blocks.begin(), candidate.blocks.end());
+    }
+
+    if (!convergence_region) continue;
+
+    // Find bypass edges: edges from outside the guarded scope to the convergence region
+    for (const auto& edge : graph_edges) {
+      if (!convergence_region->blocks.contains(edge.target)) continue;
+      if (edge.type == GraphEdgeType::BackEdge) continue;
+      if (loop_region.blocks.contains(edge.source)) continue;
+      if (convergence_region->blocks.contains(edge.source)) continue;
+      if (guarded_scope.contains(edge.source)) continue;
+      if (edge.phi_assignments.empty()) continue;
+
+      // Record bypass phi info for this convergence block
+      int conv_block = edge.target;
+      for (const auto& pa : edge.phi_assignments) {
+        if (pa.value == "undef") continue;
+        std::string parsed;
+        try { parsed = current_code_function->ParseByType(pa.value, pa.type); }
+        catch (...) {
+          if (pa.value.starts_with("%")) parsed = std::format("_{}", pa.value.substr(1));
+          else parsed = pa.value;
+        }
+        convergence_bypass_phis[conv_block][pa.variable] = {guard_var, OptimizeString(parsed), edge.source};
+      }
+      break;  // use first bypass edge
+    }
+  }
+
+  // Emit each region
+  // Safety limit: abort if the output grows beyond a reasonable size.
+  // This prevents crashes from std::string reallocation on very large shaders.
+  constexpr size_t MERMAID_MAX_OUTPUT_SIZE = 64 * 1024 * 1024;  // 64 MB
+
+  // Pre-declare __cond_N and __rc_N variables at function scope for ALL blocks
+  // that have outgoing edges to blocks NOT in the same innermost region.
+  // These variables will be referenced by subsequent regions via block_exit_rc.
+  // Declaring them here (at function scope) ensures they remain visible regardless
+  // of which nested scope they're assigned in (e.g., inside loop guards or nested loops).
+  //
+  // Strategy: for each block, check if ANY of its successors is in a different
+  // top-level region OR if the block is inside a loop whose exit target is outside.
+  // Rather than complex region membership checks, we use a simpler heuristic:
+  // pre-declare for any block whose successor has a LOWER block_id (potential
+  // back-edge target) or is not in the same loop body.
+  //
+  // Simplest correct approach: pre-declare for ALL blocks that have successors
+  // outside their own loop body (for loop blocks) or outside their own acyclic
+  // region (for acyclic blocks).
+  {
+    // Build a lookup: block_id → set of region block_ids it belongs to (innermost)
+    std::map<int, const std::set<int>*> block_to_region;
+    std::function<void(const std::vector<EmitRegion>&)> map_blocks;
+    map_blocks = [&](const std::vector<EmitRegion>& rgns) {
+      for (const auto& r : rgns) {
+        for (int bid : r.blocks) {
+          // Innermost wins — nested loops override parent
+          block_to_region[bid] = &r.blocks;
+        }
+        if (r.kind == EmitRegion::Kind::Loop) {
+          map_blocks(r.nested_loops);
+        }
+      }
+    };
+    map_blocks(regions);
+
+    for (const auto& [block_id, node] : graph_nodes) {
+      const std::set<int>* my_region = block_to_region.contains(block_id) ? block_to_region[block_id] : nullptr;
+      if (!my_region) continue;
+
+      bool has_cross_region_edge = false;
+      for (int succ : node.successors) {
+        if (!my_region->contains(succ)) {
+          has_cross_region_edge = true;
+          break;
+        }
+      }
+      if (!has_cross_region_edge) continue;
+
+      // Pre-declare __rc_N
+      std::string rc_var = std::format("__rc_{}", block_id);
+      if (!emitted_bool_vars.contains(rc_var)) {
+        string_stream << spacing << "bool " << rc_var << " = false;\n";
+        emitted_bool_vars.insert(rc_var);
+      }
+      // Pre-declare __cond_N if this block has a branch condition
+      if (current_code_function->code_blocks.contains(block_id)) {
+        const auto& cb = current_code_function->code_blocks.at(block_id);
+        if (!cb.code_branch.branch_condition.empty()) {
+          std::string cond_var = std::format("__cond_{}", block_id);
+          if (!emitted_bool_vars.contains(cond_var)) {
+            string_stream << spacing << "bool " << cond_var << " = false;\n";
+            emitted_bool_vars.insert(cond_var);
+          }
+        }
+      }
+    }
+  }
+
+  for (size_t ri = 0; ri < regions.size(); ++ri) {
+    const auto& region = regions[ri];
+    auto current_size = static_cast<size_t>(string_stream.tellp());
+    if (current_size > MERMAID_MAX_OUTPUT_SIZE) {
+      string_stream << spacing << "// [mermaid] ERROR: output exceeded "
+                    << (MERMAID_MAX_OUTPUT_SIZE / (1024 * 1024))
+                    << " MB limit, aborting emission\n";
+      break;
+    }
+    if (region.kind == EmitRegion::Kind::Acyclic) {
+      emit_acyclic_region(region);
+    } else if (region.kind == EmitRegion::Kind::Loop) {
+      // Guard the loop if its only external predecessor is a trivial empty block
+      // (no hlsl_lines, unconditional branch). This pattern occurs when LLVM IR
+      // has an explicit branch block between a conditional and the loop header:
+      //   block 735: br i1 %cond, label %909, label %740
+      //   block 740: br label %741  (trivial, empty)
+      //   block 741: loop header
+      // The loop must be guarded by __rc_740 to prevent execution when the
+      // conditional skips it.
+      bool loop_guarded = false;
+      std::string loop_guard_var;
+
+      if (region.loop_header >= 0) {
+        std::vector<int> external_preds;
+        for (const auto& edge : graph_edges) {
+          if (edge.target != region.loop_header) continue;
+          if (edge.type == GraphEdgeType::BackEdge) continue;
+          if (region.blocks.contains(edge.source)) continue;
+          external_preds.push_back(edge.source);
+        }
+
+        if (external_preds.size() == 1) {
+          int pred = external_preds[0];
+          if (current_code_function->code_blocks.contains(pred)) {
+            const auto& pred_block = current_code_function->code_blocks.at(pred);
+            // Guard if the predecessor is an unconditional branch to the loop header
+            // AND the predecessor is conditionally reachable (has a predecessor with
+            // a conditional branch). This prevents infinite loops when the loop
+            // should be skipped.
+            bool pred_is_unconditional_entry = pred_block.code_branch.branch_condition.empty();
+
+            if (pred_is_unconditional_entry) {
+              // Verify the predecessor is conditionally reachable
+              bool pred_is_conditional = false;
+              if (graph_nodes.contains(pred) && graph_nodes.at(pred).predecessors.size() >= 1) {
+                for (int pp : graph_nodes.at(pred).predecessors) {
+                  if (current_code_function->code_blocks.contains(pp)) {
+                    const auto& pp_block = current_code_function->code_blocks.at(pp);
+                    if (!pp_block.code_branch.branch_condition.empty()) {
+                      pred_is_conditional = true;
+                      break;
+                    }
+                  }
+                }
+              }
+
+              if (pred_is_conditional) {
+                std::string rc_var = std::format("__rc_{}", pred);
+                if (emitted_bool_vars.contains(rc_var)) {
+                  loop_guarded = true;
+                  loop_guard_var = rc_var;
+                }
+              }
+            }
+          }
+        }
+      }
+
+      // Extend the loop guard to cover subsequent regions that are ONLY reachable
+      // from the guarded loop's exit path. This handles the pattern where:
+      //   block A: br i1 %cond, label %convergence, label %loop_entry
+      //   loop_entry → loop_header → ... → loop_exit → post_loop_block
+      //   post_loop_block → ... → convergence
+      // With inter-region RC propagation, subsequent regions automatically get
+      // the correct RC from block_exit_rc. The extended region detection is no
+      // longer needed — compute_reaching_conditions will look up the loop body
+      // blocks' RCs and propagate the guard condition naturally.
+      // However, we still need to record the loop guard predecessor's RC in
+      // block_exit_rc so that subsequent regions can reference it.
+      if (loop_guarded) {
+        // Find the guard predecessor block and record its RC
+        for (const auto& edge : graph_edges) {
+          if (edge.target == region.loop_header && !region.blocks.contains(edge.source)) {
+            if (edge.type != GraphEdgeType::BackEdge) {
+              // The predecessor's RC is the loop_guard_var itself
+              block_exit_rc[edge.source] = loop_guard_var;
+            }
+          }
+        }
+      }
+
+      if (loop_guarded) {
+        string_stream << spacing << "if (" << loop_guard_var << ") {\n";
+        indent_spacing();
+      }
+
+      emit_loop_region(region);
+
+      if (loop_guarded) {
+        unindent_spacing();
+        string_stream << spacing << "}\n";
+      }
+    }
+  }
+
+  // Requirement 11.5: Warn when condition variable count exceeds 1000
+  {
+    std::string output = string_stream.str();
+    int cond_count = 0;
+    size_t pos = 0;
+    while ((pos = output.find("bool __cond_", pos)) != std::string::npos) {
+      cond_count++;
+      pos += 12;
+    }
+    pos = 0;
+    while ((pos = output.find("bool __rc_", pos)) != std::string::npos) {
+      cond_count++;
+      pos += 10;
+    }
+    if (cond_count > 1000) {
+      string_stream << spacing << "// [mermaid] WARNING: " << cond_count
+                    << " condition variables emitted (exceeds 1000)\n";
+    }
+  }
+}

--- a/src/utils/shader_decompiler/postprocess.hpp
+++ b/src/utils/shader_decompiler/postprocess.hpp
@@ -1144,7 +1144,9 @@
 
       auto resource = std::string(trimmed.substr(0, store_pos));
       auto address = std::string(trimmed.substr(store_pos + 7, value_pos - (store_pos + 7)));
-      auto value = std::string(trimmed.substr(value_pos + 10, trimmed.size() - value_pos - 13));
+      static constexpr std::string_view VALUE_PREFIX = ", asuint(";
+      auto value_start = value_pos + VALUE_PREFIX.size();
+      auto value = std::string(trimmed.substr(value_start, trimmed.size() - value_start - 3));
       return std::tuple<std::string, std::string, std::string, std::string>(
           line.substr(0, indent_length), resource, address, value);
     };
@@ -1238,9 +1240,17 @@
         if (next_resource != resource || next_address != address) {
           continue;
         }
+        if (next_indent != indent) {
+          continue;
+        }
 
         bool assigned_between = false;
         for (size_t k = i + 1; k < j && !assigned_between; ++k) {
+          auto trimmed_between = trim(lines[k]);
+          if (trimmed_between.find('{') != std::string_view::npos || trimmed_between.find('}') != std::string_view::npos) {
+            assigned_between = true;
+            break;
+          }
           for (const auto& identifier : identifiers) {
             if (line_assigns_identifier(lines[k], identifier)) {
               assigned_between = true;

--- a/src/utils/shader_decompiler/postprocess.hpp
+++ b/src/utils/shader_decompiler/postprocess.hpp
@@ -1,0 +1,2337 @@
+// ===== POST-PROCESSING PASSES =====
+// String-to-string transforms applied to the final HLSL output.
+// These are static methods on the Decompiler class, operating on the
+// complete HLSL text after code generation.
+//
+// Ported from ShortFuse's shader_decompiler_dxc.hpp.
+// Each pass is a self-contained function: std::string -> std::string.
+  static std::string OptimizeWholeStructBufferStores(std::string_view hlsl) {
+    static const auto STRUCT_START_REGEX = std::regex(R"(^struct\s+([A-Za-z_][A-Za-z0-9_]*)\s*\{$)");
+    static const auto STRUCT_FIELD_REGEX = std::regex(R"(^\s*[A-Za-z_][A-Za-z0-9_<>, ]*\s+([A-Za-z_][A-Za-z0-9_]*)\s*;\s*$)");
+    static const auto RW_STRUCTURED_BUFFER_REGEX =
+        std::regex(R"(^\s*RWStructuredBuffer<([A-Za-z_][A-Za-z0-9_]*)>\s+([A-Za-z_][A-Za-z0-9_]*)\s*:\s*register\(u\d+,\s*space\d+\);\s*$)");
+    static const auto STRUCT_FIELD_STORE_REGEX =
+        std::regex(R"(^(\s*)([A-Za-z_][A-Za-z0-9_]*)\[(.+)\](\.[A-Za-z_][A-Za-z0-9_]*) = (.+);\s*$)");
+
+    std::vector<std::string> lines;
+    {
+      std::stringstream line_stream{std::string(hlsl)};
+      std::string line;
+      while (std::getline(line_stream, line)) {
+        lines.push_back(line);
+      }
+    }
+
+    std::map<std::string, std::vector<std::string>> struct_fields;
+    std::map<std::string, std::string> resource_struct_types;
+
+    for (size_t i = 0; i < lines.size(); ++i) {
+      auto [struct_name] = StringViewMatch<1>(lines[i], STRUCT_START_REGEX);
+      if (!struct_name.empty()) {
+        std::vector<std::string> fields;
+        ++i;
+        while (i < lines.size() && lines[i] != "};") {
+          auto [field_name] = StringViewMatch<1>(lines[i], STRUCT_FIELD_REGEX);
+          if (!field_name.empty()) {
+            fields.emplace_back(field_name);
+          }
+          ++i;
+        }
+        if (!fields.empty()) {
+          struct_fields.emplace(std::string(struct_name), std::move(fields));
+        }
+        continue;
+      }
+
+      auto [struct_type, resource_name] = StringViewMatch<2>(lines[i], RW_STRUCTURED_BUFFER_REGEX);
+      if (!struct_type.empty() && !resource_name.empty()) {
+        resource_struct_types.emplace(std::string(resource_name), std::string(struct_type));
+      }
+    }
+
+    std::vector<std::string> output_lines;
+    output_lines.reserve(lines.size());
+    int temp_index = 0;
+
+    for (size_t i = 0; i < lines.size(); ++i) {
+      auto [indent, resource_name, element_index, field_name, expression] = StringViewMatch<5>(lines[i], STRUCT_FIELD_STORE_REGEX);
+      if (resource_name.empty() || !resource_struct_types.contains(std::string(resource_name))) {
+        output_lines.push_back(lines[i]);
+        continue;
+      }
+
+      const auto& struct_type = resource_struct_types.at(std::string(resource_name));
+      auto struct_fields_it = struct_fields.find(struct_type);
+      if (struct_fields_it == struct_fields.end()) {
+        output_lines.push_back(lines[i]);
+        continue;
+      }
+
+      std::vector<std::tuple<std::string, std::string>> run_fields = {
+          {std::string(field_name), std::string(expression)},
+      };
+      size_t run_end = i;
+      for (size_t j = i + 1; j < lines.size(); ++j) {
+        auto [next_indent, next_resource_name, next_element_index, next_field_name, next_expression] =
+            StringViewMatch<5>(lines[j], STRUCT_FIELD_STORE_REGEX);
+        if (next_indent != indent
+            || next_resource_name != resource_name
+            || next_element_index != element_index
+            || next_field_name.empty()
+            || next_expression.empty()) {
+          break;
+        }
+        run_fields.emplace_back(std::string(next_field_name), std::string(next_expression));
+        run_end = j;
+      }
+
+      if (run_fields.size() != struct_fields_it->second.size()) {
+        output_lines.push_back(lines[i]);
+        continue;
+      }
+
+      bool covers_all_fields = true;
+      std::set<std::string> seen_fields;
+      for (const auto& expected_field : struct_fields_it->second) {
+        seen_fields.insert("." + expected_field);
+      }
+      for (const auto& [run_field_name, run_expression] : run_fields) {
+        if (!seen_fields.erase(run_field_name)) {
+          covers_all_fields = false;
+          break;
+        }
+      }
+      if (!covers_all_fields || !seen_fields.empty()) {
+        output_lines.push_back(lines[i]);
+        continue;
+      }
+
+      auto temp_name = std::format("__struct_store_{}", temp_index++);
+      output_lines.push_back(std::format("{}{} {};", indent, struct_type, temp_name));
+      for (const auto& expected_field : struct_fields_it->second) {
+        auto run_it = std::ranges::find_if(
+            run_fields,
+            [&](const auto& run_field) {
+              return std::get<0>(run_field) == ("." + expected_field);
+            });
+        output_lines.push_back(std::format(
+            "{}{}{} = {};",
+            indent,
+            temp_name,
+            std::get<0>(*run_it),
+            std::get<1>(*run_it)));
+      }
+      output_lines.push_back(std::format(
+          "{}{}[{}] = {};",
+          indent,
+          resource_name,
+          element_index,
+          temp_name));
+      i = run_end;
+    }
+
+    std::stringstream output_stream;
+    for (size_t i = 0; i < output_lines.size(); ++i) {
+      output_stream << output_lines[i];
+      if (i + 1 < output_lines.size()) {
+        output_stream << "\n";
+      }
+    }
+    return output_stream.str();
+  }
+
+  static std::string OptimizeStructuredResourceVectorLoads(std::string_view hlsl) {
+    static const auto STRUCTURED_BUFFER_REGEX =
+        std::regex(R"(^\s*(?:RW)?StructuredBuffer<([A-Za-z_][A-Za-z0-9_]*)>\s+([A-Za-z_][A-Za-z0-9_]*)\s*(?:\[\])?\s*:\s*register\([tu]\d+,\s*space\d+\);\s*$)");
+    static const auto VECTOR_COMPONENT_LOAD_REGEX =
+        std::regex(R"(^(\s*)(float|half|int|uint)\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.+)\.([xyzw]);\s*$)");
+
+    std::vector<std::string> lines;
+    {
+      std::stringstream line_stream{std::string(hlsl)};
+      std::string line;
+      while (std::getline(line_stream, line)) {
+        lines.push_back(line);
+      }
+    }
+
+    std::set<std::string> structured_resource_names;
+    for (const auto& line : lines) {
+      auto [struct_type, resource_name] = StringViewMatch<2>(line, STRUCTURED_BUFFER_REGEX);
+      if (!struct_type.empty() && !resource_name.empty()) {
+        structured_resource_names.emplace(std::string(resource_name));
+      }
+    }
+
+    auto is_structured_resource_expression = [&](std::string_view expression) {
+      for (const auto& resource_name : structured_resource_names) {
+        if (expression.starts_with(resource_name) && expression.size() > resource_name.size()
+            && expression[resource_name.size()] == '[') {
+          return true;
+        }
+      }
+      return false;
+    };
+
+    std::vector<std::string> output_lines;
+    output_lines.reserve(lines.size());
+    int temp_index = 0;
+
+    for (size_t i = 0; i < lines.size();) {
+      auto [indent, scalar_type, first_variable, base_expression, swizzle] =
+          StringViewMatch<5>(lines[i], VECTOR_COMPONENT_LOAD_REGEX);
+      if (first_variable.empty() || base_expression.empty() || swizzle != "x"
+          || !is_structured_resource_expression(base_expression)) {
+        output_lines.push_back(lines[i]);
+        ++i;
+        continue;
+      }
+
+      std::vector<std::tuple<std::string, std::string>> run = {
+          {std::string(first_variable), std::string(swizzle)},
+      };
+      size_t run_end = i;
+      size_t expected_component_index = 1;
+      for (size_t j = i + 1; j < lines.size() && expected_component_index < 4; ++j) {
+        auto [next_indent, next_scalar_type, next_variable, next_base_expression, next_swizzle] =
+            StringViewMatch<5>(lines[j], VECTOR_COMPONENT_LOAD_REGEX);
+        if (next_variable.empty()
+            || next_indent != indent
+            || next_scalar_type != scalar_type
+            || next_base_expression != base_expression
+            || next_swizzle.size() != 1
+            || next_swizzle[0] != VECTOR_INDEXES[expected_component_index]) {
+          break;
+        }
+        run.emplace_back(std::string(next_variable), std::string(next_swizzle));
+        run_end = j;
+        ++expected_component_index;
+      }
+
+      if (run.size() < 2) {
+        output_lines.push_back(lines[i]);
+        ++i;
+        continue;
+      }
+
+      auto temp_name = std::format("__structured_resource_load_{}", temp_index++);
+      output_lines.push_back(std::format(
+          "{}{}{} {} = {};",
+          indent,
+          scalar_type,
+          run.size(),
+          temp_name,
+          base_expression));
+      for (const auto& [variable_name, component_swizzle] : run) {
+        output_lines.push_back(std::format(
+            "{}{} {} = {}.{};",
+            indent,
+            scalar_type,
+            variable_name,
+            temp_name,
+            component_swizzle));
+      }
+      i = run_end + 1;
+    }
+
+    std::stringstream output_stream;
+    for (size_t i = 0; i < output_lines.size(); ++i) {
+      output_stream << output_lines[i];
+      if (i + 1 < output_lines.size()) {
+        output_stream << "\n";
+      }
+    }
+    return output_stream.str();
+  }
+
+  static std::string OptimizeDeferredBoolBridgeBlocks(std::string_view hlsl) {
+    static const auto DEFER_DECL_REGEX = std::regex(R"(^(\s*)bool (__defer_\d+_\d+) = false;\s*$)");
+    static const auto DEFER_ASSIGN_REGEX = std::regex(R"(^(\s*)(__defer_\d+_\d+) = true;\s*$)");
+    static const auto DEFER_IF_REGEX = std::regex(R"(^(\s*)if \((__defer_\d+_\d+)\) \{\s*$)");
+    static const auto SIMPLE_BODY_LINE_REGEX = std::regex(R"(^\s*(?:(?://.*)|(?:[A-Za-z_][A-Za-z0-9_<>, ]*\s+_\d+\s*=.*;)|(?:_\d+ = .*;)|(?:bool _\d+;)|(?:_\d+;))\s*$)");
+
+    std::vector<std::string> lines;
+    {
+      std::stringstream line_stream{std::string(hlsl)};
+      std::string line;
+      while (std::getline(line_stream, line)) {
+        lines.push_back(line);
+      }
+    }
+
+    auto count_braces = [](std::string_view line) {
+      int delta = 0;
+      for (char c : line) {
+        if (c == '{') ++delta;
+        if (c == '}') --delta;
+      }
+      return delta;
+    };
+
+    bool changed = false;
+    for (size_t i = 0; i < lines.size(); ++i) {
+      auto [decl_indent, defer_var] = StringViewMatch<2>(lines[i], DEFER_DECL_REGEX);
+      if (defer_var.empty()) continue;
+
+      size_t defer_if_line = std::string::npos;
+      for (size_t j = i + 1; j < lines.size(); ++j) {
+        auto [if_indent, if_defer_var] = StringViewMatch<2>(lines[j], DEFER_IF_REGEX);
+        if (if_defer_var == defer_var) {
+          defer_if_line = j;
+          break;
+        }
+      }
+      if (defer_if_line == std::string::npos) continue;
+
+      int brace_depth = count_braces(lines[defer_if_line]);
+      size_t defer_if_end = defer_if_line;
+      for (size_t j = defer_if_line + 1; j < lines.size(); ++j) {
+        brace_depth += count_braces(lines[j]);
+        if (brace_depth == 0) {
+          defer_if_end = j;
+          break;
+        }
+      }
+      if (defer_if_end == defer_if_line) continue;
+
+      std::vector<std::string> defer_body_lines;
+      for (size_t j = defer_if_line + 1; j < defer_if_end; ++j) {
+        if (!std::regex_match(lines[j], SIMPLE_BODY_LINE_REGEX)) {
+          defer_body_lines.clear();
+          break;
+        }
+        defer_body_lines.push_back(lines[j]);
+      }
+      if (defer_body_lines.empty()) continue;
+
+      size_t body_min_indent = (std::numeric_limits<size_t>::max)();
+      for (const auto& line : defer_body_lines) {
+        if (line.empty()) continue;
+        size_t first_non_space = line.find_first_not_of(' ');
+        if (first_non_space == std::string::npos) continue;
+        body_min_indent = (std::min)(body_min_indent, first_non_space);
+      }
+      if (body_min_indent == (std::numeric_limits<size_t>::max)()) continue;
+
+      std::vector<size_t> assignment_positions;
+      for (size_t j = i + 1; j < defer_if_line; ++j) {
+        auto [assign_indent, assign_defer_var] = StringViewMatch<2>(lines[j], DEFER_ASSIGN_REGEX);
+        if (assign_defer_var == defer_var) {
+          assignment_positions.push_back(j);
+        }
+      }
+
+      if (assignment_positions.empty()) {
+        lines.erase(lines.begin() + defer_if_line, lines.begin() + defer_if_end + 1);
+        lines.erase(lines.begin() + i);
+        changed = true;
+        --i;
+        continue;
+      }
+
+      for (auto assignment_it = assignment_positions.rbegin(); assignment_it != assignment_positions.rend(); ++assignment_it) {
+        size_t assignment_position = *assignment_it;
+        auto [assign_indent, assign_defer_var] = StringViewMatch<2>(lines[assignment_position], DEFER_ASSIGN_REGEX);
+        std::vector<std::string> expanded_lines;
+        for (const auto& body_line : defer_body_lines) {
+          std::string trimmed = body_line.size() >= body_min_indent ? body_line.substr(body_min_indent) : body_line;
+          expanded_lines.push_back(std::string(assign_indent) + trimmed);
+        }
+
+        lines.erase(lines.begin() + assignment_position);
+        lines.insert(lines.begin() + assignment_position, expanded_lines.begin(), expanded_lines.end());
+        changed = true;
+      }
+
+      defer_if_line = std::string::npos;
+      for (size_t j = i + 1; j < lines.size(); ++j) {
+        auto [if_indent, if_defer_var] = StringViewMatch<2>(lines[j], DEFER_IF_REGEX);
+        if (if_defer_var == defer_var) {
+          defer_if_line = j;
+          break;
+        }
+      }
+      if (defer_if_line == std::string::npos) continue;
+
+      brace_depth = count_braces(lines[defer_if_line]);
+      defer_if_end = defer_if_line;
+      for (size_t j = defer_if_line + 1; j < lines.size(); ++j) {
+        brace_depth += count_braces(lines[j]);
+        if (brace_depth == 0) {
+          defer_if_end = j;
+          break;
+        }
+      }
+      if (defer_if_end == defer_if_line) continue;
+
+      lines.erase(lines.begin() + defer_if_line, lines.begin() + defer_if_end + 1);
+      lines.erase(lines.begin() + i);
+      changed = true;
+      --i;
+    }
+
+    if (!changed) {
+      return std::string(hlsl);
+    }
+
+    std::stringstream output_stream;
+    for (size_t i = 0; i < lines.size(); ++i) {
+      output_stream << lines[i];
+      if (i + 1 < lines.size()) {
+        output_stream << "\n";
+      }
+    }
+    return output_stream.str();
+  }
+
+  static std::string OptimizeSingleUseBoolChains(std::string_view hlsl) {
+    static const auto BOOL_ASSIGN_REGEX =
+        std::regex(R"(^(\s*)bool ([A-Za-z_][A-Za-z0-9_]*) = \((.+)\);\s*$)");
+    static const auto BOOL_COMBINE_REGEX =
+        std::regex(R"(^(\s*)bool ([A-Za-z_][A-Za-z0-9_]*) = \(([A-Za-z_][A-Za-z0-9_]*)\) (\&\&|\|\||\&|\|) \(([A-Za-z_][A-Za-z0-9_]*)\);\s*$)");
+
+    std::vector<std::string> lines;
+    {
+      std::stringstream line_stream{std::string(hlsl)};
+      std::string line;
+      while (std::getline(line_stream, line)) {
+        lines.push_back(line);
+      }
+    }
+
+    auto count_variable_references = [&](std::string_view variable) {
+      auto variable_regex = std::regex(std::format(R"((^|[^A-Za-z0-9_]){}([^A-Za-z0-9_]|$))", variable));
+      size_t count = 0;
+      for (const auto& line : lines) {
+        if (std::regex_search(line, variable_regex)) {
+          ++count;
+        }
+      }
+      return count;
+    };
+
+    bool changed = false;
+    for (size_t i = 0; i + 2 < lines.size(); ++i) {
+      auto [indent_a, variable_a, expression_a] = StringViewMatch<3>(lines[i], BOOL_ASSIGN_REGEX);
+      auto [indent_b, variable_b, expression_b] = StringViewMatch<3>(lines[i + 1], BOOL_ASSIGN_REGEX);
+      auto [indent_c, variable_c, lhs_variable, combine_op, rhs_variable] = StringViewMatch<5>(lines[i + 2], BOOL_COMBINE_REGEX);
+      if (variable_a.empty() || variable_b.empty() || variable_c.empty()) continue;
+      if (indent_a != indent_b || indent_b != indent_c) continue;
+
+      const bool is_direct_order = lhs_variable == variable_a && rhs_variable == variable_b;
+      const bool is_reverse_order = lhs_variable == variable_b && rhs_variable == variable_a;
+      if (!is_direct_order && !is_reverse_order) continue;
+
+      if (count_variable_references(variable_a) != 2 || count_variable_references(variable_b) != 2) {
+        continue;
+      }
+
+      auto lhs_expression = std::string(is_direct_order ? expression_a : expression_b);
+      auto rhs_expression = std::string(is_direct_order ? expression_b : expression_a);
+      lines[i + 2] = std::format(
+          "{}bool {} = (({}) {} ({}));",
+          indent_c,
+          variable_c,
+          lhs_expression,
+          combine_op,
+          rhs_expression);
+      lines.erase(lines.begin() + i, lines.begin() + i + 2);
+      changed = true;
+      if (i != 0) --i;
+    }
+
+    if (!changed) {
+      return std::string(hlsl);
+    }
+
+    std::stringstream output_stream;
+    for (size_t i = 0; i < lines.size(); ++i) {
+      output_stream << lines[i];
+      if (i + 1 < lines.size()) {
+        output_stream << "\n";
+      }
+    }
+    return output_stream.str();
+  }
+
+  static std::string OptimizeSentinelBoolIntGuards(std::string_view hlsl) {
+    static const auto IF_GUARD_REGEX =
+        std::regex(R"(^(\s*)if \(\(\((_?\w+) != 0\)\) && \(\((_?\w+) != -1\)\)\) \{\s*$)");
+    static const auto INT_FROM_BOOL_ASSIGN_REGEX =
+        std::regex(R"(^(\s*)(_\d+) = \(\(int\)\(uint\)\(\(int\)\((.+)\)\)\);\s*$)");
+    static const auto INT_FROM_BOOL_DECL_ASSIGN_REGEX =
+        std::regex(R"(^(\s*)int\s+(_\d+)\s*=\s*\(\(int\)\(uint\)\(\(int\)\((.+)\)\)\);\s*$)");
+    static const auto SIMPLE_ASSIGN_REGEX =
+        std::regex(R"(^(\s*)(_\d+) = (.+);\s*$)");
+    static const auto BOOL_DECL_REGEX =
+        std::regex(R"(^(\s*)bool (_\d+)\s*;\s*$)");
+    static const auto INT_DECL_REGEX =
+        std::regex(R"(^(\s*)int (_\d+)\s*;\s*$)");
+
+    std::vector<std::string> lines;
+    {
+      std::stringstream line_stream{std::string(hlsl)};
+      std::string line;
+      while (std::getline(line_stream, line)) {
+        lines.push_back(line);
+      }
+    }
+
+    bool changed = false;
+    for (size_t i = 0; i < lines.size(); ++i) {
+      auto [if_indent, int_guard_variable, sentinel_variable] = StringViewMatch<3>(lines[i], IF_GUARD_REGEX);
+      if (int_guard_variable.empty() || sentinel_variable.empty()) {
+        continue;
+      }
+
+      auto previous_non_empty_line = [&lines](size_t start) -> std::optional<size_t> {
+        for (size_t j = start; j-- > 0;) {
+          if (!StringViewTrim(lines[j]).empty()) {
+            return j;
+          }
+        }
+        return std::nullopt;
+      };
+
+      auto direct_guard_line = previous_non_empty_line(i);
+      if (direct_guard_line.has_value()) {
+        auto [bool_indent, bool_assign_variable, bool_expression] =
+            StringViewMatch<3>(lines[direct_guard_line.value()], INT_FROM_BOOL_ASSIGN_REGEX);
+        if (bool_assign_variable == int_guard_variable) {
+          continue;
+        }
+
+        auto [decl_indent, decl_assign_variable, decl_expression] =
+            StringViewMatch<3>(lines[direct_guard_line.value()], INT_FROM_BOOL_DECL_ASSIGN_REGEX);
+        if (decl_assign_variable == int_guard_variable) {
+          continue;
+        }
+      }
+
+      bool saw_sentinel_assignment = false;
+      std::optional<size_t> direct_guard_assignment_line;
+      std::optional<size_t> true_guard_assignment_line;
+      std::optional<size_t> false_guard_assignment_line;
+      std::optional<std::string> bool_guard_expression;
+      const size_t direct_guard_search_begin = i > 6 ? i - 6 : 0;
+      for (size_t j = i; j-- > direct_guard_search_begin;) {
+        auto [bool_indent, bool_assign_variable, bool_expression] =
+            StringViewMatch<3>(lines[j], INT_FROM_BOOL_ASSIGN_REGEX);
+        if (bool_assign_variable == int_guard_variable) {
+          direct_guard_assignment_line = j;
+          bool_guard_expression = std::string(bool_expression);
+          break;
+        }
+
+        auto [decl_indent, decl_assign_variable, decl_expression] =
+            StringViewMatch<3>(lines[j], INT_FROM_BOOL_DECL_ASSIGN_REGEX);
+        if (decl_assign_variable == int_guard_variable) {
+          direct_guard_assignment_line = j;
+          bool_guard_expression = std::string(decl_expression);
+          break;
+        }
+      }
+
+      const size_t search_begin = i > 200 ? i - 200 : 0;
+      for (size_t j = i; j-- > search_begin;) {
+        auto [assign_indent, assign_variable, assign_value] = StringViewMatch<3>(lines[j], SIMPLE_ASSIGN_REGEX);
+        if (assign_variable != sentinel_variable) {
+          continue;
+        }
+
+        if (assign_value == "-1") {
+          saw_sentinel_assignment = true;
+          const size_t false_guard_search_begin = j > 6 ? j - 6 : 0;
+          for (size_t k = j; k-- > false_guard_search_begin;) {
+            auto [bool_indent, bool_assign_variable, bool_expression] =
+                StringViewMatch<3>(lines[k], INT_FROM_BOOL_ASSIGN_REGEX);
+            if (bool_assign_variable == int_guard_variable) {
+              false_guard_assignment_line = k;
+              break;
+            }
+            auto [decl_indent, decl_assign_variable, decl_expression] =
+                StringViewMatch<3>(lines[k], INT_FROM_BOOL_DECL_ASSIGN_REGEX);
+            if (decl_assign_variable == int_guard_variable) {
+              false_guard_assignment_line = k;
+              break;
+            }
+          }
+          continue;
+        }
+
+        const size_t guard_search_begin = j > 6 ? j - 6 : 0;
+        for (size_t k = j; k-- > guard_search_begin;) {
+          auto [bool_indent, bool_assign_variable, bool_expression] =
+              StringViewMatch<3>(lines[k], INT_FROM_BOOL_ASSIGN_REGEX);
+          if (bool_assign_variable == int_guard_variable) {
+            true_guard_assignment_line = k;
+            bool_guard_expression = std::string(bool_expression);
+            break;
+          }
+          auto [decl_indent, decl_assign_variable, decl_expression] =
+              StringViewMatch<3>(lines[k], INT_FROM_BOOL_DECL_ASSIGN_REGEX);
+          if (decl_assign_variable == int_guard_variable) {
+            true_guard_assignment_line = k;
+            bool_guard_expression = std::string(decl_expression);
+            break;
+          }
+        }
+        break;
+      }
+
+      if (!saw_sentinel_assignment || !bool_guard_expression.has_value()) {
+        continue;
+      }
+
+      auto [bool_guard_variable] =
+          StringViewMatch<1>(bool_guard_expression.value(), std::regex(R"(^(_\d+)$)"));
+      if (!bool_guard_variable.empty()) {
+        std::optional<size_t> bool_decl_line;
+        std::optional<size_t> int_decl_line;
+        for (size_t j = 0; j < i; ++j) {
+          auto [decl_indent, decl_variable] = StringViewMatch<2>(lines[j], BOOL_DECL_REGEX);
+          if (decl_variable == bool_guard_variable) {
+            bool_decl_line = j;
+          }
+          auto [int_decl_indent, int_decl_variable] = StringViewMatch<2>(lines[j], INT_DECL_REGEX);
+          if (int_decl_variable == int_guard_variable) {
+            int_decl_line = j;
+          }
+        }
+
+        if (bool_decl_line.has_value()
+            && true_guard_assignment_line.has_value()
+            && false_guard_assignment_line.has_value()) {
+          auto [decl_indent, decl_variable] = StringViewMatch<2>(lines[bool_decl_line.value()], BOOL_DECL_REGEX);
+          lines[bool_decl_line.value()] = std::format("{}bool {} = false;", decl_indent, decl_variable);
+
+          std::vector<size_t> removable_lines = {
+              int_decl_line.value_or(std::string::npos),
+              true_guard_assignment_line.value(),
+              false_guard_assignment_line.value(),
+          };
+          std::ranges::sort(removable_lines);
+          removable_lines.erase(std::unique(removable_lines.begin(), removable_lines.end()), removable_lines.end());
+          removable_lines.erase(
+              std::remove(removable_lines.begin(), removable_lines.end(), std::string::npos),
+              removable_lines.end());
+          for (auto line_it = removable_lines.rbegin(); line_it != removable_lines.rend(); ++line_it) {
+            auto removed_line = *line_it;
+            lines.erase(lines.begin() + removed_line);
+            if (removed_line < i) {
+              --i;
+            }
+          }
+
+          lines.insert(
+              lines.begin() + i,
+              std::format(
+                  "{}int {} = ((int)(uint)((int)({})));",
+                  if_indent,
+                  int_guard_variable,
+                  bool_guard_expression.value()));
+          ++i;
+          changed = true;
+          continue;
+        }
+      }
+
+      lines[i] = std::format(
+          "{}if ((({} != -1)) && {}) {{",
+          if_indent,
+          sentinel_variable,
+          bool_guard_expression.value());
+      if (direct_guard_assignment_line.has_value()) {
+        auto removed_line = direct_guard_assignment_line.value();
+        lines.erase(lines.begin() + removed_line);
+        if (removed_line < i) {
+          --i;
+        }
+      }
+      changed = true;
+    }
+
+    if (!changed) {
+      return std::string(hlsl);
+    }
+
+    std::stringstream output_stream;
+    for (size_t i = 0; i < lines.size(); ++i) {
+      output_stream << lines[i];
+      if (i + 1 < lines.size()) {
+        output_stream << "\n";
+      }
+    }
+    return output_stream.str();
+  }
+
+  static std::string OptimizeBoolCarrierAssignments(std::string_view hlsl) {
+    static const auto IF_LINE_REGEX = std::regex(R"(^(\s*)if \((.+)\) \{\s*$)");
+    static const auto NOT_IF_LINE_REGEX = std::regex(R"(^(\s*)if \(!(_\d+)\) \{\s*$)");
+    static const auto ASSIGN_LINE_REGEX = std::regex(R"(^(\s*)(_\d+) = (.+);\s*$)");
+
+    auto count_char = [](std::string_view line, char value) {
+      return static_cast<int>(std::ranges::count(line, value));
+    };
+    auto trim = [](std::string_view line) {
+      return StringViewTrim(line);
+    };
+    auto next_non_empty = [&](const std::vector<std::string>& lines, size_t start) -> std::optional<size_t> {
+      for (size_t i = start; i < lines.size(); ++i) {
+        if (!trim(lines[i]).empty()) {
+          return i;
+        }
+      }
+      return std::nullopt;
+    };
+    auto previous_non_empty = [&](const std::vector<std::string>& lines, size_t start) -> std::optional<size_t> {
+      for (size_t i = start; i-- > 0;) {
+        if (!trim(lines[i]).empty()) {
+          return i;
+        }
+      }
+      return std::nullopt;
+    };
+    auto find_if_region = [&](const std::vector<std::string>& lines, size_t start) -> std::optional<std::pair<size_t, size_t>> {
+      auto [indent, condition] = StringViewMatch<2>(lines[start], IF_LINE_REGEX);
+      if (condition.empty()) {
+        return std::nullopt;
+      }
+
+      int depth = 1;
+      std::optional<size_t> else_line;
+      for (size_t i = start + 1; i < lines.size(); ++i) {
+        auto line_trimmed = trim(lines[i]);
+        if (depth == 1 && line_trimmed == "} else {") {
+          else_line = i;
+        }
+
+        depth += count_char(lines[i], '{');
+        depth -= count_char(lines[i], '}');
+        if (depth == 0) {
+          if (!else_line.has_value()) {
+            return std::nullopt;
+          }
+          return std::pair<size_t, size_t>(else_line.value(), i);
+        }
+      }
+      return std::nullopt;
+    };
+
+    std::vector<std::string> lines;
+    {
+      std::stringstream line_stream{std::string(hlsl)};
+      std::string line;
+      while (std::getline(line_stream, line)) {
+        lines.push_back(line);
+      }
+    }
+
+    bool changed = false;
+    for (size_t i = 0; i < lines.size(); ++i) {
+      auto [if_indent, outer_condition] = StringViewMatch<2>(lines[i], IF_LINE_REGEX);
+      if (outer_condition.empty()) {
+        continue;
+      }
+
+      auto outer_region = find_if_region(lines, i);
+      if (!outer_region.has_value()) {
+        continue;
+      }
+      auto [outer_else_line, outer_end_line] = outer_region.value();
+
+      auto outer_true_assignment_line = previous_non_empty(lines, outer_else_line);
+      if (!outer_true_assignment_line.has_value() || outer_true_assignment_line.value() <= i) {
+        continue;
+      }
+      auto [outer_assign_indent, source_variable, source_expression] =
+          StringViewMatch<3>(lines[outer_true_assignment_line.value()], ASSIGN_LINE_REGEX);
+      if (source_variable.empty() || source_expression.empty()) {
+        continue;
+      }
+
+      auto outer_else_assignment_line = next_non_empty(lines, outer_else_line + 1);
+      if (!outer_else_assignment_line.has_value() || outer_else_assignment_line.value() >= outer_end_line) {
+        continue;
+      }
+      auto [outer_else_assign_indent, outer_else_variable, outer_else_expression] =
+          StringViewMatch<3>(lines[outer_else_assignment_line.value()], ASSIGN_LINE_REGEX);
+      if (outer_else_variable != source_variable || outer_else_expression != "true") {
+        continue;
+      }
+
+      auto next_if_line = next_non_empty(lines, outer_end_line + 1);
+      if (!next_if_line.has_value()) {
+        continue;
+      }
+      auto [next_if_indent, not_variable] = StringViewMatch<2>(lines[next_if_line.value()], NOT_IF_LINE_REGEX);
+      if (not_variable != source_variable) {
+        continue;
+      }
+
+      auto next_region = find_if_region(lines, next_if_line.value());
+      if (!next_region.has_value()) {
+        continue;
+      }
+      auto [next_else_line, next_end_line] = next_region.value();
+
+      auto next_true_assignment_line = next_non_empty(lines, next_if_line.value() + 1);
+      if (!next_true_assignment_line.has_value() || next_true_assignment_line.value() >= next_else_line) {
+        continue;
+      }
+      auto [target_assign_indent, target_variable, target_default_expression] =
+          StringViewMatch<3>(lines[next_true_assignment_line.value()], ASSIGN_LINE_REGEX);
+      if (target_variable.empty() || target_default_expression.empty()) {
+        continue;
+      }
+
+      auto next_else_assignment_line = next_non_empty(lines, next_else_line + 1);
+      if (!next_else_assignment_line.has_value() || next_else_assignment_line.value() >= next_end_line) {
+        continue;
+      }
+      auto [next_else_assign_indent, next_else_variable, next_else_expression] =
+          StringViewMatch<3>(lines[next_else_assignment_line.value()], ASSIGN_LINE_REGEX);
+      if (next_else_variable != target_variable || next_else_expression != "true") {
+        continue;
+      }
+
+      std::vector<std::string> rewritten_lines;
+      rewritten_lines.reserve(lines.size() + 4);
+
+      rewritten_lines.insert(rewritten_lines.end(), lines.begin(), lines.begin() + i);
+      rewritten_lines.push_back(std::format("{}{} = {};", if_indent, target_variable, target_default_expression));
+      rewritten_lines.insert(
+          rewritten_lines.end(),
+          lines.begin() + i,
+          lines.begin() + outer_true_assignment_line.value());
+      rewritten_lines.push_back(std::format("{}if ({}) {{", outer_assign_indent, source_expression));
+      rewritten_lines.push_back(std::format("{}  {} = true;", outer_assign_indent, target_variable));
+      rewritten_lines.push_back(std::format("{}}}", outer_assign_indent));
+      rewritten_lines.insert(
+          rewritten_lines.end(),
+          lines.begin() + outer_true_assignment_line.value() + 1,
+          lines.begin() + outer_else_assignment_line.value());
+      rewritten_lines.push_back(std::format("{}{} = true;", outer_else_assign_indent, target_variable));
+      rewritten_lines.insert(
+          rewritten_lines.end(),
+          lines.begin() + outer_else_assignment_line.value() + 1,
+          lines.begin() + outer_end_line + 1);
+      rewritten_lines.insert(
+          rewritten_lines.end(),
+          lines.begin() + outer_end_line + 1,
+          lines.begin() + next_if_line.value());
+      rewritten_lines.insert(
+          rewritten_lines.end(),
+          lines.begin() + next_end_line + 1,
+          lines.end());
+
+      lines = std::move(rewritten_lines);
+      changed = true;
+      i = 0;
+    }
+
+    if (!changed) {
+      return std::string(hlsl);
+    }
+
+    std::stringstream output_stream;
+    for (size_t i = 0; i < lines.size(); ++i) {
+      output_stream << lines[i];
+      if (i + 1 < lines.size()) {
+        output_stream << "\n";
+      }
+    }
+    return output_stream.str();
+  }
+
+  static std::string OptimizeTrailingBoolFallbackElse(std::string_view hlsl) {
+    auto count_char = [](std::string_view line, char value) {
+      return static_cast<int>(std::ranges::count(line, value));
+    };
+    auto trim = [](std::string_view line) {
+      return StringViewTrim(line);
+    };
+    struct ParsedIfLine {
+      std::string indent;
+      std::string condition;
+    };
+    struct ParsedAssignLine {
+      std::string indent;
+      std::string variable;
+      std::string expression;
+    };
+    auto parse_if_line = [&](const std::string& line) -> std::optional<ParsedIfLine> {
+      auto trimmed = trim(line);
+      if (!trimmed.starts_with("if (") || !trimmed.ends_with(") {")) {
+        return std::nullopt;
+      }
+
+      auto indent_length = line.find_first_not_of(" \t");
+      if (indent_length == std::string::npos) {
+        indent_length = line.size();
+      }
+
+      auto condition_start = trimmed.find('(');
+      auto condition_end = trimmed.rfind(") {");
+      if (condition_start == std::string_view::npos || condition_end == std::string_view::npos ||
+          condition_end <= condition_start + 1) {
+        return std::nullopt;
+      }
+
+      return ParsedIfLine{
+          .indent = line.substr(0, indent_length),
+          .condition = std::string(trimmed.substr(condition_start + 1, condition_end - condition_start - 1)),
+      };
+    };
+    auto parse_assignment_line = [&](const std::string& line) -> std::optional<ParsedAssignLine> {
+      auto trimmed = trim(line);
+      if (trimmed.empty() || !trimmed.ends_with(";")) {
+        return std::nullopt;
+      }
+
+      auto equals = trimmed.find(" = ");
+      if (equals == std::string_view::npos) {
+        return std::nullopt;
+      }
+
+      auto variable = trimmed.substr(0, equals);
+      if (variable.size() < 2 || variable[0] != '_' ||
+          !std::ranges::all_of(variable.substr(1), [](char c) { return c >= '0' && c <= '9'; })) {
+        return std::nullopt;
+      }
+
+      auto indent_length = line.find_first_not_of(" \t");
+      if (indent_length == std::string::npos) {
+        indent_length = line.size();
+      }
+
+      return ParsedAssignLine{
+          .indent = line.substr(0, indent_length),
+          .variable = std::string(variable),
+          .expression = std::string(trimmed.substr(equals + 3, trimmed.size() - equals - 4)),
+      };
+    };
+    auto next_non_empty = [&](const std::vector<std::string>& lines, size_t start) -> std::optional<size_t> {
+      for (size_t i = start; i < lines.size(); ++i) {
+        if (!trim(lines[i]).empty()) {
+          return i;
+        }
+      }
+      return std::nullopt;
+    };
+    auto previous_non_empty = [&](const std::vector<std::string>& lines, size_t start) -> std::optional<size_t> {
+      for (size_t i = start + 1; i-- > 0;) {
+        if (!trim(lines[i]).empty()) {
+          return i;
+        }
+      }
+      return std::nullopt;
+    };
+    auto find_if_region = [&](const std::vector<std::string>& lines, size_t start) -> std::optional<std::pair<size_t, size_t>> {
+      auto parsed_if = parse_if_line(lines[start]);
+      if (!parsed_if.has_value()) {
+        return std::nullopt;
+      }
+
+      int depth = 1;
+      std::optional<size_t> else_line;
+      for (size_t i = start + 1; i < lines.size(); ++i) {
+        auto line_trimmed = trim(lines[i]);
+        if (depth == 1 && line_trimmed == "} else {") {
+          else_line = i;
+        }
+
+        depth += count_char(lines[i], '{');
+        depth -= count_char(lines[i], '}');
+        if (depth == 0) {
+          if (!else_line.has_value()) {
+            return std::nullopt;
+          }
+          return std::pair<size_t, size_t>(else_line.value(), i);
+        }
+      }
+      return std::nullopt;
+    };
+    auto find_if_end_without_else =
+        [&](const std::vector<std::string>& lines, size_t start) -> std::optional<size_t> {
+      auto parsed_if = parse_if_line(lines[start]);
+      if (!parsed_if.has_value()) {
+        return std::nullopt;
+      }
+
+      int depth = 1;
+      for (size_t i = start + 1; i < lines.size(); ++i) {
+        auto line_trimmed = trim(lines[i]);
+        if (depth == 1 && line_trimmed == "} else {") {
+          return std::nullopt;
+        }
+
+        depth += count_char(lines[i], '{');
+        depth -= count_char(lines[i], '}');
+        if (depth == 0) {
+          return i;
+        }
+      }
+      return std::nullopt;
+    };
+
+    std::vector<std::string> lines;
+    {
+      std::stringstream line_stream{std::string(hlsl)};
+      std::string line;
+      while (std::getline(line_stream, line)) {
+        lines.push_back(line);
+      }
+    }
+
+    bool changed = false;
+    for (size_t i = 0; i < lines.size(); ++i) {
+      auto outer_if = parse_if_line(lines[i]);
+      if (!outer_if.has_value()) {
+        continue;
+      }
+
+      auto outer_region = find_if_region(lines, i);
+      if (!outer_region.has_value()) {
+        continue;
+      }
+      auto [outer_else_line, outer_end_line] = outer_region.value();
+
+      auto outer_else_assign_line = next_non_empty(lines, outer_else_line + 1);
+      if (!outer_else_assign_line.has_value() || outer_else_assign_line.value() >= outer_end_line) {
+        continue;
+      }
+      auto outer_else_assignment = parse_assignment_line(lines[outer_else_assign_line.value()]);
+      if (!outer_else_assignment.has_value() || outer_else_assignment->expression != "true") {
+        continue;
+      }
+      auto outer_else_after = next_non_empty(lines, outer_else_assign_line.value() + 1);
+      if (!outer_else_after.has_value() || outer_else_after.value() != outer_end_line) {
+        continue;
+      }
+
+      std::optional<size_t> nested_if_line;
+      std::optional<size_t> nested_else_line;
+      std::optional<size_t> nested_end_line;
+      std::string nested_if_indent;
+      std::string target_variable_string;
+      std::string default_expression_string;
+
+      for (size_t candidate = i + 1; candidate < outer_else_line; ++candidate) {
+        auto candidate_if = parse_if_line(lines[candidate]);
+        if (!candidate_if.has_value()) {
+          continue;
+        }
+
+        auto candidate_region = find_if_region(lines, candidate);
+        if (!candidate_region.has_value()) {
+          continue;
+        }
+        auto [candidate_else_line, candidate_end_line] = candidate_region.value();
+        auto candidate_tail_after = next_non_empty(lines, candidate_end_line + 1);
+        if (!candidate_tail_after.has_value() || candidate_tail_after.value() != outer_else_line) {
+          continue;
+        }
+
+        auto candidate_true_assign_line = next_non_empty(lines, candidate + 1);
+        if (!candidate_true_assign_line.has_value() || candidate_true_assign_line.value() >= candidate_else_line) {
+          continue;
+        }
+        auto candidate_true_assignment = parse_assignment_line(lines[candidate_true_assign_line.value()]);
+        if (!candidate_true_assignment.has_value() || candidate_true_assignment->expression != "true") {
+          continue;
+        }
+        auto candidate_true_after = next_non_empty(lines, candidate_true_assign_line.value() + 1);
+        if (!candidate_true_after.has_value() || candidate_true_after.value() != candidate_else_line) {
+          continue;
+        }
+
+        auto candidate_else_assign_line = next_non_empty(lines, candidate_else_line + 1);
+        if (!candidate_else_assign_line.has_value() || candidate_else_assign_line.value() >= candidate_end_line) {
+          continue;
+        }
+        auto candidate_else_assignment = parse_assignment_line(lines[candidate_else_assign_line.value()]);
+        if (!candidate_else_assignment.has_value() ||
+            candidate_else_assignment->variable != candidate_true_assignment->variable) {
+          continue;
+        }
+        auto candidate_else_after = next_non_empty(lines, candidate_else_assign_line.value() + 1);
+        if (!candidate_else_after.has_value() || candidate_else_after.value() != candidate_end_line) {
+          continue;
+        }
+
+        auto target_regex = std::regex(std::format(
+            R"((^|[^A-Za-z0-9_])({})([^A-Za-z0-9_]|$))",
+            candidate_true_assignment->variable));
+        bool referenced_before_nested_if = false;
+        for (size_t line_index = i + 1; line_index < candidate; ++line_index) {
+          if (std::regex_search(lines[line_index], target_regex)) {
+            referenced_before_nested_if = true;
+            break;
+          }
+        }
+        if (referenced_before_nested_if) {
+          continue;
+        }
+
+        if (outer_else_assignment->variable != candidate_true_assignment->variable) {
+          continue;
+        }
+
+        nested_if_line = candidate;
+        nested_else_line = candidate_else_line;
+        nested_end_line = candidate_end_line;
+        nested_if_indent = candidate_if->indent;
+        target_variable_string = candidate_true_assignment->variable;
+        default_expression_string = candidate_else_assignment->expression;
+        break;
+      }
+
+      if (!nested_if_line.has_value() || !nested_else_line.has_value() || !nested_end_line.has_value()) {
+        continue;
+      }
+
+      std::vector<std::string> rewritten_lines;
+      rewritten_lines.reserve(lines.size() + 1);
+      rewritten_lines.insert(rewritten_lines.end(), lines.begin(), lines.begin() + i);
+      rewritten_lines.push_back(std::format("{}{} = {};", outer_if->indent, target_variable_string, default_expression_string));
+      rewritten_lines.insert(rewritten_lines.end(), lines.begin() + i, lines.begin() + nested_else_line.value());
+      rewritten_lines.push_back(std::format("{}}}", nested_if_indent));
+      rewritten_lines.insert(rewritten_lines.end(), lines.begin() + nested_end_line.value() + 1, lines.end());
+
+      lines = std::move(rewritten_lines);
+      changed = true;
+      i = 0;
+    }
+
+    if (!changed) {
+      return std::string(hlsl);
+    }
+
+    std::stringstream output_stream;
+    for (size_t i = 0; i < lines.size(); ++i) {
+      output_stream << lines[i];
+      if (i + 1 < lines.size()) {
+        output_stream << "\n";
+      }
+    }
+    return output_stream.str();
+  }
+
+  static std::string OptimizeRepeatedStoreAddresses(std::string_view hlsl) {
+    static const std::regex SIMPLE_IDENTIFIER_REGEX(R"(^[A-Za-z_][A-Za-z0-9_]*$)");
+
+    auto trim = [](std::string_view line) {
+      return StringViewTrim(line);
+    };
+    auto parse_store_line = [&](const std::string& line)
+        -> std::optional<std::tuple<std::string, std::string, std::string, std::string>> {
+      auto trimmed = trim(line);
+      if (!trimmed.ends_with("));")) {
+        return std::nullopt;
+      }
+
+      auto store_pos = trimmed.find(".Store(");
+      auto value_pos = trimmed.rfind(", asuint(");
+      if (store_pos == std::string_view::npos || value_pos == std::string_view::npos || value_pos <= store_pos + 7) {
+        return std::nullopt;
+      }
+
+      auto indent_length = line.find_first_not_of(" \t");
+      if (indent_length == std::string::npos) {
+        indent_length = line.size();
+      }
+
+      auto resource = std::string(trimmed.substr(0, store_pos));
+      auto address = std::string(trimmed.substr(store_pos + 7, value_pos - (store_pos + 7)));
+      auto value = std::string(trimmed.substr(value_pos + 10, trimmed.size() - value_pos - 13));
+      return std::tuple<std::string, std::string, std::string, std::string>(
+          line.substr(0, indent_length), resource, address, value);
+    };
+    auto extract_identifiers = [&](std::string_view expression) {
+      static const std::regex TOKEN_REGEX(R"([A-Za-z_][A-Za-z0-9_]*)");
+      static const std::unordered_set<std::string> KEYWORDS = {
+          "asuint", "int", "uint", "true", "false", "x", "y", "z", "w"};
+
+      std::string expression_string(expression);
+      std::vector<std::string> identifiers;
+      std::unordered_set<std::string> seen;
+      for (std::sregex_iterator it(expression_string.begin(), expression_string.end(), TOKEN_REGEX), end; it != end; ++it) {
+        auto match_pos = static_cast<size_t>(it->position());
+        if (match_pos > 0 && expression_string[match_pos - 1] == '.') {
+          continue;
+        }
+
+        auto identifier = it->str();
+        if (KEYWORDS.contains(identifier) || seen.contains(identifier)) {
+          continue;
+        }
+
+        seen.insert(identifier);
+        identifiers.push_back(std::move(identifier));
+      }
+      return identifiers;
+    };
+    auto line_assigns_identifier = [&](std::string_view line, std::string_view identifier) {
+      auto trimmed = trim(line);
+      if (trimmed.empty()) {
+        return false;
+      }
+
+      size_t equals = std::string_view::npos;
+      for (size_t i = 0; i < trimmed.size(); ++i) {
+        if (trimmed[i] != '=') {
+          continue;
+        }
+        if (i > 0 && (trimmed[i - 1] == '=' || trimmed[i - 1] == '!' || trimmed[i - 1] == '<' || trimmed[i - 1] == '>')) {
+          continue;
+        }
+        if (i + 1 < trimmed.size() && trimmed[i + 1] == '=') {
+          continue;
+        }
+        equals = i;
+        break;
+      }
+      if (equals == std::string_view::npos) {
+        return false;
+      }
+
+      auto lhs = trim(trimmed.substr(0, equals));
+      auto last_space = lhs.find_last_of(" \t");
+      auto tail = last_space == std::string_view::npos ? lhs : trim(lhs.substr(last_space + 1));
+      return tail == identifier || tail.starts_with(std::format("{}[", identifier));
+    };
+
+    std::vector<std::string> lines;
+    {
+      std::stringstream line_stream{std::string(hlsl)};
+      std::string line;
+      while (std::getline(line_stream, line)) {
+        lines.push_back(line);
+      }
+    }
+
+    bool changed = false;
+    int temp_index = 0;
+    for (size_t i = 0; i < lines.size(); ++i) {
+      auto first_store = parse_store_line(lines[i]);
+      if (!first_store.has_value()) {
+        continue;
+      }
+
+      auto [indent, resource, address, value] = first_store.value();
+      if (std::regex_match(address, SIMPLE_IDENTIFIER_REGEX)) {
+        continue;
+      }
+      auto identifiers = extract_identifiers(address);
+      if (identifiers.empty()) {
+        continue;
+      }
+
+      for (size_t j = i + 1; j < lines.size(); ++j) {
+        auto second_store = parse_store_line(lines[j]);
+        if (!second_store.has_value()) {
+          continue;
+        }
+
+        auto [next_indent, next_resource, next_address, next_value] = second_store.value();
+        if (next_resource != resource || next_address != address) {
+          continue;
+        }
+
+        bool assigned_between = false;
+        for (size_t k = i + 1; k < j && !assigned_between; ++k) {
+          for (const auto& identifier : identifiers) {
+            if (line_assigns_identifier(lines[k], identifier)) {
+              assigned_between = true;
+              break;
+            }
+          }
+        }
+        if (assigned_between) {
+          continue;
+        }
+
+        auto temp_name = std::format("_store_addr_{}", temp_index++);
+        lines.insert(lines.begin() + i, std::format("{}int {} = {};", indent, temp_name, address));
+        lines[i + 1] = std::format("{}{}.Store({}, asuint({}));", indent, resource, temp_name, value);
+        lines[j + 1] = std::format("{}{}.Store({}, asuint({}));", next_indent, next_resource, temp_name, next_value);
+        changed = true;
+        i = 0;
+        break;
+      }
+    }
+
+    if (!changed) {
+      return std::string(hlsl);
+    }
+
+    std::stringstream output_stream;
+    for (size_t i = 0; i < lines.size(); ++i) {
+      output_stream << lines[i];
+      if (i + 1 < lines.size()) {
+        output_stream << "\n";
+      }
+    }
+    return output_stream.str();
+  }
+
+  static std::string OptimizeVisibilityBindlessIndices(std::string_view hlsl) {
+    static const std::regex VISIBILITY_INDEX_LINE_REGEX(
+        R"(^(\s*)uint\s+(_\d+)\s*=\s*\(\(_visibilityParams\[(.+)\]\)\.x\)\s*\*\s*3;\s*$)");
+    static const std::regex VISIBILITY_OFFSET_LINE_REGEX(
+        R"(^(\s*)int\s+(_\d+)\s*=\s*\(int\)\(SV_DispatchThreadID\.x\)\s*-\s*\(\(_visibilityParams\[(.+)\]\)\.w\);\s*$)");
+    static const std::regex RENDER_INSTANCE_COUNT_LINE_REGEX(
+        R"(^(\s*)uint\s+(_\d+)\s*=\s*\(_renderInstanceCollectionData\[\(int\)\((_\d+)\s*\+\s*2u\)\]\)\.y;\s*$)");
+
+    auto trim = [](std::string_view line) {
+      return StringViewTrim(line);
+    };
+    auto replace_all = [](std::string& input, const std::string& from, const std::string& to) {
+      if (from.empty()) {
+        return false;
+      }
+      bool changed = false;
+      size_t pos = 0;
+      while ((pos = input.find(from, pos)) != std::string::npos) {
+        input.replace(pos, from.size(), to);
+        pos += to.size();
+        changed = true;
+      }
+      return changed;
+    };
+
+    std::vector<std::string> lines;
+    {
+      std::stringstream line_stream{std::string(hlsl)};
+      std::string line;
+      while (std::getline(line_stream, line)) {
+        lines.push_back(line);
+      }
+    }
+
+    bool changed = false;
+    std::string selected_visibility_index_expression;
+    std::string selected_visibility_index_var;
+    std::string selected_dispatch_offset_var;
+    for (size_t i = 0; i + 1 < lines.size(); ++i) {
+      auto [visibility_indent, visibility_index_var, visibility_index_expression] =
+          StringViewMatch<3>(lines[i], VISIBILITY_INDEX_LINE_REGEX);
+      auto [offset_indent, dispatch_offset_var, visibility_offset_expression] =
+          StringViewMatch<3>(lines[i + 1], VISIBILITY_OFFSET_LINE_REGEX);
+      if (visibility_index_var.empty() || dispatch_offset_var.empty() ||
+          visibility_index_expression != visibility_offset_expression || visibility_indent != offset_indent) {
+        continue;
+      }
+
+      std::optional<size_t> render_instance_count_line;
+      std::string render_instance_count_var;
+      for (size_t j = i + 2; j < lines.size(); ++j) {
+        auto trimmed = trim(lines[j]);
+        if (trimmed.empty()) {
+          continue;
+        }
+
+        auto [count_indent, count_var, count_index_var] =
+            StringViewMatch<3>(lines[j], RENDER_INSTANCE_COUNT_LINE_REGEX);
+        if (!count_var.empty() && count_index_var == visibility_index_var) {
+          render_instance_count_line = j;
+          render_instance_count_var = count_var;
+        }
+        break;
+      }
+      if (!render_instance_count_line.has_value()) {
+        continue;
+      }
+
+      auto visibility_indent_string = std::string(visibility_indent);
+      auto visibility_index_var_string = std::string(visibility_index_var);
+      auto visibility_index_expression_string = std::string(visibility_index_expression);
+      auto offset_indent_string = std::string(offset_indent);
+      auto dispatch_offset_var_string = std::string(dispatch_offset_var);
+
+      lines[i] = std::format("{}uint __visibility_param_index = {};", visibility_indent_string, visibility_index_expression_string);
+      lines[i + 1] = std::format("{}int4 __visibility_param = _visibilityParams[__visibility_param_index];", visibility_indent_string);
+      lines.insert(lines.begin() + i + 2, std::format("{}uint {} = (uint)(__visibility_param.x) * 3u;", visibility_indent_string, visibility_index_var_string));
+      lines.insert(lines.begin() + i + 3, std::format("{}int {} = (int)(SV_DispatchThreadID.x) - __visibility_param.w;", offset_indent_string, dispatch_offset_var_string));
+
+      auto count_line_index = render_instance_count_line.value() + 2;
+      lines.insert(lines.begin() + count_line_index + 1, std::format("{}int __visibility_store_address = (int)(((uint)({} + __visibility_param.z)) << 2);", visibility_indent_string, dispatch_offset_var_string));
+      lines.insert(lines.begin() + count_line_index + 2, std::format("{}uint4 __render_instance_collection_entry = _renderInstanceCollectionData[(int)({})];", visibility_indent_string, visibility_index_var_string));
+      lines.insert(lines.begin() + count_line_index + 3, std::format("{}uint __object_bound_box_data_buffer_index = select((__render_instance_collection_entry.y < 40000u), __render_instance_collection_entry.y, 0u);", visibility_indent_string));
+      lines.insert(lines.begin() + count_line_index + 4, std::format("{}uint __static_mesh_data_buffer_index = select((__render_instance_collection_entry.x < 40000u), __render_instance_collection_entry.x, 0u);", visibility_indent_string));
+
+      changed = true;
+      selected_visibility_index_expression = visibility_index_expression_string;
+      selected_visibility_index_var = visibility_index_var_string;
+      selected_dispatch_offset_var = dispatch_offset_var_string;
+      break;
+    }
+
+    if (!changed) {
+      return std::string(hlsl);
+    }
+
+    std::stringstream output_stream;
+    for (size_t i = 0; i < lines.size(); ++i) {
+      output_stream << lines[i];
+      if (i + 1 < lines.size()) {
+        output_stream << "\n";
+      }
+    }
+
+    auto output = output_stream.str();
+    auto visibility_y = std::format("((_visibilityParams[{}]).y)", selected_visibility_index_expression);
+    auto visibility_z = std::format("((_visibilityParams[{}]).z)", selected_visibility_index_expression);
+    auto visibility_store_address =
+        std::format("((int)(((uint)({} + __visibility_param.z)) << 2))", selected_dispatch_offset_var);
+    auto render_instance_y = std::format(
+        "((int)((uint)(select(((uint)((_renderInstanceCollectionData[(int)({})]).y) < (uint)40000), ((_renderInstanceCollectionData[(int)({})]).y), 0)) + 0u))",
+        selected_visibility_index_var,
+        selected_visibility_index_var);
+    auto render_instance_x = std::format(
+        "((int)((uint)(select(((uint)((_renderInstanceCollectionData[(int)({})]).x) < (uint)40000), ((_renderInstanceCollectionData[(int)({})]).x), 0)) + 0u))",
+        selected_visibility_index_var,
+        selected_visibility_index_var);
+
+    replace_all(output, visibility_y, "__visibility_param.y");
+    replace_all(output, visibility_z, "__visibility_param.z");
+    replace_all(output, visibility_store_address, "__visibility_store_address");
+    replace_all(output, render_instance_y, "(int)(__object_bound_box_data_buffer_index)");
+    replace_all(output, render_instance_x, "(int)(__static_mesh_data_buffer_index)");
+    return output;
+  }
+
+  static std::string OptimizeVisibilityParamIndexSelection(std::string_view hlsl) {
+    static const std::regex VISIBILITY_SELECTOR_LINE_REGEX(
+        R"(^(\s*)uint\s+(__visibility_param_index)\s*=\s*\(uint\)\(\(uint\)\(\(\(int\)\(65535u\s*<<\s*(_\d+)\)\)\s*&\s*\((_\d+)\[\(\(\(uint\)\(SV_GroupID\.x\)\s*>>\s*1\)\s*&\s*3\)\]\)\)\)\s*>>\s*(_\d+)\s*;\s*$)");
+
+    std::vector<std::string> lines;
+    {
+      std::stringstream line_stream{std::string(hlsl)};
+      std::string line;
+      while (std::getline(line_stream, line)) {
+        lines.push_back(line);
+      }
+    }
+
+    for (size_t i = 0; i < lines.size(); ++i) {
+      auto [selector_indent, visibility_index_var, shift_variable_a, visibility_indices_array_var, shift_variable_b] =
+          StringViewMatch<5>(lines[i], VISIBILITY_SELECTOR_LINE_REGEX);
+      if (visibility_index_var.empty() || shift_variable_a != shift_variable_b) {
+        continue;
+      }
+
+      auto declaration_line = std::find(lines.begin(), lines.end(), std::format("{}int {}[4];", selector_indent, visibility_indices_array_var));
+      if (declaration_line == lines.end()) {
+        continue;
+      }
+
+      std::array<size_t, 4> assignment_indices{};
+      bool has_assignments = true;
+      constexpr std::array<std::string_view, 4> suffixes = {"x", "y", "z", "w"};
+      for (size_t component_index = 0; component_index < suffixes.size(); ++component_index) {
+        auto assignment_it = std::find(
+            lines.begin(),
+            lines.end(),
+            std::format(
+                "{}{}[{}] = ((_visibilityParamIndices[(uint)(SV_GroupID.x) >> 3]).{});",
+                selector_indent,
+                visibility_indices_array_var,
+                component_index,
+                suffixes[component_index]));
+        if (assignment_it == lines.end()) {
+          has_assignments = false;
+          break;
+        }
+        assignment_indices[component_index] = static_cast<size_t>(std::distance(lines.begin(), assignment_it));
+      }
+      if (!has_assignments) {
+        continue;
+      }
+
+      size_t array_reference_count = 0;
+      auto array_reference = std::format("{}[", visibility_indices_array_var);
+      for (const auto& line : lines) {
+        if (line.find(array_reference) != std::string::npos) {
+          array_reference_count += 1;
+        }
+      }
+      if (array_reference_count != 5) {
+        continue;
+      }
+
+      auto declaration_index = static_cast<size_t>(std::distance(lines.begin(), declaration_line));
+      lines[declaration_index] =
+          std::format("{}int4 __visibility_param_indices_entry = _visibilityParamIndices[(uint)(SV_GroupID.x) >> 3];", selector_indent);
+      for (auto assignment_index : assignment_indices) {
+        lines[assignment_index].clear();
+      }
+      lines.insert(
+          lines.begin() + i,
+          std::format(
+              "{}int __visibility_param_index_component = __visibility_param_indices_entry[(((uint)(SV_GroupID.x) >> 1) & 3)];",
+              selector_indent));
+      lines[i + 1] = std::format(
+          "{}uint __visibility_param_index = (uint)((uint)(((int)(65535u << {})) & (__visibility_param_index_component))) >> {};",
+          selector_indent,
+          shift_variable_a,
+          shift_variable_a);
+
+      std::stringstream output_stream;
+      for (size_t line_index = 0; line_index < lines.size(); ++line_index) {
+        if (lines[line_index].empty()) {
+          continue;
+        }
+        output_stream << lines[line_index];
+        if (line_index + 1 < lines.size()) {
+          output_stream << "\n";
+        }
+      }
+      return output_stream.str();
+    }
+
+    return std::string(hlsl);
+  }
+
+  static std::string OptimizeVectorComponentTempArrays(std::string_view hlsl) {
+    static const auto ARRAY_DECL_REGEX = std::regex(
+        R"(^(\s*)(int|uint|float|half|int16_t|uint16_t|min16float|int64_t|uint64_t)\s+(_\d+)\[4\];\s*$)");
+    static const auto ARRAY_ASSIGN_REGEX =
+        std::regex(R"(^(\s*)(_\d+)\[(\d)\]\s*=\s*\(\((.+)\)\.([xyzw])\);\s*$)");
+    static const auto ARRAY_INDEX_USE_REGEX = std::regex(
+        R"(^(\s*)(int|uint|float|half|int16_t|uint16_t|min16float|int64_t|uint64_t)\s+(_\d+)\s*=\s*(_\d+)\[(.+)\];\s*$)");
+
+    std::vector<std::string> lines;
+    {
+      std::stringstream line_stream{std::string(hlsl)};
+      std::string line;
+      while (std::getline(line_stream, line)) {
+        lines.push_back(line);
+      }
+    }
+
+    bool changed = false;
+    for (size_t i = 0; i < lines.size(); ++i) {
+      auto [decl_indent, decl_type, array_var] = StringViewMatch<3>(lines[i], ARRAY_DECL_REGEX);
+      if (array_var.empty()) {
+        continue;
+      }
+
+      size_t reference_count = 0;
+      auto array_reference = std::format("{}[", array_var);
+      for (const auto& line : lines) {
+        if (line.find(array_reference) != std::string::npos) {
+          reference_count += 1;
+        }
+      }
+      if (reference_count != 6) {
+        continue;
+      }
+
+      std::array<size_t, 4> assignment_indices{};
+      std::array<bool, 4> has_assignment{};
+      std::string base_expression;
+      std::optional<size_t> use_index;
+      std::string use_indent;
+      std::string use_type;
+      std::string use_variable;
+      std::string lane_expression;
+      bool invalid = false;
+
+      for (size_t j = i + 1; j < lines.size(); ++j) {
+        if (lines[j].find(array_reference) == std::string::npos) {
+          continue;
+        }
+
+        auto [assign_indent, assign_var, component_index, assign_base, component_swizzle] =
+            StringViewMatch<5>(lines[j], ARRAY_ASSIGN_REGEX);
+        if (!assign_var.empty() && assign_var == array_var && assign_indent == decl_indent) {
+          int parsed_component_index = -1;
+          FromStringView(component_index, parsed_component_index);
+          if (parsed_component_index < 0 || parsed_component_index > 3) {
+            invalid = true;
+            break;
+          }
+          if (component_swizzle.size() != 1 || component_swizzle[0] != VECTOR_INDEXES[parsed_component_index]) {
+            invalid = true;
+            break;
+          }
+          if (has_assignment[parsed_component_index]) {
+            invalid = true;
+            break;
+          }
+          auto assign_base_string = std::string(StringViewTrim(assign_base));
+          if (base_expression.empty()) {
+            base_expression = assign_base_string;
+          } else if (base_expression != assign_base_string) {
+            invalid = true;
+            break;
+          }
+          has_assignment[parsed_component_index] = true;
+          assignment_indices[parsed_component_index] = j;
+          continue;
+        }
+
+        auto [match_use_indent, match_use_type, match_use_variable, match_array_var, match_lane_expression] =
+            StringViewMatch<5>(lines[j], ARRAY_INDEX_USE_REGEX);
+        if (!match_use_variable.empty() && match_array_var == array_var) {
+          if (use_index.has_value()) {
+            invalid = true;
+            break;
+          }
+          use_index = j;
+          use_indent = std::string(match_use_indent);
+          use_type = std::string(match_use_type);
+          use_variable = std::string(match_use_variable);
+          lane_expression = std::string(StringViewTrim(match_lane_expression));
+          continue;
+        }
+
+        invalid = true;
+        break;
+      }
+
+      if (invalid || !use_index.has_value()) {
+        continue;
+      }
+      if (!std::ranges::all_of(has_assignment, [](bool value) { return value; })) {
+        continue;
+      }
+
+      lines[i].clear();
+      for (auto assignment_index : assignment_indices) {
+        lines[assignment_index].clear();
+      }
+      lines[use_index.value()] = std::format(
+          "{}{} {} = ({})({}[{}]);",
+          use_indent,
+          use_type,
+          use_variable,
+          use_type,
+          base_expression,
+          lane_expression);
+      changed = true;
+    }
+
+    if (!changed) {
+      return std::string(hlsl);
+    }
+
+    std::stringstream output_stream;
+    bool first_line = true;
+    for (const auto& line : lines) {
+      if (line.empty()) {
+        continue;
+      }
+      if (!first_line) {
+        output_stream << "\n";
+      }
+      output_stream << line;
+      first_line = false;
+    }
+    return output_stream.str();
+  }
+
+  static std::string OptimizeUnusedLocalAssignments(std::string_view hlsl) {
+    static const auto DECL_REGEX =
+        std::regex(R"(^(\s*)(?:bool|int|uint|float|half|int16_t|uint16_t|min16float|int64_t|uint64_t)\s+((?:_\d+)|(?:__defer_\d+_\d+)|(?:__branch_chain_\d+))\s*;\s*$)");
+    static const auto DECL_ASSIGN_REGEX =
+        std::regex(R"(^(\s*)(?:bool|int|uint|float|half|int16_t|uint16_t|min16float|int64_t|uint64_t)\s+((?:_\d+)|(?:__defer_\d+_\d+)|(?:__branch_chain_\d+))\s*=.*;\s*$)");
+    static const auto ASSIGN_REGEX =
+        std::regex(R"(^(\s*)((?:_\d+)|(?:__defer_\d+_\d+)|(?:__branch_chain_\d+))\s*=.*;\s*$)");
+    static const auto VARIABLE_REGEX =
+        std::regex(R"((^|[^A-Za-z0-9_])((?:_\d+)|(?:__defer_\d+_\d+)|(?:__branch_chain_\d+))(?=$|[^A-Za-z0-9_]))");
+
+    std::vector<std::string> lines;
+    {
+      std::stringstream line_stream{std::string(hlsl)};
+      std::string line;
+      while (std::getline(line_stream, line)) {
+        lines.push_back(line);
+      }
+    }
+
+    struct LineInfo {
+      std::vector<std::string> references;
+      std::string target_variable;
+    };
+
+    std::vector<LineInfo> line_infos(lines.size());
+    std::unordered_map<std::string, size_t> occurrence_counts;
+    std::unordered_map<std::string, std::vector<size_t>> removable_lines_by_variable;
+
+    for (size_t i = 0; i < lines.size(); ++i) {
+      for (auto it = std::sregex_iterator(lines[i].begin(), lines[i].end(), VARIABLE_REGEX);
+           it != std::sregex_iterator();
+           ++it) {
+        auto variable = (*it)[2].str();
+        line_infos[i].references.push_back(variable);
+        occurrence_counts[variable] += 1;
+      }
+
+      auto [decl_indent, decl_variable] = StringViewMatch<2>(lines[i], DECL_REGEX);
+      auto [decl_assign_indent, decl_assign_variable] = StringViewMatch<2>(lines[i], DECL_ASSIGN_REGEX);
+      auto [assign_indent, assign_variable] = StringViewMatch<2>(lines[i], ASSIGN_REGEX);
+      if (!decl_variable.empty()) {
+        line_infos[i].target_variable = std::string(decl_variable);
+      } else if (!decl_assign_variable.empty()) {
+        line_infos[i].target_variable = std::string(decl_assign_variable);
+      } else if (!assign_variable.empty()) {
+        line_infos[i].target_variable = std::string(assign_variable);
+      }
+
+      if (!line_infos[i].target_variable.empty()) {
+        removable_lines_by_variable[line_infos[i].target_variable].push_back(i);
+      }
+    }
+
+    bool changed = false;
+    std::vector<bool> removed(lines.size(), false);
+    while (true) {
+      std::vector<size_t> lines_to_remove;
+
+      for (const auto& [variable, removable_lines] : removable_lines_by_variable) {
+        size_t active_line_count = 0;
+        for (auto line_index : removable_lines) {
+          if (!removed[line_index]) {
+            active_line_count += 1;
+          }
+        }
+        if (active_line_count == 0) {
+          continue;
+        }
+        auto occurrence_it = occurrence_counts.find(variable);
+        size_t occurrence_count = occurrence_it == occurrence_counts.end() ? 0 : occurrence_it->second;
+        if (occurrence_count != active_line_count) {
+          continue;
+        }
+        for (auto line_index : removable_lines) {
+          if (!removed[line_index]) {
+            lines_to_remove.push_back(line_index);
+          }
+        }
+      }
+
+      if (lines_to_remove.empty()) {
+        break;
+      }
+
+      std::ranges::sort(lines_to_remove);
+      lines_to_remove.erase(std::unique(lines_to_remove.begin(), lines_to_remove.end()), lines_to_remove.end());
+      for (auto line_index : lines_to_remove) {
+        removed[line_index] = true;
+        for (const auto& reference : line_infos[line_index].references) {
+          auto occurrence_it = occurrence_counts.find(reference);
+          if (occurrence_it != occurrence_counts.end() && occurrence_it->second > 0) {
+            occurrence_it->second -= 1;
+          }
+        }
+      }
+      changed = true;
+    }
+
+    if (!changed) {
+      return std::string(hlsl);
+    }
+
+    std::stringstream output_stream;
+    for (size_t i = 0; i < lines.size(); ++i) {
+      if (removed[i]) {
+        continue;
+      }
+      output_stream << lines[i];
+      if (i + 1 < lines.size()) {
+        output_stream << "\n";
+      }
+    }
+    return output_stream.str();
+  }
+
+  static std::string OptimizeDeferredSiblingGuards(std::string_view hlsl) {
+    static const auto DEFER_DECL_REGEX =
+        std::regex(R"(^(\s*)bool (__defer_(\d+)_(\d+)) = false;\s*$)");
+    static const auto DEFER_ASSIGN_TRUE_REGEX =
+        std::regex(R"(^(\s*)(__defer_\d+_\d+) = true;\s*$)");
+    static const auto DEFER_IF_REGEX =
+        std::regex(R"(^(\s*)if \((__defer_\d+_\d+)\) \{\s*$)");
+
+    std::vector<std::string> lines;
+    {
+      std::stringstream line_stream{std::string(hlsl)};
+      std::string line;
+      while (std::getline(line_stream, line)) {
+        lines.push_back(line);
+      }
+    }
+
+    auto count_variable_references = [&](std::string_view variable) {
+      auto variable_regex = std::regex(std::format(R"((^|[^A-Za-z0-9_]){}([^A-Za-z0-9_]|$))", variable));
+      size_t count = 0;
+      for (const auto& line : lines) {
+        if (std::regex_search(line, variable_regex)) {
+          ++count;
+        }
+      }
+      return count;
+    };
+
+    bool changed = false;
+    for (size_t i = 0; i + 1 < lines.size(); ++i) {
+      auto [indent_a, flag_a, root_a, target_a] = StringViewMatch<4>(lines[i], DEFER_DECL_REGEX);
+      auto [indent_b, flag_b, root_b, target_b] = StringViewMatch<4>(lines[i + 1], DEFER_DECL_REGEX);
+      if (flag_a.empty() || flag_b.empty()) continue;
+      if (indent_a != indent_b || root_a != root_b) continue;
+      if (count_variable_references(flag_a) < 2) continue;
+
+      std::optional<size_t> if_a_line;
+      std::optional<size_t> if_b_line;
+      std::vector<size_t> assign_a_lines;
+      for (size_t j = i + 2; j < lines.size(); ++j) {
+        auto [assign_indent, assign_flag] = StringViewMatch<2>(lines[j], DEFER_ASSIGN_TRUE_REGEX);
+        if (assign_flag == flag_a) {
+          assign_a_lines.push_back(j);
+        }
+
+        auto [if_indent, if_flag] = StringViewMatch<2>(lines[j], DEFER_IF_REGEX);
+        if (if_flag == flag_a && if_indent == indent_a && !if_a_line.has_value()) {
+          if_a_line = j;
+        } else if (if_flag == flag_b && if_indent == indent_b && if_a_line.has_value()) {
+          if_b_line = j;
+          break;
+        }
+      }
+
+      if (!if_a_line.has_value() || !if_b_line.has_value() || assign_a_lines.empty()) {
+        continue;
+      }
+
+      const auto expected_reference_count = assign_a_lines.size() + 2;
+      if (count_variable_references(flag_a) != expected_reference_count) {
+        continue;
+      }
+
+      lines[if_a_line.value()] = std::format("{}if (!{}) {{", indent_a, flag_b);
+
+      std::vector<size_t> remove_lines = {i};
+      remove_lines.insert(remove_lines.end(), assign_a_lines.begin(), assign_a_lines.end());
+      std::ranges::sort(remove_lines);
+      for (auto line_it = remove_lines.rbegin(); line_it != remove_lines.rend(); ++line_it) {
+        auto removed_line = *line_it;
+        lines.erase(lines.begin() + removed_line);
+        if (removed_line < i) {
+          --i;
+        }
+      }
+      changed = true;
+      if (i != 0) {
+        --i;
+      }
+    }
+
+    if (!changed) {
+      return std::string(hlsl);
+    }
+
+    std::stringstream output_stream;
+    for (size_t i = 0; i < lines.size(); ++i) {
+      output_stream << lines[i];
+      if (i + 1 < lines.size()) {
+        output_stream << "\n";
+      }
+    }
+    return output_stream.str();
+  }
+
+  static std::string OptimizeDeferredSelectorSentinels(std::string_view hlsl) {
+    static const auto DEFER_DECL_REGEX =
+        std::regex(R"(^(\s*)bool (__defer_(\d+)_(\d+)) = false;\s*$)");
+    static const auto DEFER_ASSIGN_TRUE_REGEX =
+        std::regex(R"(^(\s*)(__defer_\d+_\d+) = true;\s*$)");
+    static const auto SELECTOR_ASSIGN_REGEX =
+        std::regex(R"(^(\s*)(_\d+) = ([0-9]+);\s*$)");
+    static const auto DEFER_IF_REGEX =
+        std::regex(R"(^(\s*)if \((!?)(__defer_\d+_\d+)\) \{\s*$)");
+    static const auto VARIABLE_REGEX =
+        std::regex(R"((^|[^A-Za-z0-9_])((?:__defer_\d+_\d+)|(?:_\d+))([^A-Za-z0-9_]|$))");
+
+    std::vector<std::string> lines;
+    {
+      std::stringstream line_stream{std::string(hlsl)};
+      std::string line;
+      while (std::getline(line_stream, line)) {
+        lines.push_back(line);
+      }
+    }
+
+    auto count_variable_references = [&](std::string_view variable) {
+      auto variable_regex = std::regex(std::format(R"((^|[^A-Za-z0-9_]){}([^A-Za-z0-9_]|$))", variable));
+      size_t count = 0;
+      for (const auto& line : lines) {
+        if (std::regex_search(line, variable_regex)) {
+          ++count;
+        }
+      }
+      return count;
+    };
+
+    auto line_indent = [&](size_t line_index) {
+      auto first_non_space = lines[line_index].find_first_not_of(' ');
+      if (first_non_space == std::string::npos) {
+        return std::string{};
+      }
+      return std::string(first_non_space, ' ');
+    };
+
+    auto previous_non_empty_line = [&](size_t start) -> std::optional<size_t> {
+      for (size_t j = start; j-- > 0;) {
+        if (!StringViewTrim(lines[j]).empty()) {
+          return j;
+        }
+      }
+      return std::nullopt;
+    };
+
+    bool changed = false;
+    for (size_t i = 0; i < lines.size(); ++i) {
+      auto [decl_indent, defer_flag, defer_root, defer_target] = StringViewMatch<4>(lines[i], DEFER_DECL_REGEX);
+      if (defer_flag.empty()) {
+        continue;
+      }
+      auto indent = line_indent(i);
+      auto flag = std::string(defer_flag);
+
+      std::vector<size_t> assign_lines;
+      std::string selector_variable;
+      std::optional<size_t> false_guard_line;
+      std::optional<size_t> true_guard_line;
+      for (size_t j = i + 1; j < lines.size(); ++j) {
+        auto [if_indent, if_negated, if_defer_flag] = StringViewMatch<3>(lines[j], DEFER_IF_REGEX);
+        if (if_defer_flag == flag) {
+          if (if_negated == "!") {
+            false_guard_line = j;
+          } else if (true_guard_line == std::nullopt) {
+            true_guard_line = j;
+            break;
+          }
+        }
+
+        auto [assign_indent, assign_flag] = StringViewMatch<2>(lines[j], DEFER_ASSIGN_TRUE_REGEX);
+        if (assign_flag != flag) {
+          continue;
+        }
+        auto previous_line = previous_non_empty_line(j);
+        if (!previous_line.has_value()) {
+          assign_lines.clear();
+          break;
+        }
+
+        auto [selector_indent, selector_name, selector_value] =
+            StringViewMatch<3>(lines[previous_line.value()], SELECTOR_ASSIGN_REGEX);
+        if (selector_name.empty()) {
+          assign_lines.clear();
+          break;
+        }
+        if (selector_variable.empty()) {
+          selector_variable = selector_name;
+        } else if (selector_variable != selector_name) {
+          assign_lines.clear();
+          break;
+        }
+        assign_lines.push_back(j);
+      }
+
+      if (selector_variable.empty() || assign_lines.empty() || !false_guard_line.has_value() || !true_guard_line.has_value()) {
+        continue;
+      }
+
+      const auto expected_reference_count = assign_lines.size() + 3;
+      if (count_variable_references(flag) != expected_reference_count) {
+        continue;
+      }
+
+      lines[i] = std::format("{}{} = -1;", indent, selector_variable);
+      lines[false_guard_line.value()] =
+          std::format("{}if ({} == -1) {{", line_indent(false_guard_line.value()), selector_variable);
+      lines[true_guard_line.value()] =
+          std::format("{}if ({} != -1) {{", line_indent(true_guard_line.value()), selector_variable);
+
+      std::ranges::sort(assign_lines);
+      for (auto assign_it = assign_lines.rbegin(); assign_it != assign_lines.rend(); ++assign_it) {
+        auto removed_line = *assign_it;
+        lines.erase(lines.begin() + removed_line);
+        if (removed_line < false_guard_line.value()) {
+          false_guard_line = false_guard_line.value() - 1;
+        }
+        if (removed_line < true_guard_line.value()) {
+          true_guard_line = true_guard_line.value() - 1;
+        }
+      }
+      changed = true;
+    }
+
+    if (!changed) {
+      return std::string(hlsl);
+    }
+
+    std::stringstream output_stream;
+    for (size_t i = 0; i < lines.size(); ++i) {
+      output_stream << lines[i];
+      if (i + 1 < lines.size()) {
+        output_stream << "\n";
+      }
+    }
+    return output_stream.str();
+  }
+
+  static std::string OptimizeNestedReductionLoops(std::string_view hlsl) {
+    static const auto IF_POSITIVE_REGEX = std::regex(R"(^(\s*)if \(\(int\)(_\d+) > \(int\)0\) \{\s*$)");
+    static const auto ASSIGN_ZERO_INT_REGEX = std::regex(R"(^(\s*)(_\d+) = 0;\s*$)");
+    static const auto ASSIGN_ZERO_FLOAT_REGEX = std::regex(R"(^(\s*)(_\d+) = 0\.0f;\s*$)");
+    static const auto WHILE_TRUE_REGEX = std::regex(R"(^(\s*)while\(true\) \{\s*$)");
+    static const auto ASSIGN_COPY_REGEX = std::regex(R"(^(\s*)(_\d+) = (_\d+);\s*$)");
+    static const auto SAMPLE_MAX_REGEX = std::regex(R"(^(\s*)float (_\d+) = max\((_\d+), (_\d+)\.x\);\s*$)");
+    static const auto NEXT_INDEX_REGEX = std::regex(R"(^(\s*)int (_\d+) = (_\d+) \+ 1;\s*$)");
+    static const auto BOUNDED_IF_REGEX =
+        std::regex(R"(^(\s*)if \(\(\(\(int\)(_\d+) < \(int\)(_\d+)\)\) && \(\(\(int\)(_\d+) < \(int\)8\)\)\) \{\s*$)");
+    static const auto CONTINUE_REGEX = std::regex(R"(^(\s*)continue;\s*$)");
+    static const auto BREAK_REGEX = std::regex(R"(^(\s*)break;\s*$)");
+    static const auto ELSE_REGEX = std::regex(R"(^(\s*)\} else \{\s*$)");
+    static const auto CLOSE_REGEX = std::regex(R"(^(\s*)\}\s*$)");
+
+    std::vector<std::string> lines;
+    {
+      std::stringstream line_stream{std::string(hlsl)};
+      std::string line;
+      while (std::getline(line_stream, line)) {
+        lines.push_back(line);
+      }
+    }
+
+    bool changed = false;
+    for (size_t i = 0; i + 33 < lines.size(); ++i) {
+      auto [indent, outer_count] = StringViewMatch<2>(lines[i], IF_POSITIVE_REGEX);
+      auto [assign_zero_indent, outer_index] = StringViewMatch<2>(lines[i + 1], ASSIGN_ZERO_INT_REGEX);
+      auto [assign_zero_float_indent, outer_acc] = StringViewMatch<2>(lines[i + 2], ASSIGN_ZERO_FLOAT_REGEX);
+      auto [outer_loop_indent] = StringViewMatch<1>(lines[i + 3], WHILE_TRUE_REGEX);
+      auto [inner_if_indent, inner_count] = StringViewMatch<2>(lines[i + 4], IF_POSITIVE_REGEX);
+      auto [inner_zero_indent, inner_index] = StringViewMatch<2>(lines[i + 5], ASSIGN_ZERO_INT_REGEX);
+      auto [inner_copy_indent, inner_acc, copied_outer_acc] = StringViewMatch<3>(lines[i + 6], ASSIGN_COPY_REGEX);
+      auto [inner_loop_indent] = StringViewMatch<1>(lines[i + 7], WHILE_TRUE_REGEX);
+      auto [sample_max_indent, sample_max, sample_acc, sample_vec] = StringViewMatch<4>(lines[i + 9], SAMPLE_MAX_REGEX);
+      auto [next_inner_indent, next_inner, next_inner_source] = StringViewMatch<3>(lines[i + 10], NEXT_INDEX_REGEX);
+      auto [inner_bound_indent, inner_bound_var_a, inner_bound_limit, inner_bound_var_b] =
+          StringViewMatch<4>(lines[i + 11], BOUNDED_IF_REGEX);
+      auto [inner_assign_indent, inner_assign_index, inner_assign_value] = StringViewMatch<3>(lines[i + 12], ASSIGN_COPY_REGEX);
+      auto [inner_acc_assign_indent, inner_acc_assign_target, inner_acc_assign_value] = StringViewMatch<3>(lines[i + 13], ASSIGN_COPY_REGEX);
+      auto [inner_continue_indent] = StringViewMatch<1>(lines[i + 14], CONTINUE_REGEX);
+      auto [inner_if_end_indent] = StringViewMatch<1>(lines[i + 15], CLOSE_REGEX);
+      auto [result_assign_indent, result_var, result_value] = StringViewMatch<3>(lines[i + 16], ASSIGN_COPY_REGEX);
+      auto [inner_break_indent] = StringViewMatch<1>(lines[i + 17], BREAK_REGEX);
+      auto [inner_loop_end_indent] = StringViewMatch<1>(lines[i + 18], CLOSE_REGEX);
+      auto [else_indent] = StringViewMatch<1>(lines[i + 19], ELSE_REGEX);
+      auto [else_result_indent, else_result_var, else_result_value] = StringViewMatch<3>(lines[i + 20], ASSIGN_COPY_REGEX);
+      auto [else_end_indent] = StringViewMatch<1>(lines[i + 21], CLOSE_REGEX);
+      auto [next_outer_indent, next_outer, next_outer_source] = StringViewMatch<3>(lines[i + 22], NEXT_INDEX_REGEX);
+      auto [outer_bound_indent, outer_bound_var_a, outer_bound_limit, outer_bound_var_b] =
+          StringViewMatch<4>(lines[i + 23], BOUNDED_IF_REGEX);
+      auto [outer_assign_indent, outer_assign_index, outer_assign_value] = StringViewMatch<3>(lines[i + 24], ASSIGN_COPY_REGEX);
+      auto [outer_acc_assign_indent, outer_acc_assign_target, outer_acc_assign_value] = StringViewMatch<3>(lines[i + 25], ASSIGN_COPY_REGEX);
+      auto [outer_continue_indent] = StringViewMatch<1>(lines[i + 26], CONTINUE_REGEX);
+      auto [outer_if_end_indent] = StringViewMatch<1>(lines[i + 27], CLOSE_REGEX);
+      auto [final_assign_indent, final_var, final_value] = StringViewMatch<3>(lines[i + 28], ASSIGN_COPY_REGEX);
+      auto [outer_break_indent] = StringViewMatch<1>(lines[i + 29], BREAK_REGEX);
+      auto [outer_loop_end_indent_2] = StringViewMatch<1>(lines[i + 30], CLOSE_REGEX);
+      auto [outer_else_indent] = StringViewMatch<1>(lines[i + 31], ELSE_REGEX);
+      auto [outer_else_assign_indent, outer_else_var] = StringViewMatch<2>(lines[i + 32], ASSIGN_ZERO_FLOAT_REGEX);
+      auto [outer_if_end_indent_2] = StringViewMatch<1>(lines[i + 33], CLOSE_REGEX);
+
+      if (outer_count.empty() || outer_index.empty() || outer_acc.empty() || inner_count.empty()
+          || inner_index.empty() || inner_acc.empty() || sample_max.empty() || sample_vec.empty()
+          || next_inner.empty() || result_var.empty() || next_outer.empty() || final_var.empty()) {
+        continue;
+      }
+      if (copied_outer_acc != outer_acc
+          || sample_acc != inner_acc
+          || next_inner_source != inner_index
+          || inner_bound_var_a != next_inner
+          || inner_bound_var_b != next_inner
+          || inner_bound_limit != inner_count
+          || inner_assign_index != inner_index
+          || inner_assign_value != next_inner
+          || inner_acc_assign_target != inner_acc
+          || inner_acc_assign_value != sample_max
+          || result_value != sample_max
+          || else_result_var != result_var
+          || else_result_value != outer_acc
+          || next_outer_source != outer_index
+          || outer_bound_var_a != next_outer
+          || outer_bound_var_b != next_outer
+          || outer_bound_limit != outer_count
+          || outer_assign_index != outer_index
+          || outer_assign_value != next_outer
+          || outer_acc_assign_target != outer_acc
+          || outer_acc_assign_value != result_var
+          || final_value != result_var
+          || outer_else_var != final_var) {
+        continue;
+      }
+
+      auto indent_string = std::string(indent);
+      std::vector<std::string> replacement = {
+          std::format("{}if ((int){} > (int)0) {{", indent_string, outer_count),
+          std::format("{}  {} = 0;", indent_string, outer_index),
+          std::format("{}  {} = 0.0f;", indent_string, outer_acc),
+          std::format("{}  int {};", indent_string, next_outer),
+          std::format("{}  do {{", indent_string),
+          std::format("{}    if ((int){} > (int)0) {{", indent_string, inner_count),
+          std::format("{}      {} = 0;", indent_string, inner_index),
+          std::format("{}      {} = {};", indent_string, inner_acc, outer_acc),
+          std::format("{}      int {};", indent_string, next_inner),
+          std::format("{}      do {{", indent_string),
+          std::format("{}        {}", indent_string, lines[i + 8].substr(indent_string.size() + 8)),
+          std::format("{}        {} = max({}, {}.x);", indent_string, inner_acc, inner_acc, sample_vec),
+          std::format("{}        {} = {} + 1;", indent_string, next_inner, inner_index),
+          std::format(
+              "{}        if ((((int){} < (int){})) && (((int){} < (int)8))) {{",
+              indent_string,
+              next_inner,
+              inner_count,
+              next_inner),
+          std::format("{}          {} = {};", indent_string, inner_index, next_inner),
+          std::format("{}        }}", indent_string),
+          std::format(
+              "{}      }} while ((((int){} < (int){})) && (((int){} < (int)8)));",
+              indent_string,
+              next_inner,
+              inner_count,
+              next_inner),
+          std::format("{}      {} = {};", indent_string, result_var, inner_acc),
+          std::format("{}    }} else {{", indent_string),
+          std::format("{}      {} = {};", indent_string, result_var, outer_acc),
+          std::format("{}    }}", indent_string),
+          std::format("{}    {} = {};", indent_string, outer_acc, result_var),
+          std::format("{}    {} = {} + 1;", indent_string, next_outer, outer_index),
+          std::format(
+              "{}    if ((((int){} < (int){})) && (((int){} < (int)8))) {{",
+              indent_string,
+              next_outer,
+              outer_count,
+              next_outer),
+          std::format("{}      {} = {};", indent_string, outer_index, next_outer),
+          std::format("{}    }}", indent_string),
+          std::format(
+              "{}  }} while ((((int){} < (int){})) && (((int){} < (int)8)));",
+              indent_string,
+              next_outer,
+              outer_count,
+              next_outer),
+          std::format("{}  {} = {};", indent_string, final_var, result_var),
+          std::format("{}}} else {{", indent_string),
+          std::format("{}  {} = 0.0f;", indent_string, final_var),
+          std::format("{}}}", indent_string),
+      };
+
+      lines.erase(lines.begin() + i, lines.begin() + i + 34);
+      lines.insert(lines.begin() + i, replacement.begin(), replacement.end());
+      changed = true;
+      if (i != 0) {
+        --i;
+      }
+    }
+
+    if (!changed) {
+      return std::string(hlsl);
+    }
+
+    std::stringstream output_stream;
+    for (size_t i = 0; i < lines.size(); ++i) {
+      output_stream << lines[i];
+      if (i + 1 < lines.size()) {
+        output_stream << "\n";
+      }
+    }
+    return output_stream.str();
+  }
+
+  static std::string OptimizeUpperBoundGuardLoads(std::string_view hlsl) {
+    static const auto RANGE_GUARD_REGEX =
+        std::regex(R"(^(\s*)if \(\(\(\(int\)(_\d+) > \(int\)-1\)\) && \(\(\(uint\)\2 < \(uint\)\((.+)\)\)\)\) \{\s*$)");
+    static const auto VARIABLE_REGEX = std::regex(R"((^|[^A-Za-z0-9_])_(\d+)([^A-Za-z0-9_]|$))");
+    static const auto SIMPLE_ASSIGN_REGEX =
+        std::regex(R"(^(\s*)(?:[A-Za-z_][A-Za-z0-9_<> \[\]]+\s+)?(_\d+)\s*= .+;\s*$)");
+
+    std::vector<std::string> lines;
+    {
+      std::stringstream line_stream{std::string(hlsl)};
+      std::string line;
+      while (std::getline(line_stream, line)) {
+        lines.push_back(line);
+      }
+    }
+
+    uint32_t next_variable = 0;
+    for (const auto& line : lines) {
+      for (auto it = std::sregex_iterator(line.begin(), line.end(), VARIABLE_REGEX);
+           it != std::sregex_iterator();
+           ++it) {
+        uint32_t current_variable = 0;
+        FromStringView((*it)[2].str(), current_variable);
+        next_variable = std::max(next_variable, current_variable + 1);
+      }
+    }
+
+    bool changed = false;
+    for (size_t i = 0; i < lines.size(); ++i) {
+      auto [indent, lower_bound_variable, upper_bound_expression] = StringViewMatch<3>(lines[i], RANGE_GUARD_REGEX);
+      if (lower_bound_variable.empty() || upper_bound_expression.empty()) {
+        continue;
+      }
+
+      auto upper_bound_variable = [&]() {
+        auto [preferred_index_text] = StringViewMatch<1>(lower_bound_variable, std::regex(R"(^_(\d+)$)"));
+        if (preferred_index_text.empty()) {
+          return std::format("_{}", next_variable++);
+        }
+        uint32_t preferred_index = 0;
+        FromStringView(preferred_index_text, preferred_index);
+        auto preferred_variable = std::format("_{}", preferred_index + 1);
+        auto preferred_regex = std::regex(std::format(R"((^|[^A-Za-z0-9_]){}([^A-Za-z0-9_]|$))", preferred_variable));
+        bool preferred_used = false;
+        for (const auto& line : lines) {
+          if (std::regex_search(line, preferred_regex)) {
+            preferred_used = true;
+            break;
+          }
+        }
+        if (!preferred_used) {
+          next_variable = std::max(next_variable, preferred_index + 2);
+          return preferred_variable;
+        }
+        return std::format("_{}", next_variable++);
+      }();
+
+      size_t insertion_index = i;
+      for (size_t j = i; j-- > 0;) {
+        auto [assign_indent, assign_variable] = StringViewMatch<2>(lines[j], SIMPLE_ASSIGN_REGEX);
+        if (assign_variable == lower_bound_variable && assign_indent == indent) {
+          insertion_index = j + 1;
+          break;
+        }
+      }
+
+      lines.insert(
+          lines.begin() + insertion_index,
+          std::format("{}uint {} = {};", indent, upper_bound_variable, upper_bound_expression));
+      if (insertion_index <= i) {
+        ++i;
+      }
+      lines[i] = std::format(
+          "{}if ((((int){} > (int)-1)) && (((uint){} < {}))) {{",
+          indent,
+          lower_bound_variable,
+          lower_bound_variable,
+          upper_bound_variable);
+      changed = true;
+    }
+
+    if (!changed) {
+      return std::string(hlsl);
+    }
+
+    std::stringstream output_stream;
+    for (size_t i = 0; i < lines.size(); ++i) {
+      output_stream << lines[i];
+      if (i + 1 < lines.size()) {
+        output_stream << "\n";
+      }
+    }
+    return output_stream.str();
+  }
+
+  static std::string OptimizeVectorMaskedDots(std::string_view hlsl) {
+    static const auto SELECT_LINE_REGEX =
+        std::regex(R"(^(\s*)float ([A-Za-z_][A-Za-z0-9_]*) = select\(([^,]+), ([^,]+)\.([xyzw]), (.+)\);\s*$)");
+    static const auto DOT_LINE_REGEX =
+        std::regex(R"(^(\s*)float ([A-Za-z_][A-Za-z0-9_]*) = dot\(float3\(([A-Za-z_][A-Za-z0-9_]*), ([A-Za-z_][A-Za-z0-9_]*), ([A-Za-z_][A-Za-z0-9_]*)\), (.+)\);\s*$)");
+
+    std::vector<std::string> lines;
+    {
+      std::stringstream line_stream{std::string(hlsl)};
+      std::string line;
+      while (std::getline(line_stream, line)) {
+        lines.push_back(line);
+      }
+    }
+
+    auto count_variable_references = [&](std::string_view variable) {
+      auto variable_regex = std::regex(std::format(R"((^|[^A-Za-z0-9_]){}([^A-Za-z0-9_]|$))", variable));
+      size_t count = 0;
+      for (const auto& line : lines) {
+        if (std::regex_search(line, variable_regex)) {
+          ++count;
+        }
+      }
+      return count;
+    };
+
+    auto make_vector_name = [](std::string_view first_variable, std::string_view last_variable, size_t fallback_index) {
+      if (first_variable.starts_with("_") && last_variable.starts_with("_")) {
+        return std::format("{}_{}", first_variable, last_variable.substr(1));
+      }
+      return std::format("__vector_mask_{}", fallback_index);
+    };
+
+    bool changed = false;
+    size_t fallback_index = 0;
+    for (size_t i = 0; i + 3 < lines.size(); ++i) {
+      auto [indent_x, variable_x, condition_x, base_x, component_x, fallback_x] = StringViewMatch<6>(lines[i], SELECT_LINE_REGEX);
+      auto [indent_y, variable_y, condition_y, base_y, component_y, fallback_y] = StringViewMatch<6>(lines[i + 1], SELECT_LINE_REGEX);
+      auto [indent_z, variable_z, condition_z, base_z, component_z, fallback_z] = StringViewMatch<6>(lines[i + 2], SELECT_LINE_REGEX);
+      auto [dot_indent, dot_variable, dot_x, dot_y, dot_z, dot_rhs] = StringViewMatch<6>(lines[i + 3], DOT_LINE_REGEX);
+      if (variable_x.empty() || variable_y.empty() || variable_z.empty() || dot_variable.empty()) continue;
+      if (indent_x != indent_y || indent_y != indent_z || indent_z != dot_indent) continue;
+      if (condition_x != condition_y || condition_y != condition_z) continue;
+      if (base_x != base_y || base_y != base_z) continue;
+      if (fallback_x != fallback_y || fallback_y != fallback_z) continue;
+      if (dot_x != variable_x || dot_y != variable_y || dot_z != variable_z) continue;
+      if (count_variable_references(variable_x) != 2
+          || count_variable_references(variable_y) != 2
+          || count_variable_references(variable_z) != 2) {
+        continue;
+      }
+
+      auto swizzle = std::format("{}{}{}", component_x, component_y, component_z);
+      auto vector_name = make_vector_name(variable_x, variable_z, fallback_index++);
+      lines[i] = std::format(
+          "{}float3 {} = select({}, {}.{}, ({}).xxx);",
+          indent_x,
+          vector_name,
+          condition_x,
+          base_x,
+          swizzle,
+          fallback_x);
+      lines[i + 3] = std::format(
+          "{}float {} = dot({}, {});",
+          dot_indent,
+          dot_variable,
+          vector_name,
+          dot_rhs);
+      lines.erase(lines.begin() + i + 1, lines.begin() + i + 3);
+      changed = true;
+    }
+
+    if (!changed) {
+      return std::string(hlsl);
+    }
+
+    std::stringstream output_stream;
+    for (size_t i = 0; i < lines.size(); ++i) {
+      output_stream << lines[i];
+      if (i + 1 < lines.size()) {
+        output_stream << "\n";
+      }
+    }
+    return output_stream.str();
+  }
+

--- a/src/utils/shader_decompiler/semantic_labels.hpp
+++ b/src/utils/shader_decompiler/semantic_labels.hpp
@@ -1,0 +1,414 @@
+#pragma once
+
+// Semantic labeling post-pass for decompiled HLSL.
+// Propagates meaningful names from known sources (inputs, resources, cbuffers)
+// through the def-use chain and emits inline comments.
+
+#include <map>
+#include <regex>
+#include <set>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace renodx::utils::shader::decompiler {
+
+struct SemanticLabel {
+  std::string variable;   // e.g., "_42"
+  std::string label;      // e.g., "worldPos_xy"
+  float confidence;       // 0.0 - 1.0
+  std::string source;     // What derived this label (for debugging)
+};
+
+struct SemanticContext {
+  // Maps variable name -> semantic label
+  std::map<std::string, SemanticLabel> labels;
+
+  // Track which variables are derived from which
+  std::map<std::string, std::vector<std::string>> def_use;  // var -> [users]
+  std::map<std::string, std::vector<std::string>> use_def;  // var -> [sources]
+};
+
+class SemanticLabeler {
+ public:
+  // Run semantic labeling on decompiled HLSL text.
+  // Returns the HLSL with inline // [sem: ...] comments added.
+  static std::string Label(const std::string& hlsl) {
+    SemanticContext ctx;
+
+    auto lines = SplitLines(hlsl);
+
+    // Phase 1: Seed labels from known sources
+    SeedFromInputs(lines, ctx);
+    SeedFromResources(lines, ctx);
+    SeedFromCBV(lines, ctx);
+
+    // Phase 2: Build def-use chains
+    BuildDefUseChains(lines, ctx);
+
+    // Phase 3: Propagate labels forward
+    PropagateLabels(ctx);
+
+    // Phase 4: Recognize patterns and add derived labels
+    RecognizePatterns(lines, ctx);
+
+    // Phase 5: Emit annotated HLSL
+    return EmitAnnotated(lines, ctx);
+  }
+
+ private:
+  static std::vector<std::string> SplitLines(const std::string& text) {
+    std::vector<std::string> lines;
+    std::istringstream stream(text);
+    std::string line;
+    while (std::getline(stream, line)) {
+      lines.push_back(line);
+    }
+    return lines;
+  }
+
+  // --- Phase 1: Seed from input struct assignments ---
+  static void SeedFromInputs(const std::vector<std::string>& lines, SemanticContext& ctx) {
+    // Mermaid mode: float2 TEXCOORD = __TEXCOORD; (inputs are named directly)
+    // Also match: float4 SV_Position = __SV_Position;
+    static const std::regex INPUT_DECL_REGEX{
+        R"(^\s*\w+\s+(\w+)\s*=\s*__(\w+);)"};
+    // Match uses of input variables in assignments: _42 = ... TEXCOORD.x ...
+    // We'll seed from the input declarations and let propagation handle the rest
+
+    for (const auto& line : lines) {
+      std::smatch m;
+      if (std::regex_search(line, m, INPUT_DECL_REGEX)) {
+        std::string var = m[1].str();
+        std::string semantic = m[2].str();
+        std::string label = DeriveLabelFromSemantic(semantic, "");
+        ctx.labels[var] = {var, label, 1.0f, "input." + semantic};
+      }
+    }
+  }
+
+  static std::string DeriveLabelFromSemantic(const std::string& semantic, const std::string& swizzle) {
+    // Map common semantics to readable names
+    std::string base;
+    if (semantic.find("TEXCOORD") != std::string::npos) base = "uv";
+    else if (semantic.find("NORMAL") != std::string::npos) base = "normal";
+    else if (semantic.find("TANGENT") != std::string::npos) base = "tangent";
+    else if (semantic.find("BINORMAL") != std::string::npos) base = "bitangent";
+    else if (semantic.find("COLOR") != std::string::npos) base = "vertexColor";
+    else if (semantic.find("SV_Position") != std::string::npos) base = "svPosition";
+    else if (semantic.find("SV_InstanceID") != std::string::npos) base = "instanceId";
+    else if (semantic.find("SV_VertexID") != std::string::npos) base = "vertexId";
+    else if (semantic.find("SV_IsFrontFace") != std::string::npos) base = "isFrontFace";
+    else if (semantic.find("SV_DispatchThreadID") != std::string::npos) base = "dispatchId";
+    else if (semantic.find("SV_GroupThreadID") != std::string::npos) base = "groupThreadId";
+    else if (semantic.find("SV_GroupID") != std::string::npos) base = "groupId";
+    else base = semantic;
+
+    if (!swizzle.empty() && swizzle != "xyzw") {
+      base += "_" + swizzle;
+    }
+    return base;
+  }
+
+  // --- Phase 1: Seed from resource accesses ---
+  static void SeedFromResources(const std::vector<std::string>& lines, SemanticContext& ctx) {
+    // Match: _42 = resourceName.SampleLevel(sampler, coords, lod);
+    // Match: float4 _42 = resourceName.Sample(sampler, coords);
+    static const std::regex SAMPLE_REGEX{
+        R"(^\s*(?:\w+\s+)?(_\d+)\s*=\s*(?:\(\(float4\)\()?(\w+)\.(Sample\w*|Load|Gather\w*)\()"};
+    // Match: _42 = resourceName[index];
+    static const std::regex INDEX_REGEX{
+        R"(^\s*(?:\w+\s+)?(_\d+)\s*=\s*(\w+)\[)"};
+
+    for (const auto& line : lines) {
+      std::smatch m;
+      if (std::regex_search(line, m, SAMPLE_REGEX)) {
+        std::string var = m[1].str();
+        std::string resource = m[2].str();
+        std::string op = m[3].str();
+
+        std::string label = ShortenResourceName(resource) + "_" + SimplifyOp(op);
+        ctx.labels[var] = {var, label, 0.9f, resource + "." + op};
+      } else if (std::regex_search(line, m, INDEX_REGEX)) {
+        std::string var = m[1].str();
+        std::string resource = m[2].str();
+
+        // Skip if it's a known non-resource (like a local variable or array)
+        if (resource.starts_with("_")) continue;
+        if (resource == "select" || resource == "float2" || resource == "float3" || resource == "float4") continue;
+
+        ctx.labels[var] = {var, ShortenResourceName(resource) + "_load", 0.7f, resource + "[]"};
+      }
+    }
+  }
+
+  // Shorten long UE resource names like "SceneTexturesStruct_GBufferATexture" -> "GBufferA"
+  static std::string ShortenResourceName(const std::string& name) {
+    // Remove common prefixes
+    std::string shortened = name;
+    if (shortened.find("SceneTexturesStruct_") == 0) shortened = shortened.substr(20);
+    if (shortened.find("Texture") != std::string::npos) {
+      auto pos = shortened.find("Texture");
+      shortened = shortened.substr(0, pos);
+    }
+    if (shortened.find("_") == 0) shortened = shortened.substr(1);
+    // Lowercase first char
+    if (!shortened.empty() && std::isupper(shortened[0])) {
+      shortened[0] = std::tolower(shortened[0]);
+    }
+    return shortened.empty() ? name : shortened;
+  }
+
+  static std::string SimplifyOp(const std::string& op) {
+    if (op == "Sample") return "sample";
+    if (op == "SampleLevel") return "sampleLod";
+    if (op == "SampleCmp" || op == "SampleCmpLevelZero") return "shadowCmp";
+    if (op == "Load") return "load";
+    if (op.find("Gather") != std::string::npos) return "gather";
+    return op;
+  }
+
+  // --- Phase 1: Seed from CBV field loads ---
+  static void SeedFromCBV(const std::vector<std::string>& lines, SemanticContext& ctx) {
+    // Match: _42 = cbvName_012x;  (cbuffer field access, old style)
+    static const std::regex CBV_FIELD_REGEX{
+        R"(^\s*(?:\w+\s+)?(_\d+)\s*=\s*(\w+_\d{3}[xyzw]);)"};
+    // Match: _42 = View.FieldName.x; or _42 = View.FieldName;
+    static const std::regex CBV_DOT_REGEX{
+        R"(^\s*(?:\w+\s+)?(_\d+)\s*=\s*(\w+)\.(\w+)(?:\.([xyzw]+))?;)"};
+    // Match: _42 = asfloat(cbvName_raw[N].x);
+    static const std::regex CBV_RAW_REGEX{
+        R"(^\s*(?:\w+\s+)?(_\d+)\s*=\s*(?:asfloat|asint|asuint)\((\w+)_raw\[)"};
+
+    for (const auto& line : lines) {
+      std::smatch m;
+      if (std::regex_search(line, m, CBV_FIELD_REGEX)) {
+        std::string var = m[1].str();
+        std::string field = m[2].str();
+        ctx.labels[var] = {var, "cb_" + field, 0.8f, "cbuffer." + field};
+      } else if (std::regex_search(line, m, CBV_DOT_REGEX)) {
+        std::string var = m[1].str();
+        std::string cbv = m[2].str();
+        std::string field = m[3].str();
+        std::string swizzle = m[4].matched ? m[4].str() : "";
+        // Only label if it looks like a cbuffer access (capitalized name, known cbuffer names)
+        if (std::isupper(cbv[0]) && field.length() > 2) {
+          std::string label = field;
+          if (!swizzle.empty()) label += "_" + swizzle;
+          ctx.labels[var] = {var, label, 0.85f, cbv + "." + field};
+        }
+      } else if (std::regex_search(line, m, CBV_RAW_REGEX)) {
+        std::string var = m[1].str();
+        std::string cbv = m[2].str();
+        ctx.labels[var] = {var, "cb_" + cbv + "_dyn", 0.6f, cbv + "_raw[]"};
+      }
+    }
+  }
+
+  // --- Phase 2: Build def-use chains ---
+  static void BuildDefUseChains(const std::vector<std::string>& lines, SemanticContext& ctx) {
+    // Match both: "float _42 = expr;" and "_42 = expr;" (mermaid mode reassignments)
+    static const std::regex ASSIGN_REGEX{R"(^\s*(?:\w+\s+)?(_\d+)\s*=\s*(.+);)"};
+    static const std::regex VAR_REF_REGEX{R"((_\d+))"};
+
+    for (const auto& line : lines) {
+      std::smatch m;
+      if (std::regex_search(line, m, ASSIGN_REGEX)) {
+        std::string def_var = m[1].str();
+        std::string rhs = m[2].str();
+
+        // Skip zero-init declarations (float _42 = 0.0f;)
+        if (rhs == "0.0f" || rhs == "0u" || rhs == "0" || rhs == "false" ||
+            rhs.starts_with("float2(0") || rhs.starts_with("float3(0") || rhs.starts_with("float4(0")) {
+          continue;
+        }
+
+        // Find all _N references in the RHS
+        auto begin = std::sregex_iterator(rhs.begin(), rhs.end(), VAR_REF_REGEX);
+        auto end = std::sregex_iterator();
+        for (auto it = begin; it != end; ++it) {
+          std::string use_var = (*it)[1].str();
+          if (use_var != def_var) {
+            ctx.def_use[use_var].push_back(def_var);
+            ctx.use_def[def_var].push_back(use_var);
+          }
+        }
+      }
+    }
+  }
+
+  // --- Phase 3: Forward propagation ---
+  static void PropagateLabels(SemanticContext& ctx, int max_depth = 3) {
+    // BFS propagation from seeded labels
+    std::vector<std::string> worklist;
+    for (const auto& [var, label] : ctx.labels) {
+      worklist.push_back(var);
+    }
+
+    for (int depth = 0; depth < max_depth && !worklist.empty(); ++depth) {
+      std::vector<std::string> next_worklist;
+      float decay = 1.0f - (depth + 1) * 0.2f;
+
+      for (const auto& var : worklist) {
+        if (!ctx.labels.contains(var)) continue;
+        const auto& source_label = ctx.labels[var];
+
+        for (const auto& user : ctx.def_use[var]) {
+          // Don't overwrite higher-confidence labels
+          if (ctx.labels.contains(user) && ctx.labels[user].confidence >= source_label.confidence * decay) {
+            continue;
+          }
+          // Only propagate through simple assignments and swizzles
+          // More complex expressions get pattern-based labels instead
+          if (ctx.use_def[user].size() == 1) {
+            ctx.labels[user] = {user, source_label.label + "_derived", source_label.confidence * decay, "propagated from " + var};
+            next_worklist.push_back(user);
+          }
+        }
+      }
+      worklist = std::move(next_worklist);
+    }
+  }
+
+  // --- Phase 4: Pattern recognition ---
+  static void RecognizePatterns(const std::vector<std::string>& lines, SemanticContext& ctx) {
+    // All patterns handle both "type _N = expr;" and "_N = expr;" formats
+    static const std::regex NORMALIZE_REGEX{R"((?:\w+\s+)?(_\d+)\s*=\s*normalize\((.+?)\);)"};
+    static const std::regex DOT_REGEX{R"((?:\w+\s+)?(_\d+)\s*=\s*dot\((.+?),\s*(.+?)\);)"};
+    static const std::regex SATURATE_REGEX{R"((?:\w+\s+)?(_\d+)\s*=\s*saturate\((.+?)\);)"};
+    static const std::regex LERP_REGEX{R"((?:\w+\s+)?(_\d+)\s*=\s*(?:\()?lerp\()"};
+    static const std::regex MUL_REGEX{R"((?:\w+\s+)?(_\d+)\s*=\s*mul\((.+?),\s*(.+?)\);)"};
+    static const std::regex CROSS_REGEX{R"((?:\w+\s+)?(_\d+)\s*=\s*cross\((.+?),\s*(.+?)\);)"};
+    static const std::regex REFLECT_REGEX{R"((?:\w+\s+)?(_\d+)\s*=\s*reflect\((.+?),\s*(.+?)\);)"};
+    static const std::regex LENGTH_REGEX{R"((?:\w+\s+)?(_\d+)\s*=\s*(?:length|distance)\((.+?)\);)"};
+    static const std::regex POW_REGEX{R"((?:\w+\s+)?(_\d+)\s*=\s*pow\((.+?),\s*(.+?)\);)"};
+    static const std::regex RSQRT_REGEX{R"((?:\w+\s+)?(_\d+)\s*=\s*rsqrt\((.+?)\);)"};
+    static const std::regex SELECT_REGEX{R"((?:\w+\s+)?(_\d+)\s*=\s*select\((.+?),\s*(.+?),\s*(.+?)\);)"};
+    // Detect depth linearization: (a * depth + b) + (1.0 / (c * depth + d))
+    static const std::regex DEPTH_REGEX{R"(InvDeviceZToWorldZTransform)"};
+
+    for (size_t i = 0; i < lines.size(); ++i) {
+      const auto& line = lines[i];
+      std::smatch m;
+
+      // Depth linearization (specific to UE deferred lighting)
+      if (std::regex_search(line, DEPTH_REGEX)) {
+        static const std::regex DEPTH_VAR_REGEX{R"((?:\w+\s+)?(_\d+)\s*=)"};
+        std::smatch dm;
+        if (std::regex_search(line, dm, DEPTH_VAR_REGEX)) {
+          std::string var = dm[1].str();
+          ctx.labels[var] = {var, "linearDepth", 0.95f, "InvDeviceZToWorldZTransform"};
+        }
+      } else if (std::regex_search(line, m, RSQRT_REGEX)) {
+        std::string var = m[1].str();
+        std::string arg = m[2].str();
+        // rsqrt(dot(v, v)) is normalization magnitude
+        if (arg.find("dot(") != std::string::npos) {
+          ctx.labels[var] = {var, "invLength", 0.8f, "rsqrt(dot(...))"};
+        } else {
+          ctx.labels[var] = {var, "rsqrt_val", 0.5f, "rsqrt(" + arg + ")"};
+        }
+      } else if (std::regex_search(line, m, NORMALIZE_REGEX)) {
+        std::string var = m[1].str();
+        std::string arg = m[2].str();
+        std::string base = GetLabelOrVar(arg, ctx);
+        if (!ctx.labels.contains(var) || ctx.labels[var].confidence < 0.7f) {
+          ctx.labels[var] = {var, base + "_dir", 0.7f, "normalize(" + arg + ")"};
+        }
+      } else if (std::regex_search(line, m, DOT_REGEX)) {
+        std::string var = m[1].str();
+        std::string a = m[2].str();
+        std::string b = m[3].str();
+        std::string la = GetLabelOrVar(a, ctx);
+        std::string lb = GetLabelOrVar(b, ctx);
+        // Only label if at least one argument resolved to something meaningful
+        if (la == "expr" && lb == "expr") continue;
+        std::string label = la + "_dot_" + lb;
+        if (la.find("normal") != std::string::npos && lb.find("light") != std::string::npos) label = "NdotL";
+        else if (la.find("normal") != std::string::npos && lb.find("view") != std::string::npos) label = "NdotV";
+        else if (la.find("normal") != std::string::npos && lb.find("half") != std::string::npos) label = "NdotH";
+        ctx.labels[var] = {var, label, 0.8f, "dot(" + a + ", " + b + ")"};
+      } else if (std::regex_search(line, m, SATURATE_REGEX)) {
+        std::string var = m[1].str();
+        std::string arg = m[2].str();
+        std::string base = GetLabelOrVar(arg, ctx);
+        ctx.labels[var] = {var, base + "_sat", 0.7f, "saturate(" + arg + ")"};
+      } else if (std::regex_search(line, m, LERP_REGEX)) {
+        std::string var = m[1].str();
+        ctx.labels[var] = {var, "blended", 0.6f, "lerp(...)"};
+      } else if (std::regex_search(line, m, MUL_REGEX)) {
+        std::string var = m[1].str();
+        std::string a = m[2].str();
+        std::string b = m[3].str();
+        std::string label = "transformed";
+        std::string la = GetLabelOrVar(a, ctx);
+        if (la.find("Pos") != std::string::npos || la.find("pos") != std::string::npos) label = "transformed_pos";
+        else if (la.find("normal") != std::string::npos) label = "transformed_normal";
+        else if (la.find("view") != std::string::npos) label = "transformed_view";
+        ctx.labels[var] = {var, label, 0.6f, "mul(" + a + ", " + b + ")"};
+      } else if (std::regex_search(line, m, CROSS_REGEX)) {
+        std::string var = m[1].str();
+        ctx.labels[var] = {var, "cross_product", 0.7f, "cross(...)"};
+      } else if (std::regex_search(line, m, REFLECT_REGEX)) {
+        std::string var = m[1].str();
+        ctx.labels[var] = {var, "reflection_dir", 0.8f, "reflect(...)"};
+      } else if (std::regex_search(line, m, LENGTH_REGEX)) {
+        std::string var = m[1].str();
+        ctx.labels[var] = {var, "dist", 0.6f, "length/distance(...)"};
+      } else if (std::regex_search(line, m, POW_REGEX)) {
+        std::string var = m[1].str();
+        ctx.labels[var] = {var, "pow_result", 0.5f, "pow(...)"};
+      }
+    }
+  }
+
+  static std::string GetLabelOrVar(const std::string& var_or_expr, const SemanticContext& ctx) {
+    // If it's a variable reference and we have a label, use the label
+    if (var_or_expr.starts_with("_") && ctx.labels.contains(var_or_expr)) {
+      return ctx.labels.at(var_or_expr).label;
+    }
+    // If it's a simple _N variable without a label, return short form
+    static const std::regex SIMPLE_VAR{R"(^_\d+$)"};
+    if (std::regex_match(var_or_expr, SIMPLE_VAR)) {
+      return var_or_expr;
+    }
+    // For complex expressions (literals, function calls, etc.), return a generic placeholder
+    return "expr";
+  }
+
+  // --- Phase 5: Emit annotated output ---
+  static std::string EmitAnnotated(const std::vector<std::string>& lines, const SemanticContext& ctx) {
+    // Match both "type _N = ..." and "_N = ..." (reassignment in mermaid mode)
+    static const std::regex ASSIGN_VAR_REGEX{R"(^\s*(?:\w+\s+)?(_\d+)\s*=\s*(?!0\.0f|0u|0;|false|float))"};
+    std::string result;
+    result.reserve(lines.size() * 80);
+
+    for (const auto& line : lines) {
+      std::smatch m;
+      if (std::regex_search(line, m, ASSIGN_VAR_REGEX)) {
+        std::string var = m[1].str();
+        if (ctx.labels.contains(var)) {
+          const auto& label = ctx.labels.at(var);
+          if (label.confidence >= 0.5f) {
+            // Don't annotate if line is already very long
+            if (line.length() > 120) {
+              result += "  // [sem: " + label.label + "]\n";
+            }
+            result += line;
+            if (line.length() <= 120) {
+              result += "  // [sem: " + label.label + "]";
+            }
+            result += "\n";
+            continue;
+          }
+        }
+      }
+      result += line;
+      result += "\n";
+    }
+    return result;
+  }
+};
+
+}  // namespace renodx::utils::shader::decompiler

--- a/src/utils/shader_decompiler/stackify.hpp
+++ b/src/utils/shader_decompiler/stackify.hpp
@@ -1,0 +1,1133 @@
+// ===== STACKIFIER CODE GENERATION =====
+// This file is #included inside the Decompiler::Decompile() method when
+// decompile_options.stackify is true.
+//
+// Available in scope from the caller:
+//   - current_code_function, string_stream, spacing, decompile_options
+//   - indent_spacing(), unindent_spacing()
+//   - ParseType(), ParseWrapped(), OptimizeString(), IsWrapped()
+//   - convergences, recursions, ipdom, loop_bodies, dominators, predecessors
+//   - declared_vars, preprocess_state
+//
+// This code path replaces the block iteration with a recursive if/else nesting
+// approach using topological sort, scope markers, and phi_sel convergence.
+
+{
+      auto succs_fwd = current_code_function->ComputeSuccessors();
+      // Remove back edges
+      for (const auto& [header, sources] : recursions) {
+        for (int src : sources) {
+          succs_fwd[src].erase(header);
+        }
+      }
+
+      // Compute forward predecessors (predecessors minus back edges)
+      std::map<int, std::set<int>> preds_fwd;
+      for (const auto& [blk, succ_set] : succs_fwd) {
+        for (int s : succ_set) {
+          preds_fwd[s].insert(blk);
+        }
+      }
+
+      // Topological sort with loop body contiguity constraint.
+      // After emitting a loop header, all blocks dominated by the header
+      // (i.e., the loop body) must be emitted before any block outside the loop.
+      std::vector<int> topo_order;
+      std::set<int> visited;
+      std::set<int> in_queue;
+
+      // Priority: prefer blocks with single forward predecessor (for if/else nesting)
+      // and prefer lower block numbers (original program order)
+      std::function<void(int)> topo_visit = [&](int blk) {
+        if (visited.contains(blk)) return;
+        if (!current_code_function->code_blocks.contains(blk)) return;
+        visited.insert(blk);
+
+        // If this is a loop header, visit all loop body blocks first
+        if (loop_bodies.contains(blk)) {
+          const auto& body = loop_bodies.at(blk);
+          // Collect body successors in order
+          std::vector<int> body_blocks(body.begin(), body.end());
+          std::ranges::sort(body_blocks);
+          // Visit body blocks (they'll recursively visit their successors within the body)
+          for (int bb : body_blocks) {
+            if (bb != blk && !visited.contains(bb)) {
+              topo_visit(bb);
+            }
+          }
+        }
+
+        topo_order.push_back(blk);
+
+        // Visit forward successors
+        if (succs_fwd.contains(blk)) {
+          std::vector<int> succ_list(succs_fwd[blk].begin(), succs_fwd[blk].end());
+          // Sort: prefer blocks with single predecessor (nestable), then by block number
+          std::ranges::sort(succ_list, [&](int a, int b) {
+            bool a_single = preds_fwd[a].size() == 1;
+            bool b_single = preds_fwd[b].size() == 1;
+            if (a_single != b_single) return a_single > b_single;
+            return a < b;
+          });
+          for (int s : succ_list) {
+            topo_visit(s);
+          }
+        }
+      };
+
+      topo_visit(0);
+
+      // Build position map: block -> index in topo_order
+      std::map<int, int> block_pos;
+      for (int i = 0; i < static_cast<int>(topo_order.size()); ++i) {
+        block_pos[topo_order[i]] = i;
+      }
+
+      // Compute scope events using a stack-based approach.
+      // Each scope has an open position and a close-before position (the block AFTER the scope).
+      // Scopes must nest properly — they can't interleave.
+
+      struct Scope {
+        enum Type { LOOP, BLOCK };
+        Type type;
+        int open_pos;       // position where scope opens
+        int close_before;   // scope closes just before this position (target block for BLOCK, first-after-loop for LOOP)
+        int id;             // loop header or target block number
+      };
+
+      std::vector<Scope> all_scopes;
+
+      // Loop scopes: open at header, close before the first block after the loop body
+      for (const auto& [header, sources] : recursions) {
+        if (!block_pos.contains(header)) continue;
+        int header_pos = block_pos[header];
+
+        // Find the last body block position
+        int last_body_pos = header_pos;
+        if (loop_bodies.contains(header)) {
+          for (int bb : loop_bodies.at(header)) {
+            if (block_pos.contains(bb)) {
+              last_body_pos = (std::max)(last_body_pos, block_pos[bb]);
+            }
+          }
+        }
+        for (int src : sources) {
+          if (block_pos.contains(src)) {
+            last_body_pos = (std::max)(last_body_pos, block_pos[src]);
+          }
+        }
+
+        all_scopes.push_back({Scope::LOOP, header_pos, last_body_pos + 1, header});
+      }
+
+      // Block scopes: open at earliest source, close before the target block
+      std::set<int> block_scope_targets;
+      for (const auto& [blk, succ_set] : succs_fwd) {
+        if (!block_pos.contains(blk)) continue;
+        int src_pos = block_pos[blk];
+        for (int dst : succ_set) {
+          if (!block_pos.contains(dst)) continue;
+          int dst_pos = block_pos[dst];
+          if (dst_pos > src_pos + 1) {
+            block_scope_targets.insert(dst);
+          }
+        }
+      }
+
+      for (int target : block_scope_targets) {
+        if (!block_pos.contains(target)) continue;
+        int target_pos = block_pos[target];
+
+        // Find the earliest source that jumps to this target
+        int earliest_src_pos = target_pos;
+        for (const auto& [blk, succ_set] : succs_fwd) {
+          if (succ_set.contains(target) && block_pos.contains(blk)) {
+            earliest_src_pos = (std::min)(earliest_src_pos, block_pos[blk]);
+          }
+        }
+
+        // The scope must open OUTSIDE any loop scope that doesn't contain the target.
+        // For now, just open at the earliest source position.
+        all_scopes.push_back({Scope::BLOCK, earliest_src_pos, target_pos, target});
+      }
+
+      // Sort scopes: outer scopes first (wider range), then by open position
+      std::ranges::sort(all_scopes, [](const Scope& a, const Scope& b) {
+        int a_range = a.close_before - a.open_pos;
+        int b_range = b.close_before - b.open_pos;
+        if (a.open_pos != b.open_pos) return a.open_pos < b.open_pos;
+        return a_range > b_range;  // wider scope first (opens first)
+      });
+
+      // Build open/close event lists per position
+      // Opens happen BEFORE the block at that position
+      // Closes happen BEFORE the block at close_before position
+      std::map<int, std::vector<int>> opens_at;   // pos -> indices into all_scopes
+      std::map<int, std::vector<int>> closes_at;  // pos -> indices into all_scopes
+      for (int i = 0; i < static_cast<int>(all_scopes.size()); ++i) {
+        opens_at[all_scopes[i].open_pos].push_back(i);
+        closes_at[all_scopes[i].close_before].push_back(i);
+      }
+
+      // Track active scopes as a stack for proper nesting
+      std::vector<int> scope_stack;  // indices into all_scopes
+      std::vector<int> active_loops;
+
+      // Pre-scan: hoist heap resource declarations to function scope.
+      // Heap resources (ResourceDescriptorHeap[...]) are declared inside specific blocks
+      // but may be used in blocks outside that scope. Hoist them to function scope.
+      {
+        static const std::regex heap_decl_re(R"(^(ByteAddressBuffer|RWByteAddressBuffer|Texture2D<[^>]+>|Texture3D<[^>]+>|TextureCube<[^>]+>|RaytracingAccelerationStructure)\s+(_HeapResource_\d+)\s*=\s*ResourceDescriptorHeap)");
+        std::set<std::string> hoisted_heap_vars;
+        for (const auto& [blk_num, cb] : current_code_function->code_blocks) {
+          for (const auto& line : cb.hlsl_lines) {
+            std::smatch m;
+            if (std::regex_search(line, m, heap_decl_re)) {
+              std::string var_name = m[2].str();
+              if (!hoisted_heap_vars.contains(var_name)) {
+                // Emit the full declaration at function scope
+                string_stream << spacing << line << "\n";
+                hoisted_heap_vars.insert(var_name);
+              }
+            }
+          }
+        }
+      }
+
+      // ===== EMIT BLOCKS (Recursive with if/else nesting) =====
+      // Instead of linear emission with do{}while(false) + break,
+      // recursively nest blocks inside their parent's if/else branches.
+      // A block with a single forward predecessor is nested inline.
+      // This produces native if/else without break statements.
+
+      std::set<int> emitted_blocks;
+
+      // Check if a block is a back-edge target (loop continue)
+      auto is_back_edge = [&](int src, int dst) -> bool {
+        for (const auto& [header, sources] : recursions) {
+          if (dst == header && sources.contains(src)) return true;
+        }
+        return false;
+      };
+
+      // Compute the immediate post-dominator (convergence point) for a block
+      auto get_ipdom = [&](int blk) -> int {
+        if (ipdom.contains(blk)) return ipdom.at(blk);
+        return -1;
+      };
+
+      // Emit a single block's HLSL lines (no control flow)
+      auto emit_block_body = [&](int blk) {
+        auto& cb = current_code_function->code_blocks[blk];
+        // Phi declarations
+        for (const auto& [variable, type, value, predecessor, code_function, is_assign] : cb.phi_lines) {
+          if (is_assign) continue;
+          auto var_name = std::format("_{}", variable);
+          if (declared_vars.contains(var_name)) continue;
+          string_stream << spacing << ParseType(type) << " " << var_name << ";\n";
+        }
+        // HLSL lines
+        for (const auto& hlsl_line : cb.hlsl_lines) {
+          if (hlsl_line.find("ResourceDescriptorHeap") != std::string::npos
+              && hlsl_line.find("_HeapResource_") != std::string::npos) {
+            continue;
+          }
+          std::string final_line = hlsl_line;
+          static const std::regex decl_re(R"(^(float4|float3|float2|float|int64_t|uint64_t|int16_t|uint16_t|int|uint|bool|uint4|int4|int2|uint2|int3|uint3|double|half|min16float|min16int|min16uint)\s+(_\d+)\s*=)");
+          static const std::regex decl_noassign_re(R"(^(float4|float3|float2|float|int64_t|uint64_t|int16_t|uint16_t|int|uint|bool|uint4|int4|int2|uint2|int3|uint3|double|half|min16float|min16int|min16uint)\s+(_\d+)\s*;)");
+          std::smatch m;
+          if (std::regex_search(final_line, m, decl_re)) {
+            std::string var_name = m[2].str();
+            if (declared_vars.contains(var_name)) {
+              final_line = var_name + " =" + m.suffix().str();
+            }
+          } else if (std::regex_search(final_line, m, decl_noassign_re)) {
+            std::string var_name = m[2].str();
+            if (declared_vars.contains(var_name)) {
+              // Strip "type _N;" and emit only the remainder (e.g., GetDimensions call)
+              std::string remainder = m.suffix().str();
+              size_t start = remainder.find_first_not_of(" \t");
+              if (start != std::string::npos) {
+                final_line = remainder.substr(start);
+              } else {
+                continue;  // Nothing left after stripping — skip entirely
+              }
+            }
+          }
+          string_stream << spacing << final_line << "\n";
+        }
+      };
+
+      // Pre-initialize phi variables for a convergence block.
+      // Before an if/else with convergence, emit default values for all phi variables
+      // of the convergence block. This ensures variables are always defined on all paths,
+      // preventing DXC from eliminating code as undefined behavior.
+      auto emit_phi_pre_init = [&](int convergence_blk, int from_blk) {
+        if (convergence_blk < 0 || from_blk < 0) return;
+        if (!current_code_function->code_blocks.contains(from_blk)) return;
+        auto& from_cb = current_code_function->code_blocks[from_blk];
+        auto phi_defaults = current_code_function->ComputePhiAssignments(&from_cb, convergence_blk);
+        for (const auto& pl : phi_defaults) {
+          string_stream << spacing << pl << "\n";
+        }
+      };
+
+      // Compute immediate dominators for branch exclusivity analysis
+      auto idom = current_code_function->ComputeDominators();
+
+      // Phi selector state: when phi_sel_var is non-empty, emit_region
+      // sets a selector variable instead of emitting phi assignments when
+      // reaching stop_at. This creates multi-way convergence via switch,
+      // preserving 3+ input phi structure that prevents optimizer exploitation.
+      std::string phi_sel_var;
+      int phi_sel_next_value = 0;
+      std::map<int, int> phi_sel_pred_map;  // selector_value -> predecessor_block
+      int phi_sel_counter = 0;
+      int phi_sel_convergence = -1;  // The convergence block this phi_sel targets
+
+      // Helper: emit phi_sel assignment instead of phi assignments
+      auto emit_phi_sel_assign = [&](int pred_block) {
+        int val = phi_sel_next_value++;
+        phi_sel_pred_map[val] = pred_block;
+        string_stream << spacing << phi_sel_var << " = " << val << "u;\n";
+      };
+
+      // Count unique phi predecessors for a convergence block
+      auto count_phi_predecessors = [&](int convergence_blk) -> int {
+        std::set<int> preds;
+        for (const auto& [cb_num, cb] : current_code_function->code_blocks) {
+          for (const auto& [variable, type, value, predecessor, code_function, is_assign] : cb.phi_lines) {
+            if (code_function == convergence_blk && is_assign) {
+              preds.insert(cb_num);
+            }
+          }
+        }
+        return static_cast<int>(preds.size());
+      };
+
+      // Compute blocks reachable from `start` up to (not including) `stop_at`,
+      // following only forward edges (back edges already removed from succs_fwd).
+      auto reachable_from = [&](int start, int stop_at) -> std::set<int> {
+        std::set<int> visited;
+        std::deque<int> queue;
+        queue.push_back(start);
+        while (!queue.empty()) {
+          int b = queue.front();
+          queue.pop_front();
+          if (b == stop_at || visited.contains(b)) continue;
+          if (!current_code_function->code_blocks.contains(b)) continue;
+          visited.insert(b);
+          if (succs_fwd.contains(b)) {
+            for (int s : succs_fwd.at(b)) {
+              queue.push_back(s);
+            }
+          }
+        }
+        return visited;
+      };
+
+      // Compute shared blocks between two branches up to a convergence point.
+      // Returns blocks reachable from BOTH branch targets that are not
+      // exclusively dominated by either target.
+      auto compute_shared_blocks = [&](int true_target, int false_target, int convergence) -> std::set<int> {
+        if (convergence < 0) return {};
+        if (true_target == convergence || false_target == convergence) return {};
+        auto true_reach = reachable_from(true_target, convergence);
+        auto false_reach = reachable_from(false_target, convergence);
+        std::set<int> shared;
+        for (int b : true_reach) {
+          if (false_reach.contains(b)) {
+            shared.insert(b);
+          }
+        }
+        return shared;
+      };
+
+      // Check if a region from `start` to `stop_at` contains any back-edges
+      // (blocks that branch back to a loop header). If so, wrapping in
+      // do{}while(false) would intercept `continue` statements.
+      auto region_has_back_edges = [&](int start, int stop_at) -> bool {
+        auto reach = reachable_from(start, stop_at);
+        for (int b : reach) {
+          if (!current_code_function->code_blocks.contains(b)) continue;
+          auto& cb = current_code_function->code_blocks[b];
+          for (int target : {cb.code_branch.branch_condition_true, cb.code_branch.branch_condition_false}) {
+            if (target <= 0) continue;
+            if (is_back_edge(b, target)) return true;
+          }
+        }
+        return false;
+      };
+
+      // When true, convergence wrapping uses boolean flags instead of do-while
+      // to avoid intercepting continue/break from inner loops.
+      bool suppress_dowhile = false;
+      // Prevent nested deferred convergence flags (which cause exponential growth)
+      bool inside_deferred_conv = false;
+
+      // Deferred latch: when set, emit_region will set a flag instead of
+      // emitting this block, deferring it to the loop body level.
+      int deferred_latch_block = -1;
+      std::string deferred_latch_flag_name;
+
+      // Track do-while nesting depth for continue/break propagation.
+      // When inside a do-while scope within a loop, `continue` targets the
+      // do-while instead of the enclosing while(true). We use a flag to
+      // propagate the continue through the do-while scope.
+      int stackify_dowhile_depth = 0;
+      int stackify_loop_continue_counter = 0;
+      // Stack of (continue_flag_name, break_flag_name) for nested loops
+      std::vector<std::pair<std::string, std::string>> stackify_loop_flags;
+
+      // Recursive block emission.
+      std::function<void(int blk, int stop_at, bool in_loop, int loop_exit_blk)> emit_region;
+
+      // Helper: emit a `continue` statement. If inside a do-while scope,
+      // use flag-based propagation to escape the do-while first.
+      auto emit_continue = [&]() {
+        if (stackify_dowhile_depth > 0 && !stackify_loop_flags.empty()) {
+          auto& [cf, bf] = stackify_loop_flags.back();
+          string_stream << spacing << cf << " = true;\n";
+          string_stream << spacing << "break;\n";
+        } else {
+          string_stream << spacing << "continue;\n";
+        }
+      };
+
+      auto emit_loop_break = [&]() {
+        // break always targets the innermost loop/do-while scope.
+        // Inside a do-while, break exits the do-while (correct behavior).
+        // We don't need flag propagation for break.
+        string_stream << spacing << "break;\n";
+      };
+
+      auto open_dowhile = [&]() {
+        string_stream << spacing << "do {\n";
+        indent_spacing();
+        stackify_dowhile_depth++;
+      };
+
+      auto close_dowhile = [&]() {
+        stackify_dowhile_depth--;
+        unindent_spacing();
+        string_stream << spacing << "} while(false);\n";
+        // Only emit flag checks if we're back at loop body level
+        // and the do-while actually contained back-edges or loop exits
+        // (indicated by stackify_dowhile_depth returning to 0)
+        // Note: we always emit the checks because we can't easily track
+        // whether flags were set inside the do-while. The flags are
+        // initialized to false, so the checks are no-ops when not set.
+        if (stackify_dowhile_depth == 0 && !stackify_loop_flags.empty()) {
+          auto& [cf, bf] = stackify_loop_flags.back();
+          string_stream << spacing << "if (" << cf << ") { " << cf << " = false; continue; }\n";
+        }
+      };
+
+      emit_region = [&](int blk, int stop_at, bool in_loop, int loop_exit_blk) {
+        while (blk >= 0 && blk != stop_at) {
+          if (emitted_blocks.contains(blk)) {
+            // When phi_sel is active, re-emit the chain from this block to
+            // the convergence. This ensures the correct selector is set even
+            // when blocks are shared between branches.
+            if (!phi_sel_var.empty() && phi_sel_convergence >= 0) {
+              // Collect blocks reachable from blk to convergence
+              std::set<int> to_reemit;
+              std::deque<int> rq;
+              rq.push_back(blk);
+              while (!rq.empty()) {
+                int u = rq.front(); rq.pop_front();
+                if (u == phi_sel_convergence || to_reemit.contains(u)) continue;
+                if (!current_code_function->code_blocks.contains(u)) continue;
+                to_reemit.insert(u);
+                auto& ucb = current_code_function->code_blocks[u];
+                if (ucb.code_branch.branch_condition_true > 0) rq.push_back(ucb.code_branch.branch_condition_true);
+                if (ucb.code_branch.branch_condition_false > 0) rq.push_back(ucb.code_branch.branch_condition_false);
+              }
+              // Temporarily un-mark these blocks
+              for (int u : to_reemit) emitted_blocks.erase(u);
+              // Re-emit — this will process the chain and set phi_sel correctly
+              emit_region(blk, stop_at, in_loop, loop_exit_blk);
+              // Re-mark all blocks
+              for (int u : to_reemit) emitted_blocks.insert(u);
+              return;
+            }
+            return;
+          }
+          if (!current_code_function->code_blocks.contains(blk)) return;
+          // Check if this is the deferred latch block
+          if (blk == deferred_latch_block && deferred_latch_block >= 0) {
+            // Set the flag instead of emitting the block
+            string_stream << spacing << deferred_latch_flag_name << " = true;\n";
+            // Don't mark as emitted — it will be emitted later at loop body level
+            return;
+          }
+          emitted_blocks.insert(blk);
+
+          auto& cb = current_code_function->code_blocks[blk];
+
+          // Check if this is a loop header
+          bool is_loop = recursions.contains(blk);
+          int loop_exit = -1;
+          if (is_loop) {
+            // Find the loop exit block (ipdom of the loop, or the block after the loop body)
+            loop_exit = get_ipdom(blk);
+            // If ipdom is inside the loop body, look for the exit differently
+            if (loop_bodies.contains(blk) && loop_exit >= 0) {
+              const auto& body = loop_bodies.at(blk);
+              if (body.contains(loop_exit)) {
+                // ipdom is inside the loop — find the actual exit
+                // Strategy 1: ipdom of the latch block
+                bool found_exit = false;
+                for (int src : recursions.at(blk)) {
+                  int latch_ipdom = get_ipdom(src);
+                  if (latch_ipdom >= 0 && !body.contains(latch_ipdom)) {
+                    loop_exit = latch_ipdom;
+                    found_exit = true;
+                    break;
+                  }
+                }
+                // Strategy 2: find the unique exit target from loop body blocks.
+                // Only use if there's exactly one exit target (unambiguous).
+                if (!found_exit) {
+                  std::set<int> exit_targets;
+                  for (int bb : body) {
+                    if (!current_code_function->code_blocks.contains(bb)) continue;
+                    auto& bcb = current_code_function->code_blocks[bb];
+                    for (int target : {bcb.code_branch.branch_condition_true, bcb.code_branch.branch_condition_false}) {
+                      if (target > 0 && !body.contains(target) && !is_back_edge(bb, target)) {
+                        exit_targets.insert(target);
+                      }
+                    }
+                  }
+                  if (exit_targets.size() == 1) {
+                    loop_exit = *exit_targets.begin();
+                  }
+                }
+              }
+            }
+
+            auto loop_flag_id = stackify_loop_continue_counter++;
+            auto loop_continue_flag = std::format("__loop_continue_{}", loop_flag_id);
+            auto loop_break_flag = std::format("__loop_break_{}", loop_flag_id);
+            string_stream << spacing << "bool " << loop_continue_flag << " = false;\n";
+            string_stream << spacing << "bool " << loop_break_flag << " = false;\n";
+            stackify_loop_flags.push_back({loop_continue_flag, loop_break_flag});
+            string_stream << spacing << "while(true) {\n";
+            indent_spacing();
+            // Emit the header block's body inside the loop
+            emit_block_body(blk);
+            // Now handle the header's branches — they're the loop body
+            // The header is already marked as emitted, so recursive calls won't re-enter it
+            auto& loop_cb = current_code_function->code_blocks[blk];
+            if (!loop_cb.code_branch.branch_condition.empty()) {
+              int lt = loop_cb.code_branch.branch_condition_true;
+              int lf = loop_cb.code_branch.branch_condition_false;
+              auto lcond = loop_cb.code_branch.branch_condition;
+              auto lt_phis = current_code_function->ComputePhiAssignments(&loop_cb, lt);
+              auto lf_phis = current_code_function->ComputePhiAssignments(&loop_cb, lf);
+              bool lt_back = is_back_edge(blk, lt);
+              bool lf_back = is_back_edge(blk, lf);
+              bool lt_exit = (lt == loop_exit);
+              bool lf_exit = (lf == loop_exit);
+              int loop_convergence = get_ipdom(blk);
+              // If convergence is outside the loop, use loop_exit as convergence
+              if (loop_bodies.contains(blk) && loop_convergence >= 0 && !loop_bodies.at(blk).contains(loop_convergence)) {
+                loop_convergence = loop_exit;
+              }
+
+              if (lt_back && lf_back) {
+                for (const auto& pl : lt_phis) string_stream << spacing << pl << "\n";
+                string_stream << spacing << "continue;\n";
+              } else if (lt_exit && lf_exit) {
+                for (const auto& pl : lt_phis) string_stream << spacing << pl << "\n";
+                string_stream << spacing << "break;\n";
+              } else if (lt_back) {
+                string_stream << spacing << "if (" << lcond << ") {\n";
+                indent_spacing();
+                for (const auto& pl : lt_phis) string_stream << spacing << pl << "\n";
+                string_stream << spacing << "continue;\n";
+                unindent_spacing();
+                string_stream << spacing << "}\n";
+                for (const auto& pl : lf_phis) string_stream << spacing << pl << "\n";
+                emit_region(lf, loop_exit, true, loop_exit);
+              } else if (lf_back) {
+                string_stream << spacing << "if (!(" << lcond << ")) {\n";
+                indent_spacing();
+                for (const auto& pl : lf_phis) string_stream << spacing << pl << "\n";
+                string_stream << spacing << "continue;\n";
+                unindent_spacing();
+                string_stream << spacing << "}\n";
+                for (const auto& pl : lt_phis) string_stream << spacing << pl << "\n";
+                emit_region(lt, loop_exit, true, loop_exit);
+              } else if (lt_exit) {
+                string_stream << spacing << "if (" << lcond << ") {\n";
+                indent_spacing();
+                for (const auto& pl : lt_phis) string_stream << spacing << pl << "\n";
+                string_stream << spacing << "break;\n";
+                unindent_spacing();
+                string_stream << spacing << "}\n";
+                for (const auto& pl : lf_phis) string_stream << spacing << pl << "\n";
+                emit_region(lf, loop_exit, true, loop_exit);
+              } else if (lf_exit) {
+                string_stream << spacing << "if (!(" << lcond << ")) {\n";
+                indent_spacing();
+                for (const auto& pl : lf_phis) string_stream << spacing << pl << "\n";
+                string_stream << spacing << "break;\n";
+                unindent_spacing();
+                string_stream << spacing << "}\n";
+                for (const auto& pl : lt_phis) string_stream << spacing << pl << "\n";
+                emit_region(lt, loop_exit, true, loop_exit);
+              } else if (loop_convergence >= 0 && lt == loop_convergence) {
+                for (const auto& pl : lt_phis) string_stream << spacing << pl << "\n";
+                emit_phi_pre_init(loop_convergence, blk);
+                open_dowhile();
+                string_stream << spacing << "if (!(" << lcond << ")) {\n";
+                indent_spacing();
+                for (const auto& pl : lf_phis) string_stream << spacing << pl << "\n";
+                emit_region(lf, loop_convergence, true, loop_exit);
+                unindent_spacing();
+                string_stream << spacing << "}\n";
+                close_dowhile();
+                emit_region(loop_convergence, loop_exit, true, loop_exit);
+              } else if (loop_convergence >= 0 && lf == loop_convergence) {
+                for (const auto& pl : lf_phis) string_stream << spacing << pl << "\n";
+                emit_phi_pre_init(loop_convergence, blk);
+                open_dowhile();
+                string_stream << spacing << "if (" << lcond << ") {\n";
+                indent_spacing();
+                for (const auto& pl : lt_phis) string_stream << spacing << pl << "\n";
+                emit_region(lt, loop_convergence, true, loop_exit);
+                unindent_spacing();
+                string_stream << spacing << "}\n";
+                close_dowhile();
+                emit_region(loop_convergence, loop_exit, true, loop_exit);
+              } else if (loop_convergence >= 0) {
+                // Both branches diverge inside loop
+                emit_phi_pre_init(loop_convergence, lt);
+                // Find multi-predecessor blocks that lead to the back-edge source.
+                // These are convergence points that should be deferred to the
+                // loop body level to avoid do-while scope interception.
+                // Only apply when the back-edge source is also a direct branch
+                // target of the loop header (meaning it's shared between branches).
+                int back_edge_src = -1;
+                for (int src : recursions.at(blk)) {
+                  back_edge_src = src;
+                }
+                int latch_conv = -1;
+                if (back_edge_src >= 0 && (back_edge_src == lt || back_edge_src == lf)) {
+                  // The back-edge source is a direct target of the loop header.
+                  // Find blocks that unconditionally branch to it and have
+                  // multiple predecessors (convergence points).
+                  auto pm = current_code_function->ComputePredecessors();
+                  for (const auto& [pb, pi] : current_code_function->code_blocks) {
+                    if (pi.code_branch.branch_condition.empty() &&
+                        pi.code_branch.branch_condition_true == back_edge_src &&
+                        pb != blk && pm.contains(pb) && pm.at(pb).size() > 1) {
+                      latch_conv = pb;
+                      break;
+                    }
+                  }
+                }
+                // Set up deferred latch if found
+                int saved_deferred = deferred_latch_block;
+                std::string saved_flag = deferred_latch_flag_name;
+                if (latch_conv >= 0) {
+                  deferred_latch_block = latch_conv;
+                  deferred_latch_flag_name = std::format("__defer_latch_{}", blk);
+                  string_stream << spacing << "bool " << deferred_latch_flag_name << " = false;\n";
+                }
+                open_dowhile();
+                string_stream << spacing << "if (" << lcond << ") {\n";
+                indent_spacing();
+                for (const auto& pl : lt_phis) string_stream << spacing << pl << "\n";
+                emit_region(lt, loop_convergence, true, loop_exit);
+                unindent_spacing();
+                string_stream << spacing << "} else {\n";
+                indent_spacing();
+                for (const auto& pl : lf_phis) string_stream << spacing << pl << "\n";
+                emit_region(lf, loop_convergence, true, loop_exit);
+                unindent_spacing();
+                string_stream << spacing << "}\n";
+                close_dowhile();
+                // Emit deferred latch at loop body level
+                if (latch_conv >= 0) {
+                  deferred_latch_block = saved_deferred;
+                  deferred_latch_flag_name = saved_flag;
+                  string_stream << spacing << "if (" << std::format("__defer_latch_{}", blk) << ") {\n";
+                  indent_spacing();
+                  emit_region(latch_conv, loop_exit, true, loop_exit);
+                  // The deferred latch block may branch to an already-emitted
+                  // back-edge source block. Re-emit that block's body so the
+                  // Proceed() call and continue/break are not lost.
+                  if (current_code_function->code_blocks.contains(latch_conv)) {
+                    auto& latch_cb = current_code_function->code_blocks[latch_conv];
+                    int latch_next = latch_cb.code_branch.branch_condition_true;
+                    if (latch_next > 0 && latch_cb.code_branch.branch_condition.empty()
+                        && emitted_blocks.contains(latch_next)
+                        && current_code_function->code_blocks.contains(latch_next)) {
+                      // Re-emit the back-edge source block
+                      auto& be_cb = current_code_function->code_blocks[latch_next];
+                      // Emit phi assignments from latch to back-edge source
+                      auto be_phis = current_code_function->ComputePhiAssignments(&latch_cb, latch_next);
+                      for (const auto& pl : be_phis) string_stream << spacing << pl << "\n";
+                      // Emit the block body
+                      emit_block_body(latch_next);
+                      // Handle the branch (should be continue or conditional continue/break)
+                      if (!be_cb.code_branch.branch_condition.empty()) {
+                        int be_bt = be_cb.code_branch.branch_condition_true;
+                        int be_bf = be_cb.code_branch.branch_condition_false;
+                        auto be_cond = be_cb.code_branch.branch_condition;
+                        bool be_bt_back = is_back_edge(latch_next, be_bt);
+                        bool be_bf_back = is_back_edge(latch_next, be_bf);
+                        auto be_bt_phis = current_code_function->ComputePhiAssignments(&be_cb, be_bt);
+                        auto be_bf_phis = current_code_function->ComputePhiAssignments(&be_cb, be_bf);
+                        if (be_bt_back) {
+                          string_stream << spacing << "if (" << be_cond << ") {\n";
+                          indent_spacing();
+                          for (const auto& pl : be_bt_phis) string_stream << spacing << pl << "\n";
+                          string_stream << spacing << "continue;\n";
+                          unindent_spacing();
+                          string_stream << spacing << "}\n";
+                          for (const auto& pl : be_bf_phis) string_stream << spacing << pl << "\n";
+                        } else if (be_bf_back) {
+                          string_stream << spacing << "if (!(" << be_cond << ")) {\n";
+                          indent_spacing();
+                          for (const auto& pl : be_bf_phis) string_stream << spacing << pl << "\n";
+                          string_stream << spacing << "continue;\n";
+                          unindent_spacing();
+                          string_stream << spacing << "}\n";
+                          for (const auto& pl : be_bt_phis) string_stream << spacing << pl << "\n";
+                        }
+                      } else if (be_cb.code_branch.branch_condition_true > 0) {
+                        int be_target = be_cb.code_branch.branch_condition_true;
+                        auto be_phis2 = current_code_function->ComputePhiAssignments(&be_cb, be_target);
+                        for (const auto& pl : be_phis2) string_stream << spacing << pl << "\n";
+                        if (is_back_edge(latch_next, be_target)) {
+                          string_stream << spacing << "continue;\n";
+                        }
+                      }
+                    }
+                  }
+                  unindent_spacing();
+                  string_stream << spacing << "}\n";
+                } else {
+                  deferred_latch_block = saved_deferred;
+                  deferred_latch_flag_name = saved_flag;
+                }
+                emit_region(loop_convergence, loop_exit, true, loop_exit);
+              } else {
+                // No convergence inside loop — emit if/else
+                string_stream << spacing << "if (" << lcond << ") {\n";
+                indent_spacing();
+                for (const auto& pl : lt_phis) string_stream << spacing << pl << "\n";
+                emit_region(lt, loop_exit, true, loop_exit);
+                unindent_spacing();
+                string_stream << spacing << "} else {\n";
+                indent_spacing();
+                for (const auto& pl : lf_phis) string_stream << spacing << pl << "\n";
+                emit_region(lf, loop_exit, true, loop_exit);
+                unindent_spacing();
+                string_stream << spacing << "}\n";
+              }
+            } else if (loop_cb.code_branch.branch_condition_true > 0) {
+              int target = loop_cb.code_branch.branch_condition_true;
+              auto phi_lines = current_code_function->ComputePhiAssignments(&loop_cb, target);
+              for (const auto& pl : phi_lines) string_stream << spacing << pl << "\n";
+              if (is_back_edge(blk, target)) {
+                string_stream << spacing << "continue;\n";
+              } else if (target == loop_exit) {
+                string_stream << spacing << "break;\n";
+              } else {
+                emit_region(target, loop_exit, true, loop_exit);
+              }
+            }
+            unindent_spacing();
+            string_stream << spacing << "}\n";
+            if (!stackify_loop_flags.empty()) stackify_loop_flags.pop_back();
+            // Continue with the exit block
+            blk = loop_exit;
+            continue;
+          }
+
+          emit_block_body(blk);
+
+          // Handle switch
+          if (!cb.code_switch.switch_condition.empty()) {
+            string_stream << spacing << "switch (" << cb.code_switch.switch_condition << ") {\n";
+            indent_spacing();
+            int switch_ipdom = get_ipdom(blk);
+            for (const auto& [case_value, case_target] : cb.code_switch.case_values) {
+              string_stream << spacing << "case " << case_value << ": {\n";
+              indent_spacing();
+              auto phi_lines = current_code_function->ComputePhiAssignments(&cb, case_target);
+              for (const auto& pl : phi_lines) string_stream << spacing << pl << "\n";
+              if (case_target != switch_ipdom && !emitted_blocks.contains(case_target)) {
+                emit_region(case_target, switch_ipdom, false, -1);
+              }
+              string_stream << spacing << "break;\n";
+              unindent_spacing();
+              string_stream << spacing << "}\n";
+            }
+            string_stream << spacing << "default: {\n";
+            indent_spacing();
+            auto default_phis = current_code_function->ComputePhiAssignments(&cb, cb.code_switch.case_default);
+            for (const auto& pl : default_phis) string_stream << spacing << pl << "\n";
+            if (cb.code_switch.case_default != switch_ipdom && !emitted_blocks.contains(cb.code_switch.case_default)) {
+              emit_region(cb.code_switch.case_default, switch_ipdom, false, -1);
+            }
+            string_stream << spacing << "break;\n";
+            unindent_spacing();
+            string_stream << spacing << "}\n";
+            unindent_spacing();
+            string_stream << spacing << "}\n";
+            // Continue with the convergence point
+            blk = switch_ipdom;
+            continue;
+          }
+
+          // Handle conditional branch
+          if (!cb.code_branch.branch_condition.empty()) {
+            int true_target = cb.code_branch.branch_condition_true;
+            int false_target = cb.code_branch.branch_condition_false;
+            auto cond = cb.code_branch.branch_condition;
+            int convergence = get_ipdom(blk);
+
+            // Emit phi assignments as part of the branch
+            auto true_phis = current_code_function->ComputePhiAssignments(&cb, true_target);
+            auto false_phis = current_code_function->ComputePhiAssignments(&cb, false_target);
+
+            bool true_is_back = is_back_edge(blk, true_target);
+            bool false_is_back = is_back_edge(blk, false_target);
+            bool true_is_exit = (true_target == stop_at) || (in_loop && true_target == loop_exit_blk);
+            bool false_is_exit = (false_target == stop_at) || (in_loop && false_target == loop_exit_blk);
+            // Distinguish between do-while exit (stop_at) and loop exit (loop_exit_blk)
+            // Only use flag-based break for actual loop exits, not do-while exits
+            // When stop_at == loop_exit_blk, the target is a convergence exit, not a loop exit
+            bool true_is_loop_exit = (in_loop && true_target == loop_exit_blk && true_target != stop_at);
+            bool false_is_loop_exit = (in_loop && false_target == loop_exit_blk && false_target != stop_at);
+
+            if (true_is_exit && false_is_exit) {
+              for (const auto& pl : true_phis) string_stream << spacing << pl << "\n";
+              if (true_is_loop_exit || false_is_loop_exit) emit_loop_break();
+              else if (in_loop) string_stream << spacing << "break;\n";
+              return;
+            } else if (true_is_back && false_is_exit) {
+              string_stream << spacing << "if (" << cond << ") {\n";
+              indent_spacing();
+              for (const auto& pl : true_phis) string_stream << spacing << pl << "\n";
+              emit_continue();
+              unindent_spacing();
+              string_stream << spacing << "}\n";
+              for (const auto& pl : false_phis) string_stream << spacing << pl << "\n";
+              if (false_is_loop_exit) emit_loop_break();
+              else if (in_loop) string_stream << spacing << "break;\n";
+              return;
+            } else if (false_is_back && true_is_exit) {
+              string_stream << spacing << "if (!(" << cond << ")) {\n";
+              indent_spacing();
+              for (const auto& pl : false_phis) string_stream << spacing << pl << "\n";
+              emit_continue();
+              unindent_spacing();
+              string_stream << spacing << "}\n";
+              for (const auto& pl : true_phis) string_stream << spacing << pl << "\n";
+              if (true_is_loop_exit) emit_loop_break();
+              else if (in_loop) string_stream << spacing << "break;\n";
+              return;
+            } else if (true_is_back && false_is_back) {
+              for (const auto& pl : true_phis) string_stream << spacing << pl << "\n";
+              if (in_loop) emit_continue();
+              return;
+            } else if (true_is_back) {
+              string_stream << spacing << "if (" << cond << ") {\n";
+              indent_spacing();
+              for (const auto& pl : true_phis) string_stream << spacing << pl << "\n";
+              if (in_loop) emit_continue();
+              unindent_spacing();
+              string_stream << spacing << "}\n";
+              for (const auto& pl : false_phis) string_stream << spacing << pl << "\n";
+              blk = false_target;
+              continue;
+            } else if (false_is_back) {
+              // False branch is continue, true branch continues forward
+              string_stream << spacing << "if (!(" << cond << ")) {\n";
+              indent_spacing();
+              for (const auto& pl : false_phis) string_stream << spacing << pl << "\n";
+              if (in_loop) emit_continue();
+              unindent_spacing();
+              string_stream << spacing << "}\n";
+              for (const auto& pl : true_phis) string_stream << spacing << pl << "\n";
+              blk = true_target;
+              continue;
+            } else if (true_is_exit) {
+              // Phi selector mode: set selector for the exit path
+              if (!phi_sel_var.empty() && true_target == phi_sel_convergence) {
+                string_stream << spacing << "if (" << cond << ") {\n";
+                indent_spacing();
+                emit_phi_sel_assign(blk);
+                string_stream << spacing << "break;\n";
+                unindent_spacing();
+                string_stream << spacing << "}\n";
+                for (const auto& pl : false_phis) string_stream << spacing << pl << "\n";
+                blk = false_target;
+                continue;
+              }
+              // Emit BOTH true_phis and false_phis as defaults.
+              for (const auto& pl : false_phis) string_stream << spacing << pl << "\n";
+              for (const auto& pl : true_phis) string_stream << spacing << pl << "\n";
+              string_stream << spacing << "if (" << cond << ") {\n";
+              indent_spacing();
+              if (true_is_loop_exit) emit_loop_break();
+              else if (in_loop) string_stream << spacing << "break;\n";
+              unindent_spacing();
+              string_stream << spacing << "}\n";
+              blk = false_target;
+              continue;
+            } else if (false_is_exit) {
+              // Phi selector mode: set selector for the exit path
+              if (!phi_sel_var.empty() && false_target == phi_sel_convergence) {
+                string_stream << spacing << "if (!(" << cond << ")) {\n";
+                indent_spacing();
+                emit_phi_sel_assign(blk);
+                string_stream << spacing << "break;\n";
+                unindent_spacing();
+                string_stream << spacing << "}\n";
+                for (const auto& pl : true_phis) string_stream << spacing << pl << "\n";
+                blk = true_target;
+                continue;
+              }
+              for (const auto& pl : false_phis) string_stream << spacing << pl << "\n";
+              string_stream << spacing << "if (!(" << cond << ")) {\n";
+              indent_spacing();
+              if (false_is_loop_exit) emit_loop_break();
+              else if (in_loop) string_stream << spacing << "break;\n";
+              unindent_spacing();
+              string_stream << spacing << "}\n";
+              for (const auto& pl : true_phis) string_stream << spacing << pl << "\n";
+              blk = true_target;
+              continue;
+            } else if (true_target == convergence) {
+              // Check if convergence has 3+ phi predecessors — use phi_sel
+              int conv_preds = count_phi_predecessors(convergence);
+              if (conv_preds >= 3 && phi_sel_var.empty() && !in_loop) {
+                // Enable phi_sel mode for the false branch
+                auto sel_name = std::format("__phi_sel_{}", phi_sel_counter++);
+                string_stream << spacing << "uint " << sel_name << " = 0u;\n";
+                auto saved_sel = phi_sel_var;
+                auto saved_next = phi_sel_next_value;
+                auto saved_map = phi_sel_pred_map;
+                auto saved_conv = phi_sel_convergence;
+                phi_sel_var = sel_name;
+                phi_sel_convergence = convergence;
+                phi_sel_next_value = 1;  // 0 = true path (blk -> convergence)
+                phi_sel_pred_map.clear();
+                phi_sel_pred_map[0] = blk;  // selector 0 = current block
+                // Emit false branch with phi_sel active
+                string_stream << spacing << "do {\n";
+                indent_spacing();
+                string_stream << spacing << "if (!(" << cond << ")) {\n";
+                indent_spacing();
+                for (const auto& pl : false_phis) string_stream << spacing << pl << "\n";
+                emit_region(false_target, convergence, in_loop, loop_exit_blk);
+                unindent_spacing();
+                string_stream << spacing << "}\n";
+                unindent_spacing();
+                string_stream << spacing << "} while(false);\n";
+                // Collect results
+                auto sel_map = phi_sel_pred_map;
+                phi_sel_var = saved_sel;
+                phi_sel_next_value = saved_next;
+                phi_sel_pred_map = saved_map;
+                phi_sel_convergence = saved_conv;
+                // Emit switch with one case per predecessor
+                string_stream << spacing << "switch (" << sel_name << ") {\n";
+                for (const auto& [sv, pred] : sel_map) {
+                  string_stream << spacing << "case " << sv << "u:\n";
+                  indent_spacing();
+                  if (current_code_function->code_blocks.contains(pred)) {
+                    auto pred_phis = current_code_function->ComputePhiAssignments(
+                        &current_code_function->code_blocks[pred], convergence);
+                    for (const auto& pl : pred_phis) string_stream << spacing << pl << "\n";
+                  }
+                  string_stream << spacing << "break;\n";
+                  unindent_spacing();
+                }
+                string_stream << spacing << "default: break;\n";
+                string_stream << spacing << "}\n";
+                blk = convergence;
+                continue;
+              }
+              for (const auto& pl : true_phis) string_stream << spacing << pl << "\n";
+              emit_phi_pre_init(convergence, blk);
+              bool needs_flags = in_loop && region_has_back_edges(false_target, convergence);
+              if (needs_flags) { open_dowhile(); } else { string_stream << spacing << "do {\n"; indent_spacing(); }
+              string_stream << spacing << "if (!(" << cond << ")) {\n";
+              indent_spacing();
+              for (const auto& pl : false_phis) string_stream << spacing << pl << "\n";
+              emit_region(false_target, convergence, in_loop, loop_exit_blk);
+              unindent_spacing();
+              string_stream << spacing << "}\n";
+              if (needs_flags) { close_dowhile(); } else { unindent_spacing(); string_stream << spacing << "} while(false);\n"; }
+              blk = convergence;
+              continue;
+            } else if (false_target == convergence) {
+              for (const auto& pl : false_phis) string_stream << spacing << pl << "\n";
+              emit_phi_pre_init(convergence, blk);
+              bool has_inner_loop = false;
+              {
+                auto reach = reachable_from(true_target, convergence);
+                for (int b : reach) {
+                  if (recursions.contains(b)) { has_inner_loop = true; break; }
+                }
+              }
+              {
+              bool needs_flags_ft = in_loop && region_has_back_edges(true_target, convergence);
+              if (needs_flags_ft) { open_dowhile(); } else { string_stream << spacing << "do {\n"; indent_spacing(); }
+              string_stream << spacing << "if (" << cond << ") {\n";
+              indent_spacing();
+              for (const auto& pl : true_phis) string_stream << spacing << pl << "\n";
+              emit_region(true_target, convergence, in_loop, loop_exit_blk);
+              unindent_spacing();
+              string_stream << spacing << "}\n";
+              if (needs_flags_ft) { close_dowhile(); } else { unindent_spacing(); string_stream << spacing << "} while(false);\n"; }
+              }
+              blk = convergence;
+              continue;
+            } else if (convergence >= 0) {
+              auto shared = compute_shared_blocks(true_target, false_target, convergence);
+              // Check if convergence has 3+ phi predecessors — use phi_sel
+              int conv_preds_c = count_phi_predecessors(convergence);
+              if (conv_preds_c >= 3 && phi_sel_var.empty() && !in_loop) {
+                auto sel_name = std::format("__phi_sel_{}", phi_sel_counter++);
+                string_stream << spacing << "uint " << sel_name << " = 0u;\n";
+                auto saved_sel = phi_sel_var;
+                auto saved_next = phi_sel_next_value;
+                auto saved_map = phi_sel_pred_map;
+                auto saved_conv_c = phi_sel_convergence;
+                phi_sel_var = sel_name;
+                phi_sel_convergence = convergence;
+                phi_sel_next_value = 0;
+                phi_sel_pred_map.clear();
+                // Emit both branches with phi_sel active
+                string_stream << spacing << "do {\n";
+                indent_spacing();
+                string_stream << spacing << "if (" << cond << ") {\n";
+                indent_spacing();
+                for (const auto& pl : true_phis) string_stream << spacing << pl << "\n";
+                emit_region(true_target, convergence, in_loop, loop_exit_blk);
+                unindent_spacing();
+                string_stream << spacing << "} else {\n";
+                indent_spacing();
+                for (const auto& pl : false_phis) string_stream << spacing << pl << "\n";
+                emit_region(false_target, convergence, in_loop, loop_exit_blk);
+                unindent_spacing();
+                string_stream << spacing << "}\n";
+                unindent_spacing();
+                string_stream << spacing << "} while(false);\n";
+                auto sel_map = phi_sel_pred_map;
+                phi_sel_var = saved_sel;
+                phi_sel_next_value = saved_next;
+                phi_sel_pred_map = saved_map;
+                phi_sel_convergence = saved_conv_c;
+                // Emit switch
+                if (!sel_map.empty()) {
+                  string_stream << spacing << "switch (" << sel_name << ") {\n";
+                  for (const auto& [sv, pred] : sel_map) {
+                    string_stream << spacing << "case " << sv << "u:\n";
+                    indent_spacing();
+                    if (current_code_function->code_blocks.contains(pred)) {
+                      auto pred_phis = current_code_function->ComputePhiAssignments(
+                          &current_code_function->code_blocks[pred], convergence);
+                      for (const auto& pl : pred_phis) string_stream << spacing << pl << "\n";
+                    }
+                    string_stream << spacing << "break;\n";
+                    unindent_spacing();
+                  }
+                  string_stream << spacing << "default: break;\n";
+                  string_stream << spacing << "}\n";
+                }
+                blk = convergence;
+                continue;
+              }
+              emit_phi_pre_init(convergence, true_target);
+              bool use_dw_c = !(in_loop && (
+                  region_has_back_edges(true_target, convergence) ||
+                  region_has_back_edges(false_target, convergence)));
+              if (use_dw_c) {
+                bool needs_flags_c = in_loop && (
+                    region_has_back_edges(true_target, convergence) ||
+                    region_has_back_edges(false_target, convergence));
+                if (needs_flags_c) { open_dowhile(); } else { string_stream << spacing << "do {\n"; indent_spacing(); }
+              }
+              string_stream << spacing << "if (" << cond << ") {\n";
+              indent_spacing();
+              for (const auto& pl : true_phis) string_stream << spacing << pl << "\n";
+              emit_region(true_target, convergence, in_loop, loop_exit_blk);
+              unindent_spacing();
+              string_stream << spacing << "} else {\n";
+              indent_spacing();
+              for (const auto& pl : false_phis) string_stream << spacing << pl << "\n";
+              emit_region(false_target, convergence, in_loop, loop_exit_blk);
+              unindent_spacing();
+              string_stream << spacing << "}\n";
+              if (use_dw_c) {
+                bool needs_flags_c2 = in_loop && (
+                    region_has_back_edges(true_target, convergence) ||
+                    region_has_back_edges(false_target, convergence));
+                if (needs_flags_c2) { close_dowhile(); } else { unindent_spacing(); string_stream << spacing << "} while(false);\n"; }
+              }
+              blk = convergence;
+              continue;
+            } else {
+              // No convergence — emit if/else with both as terminal
+              string_stream << spacing << "if (" << cond << ") {\n";
+              indent_spacing();
+              for (const auto& pl : true_phis) string_stream << spacing << pl << "\n";
+              emit_region(true_target, stop_at, in_loop, loop_exit_blk);
+              unindent_spacing();
+              string_stream << spacing << "} else {\n";
+              indent_spacing();
+              for (const auto& pl : false_phis) string_stream << spacing << pl << "\n";
+              emit_region(false_target, stop_at, in_loop, loop_exit_blk);
+              unindent_spacing();
+              string_stream << spacing << "}\n";
+              return;
+            }
+          } else if (cb.code_branch.branch_condition_true > 0) {
+            // Unconditional branch
+            int target = cb.code_branch.branch_condition_true;
+            // Phi selector mode: set selector instead of emitting phi assignments
+            if (!phi_sel_var.empty() && target == phi_sel_convergence) {
+              emit_phi_sel_assign(blk);
+              return;
+            }
+            auto phi_lines = current_code_function->ComputePhiAssignments(&cb, target);
+            for (const auto& pl : phi_lines) string_stream << spacing << pl << "\n";
+
+            if (is_back_edge(blk, target)) {
+              if (in_loop) emit_continue();
+              return;
+            }
+            if (target == stop_at || (in_loop && target == loop_exit_blk)) {
+              if (in_loop && target == loop_exit_blk) emit_loop_break();
+              else if (in_loop) string_stream << spacing << "break;\n";
+              return;
+            }
+            blk = target;
+            continue;
+          } else {
+            // No branch — terminal block
+            return;
+          }
+        }
+        // Reached stop_at by falling through convergence points.
+        // If we're inside a loop and stop_at is the loop exit, emit break.
+        if (in_loop && blk == loop_exit_blk) {
+          emit_loop_break();  // This is always a real loop exit
+        }
+      };
+
+      emit_region(0, -1, false, -1);
+      // ===== END STACKIFIER =====
+
+}
+// ===== END STACKIFIER =====

--- a/src/utils/shader_decompiler/structural.hpp
+++ b/src/utils/shader_decompiler/structural.hpp
@@ -1,0 +1,2188 @@
+// ===== STRUCTURAL CODE GENERATION =====
+// Ported from ShortFuse's structural analysis code path.
+// This file is #included inside the Decompiler::Decompile() method when
+// decompile_options.structural is true.
+//
+// Available in scope from the caller:
+//   - current_code_function, string_stream, spacing, decompile_options
+//   - indent_spacing(), unindent_spacing()
+//   - ParseType(), ParseWrapped(), OptimizeString(), IsWrapped()
+//   - convergences, recursions, dominators, predecessors (from default path setup)
+//   - preprocess_state
+//
+// This code path replaces the entire block iteration loop (append_code_block)
+// with ShortFuse's deferred-target + branch-folding approach.
+
+{
+  // The structural path uses ListRecursions (any backward edge = loop) instead
+  // of ListNaturalLoops (only dominator-validated back edges).  ShortFuse's
+  // structural analysis relies on this broader detection to avoid "unsupported
+  // loop" errors on blocks that branch backward to convergence targets.
+  auto recursions = current_code_function->ListRecursions();  // shadows outer `recursions`
+
+  // Recompute analysis using structural-specific functions
+  auto postdominators = current_code_function->ListPostDominators();
+  auto immediate_postdominators = current_code_function->ListImmediatePostDominators(postdominators);
+  auto structural_predecessors = current_code_function->ListPredecessorsVec();
+  auto ladder_index = current_code_function->BuildBranchLadderIndex(structural_predecessors, immediate_postdominators);
+
+  // Track which block declares each temporary variable (for scope validation)
+  std::map<int, int> temporary_declaration_blocks;
+
+  auto is_temp_local_variable_token = [](std::string_view token) {
+    if (token.size() < 2 || token.front() != '_') return false;
+    return std::ranges::all_of(token.substr(1), [](char c) { return c >= '0' && c <= '9'; });
+  };
+  auto is_temp_local_qualifier_token = [](std::string_view token) {
+    return token == "const" || token == "row_major" || token == "column_major" || token == "precise";
+  };
+  auto is_temp_local_type_token = [&](std::string_view token) {
+    if (token.empty() || is_temp_local_qualifier_token(token)) return false;
+    const char first = token.front();
+    if (!((first >= 'A' && first <= 'Z') || (first >= 'a' && first <= 'z') || first == '_')) return false;
+    for (char c : token) {
+      if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_' || c == '<'
+          || c == '>' || c == ',') {
+        continue;
+      }
+      return false;
+    }
+    return true;
+  };
+  auto split_temp_local_tokens = [](std::string_view input) {
+    std::vector<std::string_view> tokens;
+    size_t offset = 0;
+    while (offset < input.size()) {
+      while (offset < input.size() && (input[offset] == ' ' || input[offset] == '\t')) {
+        offset++;
+      }
+      if (offset >= input.size()) break;
+      size_t end = offset;
+      while (end < input.size() && input[end] != ' ' && input[end] != '\t') {
+        end++;
+      }
+      tokens.push_back(input.substr(offset, end - offset));
+      offset = end;
+    }
+    return tokens;
+  };
+  auto try_parse_temp_local_assignment_number = [&](std::string_view hlsl_line) -> std::optional<int> {
+    auto line = StringViewTrim(hlsl_line);
+    if (line.empty() || line.starts_with("//")) return std::nullopt;
+    auto semicolon = line.find(';');
+    if (semicolon == std::string_view::npos) return std::nullopt;
+    auto equals = line.find('=');
+    const bool has_assignment = equals != std::string_view::npos && equals < semicolon;
+    auto lhs = StringViewTrim(line.substr(0, has_assignment ? equals : semicolon));
+    if (lhs.empty()) return std::nullopt;
+    auto tokens = split_temp_local_tokens(lhs);
+    if (tokens.empty()) return std::nullopt;
+    auto variable_token = tokens.back();
+    if (!is_temp_local_variable_token(variable_token)) return std::nullopt;
+    const auto prefix_count = tokens.size() - 1;
+    if (!has_assignment && prefix_count == 0) return std::nullopt;
+    if (prefix_count == 0) {
+      int variable_number;
+      FromStringView(variable_token.substr(1), variable_number);
+      return variable_number;
+    }
+    size_t type_token_index = 0;
+    while (type_token_index < prefix_count && is_temp_local_qualifier_token(tokens[type_token_index])) {
+      type_token_index++;
+    }
+    if (type_token_index != prefix_count - 1 || !is_temp_local_type_token(tokens[type_token_index])) {
+      return std::nullopt;
+    }
+    int variable_number;
+    FromStringView(variable_token.substr(1), variable_number);
+    return variable_number;
+  };
+
+  for (const auto& [declaration_block_line_number, declaration_code_block] : current_code_function->code_blocks) {
+    for (const auto& hlsl_line : declaration_code_block.hlsl_lines) {
+      auto declared_variable_number = try_parse_temp_local_assignment_number(hlsl_line);
+      if (!declared_variable_number.has_value()) continue;
+      temporary_declaration_blocks.try_emplace(declared_variable_number.value(), declaration_block_line_number);
+    }
+  }
+
+  // AssumedCondition: tracks assumed branch conditions for optimization
+  struct AssumedCondition {
+    std::string variable;
+    bool value;
+  };
+  std::vector<AssumedCondition> assumed_conditions;
+  std::vector<std::pair<int, std::string>> structural_deferred_branch_targets;
+  std::vector<int> structural_pending_convergences;
+  std::vector<int> structural_current_loops;
+  std::vector<int> active_deferred_phi_join_targets;
+
+  // Phi variable coalescing map: maps convergence phi variable names to loop phi variable names.
+  // When a convergence point inside a loop has a phi that forwards a loop header phi unchanged
+  // on the pass-through path, and that convergence phi feeds back into the same loop phi on the
+  // back-edge, the two variables form an identity cycle. DXC can exploit this by replacing the
+  // initial loop phi value with undef. Coalescing prevents this by using the same variable name
+  // for both, eliminating the intermediate copy.
+  // NOTE: Currently disabled - requires liveness analysis to verify the convergence phi variable
+  // is not used between the convergence point and the back-edge (other than in the back-edge
+  // phi assignment itself). Without this check, coalescing can break shaders where the
+  // convergence phi is read by code after the convergence.
+  std::map<std::string, std::string> structural_phi_coalescing;
+
+  auto emit_annotation_comment = [&](std::string_view comment) {
+    if (!decompile_options.annotate) return;
+    string_stream << spacing << "// " << comment << "\n";
+  };
+  auto format_int_list = [&](const auto& values) {
+    std::stringstream stream;
+    bool first = true;
+    for (const auto& value : values) {
+      if (!first) {
+        stream << ", ";
+      }
+      stream << value;
+      first = false;
+    }
+    return stream.str();
+  };
+  auto has_active_deferred_phi_join_target = [&](int target) {
+    return std::ranges::find(active_deferred_phi_join_targets, target) != active_deferred_phi_join_targets.end();
+  };
+
+  auto normalize_assumed_condition = [&](std::string_view input) -> std::optional<std::pair<std::string, bool>> {
+    auto condition = StringViewTrim(input);
+    bool negated = false;
+    while (true) {
+      while (!condition.empty() && IsWrapped(condition)) {
+        condition = StringViewTrim(condition.substr(1, condition.size() - 2));
+      }
+      if (!condition.empty() && condition.front() == '!') {
+        negated = !negated;
+        condition = StringViewTrim(condition.substr(1));
+        continue;
+      }
+      break;
+    }
+    if (condition.empty() || condition.front() != '_') {
+      return std::nullopt;
+    }
+    for (size_t index = 1; index < condition.size(); ++index) {
+      unsigned char character = static_cast<unsigned char>(condition[index]);
+      if (!std::isalnum(character) && condition[index] != '_') {
+        return std::nullopt;
+      }
+    }
+    return std::pair{std::string(condition), negated};
+  };
+
+  auto resolve_assumed_condition = [&](std::string_view input) -> std::optional<bool> {
+    auto normalized = normalize_assumed_condition(input);
+    if (!normalized.has_value()) {
+      return std::nullopt;
+    }
+    auto [variable, negated] = normalized.value();
+    for (auto assumption_it = assumed_conditions.rbegin(); assumption_it != assumed_conditions.rend(); ++assumption_it) {
+      if (assumption_it->variable == variable) {
+        return negated ? !assumption_it->value : assumption_it->value;
+      }
+    }
+    return std::nullopt;
+  };
+
+  auto with_assumed_condition = [&](std::string_view input, bool condition_value, auto&& callback) {
+    auto normalized = normalize_assumed_condition(input);
+    if (!normalized.has_value()) {
+      callback();
+      return;
+    }
+    auto [variable, negated] = normalized.value();
+    assumed_conditions.push_back({
+        .variable = std::move(variable),
+        .value = negated ? !condition_value : condition_value,
+    });
+    callback();
+    assumed_conditions.pop_back();
+  };
+
+  auto expand_block_branch_condition = [&](const CodeBlock& branch_code_block) -> std::optional<std::string> {
+    if (branch_code_block.code_branch.branch_condition.empty()) {
+      return std::nullopt;
+    }
+    auto is_identifier_character = [](char character) {
+      return (character >= '0' && character <= '9')
+          || (character >= 'A' && character <= 'Z')
+          || (character >= 'a' && character <= 'z')
+          || character == '_';
+    };
+    auto replace_whole_identifier = [&](std::string_view input, std::string_view identifier, std::string_view replacement) {
+      std::string output;
+      output.reserve(input.size());
+      size_t cursor = 0;
+      while (cursor < input.size()) {
+        auto match_index = input.find(identifier, cursor);
+        if (match_index == std::string_view::npos) {
+          output.append(input.substr(cursor));
+          break;
+        }
+        auto has_left_identifier =
+            match_index > 0 && is_identifier_character(input[match_index - 1]);
+        auto match_end = match_index + identifier.size();
+        auto has_right_identifier =
+            match_end < input.size() && is_identifier_character(input[match_end]);
+        if (has_left_identifier || has_right_identifier) {
+          output.append(input.substr(cursor, match_end - cursor));
+          cursor = match_end;
+          continue;
+        }
+        output.append(input.substr(cursor, match_index - cursor));
+        output.append(replacement);
+        cursor = match_end;
+      }
+      return output;
+    };
+
+    std::vector<std::string_view> executable_lines;
+    executable_lines.reserve(branch_code_block.hlsl_lines.size());
+    for (const auto& hlsl_line : branch_code_block.hlsl_lines) {
+      if (hlsl_line.starts_with("//")) continue;
+      executable_lines.emplace_back(hlsl_line);
+    }
+    if (executable_lines.empty()) {
+      return ParseWrapped(branch_code_block.code_branch.branch_condition);
+    }
+
+    static const auto ASSIGN_REGEX = std::regex(R"(^(?:const\s+)?(\S+) (\S+) = (.*);$)");
+    std::map<std::string, std::string> known_assignments;
+    for (const auto& executable_line : executable_lines) {
+      auto [assignment_type, variable_name, expression] = StringViewMatch<3>(executable_line, ASSIGN_REGEX);
+      if (assignment_type.empty() || variable_name.empty() || expression.empty()) {
+        return std::nullopt;
+      }
+      std::string expanded_expression(expression);
+      for (const auto& [known_variable, known_expression] : known_assignments) {
+        expanded_expression = replace_whole_identifier(
+            expanded_expression,
+            known_variable,
+            std::format("({})", known_expression));
+      }
+      known_assignments.emplace(variable_name, expanded_expression);
+    }
+
+    std::string expanded_condition(branch_code_block.code_branch.branch_condition);
+    for (const auto& [known_variable, known_expression] : known_assignments) {
+      expanded_condition = replace_whole_identifier(
+          expanded_condition,
+          known_variable,
+          std::format("({})", known_expression));
+    }
+
+    // Safety check: if any variable defined in this block is used outside the
+    // block (i.e., not transitively consumed by the branch condition), expanding
+    // would lose its definition.  Detect this by checking whether each defined
+    // variable is referenced by at least one other assignment in the block or by
+    // the branch condition itself.
+    for (const auto& [var_name, _expr] : known_assignments) {
+      bool referenced_internally = false;
+      // Check if used by another assignment in the block
+      for (const auto& [other_var, other_expr] : known_assignments) {
+        if (other_var == var_name) continue;
+        if (other_expr.find(var_name) != std::string::npos) {
+          // Verify it's a whole-identifier match, not a substring
+          auto pos = other_expr.find(var_name);
+          while (pos != std::string::npos) {
+            bool left_ok = (pos == 0) || !is_identifier_character(other_expr[pos - 1]);
+            bool right_ok = (pos + var_name.size() >= other_expr.size()) || !is_identifier_character(other_expr[pos + var_name.size()]);
+            if (left_ok && right_ok) {
+              referenced_internally = true;
+              break;
+            }
+            pos = other_expr.find(var_name, pos + 1);
+          }
+          if (referenced_internally) break;
+        }
+      }
+      if (!referenced_internally) {
+        // Check if used by the branch condition
+        auto cond_str = std::string(branch_code_block.code_branch.branch_condition);
+        auto pos = cond_str.find(var_name);
+        while (pos != std::string::npos) {
+          bool left_ok = (pos == 0) || !is_identifier_character(cond_str[pos - 1]);
+          bool right_ok = (pos + var_name.size() >= cond_str.size()) || !is_identifier_character(cond_str[pos + var_name.size()]);
+          if (left_ok && right_ok) {
+            referenced_internally = true;
+            break;
+          }
+          pos = cond_str.find(var_name, pos + 1);
+        }
+      }
+      if (!referenced_internally) {
+        // This variable is defined in the block but not used by the condition
+        // or any other assignment that feeds the condition — it must be used
+        // externally.  Bail out to preserve its definition.
+        return std::nullopt;
+      }
+    }
+
+    // Safety check 2: even if a variable is used internally, it may ALSO be
+    // used by other code blocks in the function (e.g. a sibling branch that
+    // will be emitted via a chained fold). Folding would make the assignment
+    // disappear, leaving the external reference dangling (produces `undef`
+    // in DXIL). Scan every other block's hlsl_lines, phi assignments, and
+    // branch_condition string for whole-identifier references; if any are
+    // found, bail out.
+    auto check_variable_referenced_externally = [&](const std::string& var_name) -> bool {
+      auto contains_whole_identifier = [&](std::string_view haystack) -> bool {
+        auto pos = haystack.find(var_name);
+        while (pos != std::string_view::npos) {
+          bool left_ok = (pos == 0) || !is_identifier_character(haystack[pos - 1]);
+          bool right_ok = (pos + var_name.size() >= haystack.size()) || !is_identifier_character(haystack[pos + var_name.size()]);
+          if (left_ok && right_ok) return true;
+          pos = haystack.find(var_name, pos + 1);
+        }
+        return false;
+      };
+      for (const auto& [other_block_line_number, other_code_block] : current_code_function->code_blocks) {
+        if (&other_code_block == &branch_code_block) continue;
+        for (const auto& other_line : other_code_block.hlsl_lines) {
+          if (other_line.starts_with("//")) continue;
+          if (contains_whole_identifier(other_line)) return true;
+        }
+        // Phi lines can also reference the variable
+        for (const auto& [phi_var, phi_type, phi_value, phi_predecessor, phi_code_function, phi_is_assign] : other_code_block.phi_lines) {
+          if (!phi_is_assign) continue;
+          if (contains_whole_identifier(phi_value)) return true;
+        }
+        // Branch condition string lives outside hlsl_lines and can reference
+        // the variable directly (e.g. `_784 * ... > ...`).
+        if (contains_whole_identifier(other_code_block.code_branch.branch_condition)) return true;
+      }
+      return false;
+    };
+    for (const auto& [var_name, _expr] : known_assignments) {
+      if (check_variable_referenced_externally(var_name)) {
+        return std::nullopt;
+      }
+    }
+
+    return ParseWrapped(expanded_condition);
+  };
+
+  // Loop jump target for nonlocal loop breaks
+  constexpr std::string_view LOOP_JUMP_TARGET_NAME = "__loop_jump_target";
+  auto loop_can_jump_to_ancestor = [&](int loop_header, int ancestor_loop) {
+    auto recursion_it = recursions.find(ancestor_loop);
+    if (recursion_it == recursions.end()) {
+      return false;
+    }
+    for (const auto source_line_number : recursion_it->second) {
+      auto dominator_it = dominators.find(source_line_number);
+      if (dominator_it != dominators.end() && dominator_it->second.contains(loop_header)) {
+        return true;
+      }
+    }
+    return false;
+  };
+  auto loop_has_nonlocal_jump = [&](int loop_header) {
+    auto dominator_it = dominators.find(loop_header);
+    if (dominator_it == dominators.end()) {
+      return false;
+    }
+    for (const auto& [ancestor_loop, ancestor_sources] : recursions) {
+      if (ancestor_loop == loop_header) continue;
+      if (!dominator_it->second.contains(ancestor_loop)) continue;
+      if (loop_can_jump_to_ancestor(loop_header, ancestor_loop)) {
+        return true;
+      }
+    }
+    return false;
+  };
+  const bool uses_loop_jump_target = [&]() {
+    for (const auto& [loop_header, loop_sources] : recursions) {
+      if (loop_has_nonlocal_jump(loop_header)) {
+        return true;
+      }
+    }
+    return false;
+  }();
+
+  // ===== Main structural append_code_block =====
+  // Safety limit: abort with an exception if the output grows beyond a
+  // reasonable size.  This prevents the "vector too long" crash from
+  // std::string reallocation and gives a clear error message instead.
+  constexpr size_t MAX_OUTPUT_SIZE = 128 * 1024 * 1024;  // 128 MB
+
+  std::function<void(int line_number)> structural_append_code_block = [&](int line_number) {
+    // Check for code size explosion
+    auto current_size = static_cast<size_t>(string_stream.tellp());
+    if (current_size > MAX_OUTPUT_SIZE) {
+      throw std::runtime_error(std::format(
+          "Structural code generation exceeded {} MB output limit at block {}. "
+          "This shader may require --use-do-while or --stackify instead.",
+          MAX_OUTPUT_SIZE / (1024 * 1024), line_number));
+    }
+
+    bool using_recursion = recursions.contains(line_number);
+    if (using_recursion) {
+      structural_current_loops.push_back(line_number);
+      string_stream << spacing << "while(true) {\n";
+      indent_spacing();
+
+      // Phi pre-initialization for inner-loop convergence points.
+      // Detects identity cycles between loop header phis and convergence phis,
+      // and emits pre-initialization assignments at the loop header to prevent
+      // DXC from replacing initial values with undef.
+      // Only applies when:
+      // 1. The convergence is a direct successor of the loop header
+      // 2. The convergence is inside the loop (dominated by the loop header)
+      // 3. The convergence phi forms a back-edge cycle with the loop header phi
+      // 4. The convergence phi is not used in any hlsl_lines (pure forwarding)
+      {
+        auto& loop_header_block = current_code_function->code_blocks[line_number];
+        auto loop_dom_it = dominators.find(line_number);
+        
+        for (const auto& [cv_variable, cv_type, cv_value, cv_predecessor, cv_code_function, cv_is_assign] : loop_header_block.phi_lines) {
+          if (!cv_is_assign) continue;
+          if (cv_code_function == line_number) continue;
+          // Must be a direct successor of the loop header
+          if (cv_code_function != loop_header_block.code_branch.branch_condition_true
+              && cv_code_function != loop_header_block.code_branch.branch_condition_false) continue;
+          // Must be inside the loop (dominated by loop header)
+          auto conv_dom_it = dominators.find(cv_code_function);
+          if (conv_dom_it == dominators.end() || !conv_dom_it->second.contains(line_number)) continue;
+          auto cv_value_str = std::string(cv_value);
+          if (cv_value_str.empty() || cv_value_str[0] != '%') continue;
+          auto loop_phi_var = cv_value_str.substr(1);
+          
+          // Verify back-edge cycle
+          bool found_back_edge = false;
+          for (auto& [block_num, block] : current_code_function->code_blocks) {
+            if (block_num == line_number) continue;
+            for (const auto& [be_variable, be_type, be_value, be_predecessor, be_code_function, be_is_assign] : block.phi_lines) {
+              if (!be_is_assign || be_code_function != line_number || be_variable != loop_phi_var) continue;
+              if (std::string(be_value) == std::format("%{}", cv_variable)) {
+                found_back_edge = true;
+                break;
+              }
+            }
+            if (found_back_edge) break;
+          }
+          if (!found_back_edge) continue;
+          
+          // Safety: convergence phi must not appear in any hlsl_lines
+          auto conv_var_name = std::format("_{}", cv_variable);
+          bool used_in_code = false;
+          for (const auto& [block_num, block] : current_code_function->code_blocks) {
+            for (const auto& hlsl_line : block.hlsl_lines) {
+              size_t pos = hlsl_line.find(conv_var_name);
+              while (pos != std::string::npos) {
+                size_t end_pos = pos + conv_var_name.size();
+                if (end_pos >= hlsl_line.size() || !(hlsl_line[end_pos] >= '0' && hlsl_line[end_pos] <= '9')) {
+                  used_in_code = true;
+                  break;
+                }
+                pos = hlsl_line.find(conv_var_name, end_pos);
+              }
+              if (used_in_code) break;
+            }
+            if (used_in_code) break;
+          }
+          if (used_in_code) continue;
+          
+          string_stream << spacing << conv_var_name << " = _" << loop_phi_var << ";\n";
+        }
+      }
+    }
+    auto on_complete = [&]() {
+      if (using_recursion) {
+        string_stream << spacing << "break;\n";
+        unindent_spacing();
+        string_stream << spacing << "}\n";
+        auto enclosing_loop = structural_current_loops.size() > 1 ? structural_current_loops[structural_current_loops.size() - 2] : -1;
+        const bool can_jump_to_enclosing_loop =
+            enclosing_loop != -1 && loop_can_jump_to_ancestor(line_number, enclosing_loop);
+        bool can_jump_to_outer_ancestor = false;
+        if (enclosing_loop != -1) {
+          for (size_t loop_index = 0; loop_index + 1 < structural_current_loops.size(); ++loop_index) {
+            int ancestor_loop = structural_current_loops[loop_index];
+            if (ancestor_loop == enclosing_loop) continue;
+            if (loop_can_jump_to_ancestor(line_number, ancestor_loop)) {
+              can_jump_to_outer_ancestor = true;
+              break;
+            }
+          }
+        }
+        if (can_jump_to_enclosing_loop) {
+          string_stream << spacing << "if (" << LOOP_JUMP_TARGET_NAME << " == " << enclosing_loop << ") {\n";
+          indent_spacing();
+          string_stream << spacing << LOOP_JUMP_TARGET_NAME << " = -1;\n";
+          string_stream << spacing << "continue;\n";
+          unindent_spacing();
+          string_stream << spacing << "}\n";
+        }
+        if (can_jump_to_enclosing_loop || can_jump_to_outer_ancestor) {
+          string_stream << spacing << "if (" << LOOP_JUMP_TARGET_NAME << " != -1) {\n";
+          indent_spacing();
+          string_stream << spacing << "break;\n";
+          unindent_spacing();
+          string_stream << spacing << "}\n";
+        }
+        structural_current_loops.pop_back();
+        // Clean up phi coalescing entries for this loop
+        std::erase_if(structural_phi_coalescing, [&](const auto& entry) {
+          // Remove entries that were added for this loop (their target is a phi of this loop header)
+          // We identify them by checking if the coalesced target is a phi variable of this loop header
+          for (const auto& [lh_variable, lh_type, lh_value, lh_predecessor, lh_code_function, lh_is_assign] : current_code_function->code_blocks[line_number].phi_lines) {
+            if (lh_is_assign && std::format("_{}", lh_variable) == entry.second) return true;
+          }
+          return false;
+        });
+      }
+    };
+
+    auto emit_code_block_prelude = [&](int emit_line_number) {
+      auto& emit_code_block = current_code_function->code_blocks[emit_line_number];
+      if (decompile_options.annotate) {
+        std::stringstream block_comment;
+        block_comment << "bb " << emit_line_number;
+        if (auto predecessor_it = structural_predecessors.find(emit_line_number);
+            predecessor_it != structural_predecessors.end() && !predecessor_it->second.empty()) {
+          block_comment << " preds=[" << format_int_list(predecessor_it->second) << "]";
+        }
+        if (auto postdominator_it = immediate_postdominators.find(emit_line_number);
+            postdominator_it != immediate_postdominators.end()) {
+          block_comment << " ipdom=" << postdominator_it->second;
+        }
+        auto successors = current_code_function->ListNormalizedSuccessors(emit_code_block);
+        if (!successors.empty()) {
+          block_comment << " succ=[" << format_int_list(successors) << "]";
+        }
+        if (recursions.contains(emit_line_number)) {
+          block_comment << " loop-header";
+        }
+        emit_annotation_comment(block_comment.str());
+        if (!structural_pending_convergences.empty()) {
+          emit_annotation_comment(std::format("pending-convergence [{}]", format_int_list(structural_pending_convergences)));
+        }
+      }
+      // Regex to detect type-prefixed variable assignments like "float _30 = ..."
+      // When the variable was already pre-declared at function scope, strip the
+      // type prefix to avoid redefinition errors.
+      static const std::regex structural_var_decl_re(
+          R"(^(float4|float3|float2|float|int|uint|bool|uint4|int4|int2|uint2|int3|uint3|double|int64_t|uint64_t|int16_t|uint16_t|half|min16float|min16int|min16uint|[A-Z_]\w*)\s+(_\d+)\s*=)");
+      // Also match "type _N; ..." patterns (e.g., GetDimensions: "uint2 _39; srv.GetDimensions(...)")
+      // where the declaration is followed by a semicolon and then a function call.
+      static const std::regex structural_var_decl_noassign_re(
+          R"(^(float4|float3|float2|float|int|uint|bool|uint4|int4|int2|uint2|int3|uint3|double|int64_t|uint64_t|int16_t|uint16_t|half|min16float|min16int|min16uint|[A-Z_]\w*)\s+(_\d+)\s*;)");
+      for (const auto& hlsl_line : emit_code_block.hlsl_lines) {
+        auto optimized_line = (decompile_options.flatten ? OptimizeString(hlsl_line) : hlsl_line);
+        // Strip type prefix if variable was pre-declared
+        std::smatch decl_match;
+        auto line_str = std::string(optimized_line);
+        if (std::regex_search(line_str, decl_match, structural_var_decl_re)) {
+          std::string var_name = decl_match[2].str();
+          if (declared_vars.contains(var_name)) {
+            // Replace "type _N = ..." with "_N = ..."
+            line_str = line_str.substr(decl_match[1].length() + 1);  // skip "type "
+            string_stream << spacing << line_str << "\n";
+            continue;
+          }
+        } else if (std::regex_search(line_str, decl_match, structural_var_decl_noassign_re)) {
+          std::string var_name = decl_match[2].str();
+          if (declared_vars.contains(var_name)) {
+            // Replace "type _N; rest..." with "rest..." (strip the redundant declaration)
+            // The declaration part ends at the semicolon after the variable name
+            auto decl_end = decl_match[0].length();  // length of "type _N;"
+            auto remainder = StringViewTrim(std::string_view(line_str).substr(decl_end));
+            if (!remainder.empty()) {
+              string_stream << spacing << remainder << "\n";
+            }
+            continue;
+          }
+        }
+        string_stream << spacing << optimized_line << "\n";
+      }
+      for (const auto& [variable, type, value, predecessor, code_function, is_assign] : emit_code_block.phi_lines) {
+        if (is_assign) continue;
+        auto var_name = std::format("_{}", variable);
+        // Only declare if not already pre-declared at function scope
+        if (!declared_vars.contains(var_name)) {
+          auto assignment_type = ParseType(type);
+          string_stream << spacing << std::format("{} {};", assignment_type, var_name) << "\n";
+        }
+      }
+    };
+
+    auto emit_phi_assignments = [&](CodeBlock* source_code_block, int branch_number) {
+      for (const auto& phi_line : current_code_function->ComputePhiAssignments(source_code_block, branch_number)) {
+        auto optimized_line = (decompile_options.flatten ? OptimizeString(phi_line) : phi_line);
+        string_stream << spacing << optimized_line << "\n";
+      }
+    };
+
+    auto& code_block = current_code_function->code_blocks[line_number];
+    emit_code_block_prelude(line_number);
+
+    int current_loop = structural_current_loops.empty() ? -1 : structural_current_loops.back();
+
+    if (code_block.code_branch.branch_condition_true <= 0 && code_block.code_switch.switch_condition.empty()) {
+      on_complete();
+      return;
+    }
+
+    int next_convergence = structural_pending_convergences.empty() ? -1 : structural_pending_convergences.back();
+
+    auto close_lonely_if = [&](int else_code_function) {
+      std::vector<std::string> phi_lines = current_code_function->ComputePhiAssignments(&code_block, else_code_function);
+      if (phi_lines.empty()) {
+        string_stream << spacing << "}\n";
+      } else {
+        string_stream << spacing << "} else {\n";
+        indent_spacing();
+        for (const auto& phi_line : phi_lines) {
+          auto optimized_line = (decompile_options.flatten ? OptimizeString(phi_line) : phi_line);
+          string_stream << spacing << optimized_line << "\n";
+        }
+        unindent_spacing();
+        string_stream << spacing << "}\n";
+      }
+    };
+
+    std::optional<int> deferred_phi_join_target;
+    auto on_branch_from = [&](CodeBlock* source_code_block, int branch_number, bool is_fallthrough = false) {
+      // Capture the CURRENT convergence at call time, not at lambda definition time.
+      // pending_convergences changes during recursive emission, so next_convergence
+      // (captured at block start) may be stale.
+      int active_convergence = structural_pending_convergences.empty() ? -1 : structural_pending_convergences.back();
+
+      if (!is_fallthrough) {
+        emit_phi_assignments(source_code_block, branch_number);
+      }
+      if (deferred_phi_join_target.has_value() && branch_number == deferred_phi_join_target.value()) {
+        emit_annotation_comment(std::format("edge {} -> {} phi-join", line_number, branch_number));
+      } else if (has_active_deferred_phi_join_target(branch_number)) {
+        emit_annotation_comment(std::format("edge {} -> {} phi-join-active", line_number, branch_number));
+      } else if (current_loop == branch_number) {
+        emit_annotation_comment(std::format("edge {} -> {} continue", line_number, branch_number));
+        string_stream << spacing << "continue;\n";
+      } else if (std::ranges::find(structural_current_loops, branch_number) != structural_current_loops.end()) {
+        emit_annotation_comment(std::format("edge {} -> {} break-to-loop", line_number, branch_number));
+        string_stream << spacing << LOOP_JUMP_TARGET_NAME << " = " << branch_number << ";\n";
+        string_stream << spacing << "break;\n";
+      } else if (active_convergence == branch_number) {
+        emit_annotation_comment(std::format("edge {} -> {} converge", line_number, branch_number));
+      } else if (std::ranges::find(structural_pending_convergences, branch_number) != structural_pending_convergences.end()) {
+        emit_annotation_comment(std::format("edge {} -> {} break-pending-convergence", line_number, branch_number));
+        if (decompile_options.use_do_while) {
+          string_stream << spacing << "break;\n";
+        } else {
+          throw std::runtime_error("Unexpected goto");
+        }
+      } else if (auto deferred_target = std::ranges::find_if(
+                     structural_deferred_branch_targets.rbegin(),
+                     structural_deferred_branch_targets.rend(),
+                     [&](const auto& entry) {
+                       return entry.first == branch_number;
+                     });
+                 deferred_target != structural_deferred_branch_targets.rend()) {
+        emit_annotation_comment(std::format("edge {} -> {} defer({})", line_number, branch_number, deferred_target->second));
+        string_stream << spacing << deferred_target->second << " = true;\n";
+      } else {
+        emit_annotation_comment(std::format("edge {} -> {} inline", line_number, branch_number));
+        structural_append_code_block(branch_number);
+      }
+    };
+    auto on_branch = [&](int branch_number, bool is_fallthrough = false) {
+      on_branch_from(&code_block, branch_number, is_fallthrough);
+    };
+    auto on_branch_assuming = [&](int branch_number, bool condition_value, bool is_fallthrough = false) {
+      with_assumed_condition(code_block.code_branch.branch_condition, condition_value, [&]() {
+        on_branch(branch_number, is_fallthrough);
+      });
+    };
+    auto append_or_defer = [&](int branch_number) {
+      if (has_active_deferred_phi_join_target(branch_number)) {
+        emit_annotation_comment(std::format("edge {} -> {} phi-join-active-append", line_number, branch_number));
+        emit_phi_assignments(&code_block, branch_number);
+      } else if (auto deferred_target = std::ranges::find_if(
+              structural_deferred_branch_targets.rbegin(),
+              structural_deferred_branch_targets.rend(),
+              [&](const auto& entry) {
+                return entry.first == branch_number;
+              });
+          deferred_target != structural_deferred_branch_targets.rend()) {
+        string_stream << spacing << deferred_target->second << " = true;\n";
+      } else {
+        structural_append_code_block(branch_number);
+      }
+    };
+
+    // Fold assumed conditions
+    if (code_block.code_switch.switch_condition.empty()) {
+      if (auto known_condition = resolve_assumed_condition(code_block.code_branch.branch_condition);
+          known_condition.has_value()) {
+        emit_annotation_comment(std::format(
+            "fold assume {}={} -> {}",
+            code_block.code_branch.branch_condition,
+            known_condition.value() ? "true" : "false",
+            known_condition.value()
+                ? code_block.code_branch.branch_condition_true
+                : code_block.code_branch.branch_condition_false));
+        on_branch(known_condition.value()
+                      ? code_block.code_branch.branch_condition_true
+                      : code_block.code_branch.branch_condition_false);
+        on_complete();
+        return;
+      }
+    }
+
+    // Switch handling
+    if (!code_block.code_switch.switch_condition.empty()) {
+      int switch_convergence = -1;
+      if (auto pair = immediate_postdominators.find(line_number);
+          pair != immediate_postdominators.end()) {
+        switch_convergence = pair->second;
+      }
+      assert(switch_convergence != -1);
+      structural_pending_convergences.push_back(switch_convergence);
+
+      const auto add_convergence_phis = [&]() {
+        for (const auto& phi_line : current_code_function->ComputePhiAssignments(&code_block, switch_convergence)) {
+          auto optimized_line = (decompile_options.flatten ? OptimizeString(phi_line) : phi_line);
+          string_stream << spacing << optimized_line << "\n";
+        }
+      };
+
+      string_stream << spacing << "switch (" << code_block.code_switch.switch_condition << ") {\n";
+      indent_spacing();
+      for (const auto& [case_value, case_function] : code_block.code_switch.case_values) {
+        string_stream << spacing << "case " << case_value << ": {\n";
+        indent_spacing();
+        if (case_function == switch_convergence) {
+          add_convergence_phis();
+        } else {
+          on_branch(case_function);
+        }
+        string_stream << spacing << "break;\n";
+        unindent_spacing();
+        string_stream << spacing << "}\n";
+      }
+      string_stream << spacing << "default: {\n";
+      indent_spacing();
+      if (code_block.code_switch.case_default == switch_convergence) {
+        add_convergence_phis();
+      } else {
+        on_branch(code_block.code_switch.case_default);
+      }
+      string_stream << spacing << "break;\n";
+      unindent_spacing();
+      string_stream << spacing << "}\n";
+      unindent_spacing();
+      string_stream << spacing << "}\n";
+
+      structural_pending_convergences.pop_back();
+      bool is_empty = structural_pending_convergences.empty();
+      on_branch(switch_convergence, true);
+      on_complete();
+      return;
+    }
+
+    // Unconditional branch
+    if (code_block.code_branch.branch_condition.empty()) {
+      on_branch(code_block.code_branch.branch_condition_true);
+      on_complete();
+      return;
+    }
+
+    auto targets_active_loop = [&](int branch_number) {
+      return std::ranges::find(structural_current_loops, branch_number) != structural_current_loops.end();
+    };
+
+    if (code_block.code_branch.branch_condition_false <= line_number
+        && code_block.code_branch.branch_condition_true <= line_number
+        && !targets_active_loop(code_block.code_branch.branch_condition_true)
+        && !targets_active_loop(code_block.code_branch.branch_condition_false)
+        && code_block.code_branch.branch_condition_true != next_convergence
+        && code_block.code_branch.branch_condition_false != next_convergence
+        && std::ranges::find(structural_pending_convergences, code_block.code_branch.branch_condition_true) == structural_pending_convergences.end()
+        && std::ranges::find(structural_pending_convergences, code_block.code_branch.branch_condition_false) == structural_pending_convergences.end()) {
+      auto message = std::format(
+          "Unsupported loop detected at block {} (true={}, false={}, current_loop={}, next_convergence={})",
+          line_number,
+          code_block.code_branch.branch_condition_true,
+          code_block.code_branch.branch_condition_false,
+          current_loop,
+          next_convergence);
+      throw std::runtime_error(message);
+    }
+
+    // Single-side convergence shortcuts
+    if (code_block.code_branch.branch_condition_true == next_convergence) {
+      if (code_block.code_branch.use_hint) {
+        string_stream << spacing << "[branch]\n";
+      }
+      string_stream << spacing << "if (!" << code_block.code_branch.branch_condition << ") {\n";
+      indent_spacing();
+      on_branch_assuming(code_block.code_branch.branch_condition_false, false);
+      unindent_spacing();
+      close_lonely_if(next_convergence);
+      on_complete();
+      return;
+    }
+
+    if (code_block.code_branch.branch_condition_false == next_convergence) {
+      if (code_block.code_branch.use_hint) {
+        string_stream << spacing << "[branch]\n";
+      }
+      string_stream << spacing << std::format("if {} {{\n", ParseWrapped(code_block.code_branch.branch_condition));
+      indent_spacing();
+      on_branch_assuming(code_block.code_branch.branch_condition_true, true);
+      unindent_spacing();
+      close_lonely_if(next_convergence);
+      on_complete();
+      return;
+    }
+
+    // Find pair convergence (immediate post-dominator)
+    int pair_convergence = -1;
+    bool pushed_pair_convergence = false;
+    bool uses_convergence_wrapper = false;
+    if (auto pair = immediate_postdominators.find(line_number);
+        pair != immediate_postdominators.end()) {
+      pair_convergence = pair->second;
+      if (pair_convergence != next_convergence) {
+        if (!structural_pending_convergences.empty()) {
+          uses_convergence_wrapper =
+              decompile_options.use_do_while && (current_code_function->RegionNeedsConvergenceWrapper(code_block.code_branch.branch_condition_true, pair_convergence, structural_pending_convergences) || current_code_function->RegionNeedsConvergenceWrapper(code_block.code_branch.branch_condition_false, pair_convergence, structural_pending_convergences));
+          if (uses_convergence_wrapper) {
+            string_stream << spacing << "do {\n";
+            indent_spacing();
+          }
+        }
+        structural_pending_convergences.push_back(pair_convergence);
+        pushed_pair_convergence = true;
+      }
+    } else {
+      // No immediate post-dominator found — unconditional blocks or exit blocks.
+      // Conditional blocks without ipdom would cause code duplication, but the
+      // re-emission guard above prevents exponential blowup.
+    }
+
+    // ===== Structural analysis: SharedBranchChain =====
+    struct SharedBranchChainStep {
+      int line_number;
+      bool shared_on_true;
+    };
+    struct SharedBranchChain {
+      int shared_target;
+      int final_continue_target;
+      std::vector<SharedBranchChainStep> steps;
+    };
+
+    auto build_shared_branch_chain =
+        [&](int shared_target, int continue_target, bool shared_on_true) -> std::optional<SharedBranchChain> {
+      if (pair_convergence == -1 || shared_target <= 0 || continue_target <= 0 || shared_target == pair_convergence
+          || continue_target == pair_convergence) {
+        return std::nullopt;
+      }
+      SharedBranchChain chain = {
+          .shared_target = shared_target,
+          .final_continue_target = pair_convergence,
+          .steps = {{line_number, shared_on_true}},
+      };
+      std::set<int> visited = {line_number};
+      int current_line_number = continue_target;
+      while (true) {
+        if (current_line_number <= 0 || !current_code_function->code_blocks.contains(current_line_number)
+            || !visited.emplace(current_line_number).second) {
+          return std::nullopt;
+        }
+        if (recursions.contains(current_line_number)) {
+          return std::nullopt;
+        }
+        auto convergence_pair = immediate_postdominators.find(current_line_number);
+        if (convergence_pair == immediate_postdominators.end() || convergence_pair->second != pair_convergence) {
+          return std::nullopt;
+        }
+        const auto& current_chain_block = current_code_function->code_blocks.at(current_line_number);
+        if (!current_chain_block.code_switch.switch_condition.empty()
+            || current_chain_block.code_branch.branch_condition.empty()
+            || current_chain_block.code_branch.branch_condition_true <= 0
+            || current_chain_block.code_branch.branch_condition_false <= 0) {
+          return std::nullopt;
+        }
+        int next_continue_target = -1;
+        bool current_shared_on_true = false;
+        if (current_chain_block.code_branch.branch_condition_true == shared_target
+            && current_chain_block.code_branch.branch_condition_false != shared_target) {
+          current_shared_on_true = true;
+          next_continue_target = current_chain_block.code_branch.branch_condition_false;
+        } else if (current_chain_block.code_branch.branch_condition_false == shared_target
+                   && current_chain_block.code_branch.branch_condition_true != shared_target) {
+          current_shared_on_true = false;
+          next_continue_target = current_chain_block.code_branch.branch_condition_true;
+        } else {
+          return std::nullopt;
+        }
+        chain.steps.push_back({current_line_number, current_shared_on_true});
+        if (next_continue_target == pair_convergence) {
+          chain.final_continue_target = pair_convergence;
+          break;
+        }
+        if (next_continue_target <= current_line_number) {
+          return std::nullopt;
+        }
+        const auto& next_continue_code_block = current_code_function->code_blocks.at(next_continue_target);
+        if (next_continue_code_block.code_switch.switch_condition.empty()
+            && next_continue_code_block.code_branch.branch_condition.empty()
+            && next_continue_code_block.code_branch.branch_condition_true == pair_convergence) {
+          chain.final_continue_target = next_continue_target;
+          break;
+        }
+        current_line_number = next_continue_target;
+      }
+      if (chain.steps.size() < 2) {
+        return std::nullopt;
+      }
+      return chain;
+    };
+
+    std::optional<SharedBranchChain> shared_branch_chain;
+    if (pair_convergence != -1) {
+      auto true_candidate = build_shared_branch_chain(code_block.code_branch.branch_condition_true,
+                                                      code_block.code_branch.branch_condition_false, true);
+      auto false_candidate = build_shared_branch_chain(code_block.code_branch.branch_condition_false,
+                                                       code_block.code_branch.branch_condition_true, false);
+      if (true_candidate && (!false_candidate || true_candidate->steps.size() >= false_candidate->steps.size())) {
+        shared_branch_chain = std::move(true_candidate);
+      } else if (false_candidate) {
+        shared_branch_chain = std::move(false_candidate);
+      }
+    }
+
+    auto get_foldable_chain_branch_condition =
+        [&](const CodeBlock& chain_code_block) -> std::optional<std::string> {
+      return expand_block_branch_condition(chain_code_block);
+    };
+
+    // ===== FoldedSharedBranchJoin =====
+    struct FoldedSharedBranchJoin {
+      int shared_target;
+      int continue_target;
+      bool use_branch_hint;
+      std::string shared_target_condition;
+    };
+
+    auto build_folded_shared_branch_join = [&]() -> std::optional<FoldedSharedBranchJoin> {
+      if (pair_convergence == -1) return std::nullopt;
+      auto inspect_child = [&](int child_line_number) -> std::optional<std::tuple<const CodeBlock*, std::string, int, int>> {
+        if (child_line_number <= 0 || !current_code_function->code_blocks.contains(child_line_number)
+            || recursions.contains(child_line_number)) {
+          return std::nullopt;
+        }
+        const auto& child_code_block = current_code_function->code_blocks.at(child_line_number);
+        if (!child_code_block.code_switch.switch_condition.empty()
+            || child_code_block.code_branch.branch_condition.empty()
+            || child_code_block.code_branch.branch_condition_true <= 0
+            || child_code_block.code_branch.branch_condition_false <= 0) {
+          return std::nullopt;
+        }
+        auto convergence_pair = immediate_postdominators.find(child_line_number);
+        if (convergence_pair == immediate_postdominators.end() || convergence_pair->second != pair_convergence) {
+          return std::nullopt;
+        }
+        if (!current_code_function->ComputePhiAssignments(&code_block, child_line_number).empty()) {
+          return std::nullopt;
+        }
+        auto child_condition = get_foldable_chain_branch_condition(child_code_block);
+        if (!child_condition.has_value()) return std::nullopt;
+        return std::tuple<const CodeBlock*, std::string, int, int>{
+            &child_code_block, child_condition.value(),
+            child_code_block.code_branch.branch_condition_true,
+            child_code_block.code_branch.branch_condition_false};
+      };
+      auto true_child = inspect_child(code_block.code_branch.branch_condition_true);
+      auto false_child = inspect_child(code_block.code_branch.branch_condition_false);
+      if (!true_child.has_value() || !false_child.has_value()) return std::nullopt;
+      const auto& [true_child_block, true_child_condition, true_true_target, true_false_target] = true_child.value();
+      const auto& [false_child_block, false_child_condition, false_true_target, false_false_target] = false_child.value();
+      std::set<int> true_child_targets = {true_true_target, true_false_target};
+      std::set<int> false_child_targets = {false_true_target, false_false_target};
+      if (true_child_targets.size() != 2 || true_child_targets != false_child_targets) return std::nullopt;
+      auto root_condition = ParseWrapped(code_block.code_branch.branch_condition);
+      const bool use_branch_hint =
+          code_block.code_branch.use_hint || true_child_block->code_branch.use_hint || false_child_block->code_branch.use_hint;
+      auto build_join_for_target = [&](int candidate_shared_target) -> std::optional<FoldedSharedBranchJoin> {
+        auto candidate_continue_target_it = true_child_targets.begin();
+        while (candidate_continue_target_it != true_child_targets.end()
+               && *candidate_continue_target_it == candidate_shared_target) {
+          ++candidate_continue_target_it;
+        }
+        if (candidate_continue_target_it == true_child_targets.end()) return std::nullopt;
+        int candidate_continue_target = *candidate_continue_target_it;
+        if (candidate_shared_target <= 0 || candidate_continue_target <= 0
+            || candidate_shared_target == pair_convergence || candidate_continue_target == pair_convergence) {
+          return std::nullopt;
+        }
+        if (!current_code_function->ComputePhiAssignments(const_cast<CodeBlock*>(true_child_block), candidate_shared_target).empty()
+            || !current_code_function->ComputePhiAssignments(const_cast<CodeBlock*>(true_child_block), candidate_continue_target).empty()
+            || !current_code_function->ComputePhiAssignments(const_cast<CodeBlock*>(false_child_block), candidate_shared_target).empty()
+            || !current_code_function->ComputePhiAssignments(const_cast<CodeBlock*>(false_child_block), candidate_continue_target).empty()) {
+          return std::nullopt;
+        }
+        auto true_path_shared_condition = (true_true_target == candidate_shared_target)
+                                              ? true_child_condition
+                                              : std::format("!{}", true_child_condition);
+        auto false_path_shared_condition = (false_true_target == candidate_shared_target)
+                                               ? false_child_condition
+                                               : std::format("!{}", false_child_condition);
+        return FoldedSharedBranchJoin{
+            .shared_target = candidate_shared_target,
+            .continue_target = candidate_continue_target,
+            .use_branch_hint = use_branch_hint,
+            .shared_target_condition = std::format(
+                "(({} && {}) || (!{} && {}))",
+                root_condition, true_path_shared_condition,
+                root_condition, false_path_shared_condition),
+        };
+      };
+      auto shared_target_it = true_child_targets.begin();
+      auto shared_join = build_join_for_target(*shared_target_it);
+      if (shared_join.has_value()) return shared_join;
+      ++shared_target_it;
+      if (shared_target_it == true_child_targets.end()) return std::nullopt;
+      return build_join_for_target(*shared_target_it);
+    };
+
+    // ===== FoldedSharedContinueJoin =====
+    struct FoldedSharedContinueJoin {
+      int continue_target;
+      int true_target;
+      int false_target;
+      bool use_branch_hint;
+      std::string continue_target_condition;
+      std::string true_target_condition;
+      std::string false_target_condition;
+    };
+
+    auto build_folded_shared_continue_join = [&]() -> std::optional<FoldedSharedContinueJoin> {
+      if (pair_convergence == -1) return std::nullopt;
+      auto inspect_child = [&](int child_line_number) -> std::optional<std::tuple<const CodeBlock*, std::string, int, int>> {
+        if (child_line_number <= 0 || !current_code_function->code_blocks.contains(child_line_number)
+            || recursions.contains(child_line_number)) {
+          return std::nullopt;
+        }
+        const auto& child_code_block = current_code_function->code_blocks.at(child_line_number);
+        if (!child_code_block.code_switch.switch_condition.empty()
+            || child_code_block.code_branch.branch_condition.empty()
+            || child_code_block.code_branch.branch_condition_true <= 0
+            || child_code_block.code_branch.branch_condition_false <= 0) {
+          return std::nullopt;
+        }
+        auto convergence_pair = immediate_postdominators.find(child_line_number);
+        if (convergence_pair == immediate_postdominators.end() || convergence_pair->second != pair_convergence) {
+          return std::nullopt;
+        }
+        if (!current_code_function->ComputePhiAssignments(&code_block, child_line_number).empty()) {
+          return std::nullopt;
+        }
+        auto child_condition = get_foldable_chain_branch_condition(child_code_block);
+        if (!child_condition.has_value()) return std::nullopt;
+        return std::tuple<const CodeBlock*, std::string, int, int>{
+            &child_code_block, child_condition.value(),
+            child_code_block.code_branch.branch_condition_true,
+            child_code_block.code_branch.branch_condition_false};
+      };
+      auto true_child = inspect_child(code_block.code_branch.branch_condition_true);
+      auto false_child = inspect_child(code_block.code_branch.branch_condition_false);
+      if (!true_child.has_value() || !false_child.has_value()) return std::nullopt;
+      const auto& [true_child_block, true_child_condition, true_true_target, true_false_target] = true_child.value();
+      const auto& [false_child_block, false_child_condition, false_true_target, false_false_target] = false_child.value();
+      std::set<int> common_targets = {true_true_target, true_false_target};
+      std::set<int> other_targets = {false_true_target, false_false_target};
+      std::vector<int> shared_targets;
+      std::set_intersection(common_targets.begin(), common_targets.end(),
+                            other_targets.begin(), other_targets.end(),
+                            std::back_inserter(shared_targets));
+      if (shared_targets.size() != 1) return std::nullopt;
+      int continue_target = shared_targets.front();
+      if (continue_target <= 0 || continue_target == pair_convergence) return std::nullopt;
+      auto pick_noncontinue_target = [&](int a, int b) -> std::optional<int> {
+        if (a == continue_target && b != continue_target) return b;
+        if (b == continue_target && a != continue_target) return a;
+        return std::nullopt;
+      };
+      auto true_noncontinue_target = pick_noncontinue_target(true_true_target, true_false_target);
+      auto false_noncontinue_target = pick_noncontinue_target(false_true_target, false_false_target);
+      if (!true_noncontinue_target.has_value() || !false_noncontinue_target.has_value()) return std::nullopt;
+      if (!current_code_function->ComputePhiAssignments(const_cast<CodeBlock*>(true_child_block), continue_target).empty()
+          || !current_code_function->ComputePhiAssignments(const_cast<CodeBlock*>(false_child_block), continue_target).empty()
+          || !current_code_function->ComputePhiAssignments(const_cast<CodeBlock*>(true_child_block), true_noncontinue_target.value()).empty()
+          || !current_code_function->ComputePhiAssignments(const_cast<CodeBlock*>(false_child_block), false_noncontinue_target.value()).empty()) {
+        return std::nullopt;
+      }
+      auto root_condition = ParseWrapped(code_block.code_branch.branch_condition);
+      auto true_continue_condition = (true_true_target == continue_target)
+                                         ? true_child_condition : std::format("!{}", true_child_condition);
+      auto false_continue_condition = (false_true_target == continue_target)
+                                          ? false_child_condition : std::format("!{}", false_child_condition);
+      auto true_noncontinue_condition = (true_true_target == continue_target)
+                                            ? std::format("!{}", true_child_condition) : true_child_condition;
+      auto false_noncontinue_condition = (false_true_target == continue_target)
+                                             ? std::format("!{}", false_child_condition) : false_child_condition;
+      return FoldedSharedContinueJoin{
+          .continue_target = continue_target,
+          .true_target = true_noncontinue_target.value(),
+          .false_target = false_noncontinue_target.value(),
+          .use_branch_hint = code_block.code_branch.use_hint
+                             || true_child_block->code_branch.use_hint
+                             || false_child_block->code_branch.use_hint,
+          .continue_target_condition = std::format(
+              "(({} && {}) || (!{} && {}))",
+              root_condition, true_continue_condition,
+              root_condition, false_continue_condition),
+          .true_target_condition = std::format("({} && {})", root_condition, ParseWrapped(true_noncontinue_condition)),
+          .false_target_condition = std::format("(!{} && {})", root_condition, ParseWrapped(false_noncontinue_condition)),
+      };
+    };
+
+    // ===== FoldedNestedContinueReduction =====
+    auto can_fold_path_reach_target =
+        [&](int start_line_number, int target_line_number, auto&& self, std::set<int>& visited) -> bool {
+      if (start_line_number == target_line_number) return true;
+      if (start_line_number <= 0 || !current_code_function->code_blocks.contains(start_line_number)
+          || !visited.emplace(start_line_number).second
+          || recursions.contains(start_line_number)) {
+        return false;
+      }
+      const auto& path_code_block = current_code_function->code_blocks.at(start_line_number);
+      if (!path_code_block.code_switch.switch_condition.empty()
+          || path_code_block.code_branch.branch_condition.empty()
+          || path_code_block.code_branch.branch_condition_true <= 0
+          || path_code_block.code_branch.branch_condition_false <= 0) {
+        return false;
+      }
+      auto convergence_pair = immediate_postdominators.find(start_line_number);
+      if (convergence_pair == immediate_postdominators.end() || convergence_pair->second != pair_convergence) {
+        return false;
+      }
+      return self(path_code_block.code_branch.branch_condition_true, target_line_number, self, visited)
+             || self(path_code_block.code_branch.branch_condition_false, target_line_number, self, visited);
+    };
+
+    struct FoldedNestedContinueReduction {
+      int unique_target;
+      int direct_target;
+      int nested_convergence;
+      bool use_branch_hint;
+      std::string unique_condition;
+    };
+
+    auto build_folded_nested_continue_reduction =
+        [&](const FoldedSharedContinueJoin& shared_continue_join) -> std::optional<FoldedNestedContinueReduction> {
+      auto try_orientation =
+          [&](int branch_root_target, std::string_view branch_root_entry_condition,
+              int direct_target) -> std::optional<FoldedNestedContinueReduction> {
+        if (branch_root_target <= 0 || direct_target <= 0 || branch_root_target == direct_target
+            || !current_code_function->code_blocks.contains(branch_root_target)
+            || recursions.contains(branch_root_target)) {
+          return std::nullopt;
+        }
+        const auto& branch_root_code_block = current_code_function->code_blocks.at(branch_root_target);
+        if (!branch_root_code_block.code_switch.switch_condition.empty()
+            || branch_root_code_block.code_branch.branch_condition.empty()
+            || branch_root_code_block.code_branch.branch_condition_true <= 0
+            || branch_root_code_block.code_branch.branch_condition_false <= 0) {
+          return std::nullopt;
+        }
+        auto convergence_pair = immediate_postdominators.find(branch_root_target);
+        if (convergence_pair == immediate_postdominators.end()) return std::nullopt;
+        int nested_convergence = convergence_pair->second;
+        if (nested_convergence <= 0 || nested_convergence == pair_convergence) return std::nullopt;
+        auto branch_condition = get_foldable_chain_branch_condition(branch_root_code_block);
+        if (!branch_condition.has_value()) return std::nullopt;
+        int unique_target = -1;
+        std::string unique_branch_condition;
+        if (branch_root_code_block.code_branch.branch_condition_true == direct_target
+            && branch_root_code_block.code_branch.branch_condition_false != direct_target) {
+          unique_target = branch_root_code_block.code_branch.branch_condition_false;
+          unique_branch_condition = std::format("!{}", branch_condition.value());
+        } else if (branch_root_code_block.code_branch.branch_condition_false == direct_target
+                   && branch_root_code_block.code_branch.branch_condition_true != direct_target) {
+          unique_target = branch_root_code_block.code_branch.branch_condition_true;
+          unique_branch_condition = branch_condition.value();
+        } else {
+          return std::nullopt;
+        }
+        if (!current_code_function->ComputePhiAssignments(&code_block, branch_root_target).empty()
+            || !current_code_function->ComputePhiAssignments(&code_block, direct_target).empty()
+            || !current_code_function->ComputePhiAssignments(
+                                         const_cast<CodeBlock*>(&branch_root_code_block), unique_target).empty()
+            || !current_code_function->ComputePhiAssignments(
+                                         const_cast<CodeBlock*>(&branch_root_code_block), direct_target).empty()) {
+          return std::nullopt;
+        }
+        return FoldedNestedContinueReduction{
+            .unique_target = unique_target,
+            .direct_target = direct_target,
+            .nested_convergence = nested_convergence,
+            .use_branch_hint = branch_root_code_block.code_branch.use_hint,
+            .unique_condition = std::format("({} && {})", ParseWrapped(branch_root_entry_condition), ParseWrapped(unique_branch_condition)),
+        };
+      };
+      if (auto reduction = try_orientation(shared_continue_join.true_target,
+              shared_continue_join.true_target_condition, shared_continue_join.false_target);
+          reduction.has_value()) {
+        return reduction;
+      }
+      return try_orientation(shared_continue_join.false_target,
+          shared_continue_join.false_target_condition, shared_continue_join.true_target);
+    };
+
+    // ===== FoldedSharedBranchLadder =====
+    struct FoldedSharedBranchLadder {
+      int shared_target;
+      int continue_target;
+      bool use_branch_hint;
+      std::string shared_target_condition;
+    };
+
+    auto build_folded_shared_branch_ladder =
+        [&](int shared_target, int next_step, bool shared_on_true) -> std::optional<FoldedSharedBranchLadder> {
+      if (pair_convergence == -1 || shared_target <= 0 || next_step <= 0
+          || shared_target == pair_convergence
+          || !current_code_function->code_blocks.contains(next_step)
+          || recursions.contains(next_step)) {
+        return std::nullopt;
+      }
+      if (!current_code_function->ComputePhiAssignments(&code_block, next_step).empty()) {
+        return std::nullopt;
+      }
+      auto negate_condition = [&](std::string_view condition) {
+        return std::format("!{}", ParseWrapped(condition));
+      };
+      auto and_conditions = [&](std::string_view a, std::string_view b) {
+        return std::format("({} && {})", ParseWrapped(a), ParseWrapped(b));
+      };
+      auto or_conditions = [&](const std::vector<std::string>& predicates) {
+        std::stringstream stream;
+        for (size_t i = 0; i < predicates.size(); ++i) {
+          if (i != 0) stream << " || ";
+          stream << predicates[i];
+        }
+        return stream.str();
+      };
+      bool use_branch_hint = code_block.code_branch.use_hint;
+      auto root_condition = ParseWrapped(code_block.code_branch.branch_condition);
+      std::vector<std::string> shared_predicates = {
+          shared_on_true ? std::string(root_condition) : negate_condition(root_condition)};
+      std::vector<std::string> continue_predicates;
+      std::string current_path_condition =
+          shared_on_true ? negate_condition(root_condition) : std::string(root_condition);
+      int continue_target = -1;
+      std::set<int> visited = {line_number};
+      int current_line_number = next_step;
+      while (true) {
+        if (current_line_number <= 0 || !current_code_function->code_blocks.contains(current_line_number)
+            || !visited.emplace(current_line_number).second
+            || recursions.contains(current_line_number)) {
+          return std::nullopt;
+        }
+        const auto& ladder_code_block = current_code_function->code_blocks.at(current_line_number);
+        if (!ladder_code_block.code_switch.switch_condition.empty()
+            || ladder_code_block.code_branch.branch_condition.empty()
+            || ladder_code_block.code_branch.branch_condition_true <= 0
+            || ladder_code_block.code_branch.branch_condition_false <= 0) {
+          return std::nullopt;
+        }
+        auto convergence_pair = immediate_postdominators.find(current_line_number);
+        if (convergence_pair == immediate_postdominators.end() || convergence_pair->second != pair_convergence) {
+          return std::nullopt;
+        }
+        auto ladder_condition = get_foldable_chain_branch_condition(ladder_code_block);
+        if (!ladder_condition.has_value()) return std::nullopt;
+        use_branch_hint = use_branch_hint || ladder_code_block.code_branch.use_hint;
+
+        struct ClassifiedEdge {
+          enum class Kind { Shared, Continue, Next } kind;
+          int target;
+          std::string predicate;
+        };
+        auto classify_edge = [&](int edge_target, std::string predicate) -> std::optional<ClassifiedEdge> {
+          if (edge_target == shared_target) {
+            return ClassifiedEdge{.kind = ClassifiedEdge::Kind::Shared, .target = edge_target, .predicate = std::move(predicate)};
+          }
+          if (continue_target != -1 && edge_target == continue_target) {
+            return ClassifiedEdge{.kind = ClassifiedEdge::Kind::Continue, .target = edge_target, .predicate = std::move(predicate)};
+          }
+          bool reaches_shared_target = false;
+          if (edge_target != pair_convergence) {
+            std::set<int> reachability_visited;
+            reaches_shared_target = can_fold_path_reach_target(edge_target, shared_target, can_fold_path_reach_target, reachability_visited);
+          }
+          if (reaches_shared_target) {
+            return ClassifiedEdge{.kind = ClassifiedEdge::Kind::Next, .target = edge_target, .predicate = std::move(predicate)};
+          }
+          return ClassifiedEdge{.kind = ClassifiedEdge::Kind::Continue, .target = edge_target, .predicate = std::move(predicate)};
+        };
+        auto true_edge = classify_edge(
+            ladder_code_block.code_branch.branch_condition_true,
+            and_conditions(current_path_condition, ladder_condition.value()));
+        auto false_edge = classify_edge(
+            ladder_code_block.code_branch.branch_condition_false,
+            and_conditions(current_path_condition, negate_condition(ladder_condition.value())));
+        if (!true_edge.has_value() || !false_edge.has_value()) return std::nullopt;
+        int next_edge_count = 0;
+        std::optional<ClassifiedEdge> next_edge;
+        for (const auto& edge : {true_edge.value(), false_edge.value()}) {
+          switch (edge.kind) {
+            case ClassifiedEdge::Kind::Shared:
+              if (!current_code_function->ComputePhiAssignments(const_cast<CodeBlock*>(&ladder_code_block), edge.target).empty()) {
+                return std::nullopt;
+              }
+              shared_predicates.push_back(edge.predicate);
+              break;
+            case ClassifiedEdge::Kind::Continue:
+              if (continue_target == -1) {
+                continue_target = edge.target;
+              } else if (continue_target != edge.target) {
+                return std::nullopt;
+              }
+              if (!current_code_function->ComputePhiAssignments(const_cast<CodeBlock*>(&ladder_code_block), edge.target).empty()) {
+                return std::nullopt;
+              }
+              continue_predicates.push_back(edge.predicate);
+              break;
+            case ClassifiedEdge::Kind::Next:
+              if (!current_code_function->ComputePhiAssignments(const_cast<CodeBlock*>(&ladder_code_block), edge.target).empty()) {
+                return std::nullopt;
+              }
+              ++next_edge_count;
+              next_edge = edge;
+              break;
+          }
+        }
+        if (next_edge_count > 1) return std::nullopt;
+        if (next_edge_count == 0) break;
+        current_path_condition = next_edge->predicate;
+        current_line_number = next_edge->target;
+      }
+      if (continue_target == -1 || shared_predicates.empty() || continue_predicates.empty()) {
+        return std::nullopt;
+      }
+      return FoldedSharedBranchLadder{
+          .shared_target = shared_target,
+          .continue_target = continue_target,
+          .use_branch_hint = use_branch_hint,
+          .shared_target_condition = or_conditions(shared_predicates),
+      };
+    };
+
+    // ===== Deferred target detection =====
+    auto can_defer_shared_target = [&](int candidate_target, bool allow_phi_assignments = false) -> bool {
+      if (pair_convergence == -1 || candidate_target <= 0 || candidate_target == pair_convergence
+          || candidate_target <= line_number
+          || !current_code_function->code_blocks.contains(candidate_target)
+          || recursions.contains(candidate_target)) {
+        return false;
+      }
+      auto predecessor_it = structural_predecessors.find(candidate_target);
+      if (predecessor_it == structural_predecessors.end() || predecessor_it->second.size() < 2) {
+        return false;
+      }
+      for (int predecessor_line_number : predecessor_it->second) {
+        if (!current_code_function->code_blocks.contains(predecessor_line_number)) return false;
+        auto dominator_it = dominators.find(predecessor_line_number);
+        if (dominator_it == dominators.end() || !dominator_it->second.contains(line_number)) return false;
+        if (!current_code_function->ComputePhiAssignments(
+                                      &current_code_function->code_blocks.at(predecessor_line_number),
+                                      candidate_target).empty()) {
+          if (!allow_phi_assignments) return false;
+        }
+      }
+      return true;
+    };
+
+    auto candidate_spans_both_root_sides = [&](int candidate_target) -> bool {
+      auto predecessor_it = structural_predecessors.find(candidate_target);
+      if (predecessor_it == structural_predecessors.end() || predecessor_it->second.size() < 2) return false;
+      bool has_true_side = candidate_target == code_block.code_branch.branch_condition_true;
+      bool has_false_side = candidate_target == code_block.code_branch.branch_condition_false;
+      for (int predecessor_line_number : predecessor_it->second) {
+        auto predecessor_dominators_it = dominators.find(predecessor_line_number);
+        if (predecessor_dominators_it == dominators.end()) continue;
+        if (predecessor_line_number == code_block.code_branch.branch_condition_true
+            || predecessor_dominators_it->second.contains(code_block.code_branch.branch_condition_true)) {
+          has_true_side = true;
+        }
+        if (predecessor_line_number == code_block.code_branch.branch_condition_false
+            || predecessor_dominators_it->second.contains(code_block.code_branch.branch_condition_false)) {
+          has_false_side = true;
+        }
+      }
+      return has_true_side && has_false_side;
+    };
+
+    auto get_convergence_join_rejection_reason = [&](int candidate_target) -> std::optional<std::string> {
+      if (pair_convergence == -1 || candidate_target <= 0 || candidate_target == pair_convergence
+          || candidate_target <= line_number || candidate_target >= pair_convergence
+          || !current_code_function->code_blocks.contains(candidate_target)
+          || recursions.contains(candidate_target)) {
+        return "out-of-range";
+      }
+      const auto& candidate_code_block = current_code_function->code_blocks.at(candidate_target);
+      if (!candidate_code_block.code_switch.switch_condition.empty()
+          || candidate_code_block.code_branch.branch_condition.empty()
+          || candidate_code_block.code_branch.branch_condition_true <= 0
+          || candidate_code_block.code_branch.branch_condition_false <= 0) {
+        return "not-conditional-join";
+      }
+      const bool true_converges = candidate_code_block.code_branch.branch_condition_true == pair_convergence;
+      const bool false_converges = candidate_code_block.code_branch.branch_condition_false == pair_convergence;
+      if (true_converges == false_converges) return "not-single-converging-join";
+      auto ipdom_it = immediate_postdominators.find(candidate_target);
+      if (ipdom_it == immediate_postdominators.end() || ipdom_it->second != pair_convergence) {
+        return "ipdom-mismatch";
+      }
+      auto predecessor_it = structural_predecessors.find(candidate_target);
+      if (predecessor_it == structural_predecessors.end() || predecessor_it->second.size() < 2) {
+        return "need-multi-preds";
+      }
+      auto candidate_dominators_it = dominators.find(candidate_target);
+      if (candidate_dominators_it == dominators.end()) return "missing-dominators";
+      for (int predecessor_line_number : predecessor_it->second) {
+        if (!current_code_function->code_blocks.contains(predecessor_line_number)) {
+          return std::format("missing-pred-{}", predecessor_line_number);
+        }
+        auto dominator_it = dominators.find(predecessor_line_number);
+        if (dominator_it == dominators.end() || !dominator_it->second.contains(line_number)) {
+          return std::format("pred-not-dominated-{}", predecessor_line_number);
+        }
+      }
+      bool has_true_side = candidate_target == code_block.code_branch.branch_condition_true;
+      bool has_false_side = candidate_target == code_block.code_branch.branch_condition_false;
+      for (int predecessor_line_number : predecessor_it->second) {
+        auto predecessor_dominators_it = dominators.find(predecessor_line_number);
+        if (predecessor_dominators_it == dominators.end()) continue;
+        if (predecessor_line_number == code_block.code_branch.branch_condition_true
+            || predecessor_dominators_it->second.contains(code_block.code_branch.branch_condition_true)) {
+          has_true_side = true;
+        }
+        if (predecessor_line_number == code_block.code_branch.branch_condition_false
+            || predecessor_dominators_it->second.contains(code_block.code_branch.branch_condition_false)) {
+          has_false_side = true;
+        }
+      }
+      if (!has_true_side || !has_false_side) {
+        return has_true_side ? "single-side-false" : "single-side-true";
+      }
+      // Bypass-edge check: reject if any block branches to BOTH the candidate
+      // AND directly to pair_convergence. Such a block bypasses the candidate
+      // on one of its outgoing edges, so the candidate does not dominate all
+      // paths to the convergence. Deferring the candidate would cause the
+      // bypass path to fall through into the candidate's body (emitted after
+      // the if/else), executing it unexpectedly on the bypass path.
+      //
+      // Example (bug in 0x1873FC64 ReflectionTraceVoxelsCS):
+      //   %1543 -> %1553  (candidate)
+      //   %1543 -> %1568  (pair_convergence; bypass edge)
+      //   %1038 (current) -> %1553 (false edge)
+      //   %1038 -> %1057 -> ... -> %1543
+      //   %1553 is a 2-pred phi-join target, but %1543 branches to EITHER
+      //   %1553 OR %1568 directly. Deferring %1553 causes the %1543->%1568
+      //   path to fall through into %1553's body after the if/else.
+      {
+        auto pair_convergence_preds_it = structural_predecessors.find(pair_convergence);
+        if (pair_convergence_preds_it != structural_predecessors.end()) {
+          auto candidate_preds_set = std::set<int>(predecessor_it->second.begin(), predecessor_it->second.end());
+          for (int convergence_predecessor : pair_convergence_preds_it->second) {
+            if (convergence_predecessor == candidate_target) continue;
+            if (candidate_preds_set.contains(convergence_predecessor)) {
+              return std::format("bypass-edge-from-{}", convergence_predecessor);
+            }
+          }
+        }
+      }
+      // Scope validation for temporary variables
+      static const auto TEMP_REFERENCE_REGEX = std::regex(R"(\b_(\d+)\b)");
+      for (const auto& hlsl_line : candidate_code_block.hlsl_lines) {
+        if (hlsl_line.starts_with("//")) continue;
+        auto line = std::string(hlsl_line);
+        auto line_declared_variable_number = try_parse_temp_local_assignment_number(hlsl_line);
+        auto refs_begin = std::sregex_iterator(line.begin(), line.end(), TEMP_REFERENCE_REGEX);
+        auto refs_end = std::sregex_iterator();
+        for (auto ref_it = refs_begin; ref_it != refs_end; ++ref_it) {
+          int referenced_variable_number = std::stoi((*ref_it)[1].str());
+          if (line_declared_variable_number.has_value()
+              && referenced_variable_number == line_declared_variable_number.value()) {
+            continue;
+          }
+          auto declaration_it = temporary_declaration_blocks.find(referenced_variable_number);
+          if (declaration_it == temporary_declaration_blocks.end()) {
+            if (!current_code_function->phi_variables.contains(std::to_string(referenced_variable_number))) {
+              return std::format("missing-temp-{}", referenced_variable_number);
+            }
+            continue;
+          }
+          int declaration_block_line_number = declaration_it->second;
+          if (declaration_block_line_number == candidate_target) continue;
+          if (!candidate_dominators_it->second.contains(declaration_block_line_number)) {
+            return std::format("temp-{}-decl-after-{}", referenced_variable_number, declaration_block_line_number);
+          }
+        }
+      }
+      return std::nullopt;
+    };
+
+    auto get_convergence_bridge_rejection_reason = [&](int candidate_target) -> std::optional<std::string> {
+      if (pair_convergence == -1 || candidate_target <= 0 || candidate_target == pair_convergence
+          || candidate_target <= line_number || candidate_target >= pair_convergence
+          || !current_code_function->code_blocks.contains(candidate_target)
+          || recursions.contains(candidate_target)) {
+        return "out-of-range";
+      }
+      const auto& candidate_code_block = current_code_function->code_blocks.at(candidate_target);
+      if (!candidate_code_block.code_switch.switch_condition.empty()
+          || !candidate_code_block.code_branch.branch_condition.empty()
+          || candidate_code_block.code_branch.branch_condition_true != pair_convergence
+          || candidate_code_block.code_branch.branch_condition_false != -1) {
+        return "not-direct-bridge";
+      }
+      auto ipdom_it = immediate_postdominators.find(candidate_target);
+      if (ipdom_it == immediate_postdominators.end() || ipdom_it->second != pair_convergence) {
+        return "ipdom-mismatch";
+      }
+      auto predecessor_it = structural_predecessors.find(candidate_target);
+      if (predecessor_it == structural_predecessors.end() || predecessor_it->second.size() < 2) {
+        return "need-multi-preds";
+      }
+      auto candidate_dominators_it = dominators.find(candidate_target);
+      if (candidate_dominators_it == dominators.end()) return "missing-dominators";
+      for (int predecessor_line_number : predecessor_it->second) {
+        if (!current_code_function->code_blocks.contains(predecessor_line_number)) {
+          return std::format("missing-pred-{}", predecessor_line_number);
+        }
+        auto dominator_it = dominators.find(predecessor_line_number);
+        if (dominator_it == dominators.end() || !dominator_it->second.contains(line_number)) {
+          return std::format("pred-not-dominated-{}", predecessor_line_number);
+        }
+      }
+      bool has_true_side = candidate_target == code_block.code_branch.branch_condition_true;
+      bool has_false_side = candidate_target == code_block.code_branch.branch_condition_false;
+      for (int predecessor_line_number : predecessor_it->second) {
+        auto predecessor_dominators_it = dominators.find(predecessor_line_number);
+        if (predecessor_dominators_it == dominators.end()) continue;
+        if (predecessor_line_number == code_block.code_branch.branch_condition_true
+            || predecessor_dominators_it->second.contains(code_block.code_branch.branch_condition_true)) {
+          has_true_side = true;
+        }
+        if (predecessor_line_number == code_block.code_branch.branch_condition_false
+            || predecessor_dominators_it->second.contains(code_block.code_branch.branch_condition_false)) {
+          has_false_side = true;
+        }
+      }
+      if (!has_true_side || !has_false_side) {
+        return has_true_side ? "single-side-false" : "single-side-true";
+      }
+      // Scope validation
+      static const auto TEMP_REFERENCE_REGEX = std::regex(R"(\b_(\d+)\b)");
+      for (const auto& hlsl_line : candidate_code_block.hlsl_lines) {
+        if (hlsl_line.starts_with("//")) continue;
+        auto line = std::string(hlsl_line);
+        auto line_declared_variable_number = try_parse_temp_local_assignment_number(hlsl_line);
+        auto refs_begin = std::sregex_iterator(line.begin(), line.end(), TEMP_REFERENCE_REGEX);
+        auto refs_end = std::sregex_iterator();
+        for (auto ref_it = refs_begin; ref_it != refs_end; ++ref_it) {
+          int referenced_variable_number = std::stoi((*ref_it)[1].str());
+          if (line_declared_variable_number.has_value()
+              && referenced_variable_number == line_declared_variable_number.value()) {
+            continue;
+          }
+          auto declaration_it = temporary_declaration_blocks.find(referenced_variable_number);
+          if (declaration_it == temporary_declaration_blocks.end()) {
+            if (!current_code_function->phi_variables.contains(std::to_string(referenced_variable_number))) {
+              return std::format("missing-temp-{}", referenced_variable_number);
+            }
+            continue;
+          }
+          int declaration_block_line_number = declaration_it->second;
+          if (declaration_block_line_number == candidate_target) continue;
+          if (!candidate_dominators_it->second.contains(declaration_block_line_number)) {
+            return std::format("temp-{}-decl-after-{}", referenced_variable_number, declaration_block_line_number);
+          }
+        }
+      }
+      return std::nullopt;
+    };
+
+    // ===== FoldedSharedBranchConditions =====
+    struct FoldedSharedBranchConditions {
+      std::string shared_target_condition;
+      std::string continue_target_condition;
+    };
+
+    auto build_folded_shared_branch_condition =
+        [&](const SharedBranchChain& chain) -> std::optional<FoldedSharedBranchConditions> {
+      std::vector<std::string> shared_predicates;
+      std::vector<std::string> continue_predicates;
+      shared_predicates.reserve(chain.steps.size());
+      continue_predicates.reserve(chain.steps.size());
+      for (size_t step_index = 0; step_index < chain.steps.size(); ++step_index) {
+        const auto& chain_step = chain.steps[step_index];
+        const auto& chain_code_block = current_code_function->code_blocks.at(chain_step.line_number);
+        if (!current_code_function->ComputePhiAssignments(const_cast<CodeBlock*>(&chain_code_block), chain.shared_target).empty()) {
+          return std::nullopt;
+        }
+        if (step_index + 1 < chain.steps.size()) {
+          if (!current_code_function->ComputePhiAssignments(
+                  const_cast<CodeBlock*>(&chain_code_block), chain.steps[step_index + 1].line_number).empty()) {
+            return std::nullopt;
+          }
+        } else if (chain.final_continue_target != pair_convergence) {
+          if (!current_code_function->ComputePhiAssignments(
+                  const_cast<CodeBlock*>(&chain_code_block), chain.final_continue_target).empty()) {
+            return std::nullopt;
+          }
+        }
+        std::optional<std::string> wrapped_condition;
+        if (step_index == 0) {
+          wrapped_condition = ParseWrapped(chain_code_block.code_branch.branch_condition);
+        } else {
+          wrapped_condition = get_foldable_chain_branch_condition(chain_code_block);
+          if (!wrapped_condition.has_value()) return std::nullopt;
+        }
+        if (chain_step.shared_on_true) {
+          shared_predicates.push_back(wrapped_condition.value());
+          continue_predicates.push_back(std::format("!{}", wrapped_condition.value()));
+        } else {
+          shared_predicates.push_back(std::format("!{}", wrapped_condition.value()));
+          continue_predicates.push_back(wrapped_condition.value());
+        }
+      }
+      if (shared_predicates.empty() || continue_predicates.empty()) return std::nullopt;
+      std::stringstream shared_condition_stream;
+      for (size_t i = 0; i < shared_predicates.size(); ++i) {
+        if (i != 0) shared_condition_stream << " | ";
+        shared_condition_stream << shared_predicates[i];
+      }
+      std::stringstream continue_condition_stream;
+      for (size_t i = 0; i < continue_predicates.size(); ++i) {
+        if (i != 0) continue_condition_stream << " && ";
+        continue_condition_stream << continue_predicates[i];
+      }
+      return FoldedSharedBranchConditions{
+          .shared_target_condition = shared_condition_stream.str(),
+          .continue_target_condition = continue_condition_stream.str(),
+      };
+    };
+
+    // Build all folded structures
+    std::optional<FoldedSharedBranchConditions> folded_shared_branch_condition;
+    if (shared_branch_chain.has_value()) {
+      folded_shared_branch_condition = build_folded_shared_branch_condition(shared_branch_chain.value());
+    }
+    auto folded_shared_branch_join = build_folded_shared_branch_join();
+    auto folded_shared_continue_join = build_folded_shared_continue_join();
+    std::optional<FoldedNestedContinueReduction> folded_nested_continue_reduction;
+    if (folded_shared_continue_join.has_value()) {
+      folded_nested_continue_reduction = build_folded_nested_continue_reduction(folded_shared_continue_join.value());
+    }
+    std::optional<FoldedSharedBranchLadder> folded_shared_branch_ladder;
+    if (pair_convergence != -1) {
+      auto true_ladder = build_folded_shared_branch_ladder(code_block.code_branch.branch_condition_true,
+                                                           code_block.code_branch.branch_condition_false, true);
+      auto false_ladder = build_folded_shared_branch_ladder(code_block.code_branch.branch_condition_false,
+                                                            code_block.code_branch.branch_condition_true, false);
+      if (true_ladder.has_value()) {
+        folded_shared_branch_ladder = std::move(true_ladder);
+      } else if (false_ladder.has_value()) {
+        folded_shared_branch_ladder = std::move(false_ladder);
+      }
+    }
+
+    // Deferred phi join target detection
+    if (pair_convergence != -1) {
+      size_t deferred_phi_join_predecessor_count = 0;
+      for (const auto& [candidate_target, candidate_code_block] : current_code_function->code_blocks) {
+        if (get_convergence_join_rejection_reason(candidate_target).has_value()) continue;
+        if (has_active_deferred_phi_join_target(candidate_target)) continue;
+        auto predecessor_it = structural_predecessors.find(candidate_target);
+        if (predecessor_it == structural_predecessors.end()
+            || predecessor_it->second.size() != 2
+            || std::ranges::find(predecessor_it->second, line_number) == predecessor_it->second.end()) {
+          continue;
+        }
+        if (current_code_function->ComputePhiAssignments(&code_block, candidate_target).empty()) continue;
+        auto existing_deferred_target = std::ranges::find_if(
+            structural_deferred_branch_targets.rbegin(),
+            structural_deferred_branch_targets.rend(),
+            [&](const auto& entry) { return entry.first == candidate_target; });
+        if (existing_deferred_target != structural_deferred_branch_targets.rend()) continue;
+        size_t candidate_predecessor_count = predecessor_it->second.size();
+        if (!deferred_phi_join_target.has_value()
+            || candidate_predecessor_count > deferred_phi_join_predecessor_count
+            || (candidate_predecessor_count == deferred_phi_join_predecessor_count
+                && candidate_target > deferred_phi_join_target.value())) {
+          deferred_phi_join_target = candidate_target;
+          deferred_phi_join_predecessor_count = candidate_predecessor_count;
+        }
+      }
+    }
+
+    auto branch_plan = current_code_function->AnalyzeBranchStructure(line_number, immediate_postdominators, ladder_index);
+    auto should_skip_simple_two_arm_defer = [&](int candidate_target) {
+      if (!branch_plan.has_value() || branch_plan->shape != "if/else"
+          || branch_plan->arm_count != 2 || !branch_plan->exits.contains(candidate_target)) {
+        return false;
+      }
+      auto predecessor_it = structural_predecessors.find(candidate_target);
+      if (predecessor_it == structural_predecessors.end() || predecessor_it->second.size() > 2) return false;
+      if (ladder_index.owner.contains(candidate_target)) return false;
+      return true;
+    };
+
+    // Deferred shared target setup
+    std::vector<std::pair<int, std::string>> deferred_shared_targets;
+    const bool allow_deferred_shared_targets = !decompile_options.flatten;
+    if (pair_convergence != -1 && allow_deferred_shared_targets) {
+      std::optional<int> deferred_target;
+      size_t deferred_target_predecessor_count = 0;
+      auto consider_deferred_target = [&](int candidate_target) {
+        if (deferred_phi_join_target.has_value() && candidate_target == deferred_phi_join_target.value()) return;
+        if (has_active_deferred_phi_join_target(candidate_target)) return;
+        if (should_skip_simple_two_arm_defer(candidate_target)) return;
+        if (!can_defer_shared_target(candidate_target)) return;
+        size_t candidate_predecessor_count = structural_predecessors.at(candidate_target).size();
+        if (!deferred_target.has_value()
+            || candidate_predecessor_count > deferred_target_predecessor_count
+            || (candidate_predecessor_count == deferred_target_predecessor_count
+                && candidate_target > deferred_target.value())) {
+          deferred_target = candidate_target;
+          deferred_target_predecessor_count = candidate_predecessor_count;
+        }
+      };
+      if (folded_shared_branch_join.has_value()) {
+        consider_deferred_target(folded_shared_branch_join->shared_target);
+        consider_deferred_target(folded_shared_branch_join->continue_target);
+      }
+      if (folded_shared_continue_join.has_value()) {
+        consider_deferred_target(folded_shared_continue_join->continue_target);
+      }
+      if (folded_shared_branch_ladder.has_value()) {
+        consider_deferred_target(folded_shared_branch_ladder->shared_target);
+        consider_deferred_target(folded_shared_branch_ladder->continue_target);
+      }
+      if (shared_branch_chain.has_value()) {
+        consider_deferred_target(shared_branch_chain->shared_target);
+        if (shared_branch_chain->final_continue_target != pair_convergence) {
+          consider_deferred_target(shared_branch_chain->final_continue_target);
+        }
+      }
+      for (const auto& [candidate_target, candidate_code_block_unused] : current_code_function->code_blocks) {
+        if (has_active_deferred_phi_join_target(candidate_target)) continue;
+        auto join_rejection_reason = get_convergence_join_rejection_reason(candidate_target);
+        if (!join_rejection_reason.has_value()) {
+          if (deferred_phi_join_target.has_value() && candidate_target == deferred_phi_join_target.value()) continue;
+          if (should_skip_simple_two_arm_defer(candidate_target)) continue;
+          size_t candidate_predecessor_count = structural_predecessors.at(candidate_target).size();
+          if (!deferred_target.has_value()
+              || candidate_predecessor_count > deferred_target_predecessor_count
+              || (candidate_predecessor_count == deferred_target_predecessor_count
+                  && candidate_target > deferred_target.value())) {
+            deferred_target = candidate_target;
+            deferred_target_predecessor_count = candidate_predecessor_count;
+          }
+          continue;
+        }
+        auto bridge_rejection_reason = get_convergence_bridge_rejection_reason(candidate_target);
+        if (bridge_rejection_reason.has_value()) continue;
+        size_t candidate_predecessor_count = structural_predecessors.at(candidate_target).size();
+        if (!deferred_target.has_value()
+            || candidate_predecessor_count > deferred_target_predecessor_count
+            || (candidate_predecessor_count == deferred_target_predecessor_count
+                && candidate_target > deferred_target.value())) {
+          deferred_target = candidate_target;
+          deferred_target_predecessor_count = candidate_predecessor_count;
+        }
+      }
+
+      // Secondary phi deferred target
+      std::optional<int> secondary_phi_deferred_target;
+      size_t secondary_phi_deferred_target_predecessor_count = 0;
+      for (const auto& [candidate_target, candidate_code_block_unused2] : current_code_function->code_blocks) {
+        if (candidate_target == deferred_phi_join_target
+            || (deferred_target.has_value() && candidate_target == deferred_target.value())
+            || has_active_deferred_phi_join_target(candidate_target)) {
+          continue;
+        }
+        if (!candidate_spans_both_root_sides(candidate_target)) continue;
+        if (!can_defer_shared_target(candidate_target, true)) continue;
+        bool has_phi_assignments = false;
+        auto predecessor_it = structural_predecessors.find(candidate_target);
+        if (predecessor_it == structural_predecessors.end()) continue;
+        for (int predecessor_line_number : predecessor_it->second) {
+          if (!current_code_function->ComputePhiAssignments(
+                  &current_code_function->code_blocks.at(predecessor_line_number), candidate_target).empty()) {
+            has_phi_assignments = true;
+            break;
+          }
+        }
+        if (!has_phi_assignments) continue;
+        size_t candidate_predecessor_count = predecessor_it->second.size();
+        if (!secondary_phi_deferred_target.has_value()
+            || candidate_predecessor_count > secondary_phi_deferred_target_predecessor_count
+            || (candidate_predecessor_count == secondary_phi_deferred_target_predecessor_count
+                && candidate_target > secondary_phi_deferred_target.value())) {
+          secondary_phi_deferred_target = candidate_target;
+          secondary_phi_deferred_target_predecessor_count = candidate_predecessor_count;
+        }
+      }
+
+      if (deferred_target.has_value()) {
+        auto existing = std::ranges::find_if(
+            structural_deferred_branch_targets.rbegin(), structural_deferred_branch_targets.rend(),
+            [&](const auto& entry) { return entry.first == deferred_target.value(); });
+        if (existing != structural_deferred_branch_targets.rend()) {
+          deferred_target.reset();
+        }
+      }
+      if (deferred_target.has_value()) {
+        auto deferred_target_variable = std::format("__defer_{}_{}", line_number, deferred_target.value());
+        emit_annotation_comment(std::format("defer-target bb {} target={} preds={} phi=no",
+            line_number, deferred_target.value(), deferred_target_predecessor_count));
+        string_stream << spacing << "bool " << deferred_target_variable << " = false;\n";
+        structural_deferred_branch_targets.emplace_back(deferred_target.value(), deferred_target_variable);
+        deferred_shared_targets.emplace_back(deferred_target.value(), deferred_target_variable);
+      }
+      if (secondary_phi_deferred_target.has_value()) {
+        auto existing = std::ranges::find_if(
+            structural_deferred_branch_targets.rbegin(), structural_deferred_branch_targets.rend(),
+            [&](const auto& entry) { return entry.first == secondary_phi_deferred_target.value(); });
+        if (existing == structural_deferred_branch_targets.rend()) {
+          auto deferred_target_variable = std::format("__defer_{}_{}", line_number, secondary_phi_deferred_target.value());
+          emit_annotation_comment(std::format("defer-target bb {} target={} preds={} phi=yes",
+              line_number, secondary_phi_deferred_target.value(), secondary_phi_deferred_target_predecessor_count));
+          string_stream << spacing << "bool " << deferred_target_variable << " = false;\n";
+          structural_deferred_branch_targets.emplace_back(secondary_phi_deferred_target.value(), deferred_target_variable);
+          deferred_shared_targets.emplace_back(secondary_phi_deferred_target.value(), deferred_target_variable);
+        }
+      }
+    }
+
+    // ===== Main emission decision tree =====
+    bool pushed_deferred_phi_join_target = false;
+    if (deferred_phi_join_target.has_value()) {
+      active_deferred_phi_join_targets.push_back(deferred_phi_join_target.value());
+      pushed_deferred_phi_join_target = true;
+    }
+
+    auto emit_single_branch = [&](bool take_true_branch) {
+      if (code_block.code_branch.use_hint) {
+        string_stream << spacing << "[branch]\n";
+      }
+      if (take_true_branch) {
+        string_stream << spacing << std::format("if {} {{\n", ParseWrapped(code_block.code_branch.branch_condition));
+        indent_spacing();
+        on_branch_assuming(code_block.code_branch.branch_condition_true, true);
+        unindent_spacing();
+      } else {
+        string_stream << spacing << "if (!" << code_block.code_branch.branch_condition << ") {\n";
+        indent_spacing();
+        on_branch_assuming(code_block.code_branch.branch_condition_false, false);
+        unindent_spacing();
+      }
+      close_lonely_if(pair_convergence);
+    };
+
+    auto emit_full_branch = [&](bool true_branch_first) {
+      if (code_block.code_branch.use_hint) {
+        string_stream << spacing << "[branch]\n";
+      }
+      if (true_branch_first) {
+        string_stream << spacing << std::format("if {} {{\n", ParseWrapped(code_block.code_branch.branch_condition));
+        indent_spacing();
+        on_branch_assuming(code_block.code_branch.branch_condition_true, true);
+        unindent_spacing();
+        string_stream << spacing << "} else {\n";
+        indent_spacing();
+        on_branch_assuming(code_block.code_branch.branch_condition_false, false);
+        unindent_spacing();
+        string_stream << spacing << "}\n";
+      } else {
+        string_stream << spacing << "if (!" << code_block.code_branch.branch_condition << ") {\n";
+        indent_spacing();
+        on_branch_assuming(code_block.code_branch.branch_condition_false, false);
+        unindent_spacing();
+        string_stream << spacing << "} else {\n";
+        indent_spacing();
+        on_branch_assuming(code_block.code_branch.branch_condition_true, true);
+        unindent_spacing();
+        string_stream << spacing << "}\n";
+      }
+    };
+
+    if (pair_convergence == code_block.code_branch.branch_condition_true) {
+      emit_single_branch(false);
+    } else if (pair_convergence == code_block.code_branch.branch_condition_false) {
+      emit_single_branch(true);
+    } else if (folded_shared_branch_join.has_value()) {
+      emit_annotation_comment(std::format("fold shared-branch-join bb {} shared={} continue={}",
+          line_number, folded_shared_branch_join->shared_target, folded_shared_branch_join->continue_target));
+      if (folded_shared_branch_join->use_branch_hint) {
+        string_stream << spacing << "[branch]\n";
+      }
+      string_stream << spacing << "if (" << folded_shared_branch_join->shared_target_condition << ") {\n";
+      indent_spacing();
+      append_or_defer(folded_shared_branch_join->shared_target);
+      unindent_spacing();
+      string_stream << spacing << "} else {\n";
+      indent_spacing();
+      append_or_defer(folded_shared_branch_join->continue_target);
+      unindent_spacing();
+      string_stream << spacing << "}\n";
+    } else if (folded_shared_continue_join.has_value()) {
+      emit_annotation_comment(std::format("fold shared-continue-join bb {} continue={} true={} false={}",
+          line_number, folded_shared_continue_join->continue_target,
+          folded_shared_continue_join->true_target, folded_shared_continue_join->false_target));
+      if (folded_shared_continue_join->use_branch_hint) {
+        string_stream << spacing << "[branch]\n";
+      }
+      string_stream << spacing << "if (" << folded_shared_continue_join->continue_target_condition << ") {\n";
+      indent_spacing();
+      append_or_defer(folded_shared_continue_join->continue_target);
+      unindent_spacing();
+      string_stream << spacing << "} else {\n";
+      indent_spacing();
+      if (folded_nested_continue_reduction.has_value()) {
+        emit_annotation_comment(std::format("fold nested-continue-reduction bb {} unique={} direct={} converge={}",
+            line_number, folded_nested_continue_reduction->unique_target,
+            folded_nested_continue_reduction->direct_target, folded_nested_continue_reduction->nested_convergence));
+        if (folded_nested_continue_reduction->use_branch_hint) {
+          string_stream << spacing << "[branch]\n";
+        }
+        structural_pending_convergences.push_back(folded_nested_continue_reduction->nested_convergence);
+        string_stream << spacing << "if (" << folded_nested_continue_reduction->unique_condition << ") {\n";
+        indent_spacing();
+        structural_append_code_block(folded_nested_continue_reduction->unique_target);
+        unindent_spacing();
+        string_stream << spacing << "} else {\n";
+        indent_spacing();
+        structural_append_code_block(folded_nested_continue_reduction->direct_target);
+        unindent_spacing();
+        string_stream << spacing << "}\n";
+        structural_pending_convergences.pop_back();
+        structural_append_code_block(folded_nested_continue_reduction->nested_convergence);
+      } else {
+        string_stream << spacing << "if (" << ParseWrapped(code_block.code_branch.branch_condition) << ") {\n";
+        indent_spacing();
+        append_or_defer(folded_shared_continue_join->true_target);
+        unindent_spacing();
+        string_stream << spacing << "} else {\n";
+        indent_spacing();
+        append_or_defer(folded_shared_continue_join->false_target);
+        unindent_spacing();
+        string_stream << spacing << "}\n";
+      }
+      unindent_spacing();
+      string_stream << spacing << "}\n";
+    } else if (folded_shared_branch_ladder.has_value()) {
+      emit_annotation_comment(std::format("fold shared-branch-ladder bb {} shared={} continue={}",
+          line_number, folded_shared_branch_ladder->shared_target, folded_shared_branch_ladder->continue_target));
+      if (folded_shared_branch_ladder->use_branch_hint) {
+        string_stream << spacing << "[branch]\n";
+      }
+      string_stream << spacing << "if (" << folded_shared_branch_ladder->shared_target_condition << ") {\n";
+      indent_spacing();
+      append_or_defer(folded_shared_branch_ladder->shared_target);
+      unindent_spacing();
+      string_stream << spacing << "} else {\n";
+      indent_spacing();
+      append_or_defer(folded_shared_branch_ladder->continue_target);
+      unindent_spacing();
+      string_stream << spacing << "}\n";
+    } else if (shared_branch_chain.has_value() && folded_shared_branch_condition.has_value()) {
+      emit_annotation_comment(std::format("fold shared-branch-chain-cond bb {} shared={} continue={}",
+          line_number, shared_branch_chain->shared_target, shared_branch_chain->final_continue_target));
+      bool use_branch_hint = false;
+      for (const auto& chain_step : shared_branch_chain->steps) {
+        if (current_code_function->code_blocks.at(chain_step.line_number).code_branch.use_hint) {
+          use_branch_hint = true;
+          break;
+        }
+      }
+      if (use_branch_hint) {
+        string_stream << spacing << "[branch]\n";
+      }
+      const auto& last_chain_step = shared_branch_chain->steps.back();
+      auto& last_chain_code_block = current_code_function->code_blocks.at(last_chain_step.line_number);
+      if (shared_branch_chain->final_continue_target != pair_convergence) {
+        string_stream << spacing << "if (" << folded_shared_branch_condition->continue_target_condition << ") {\n";
+        indent_spacing();
+        on_branch_from(&last_chain_code_block, shared_branch_chain->final_continue_target);
+        unindent_spacing();
+        string_stream << spacing << "} else {\n";
+        indent_spacing();
+        append_or_defer(shared_branch_chain->shared_target);
+        unindent_spacing();
+        string_stream << spacing << "}\n";
+      } else {
+        string_stream << spacing << "if (" << folded_shared_branch_condition->shared_target_condition << ") {\n";
+        indent_spacing();
+        append_or_defer(shared_branch_chain->shared_target);
+        unindent_spacing();
+        string_stream << spacing << "} else {\n";
+        indent_spacing();
+        emit_phi_assignments(&last_chain_code_block, pair_convergence);
+        unindent_spacing();
+        string_stream << spacing << "}\n";
+      }
+    } else if (shared_branch_chain.has_value()) {
+      // Fallback: emit the chain step-by-step with a branch variable
+      emit_annotation_comment(std::format("fold shared-branch-chain-fallback bb {} shared={} continue={}",
+          line_number, shared_branch_chain->shared_target, shared_branch_chain->final_continue_target));
+      const auto& shared_target_code_block =
+          current_code_function->code_blocks.at(shared_branch_chain->shared_target);
+      const bool inlineable_shared_target =
+          shared_target_code_block.code_switch.switch_condition.empty()
+          && shared_target_code_block.code_branch.branch_condition.empty()
+          && shared_target_code_block.code_branch.branch_condition_true > 0
+          && shared_target_code_block.code_branch.branch_condition_false == -1
+          && shared_target_code_block.hlsl_lines.empty();
+      std::string chain_branch_variable;
+      if (!inlineable_shared_target) {
+        chain_branch_variable = std::format("__branch_chain_{}", line_number);
+        string_stream << spacing << "bool " << chain_branch_variable << ";\n";
+      }
+      std::function<void(size_t, CodeBlock*)> emit_shared_branch_chain_step =
+          [&](size_t step_index, CodeBlock* predecessor_code_block) {
+            const auto& chain_step = shared_branch_chain->steps[step_index];
+            auto& chain_code_block = current_code_function->code_blocks[chain_step.line_number];
+            if (predecessor_code_block != nullptr) {
+              emit_phi_assignments(predecessor_code_block, chain_step.line_number);
+              emit_code_block_prelude(chain_step.line_number);
+            }
+            auto emit_chain_branch = [&](bool take_shared_target) {
+              if (take_shared_target) {
+                emit_phi_assignments(&chain_code_block, shared_branch_chain->shared_target);
+                if (inlineable_shared_target) {
+                  on_branch_from(const_cast<CodeBlock*>(&shared_target_code_block),
+                                 shared_target_code_block.code_branch.branch_condition_true);
+                } else {
+                  string_stream << spacing << chain_branch_variable << " = true;\n";
+                }
+              } else if (step_index + 1 < shared_branch_chain->steps.size()) {
+                emit_shared_branch_chain_step(step_index + 1, &chain_code_block);
+              } else {
+                if (inlineable_shared_target && shared_branch_chain->final_continue_target != pair_convergence) {
+                  on_branch_from(&chain_code_block, shared_branch_chain->final_continue_target);
+                } else {
+                  if (shared_branch_chain->final_continue_target == pair_convergence) {
+                    emit_phi_assignments(&chain_code_block, pair_convergence);
+                  }
+                  if (!inlineable_shared_target) {
+                    string_stream << spacing << chain_branch_variable << " = false;\n";
+                  }
+                }
+              }
+            };
+            if (chain_code_block.code_branch.use_hint) {
+              string_stream << spacing << "[branch]\n";
+            }
+            if (chain_step.shared_on_true) {
+              string_stream << spacing << std::format("if {} {{\n", ParseWrapped(chain_code_block.code_branch.branch_condition));
+            } else {
+              string_stream << spacing << "if (!" << chain_code_block.code_branch.branch_condition << ") {\n";
+            }
+            indent_spacing();
+            with_assumed_condition(chain_code_block.code_branch.branch_condition, chain_step.shared_on_true, [&]() {
+              emit_chain_branch(true);
+            });
+            unindent_spacing();
+            string_stream << spacing << "} else {\n";
+            indent_spacing();
+            with_assumed_condition(chain_code_block.code_branch.branch_condition, !chain_step.shared_on_true, [&]() {
+              emit_chain_branch(false);
+            });
+            unindent_spacing();
+            string_stream << spacing << "}\n";
+          };
+      emit_shared_branch_chain_step(0, nullptr);
+      if (!inlineable_shared_target) {
+        string_stream << spacing << "if (" << chain_branch_variable << ") {\n";
+        indent_spacing();
+        append_or_defer(shared_branch_chain->shared_target);
+        unindent_spacing();
+        if (shared_branch_chain->final_continue_target != pair_convergence) {
+          string_stream << spacing << "} else {\n";
+          indent_spacing();
+          const auto& last_chain_step = shared_branch_chain->steps.back();
+          auto& last_chain_code_block = current_code_function->code_blocks.at(last_chain_step.line_number);
+          on_branch_from(&last_chain_code_block, shared_branch_chain->final_continue_target);
+          unindent_spacing();
+          string_stream << spacing << "}\n";
+        } else {
+          string_stream << spacing << "}\n";
+        }
+      }
+    } else if (branch_plan.has_value() && branch_plan->shape == "if" && branch_plan->arm_count == 1) {
+      if (branch_plan->then_target > 0 && branch_plan->then_target != branch_plan->convergence
+          && (branch_plan->else_target <= 0 || branch_plan->else_target == branch_plan->convergence)) {
+        emit_single_branch(true);
+      } else if (branch_plan->else_target > 0 && branch_plan->else_target != branch_plan->convergence
+                 && (branch_plan->then_target <= 0 || branch_plan->then_target == branch_plan->convergence)) {
+        emit_single_branch(false);
+      } else if (code_block.code_branch.branch_condition_true < code_block.code_branch.branch_condition_false) {
+        emit_full_branch(true);
+      } else {
+        emit_full_branch(false);
+      }
+    } else if (branch_plan.has_value() && branch_plan->shape == "if/else" && branch_plan->arm_count == 2) {
+      emit_full_branch(true);
+    } else if (code_block.code_branch.branch_condition_true < code_block.code_branch.branch_condition_false) {
+      emit_full_branch(true);
+    } else {
+      emit_full_branch(false);
+    }
+
+    // Deferred phi join target emission
+    if (deferred_phi_join_target.has_value()) {
+      emit_annotation_comment(std::format("append phi-join bb {} target={}", line_number, deferred_phi_join_target.value()));
+      structural_append_code_block(deferred_phi_join_target.value());
+    }
+    if (pushed_deferred_phi_join_target) {
+      active_deferred_phi_join_targets.pop_back();
+    }
+
+    // Convergence completion
+    if (pushed_pair_convergence) {
+      structural_pending_convergences.pop_back();
+      bool is_empty = structural_pending_convergences.empty();
+      on_branch(pair_convergence, true);
+      if (!is_empty && uses_convergence_wrapper) {
+        unindent_spacing();
+        string_stream << spacing << "} while (false);\n";
+      }
+    }
+
+    // Deferred shared target emission
+    for (const auto& [deferred_target, deferred_target_variable] : deferred_shared_targets) {
+      string_stream << spacing << "if (" << deferred_target_variable << ") {\n";
+      indent_spacing();
+      structural_append_code_block(deferred_target);
+      unindent_spacing();
+      string_stream << spacing << "}\n";
+    }
+    for (size_t deferred_target_index = 0; deferred_target_index < deferred_shared_targets.size(); ++deferred_target_index) {
+      structural_deferred_branch_targets.pop_back();
+    }
+
+    on_complete();
+  };  // end structural_append_code_block
+
+  // Emit loop jump target variable if needed
+  if (uses_loop_jump_target) {
+    string_stream << spacing << "int " << LOOP_JUMP_TARGET_NAME << " = -1;\n";
+  }
+
+  structural_append_code_block(0);
+}
+// ===== END STRUCTURAL =====

--- a/src/utils/shader_decompiler/structural.hpp
+++ b/src/utils/shader_decompiler/structural.hpp
@@ -1,23 +1,9 @@
 // ===== STRUCTURAL CODE GENERATION =====
-// Ported from ShortFuse's structural analysis code path.
-// This file is #included inside the Decompiler::Decompile() method when
-// decompile_options.structural is true.
-//
-// Available in scope from the caller:
-//   - current_code_function, string_stream, spacing, decompile_options
-//   - indent_spacing(), unindent_spacing()
-//   - ParseType(), ParseWrapped(), OptimizeString(), IsWrapped()
-//   - convergences, recursions, dominators, predecessors (from default path setup)
-//   - preprocess_state
-//
-// This code path replaces the entire block iteration loop (append_code_block)
-// with ShortFuse's deferred-target + branch-folding approach.
+// #included inside Decompiler::Decompile() when decompile_options.structural is true.
+// Replaces the default append_code_block loop with deferred-target + branch-folding.
 
 {
-  // The structural path uses ListRecursions (any backward edge = loop) instead
-  // of ListNaturalLoops (only dominator-validated back edges).  ShortFuse's
-  // structural analysis relies on this broader detection to avoid "unsupported
-  // loop" errors on blocks that branch backward to convergence targets.
+  // Use ListRecursions (any backward edge) instead of ListNaturalLoops
   auto recursions = current_code_function->ListRecursions();  // shadows outer `recursions`
 
   // Recompute analysis using structural-specific functions
@@ -26,7 +12,6 @@
   auto structural_predecessors = current_code_function->ListPredecessorsVec();
   auto ladder_index = current_code_function->BuildBranchLadderIndex(structural_predecessors, immediate_postdominators);
 
-  // Track which block declares each temporary variable (for scope validation)
   std::map<int, int> temporary_declaration_blocks;
 
   auto is_temp_local_variable_token = [](std::string_view token) {
@@ -106,7 +91,6 @@
     }
   }
 
-  // AssumedCondition: tracks assumed branch conditions for optimization
   struct AssumedCondition {
     std::string variable;
     bool value;
@@ -117,16 +101,8 @@
   std::vector<int> structural_current_loops;
   std::vector<int> active_deferred_phi_join_targets;
 
-  // Phi variable coalescing map: maps convergence phi variable names to loop phi variable names.
-  // When a convergence point inside a loop has a phi that forwards a loop header phi unchanged
-  // on the pass-through path, and that convergence phi feeds back into the same loop phi on the
-  // back-edge, the two variables form an identity cycle. DXC can exploit this by replacing the
-  // initial loop phi value with undef. Coalescing prevents this by using the same variable name
-  // for both, eliminating the intermediate copy.
-  // NOTE: Currently disabled - requires liveness analysis to verify the convergence phi variable
-  // is not used between the convergence point and the back-edge (other than in the back-edge
-  // phi assignment itself). Without this check, coalescing can break shaders where the
-  // convergence phi is read by code after the convergence.
+  // Phi coalescing: maps convergence phi names to loop phi names to prevent
+  // DXC from exploiting identity cycles. Currently disabled (needs liveness analysis).
   std::map<std::string, std::string> structural_phi_coalescing;
 
   auto emit_annotation_comment = [&](std::string_view comment) {
@@ -276,18 +252,12 @@
           std::format("({})", known_expression));
     }
 
-    // Safety check: if any variable defined in this block is used outside the
-    // block (i.e., not transitively consumed by the branch condition), expanding
-    // would lose its definition.  Detect this by checking whether each defined
-    // variable is referenced by at least one other assignment in the block or by
-    // the branch condition itself.
+    // Safety: bail if a variable defined here is used only externally
     for (const auto& [var_name, _expr] : known_assignments) {
       bool referenced_internally = false;
-      // Check if used by another assignment in the block
       for (const auto& [other_var, other_expr] : known_assignments) {
         if (other_var == var_name) continue;
         if (other_expr.find(var_name) != std::string::npos) {
-          // Verify it's a whole-identifier match, not a substring
           auto pos = other_expr.find(var_name);
           while (pos != std::string::npos) {
             bool left_ok = (pos == 0) || !is_identifier_character(other_expr[pos - 1]);
@@ -302,7 +272,6 @@
         }
       }
       if (!referenced_internally) {
-        // Check if used by the branch condition
         auto cond_str = std::string(branch_code_block.code_branch.branch_condition);
         auto pos = cond_str.find(var_name);
         while (pos != std::string::npos) {
@@ -316,20 +285,11 @@
         }
       }
       if (!referenced_internally) {
-        // This variable is defined in the block but not used by the condition
-        // or any other assignment that feeds the condition — it must be used
-        // externally.  Bail out to preserve its definition.
         return std::nullopt;
       }
     }
 
-    // Safety check 2: even if a variable is used internally, it may ALSO be
-    // used by other code blocks in the function (e.g. a sibling branch that
-    // will be emitted via a chained fold). Folding would make the assignment
-    // disappear, leaving the external reference dangling (produces `undef`
-    // in DXIL). Scan every other block's hlsl_lines, phi assignments, and
-    // branch_condition string for whole-identifier references; if any are
-    // found, bail out.
+    // Safety: bail if a variable is also referenced by other blocks
     auto check_variable_referenced_externally = [&](const std::string& var_name) -> bool {
       auto contains_whole_identifier = [&](std::string_view haystack) -> bool {
         auto pos = haystack.find(var_name);
@@ -347,13 +307,10 @@
           if (other_line.starts_with("//")) continue;
           if (contains_whole_identifier(other_line)) return true;
         }
-        // Phi lines can also reference the variable
         for (const auto& [phi_var, phi_type, phi_value, phi_predecessor, phi_code_function, phi_is_assign] : other_code_block.phi_lines) {
           if (!phi_is_assign) continue;
           if (contains_whole_identifier(phi_value)) return true;
         }
-        // Branch condition string lives outside hlsl_lines and can reference
-        // the variable directly (e.g. `_784 * ... > ...`).
         if (contains_whole_identifier(other_code_block.code_branch.branch_condition)) return true;
       }
       return false;
@@ -406,13 +363,9 @@
   }();
 
   // ===== Main structural append_code_block =====
-  // Safety limit: abort with an exception if the output grows beyond a
-  // reasonable size.  This prevents the "vector too long" crash from
-  // std::string reallocation and gives a clear error message instead.
-  constexpr size_t MAX_OUTPUT_SIZE = 128 * 1024 * 1024;  // 128 MB
+  constexpr size_t MAX_OUTPUT_SIZE = 128 * 1024 * 1024;  // 128 MB safety limit
 
   std::function<void(int line_number)> structural_append_code_block = [&](int line_number) {
-    // Check for code size explosion
     auto current_size = static_cast<size_t>(string_stream.tellp());
     if (current_size > MAX_OUTPUT_SIZE) {
       throw std::runtime_error(std::format(
@@ -427,15 +380,8 @@
       string_stream << spacing << "while(true) {\n";
       indent_spacing();
 
-      // Phi pre-initialization for inner-loop convergence points.
-      // Detects identity cycles between loop header phis and convergence phis,
-      // and emits pre-initialization assignments at the loop header to prevent
-      // DXC from replacing initial values with undef.
-      // Only applies when:
-      // 1. The convergence is a direct successor of the loop header
-      // 2. The convergence is inside the loop (dominated by the loop header)
-      // 3. The convergence phi forms a back-edge cycle with the loop header phi
-      // 4. The convergence phi is not used in any hlsl_lines (pure forwarding)
+      // Phi pre-initialization: emit _convergence = _loop_phi at loop header
+      // to prevent DXC from replacing initial values with undef in identity cycles.
       {
         auto& loop_header_block = current_code_function->code_blocks[line_number];
         auto loop_dom_it = dominators.find(line_number);
@@ -443,17 +389,14 @@
         for (const auto& [cv_variable, cv_type, cv_value, cv_predecessor, cv_code_function, cv_is_assign] : loop_header_block.phi_lines) {
           if (!cv_is_assign) continue;
           if (cv_code_function == line_number) continue;
-          // Must be a direct successor of the loop header
           if (cv_code_function != loop_header_block.code_branch.branch_condition_true
               && cv_code_function != loop_header_block.code_branch.branch_condition_false) continue;
-          // Must be inside the loop (dominated by loop header)
           auto conv_dom_it = dominators.find(cv_code_function);
           if (conv_dom_it == dominators.end() || !conv_dom_it->second.contains(line_number)) continue;
           auto cv_value_str = std::string(cv_value);
           if (cv_value_str.empty() || cv_value_str[0] != '%') continue;
           auto loop_phi_var = cv_value_str.substr(1);
           
-          // Verify back-edge cycle
           bool found_back_edge = false;
           for (auto& [block_num, block] : current_code_function->code_blocks) {
             if (block_num == line_number) continue;
@@ -468,7 +411,6 @@
           }
           if (!found_back_edge) continue;
           
-          // Safety: convergence phi must not appear in any hlsl_lines
           auto conv_var_name = std::format("_{}", cv_variable);
           bool used_in_code = false;
           for (const auto& [block_num, block] : current_code_function->code_blocks) {
@@ -564,34 +506,26 @@
           emit_annotation_comment(std::format("pending-convergence [{}]", format_int_list(structural_pending_convergences)));
         }
       }
-      // Regex to detect type-prefixed variable assignments like "float _30 = ..."
-      // When the variable was already pre-declared at function scope, strip the
-      // type prefix to avoid redefinition errors.
+      // Strip type prefix from pre-declared variables to avoid redefinition
       static const std::regex structural_var_decl_re(
           R"(^(float4|float3|float2|float|int|uint|bool|uint4|int4|int2|uint2|int3|uint3|double|int64_t|uint64_t|int16_t|uint16_t|half|min16float|min16int|min16uint|[A-Z_]\w*)\s+(_\d+)\s*=)");
-      // Also match "type _N; ..." patterns (e.g., GetDimensions: "uint2 _39; srv.GetDimensions(...)")
-      // where the declaration is followed by a semicolon and then a function call.
       static const std::regex structural_var_decl_noassign_re(
           R"(^(float4|float3|float2|float|int|uint|bool|uint4|int4|int2|uint2|int3|uint3|double|int64_t|uint64_t|int16_t|uint16_t|half|min16float|min16int|min16uint|[A-Z_]\w*)\s+(_\d+)\s*;)");
       for (const auto& hlsl_line : emit_code_block.hlsl_lines) {
         auto optimized_line = (decompile_options.flatten ? OptimizeString(hlsl_line) : hlsl_line);
-        // Strip type prefix if variable was pre-declared
         std::smatch decl_match;
         auto line_str = std::string(optimized_line);
         if (std::regex_search(line_str, decl_match, structural_var_decl_re)) {
           std::string var_name = decl_match[2].str();
           if (declared_vars.contains(var_name)) {
-            // Replace "type _N = ..." with "_N = ..."
-            line_str = line_str.substr(decl_match[1].length() + 1);  // skip "type "
+            line_str = line_str.substr(decl_match[1].length() + 1);
             string_stream << spacing << line_str << "\n";
             continue;
           }
         } else if (std::regex_search(line_str, decl_match, structural_var_decl_noassign_re)) {
           std::string var_name = decl_match[2].str();
           if (declared_vars.contains(var_name)) {
-            // Replace "type _N; rest..." with "rest..." (strip the redundant declaration)
-            // The declaration part ends at the semicolon after the variable name
-            auto decl_end = decl_match[0].length();  // length of "type _N;"
+            auto decl_end = decl_match[0].length();
             auto remainder = StringViewTrim(std::string_view(line_str).substr(decl_end));
             if (!remainder.empty()) {
               string_stream << spacing << remainder << "\n";
@@ -604,7 +538,6 @@
       for (const auto& [variable, type, value, predecessor, code_function, is_assign] : emit_code_block.phi_lines) {
         if (is_assign) continue;
         auto var_name = std::format("_{}", variable);
-        // Only declare if not already pre-declared at function scope
         if (!declared_vars.contains(var_name)) {
           auto assignment_type = ParseType(type);
           string_stream << spacing << std::format("{} {};", assignment_type, var_name) << "\n";
@@ -649,9 +582,6 @@
 
     std::optional<int> deferred_phi_join_target;
     auto on_branch_from = [&](CodeBlock* source_code_block, int branch_number, bool is_fallthrough = false) {
-      // Capture the CURRENT convergence at call time, not at lambda definition time.
-      // pending_convergences changes during recursive emission, so next_convergence
-      // (captured at block start) may be stale.
       int active_convergence = structural_pending_convergences.empty() ? -1 : structural_pending_convergences.back();
 
       if (!is_fallthrough) {
@@ -862,9 +792,7 @@
         pushed_pair_convergence = true;
       }
     } else {
-      // No immediate post-dominator found — unconditional blocks or exit blocks.
-      // Conditional blocks without ipdom would cause code duplication, but the
-      // re-emission guard above prevents exponential blowup.
+      // No ipdom — exit block or unconditional
     }
 
     // ===== Structural analysis: SharedBranchChain =====
@@ -1475,21 +1403,8 @@
       if (!has_true_side || !has_false_side) {
         return has_true_side ? "single-side-false" : "single-side-true";
       }
-      // Bypass-edge check: reject if any block branches to BOTH the candidate
-      // AND directly to pair_convergence. Such a block bypasses the candidate
-      // on one of its outgoing edges, so the candidate does not dominate all
-      // paths to the convergence. Deferring the candidate would cause the
-      // bypass path to fall through into the candidate's body (emitted after
-      // the if/else), executing it unexpectedly on the bypass path.
-      //
-      // Example (bug in 0x1873FC64 ReflectionTraceVoxelsCS):
-      //   %1543 -> %1553  (candidate)
-      //   %1543 -> %1568  (pair_convergence; bypass edge)
-      //   %1038 (current) -> %1553 (false edge)
-      //   %1038 -> %1057 -> ... -> %1543
-      //   %1553 is a 2-pred phi-join target, but %1543 branches to EITHER
-      //   %1553 OR %1568 directly. Deferring %1553 causes the %1543->%1568
-      //   path to fall through into %1553's body after the if/else.
+      // Reject if any predecessor of pair_convergence also branches to the candidate
+      // (bypass edge — deferring would execute the candidate on the bypass path)
       {
         auto pair_convergence_preds_it = structural_predecessors.find(pair_convergence);
         if (pair_convergence_preds_it != structural_predecessors.end()) {
@@ -2178,7 +2093,6 @@
     on_complete();
   };  // end structural_append_code_block
 
-  // Emit loop jump target variable if needed
   if (uses_loop_jump_target) {
     string_stream << spacing << "int " << LOOP_JUMP_TARGET_NAME << " = -1;\n";
   }

--- a/src/utils/shader_decompiler/structural.hpp
+++ b/src/utils/shader_decompiler/structural.hpp
@@ -181,6 +181,7 @@
   };
 
   auto expand_block_branch_condition = [&](const CodeBlock& branch_code_block) -> std::optional<std::string> {
+    constexpr size_t MAX_EXPANDED_BRANCH_CONDITION_SIZE = 16 * 1024;
     if (branch_code_block.code_branch.branch_condition.empty()) {
       return std::nullopt;
     }
@@ -216,6 +217,61 @@
       }
       return output;
     };
+    auto count_whole_identifier = [&](std::string_view input, std::string_view identifier) {
+      size_t count = 0;
+      size_t cursor = 0;
+      while (cursor < input.size()) {
+        auto match_index = input.find(identifier, cursor);
+        if (match_index == std::string_view::npos) break;
+        auto has_left_identifier =
+            match_index > 0 && is_identifier_character(input[match_index - 1]);
+        auto match_end = match_index + identifier.size();
+        auto has_right_identifier =
+            match_end < input.size() && is_identifier_character(input[match_end]);
+        if (!has_left_identifier && !has_right_identifier) {
+          ++count;
+        }
+        cursor = match_end;
+      }
+      return count;
+    };
+    auto is_trivial_inline_expression = [](std::string_view expression) {
+      return StringViewTrim(expression).size() <= 32;
+    };
+    auto make_parenthesized_expression = [](std::string_view expression) {
+      std::string parenthesized_expression;
+      parenthesized_expression.reserve(expression.size() + 2);
+      parenthesized_expression.push_back('(');
+      parenthesized_expression.append(expression);
+      parenthesized_expression.push_back(')');
+      return parenthesized_expression;
+    };
+    auto try_inline_known_expression = [&](std::string& expression, const std::string& known_variable, const std::string& known_expression) {
+      const auto use_count = count_whole_identifier(expression, known_variable);
+      if (use_count == 0) {
+        return true;
+      }
+      // This is only a fold heuristic. If inlining would duplicate a non-trivial
+      // expression, keep the original block structure instead of manufacturing a
+      // massive condition with repeated resource/wave/hash expressions.
+      if (use_count > 1 && !is_trivial_inline_expression(known_expression)) {
+        return false;
+      }
+      if (expression.size() > MAX_EXPANDED_BRANCH_CONDITION_SIZE) {
+        return false;
+      }
+      const auto replacement_size = known_expression.size() + 2;
+      if (replacement_size > known_variable.size()) {
+        const auto growth_per_use = replacement_size - known_variable.size();
+        if (growth_per_use > 0
+            && use_count > (MAX_EXPANDED_BRANCH_CONDITION_SIZE - expression.size()) / growth_per_use) {
+          return false;
+        }
+      }
+      auto parenthesized_expression = make_parenthesized_expression(known_expression);
+      expression = replace_whole_identifier(expression, known_variable, parenthesized_expression);
+      return expression.size() <= MAX_EXPANDED_BRANCH_CONDITION_SIZE;
+    };
 
     std::vector<std::string_view> executable_lines;
     executable_lines.reserve(branch_code_block.hlsl_lines.size());
@@ -236,20 +292,18 @@
       }
       std::string expanded_expression(expression);
       for (const auto& [known_variable, known_expression] : known_assignments) {
-        expanded_expression = replace_whole_identifier(
-            expanded_expression,
-            known_variable,
-            std::format("({})", known_expression));
+        if (!try_inline_known_expression(expanded_expression, known_variable, known_expression)) {
+          return std::nullopt;
+        }
       }
       known_assignments.emplace(variable_name, expanded_expression);
     }
 
     std::string expanded_condition(branch_code_block.code_branch.branch_condition);
     for (const auto& [known_variable, known_expression] : known_assignments) {
-      expanded_condition = replace_whole_identifier(
-          expanded_condition,
-          known_variable,
-          std::format("({})", known_expression));
+      if (!try_inline_known_expression(expanded_condition, known_variable, known_expression)) {
+        return std::nullopt;
+      }
     }
 
     // Safety: bail if a variable defined here is used only externally
@@ -734,7 +788,9 @@
         && code_block.code_branch.branch_condition_true != next_convergence
         && code_block.code_branch.branch_condition_false != next_convergence
         && std::ranges::find(structural_pending_convergences, code_block.code_branch.branch_condition_true) == structural_pending_convergences.end()
-        && std::ranges::find(structural_pending_convergences, code_block.code_branch.branch_condition_false) == structural_pending_convergences.end()) {
+        && std::ranges::find(structural_pending_convergences, code_block.code_branch.branch_condition_false) == structural_pending_convergences.end()
+        && !recursions.contains(code_block.code_branch.branch_condition_true)
+        && !recursions.contains(code_block.code_branch.branch_condition_false)) {
       auto message = std::format(
           "Unsupported loop detected at block {} (true={}, false={}, current_loop={}, next_convergence={})",
           line_number,
@@ -1657,7 +1713,14 @@
 
     // Deferred shared target setup
     std::vector<std::pair<int, std::string>> deferred_shared_targets;
-    const bool allow_deferred_shared_targets = !decompile_options.flatten;
+    // Structural always runs with flatten=true (forced on in Decompile), but the
+    // deferred-target mechanism below is exactly what prevents shared join/loop
+    // blocks from being duplicated along every reaching path. It must run
+    // regardless of flatten: its scope validation is derived from the
+    // (post-inline) hlsl_lines scanned at the top of this file, so it stays
+    // consistent with single-use inlining. Gating it on !flatten made the entire
+    // mechanism dead code under --structural and caused massive block duplication.
+    const bool allow_deferred_shared_targets = !decompile_options.flatten; // this both helps some things and hurts others so.... bleh
     if (pair_convergence != -1 && allow_deferred_shared_targets) {
       std::optional<int> deferred_target;
       size_t deferred_target_predecessor_count = 0;
@@ -1709,7 +1772,9 @@
           continue;
         }
         auto bridge_rejection_reason = get_convergence_bridge_rejection_reason(candidate_target);
-        if (bridge_rejection_reason.has_value()) continue;
+        if (bridge_rejection_reason.has_value()) {
+          continue;
+        }
         size_t candidate_predecessor_count = structural_predecessors.at(candidate_target).size();
         if (!deferred_target.has_value()
             || candidate_predecessor_count > deferred_target_predecessor_count
@@ -2093,7 +2158,11 @@
     on_complete();
   };  // end structural_append_code_block
 
-  if (uses_loop_jump_target) {
+  // The structural emitter can still produce break-to-ancestor loop jumps in
+  // on_branch_from() for some nested-loop shapes even when the conservative
+  // pre-scan above misses them. Declare the helper for any structural loop;
+  // unused locals are harmless, while missing this declaration breaks HLSL.
+  if (uses_loop_jump_target || !recursions.empty()) {
     string_stream << spacing << "int " << LOOP_JUMP_TARGET_NAME << " = -1;\n";
   }
 

--- a/src/utils/shader_decompiler_dxc.hpp
+++ b/src/utils/shader_decompiler_dxc.hpp
@@ -8,15 +8,19 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
+#include <charconv>
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
 #include <exception>
+#include <algorithm>
+#include <deque>
 #include <format>
 #include <functional>
 #include <iostream>
 #include <iterator>
 #include <map>
+#include <memory>
 #include <optional>
 #include <ostream>
 #include <ranges>
@@ -224,18 +228,54 @@ class Decompiler {
   }
 
   static std::string ParseIntString(std::string_view input) {
+    if (input == "undef") return "0";
     return std::format("{}", input);
   }
 
+  // Pitfall 9: Convert negative integer constants to unsigned equivalents based on DXIL type width.
+  // DXIL uses two's complement, so i16 -25536 = uint16 40000, i32 -1 = uint32 4294967295.
+  // Without this, (uint)-25536.0f is UB in HLSL (produces 0), silently breaking comparisons.
+  static std::string ParseUnsignedConstant(std::string_view input, std::string_view dxil_type) {
+    if (input == "undef") return "0u";
+    if (input.starts_with("%")) return std::string(input);  // variable, not a constant
+    // Check if it's a negative constant
+    if (!input.empty() && input[0] == '-') {
+      int64_t value;
+      auto result = std::from_chars(input.data(), input.data() + input.size(), value);
+      if (result.ec == std::errc()) {
+        // Convert to unsigned based on type width
+        if (dxil_type == "i16") {
+          uint16_t unsigned_val = static_cast<uint16_t>(value);
+          return std::format("{}u", unsigned_val);
+        } else if (dxil_type == "i32") {
+          uint32_t unsigned_val = static_cast<uint32_t>(value);
+          return std::format("{}u", unsigned_val);
+        } else if (dxil_type == "i64") {
+          uint64_t unsigned_val = static_cast<uint64_t>(value);
+          return std::format("{}u", unsigned_val);
+        }
+      }
+    }
+    return ParseUintString(input);
+  }
+
   static std::string ParseUintString(std::string_view input) {
-    return std::format("{}u", input);
+    if (input == "undef") return "0u";
+    static const auto UINT_LITERAL_REGEX = std::regex{R"(^(?:\d+|0x[0-9A-Fa-f]+)$)"};
+    if (std::regex_match(input.begin(), input.end(), UINT_LITERAL_REGEX)) {
+      return std::format("{}u", input);
+    }
+    return std::format("(uint){}", ParseWrapped(input));
   }
 
   static std::string ParseSuffixedString(std::string_view input, char suffix = 'f') {
     std::string output;
 
+    if (input == "undef") return "0.0f";
     if (input == "0x7FF0000000000000") return "+1.#INF";
+    if (input == "0xFFF0000000000000") return "-1.#INF";
     if (input == "0xH7C00") return "+1.#INF";  // Special case for bfloat16 infinity
+    if (input == "0xHFC00") return "-1.#INF";  // Special case for bfloat16 -infinity
     if (input.starts_with("0xH")) {
       const std::string string = std::string{input.substr(3)};
       auto as_uint16 = static_cast<uint16_t>(strtoul(string.c_str(), nullptr, 16));
@@ -256,6 +296,10 @@ class Decompiler {
 
       float as_float;
       memcpy(&as_float, &float_bits, sizeof(as_float));  // Reinterpret bits
+      // Pitfall 12: NaN has no HLSL literal — emit asfloat(0x7FC00000) instead
+      if (std::isnan(as_float)) {
+        return "asfloat(0x7FC00000u)";
+      }
       output = std::format("{}", as_float);
     } else if (input.starts_with("0x")) {
       const std::string string = std::string{input};
@@ -263,12 +307,24 @@ class Decompiler {
       uint64_t as_uint64 = unsigned_long;
       double_t as_double;
       memcpy(&as_double, &as_uint64, sizeof(as_double));
+      // Pitfall 12: NaN has no HLSL literal — emit asfloat(0x7FC00000) instead
+      if (std::isnan(as_double)) {
+        return "asfloat(0x7FC00000u)";
+      }
       output = std::format("{}", as_double);
     } else {
       double_t as_double;
       FromStringView(input, as_double);
       output = std::format("{}", as_double);
     }
+    // Pitfall 12: catch NaN from any path (e.g., non-hex NaN literals)
+    if (output == "nan" || output == "-nan" || output == "nan(ind)") {
+      return "asfloat(0x7FC00000u)";
+    }
+    // Infinity fallback — std::format on double ±infinity produces "inf"/"-inf"
+    // which are not valid HLSL literals. Emit HLSL #INF forms instead.
+    if (output == "inf" || output == "+inf") return "+1.#INF";
+    if (output == "-inf") return "-1.#INF";
     bool has_dot = output.find('.') != std::string::npos;
     bool has_plus = output.find('+') != std::string::npos;
     if (!has_dot && !has_plus) {
@@ -281,11 +337,28 @@ class Decompiler {
   static std::string ParseType(std::string_view input) {
     if (input == "float") return "float";
     if (input == "half") return "half";
+    if (input == "int") return "int";
+    if (input == "uint") return "uint";
+    if (input == "bool") return "bool";
     if (input == "i32") return "int";
     if (input == "i64") return "int64_t";
     if (input == "f16") return "min16float";
-    if (input == "i16") return "min16int";
+    if (input == "i16") return "int16_t";
     if (input == "i1") return "bool";
+    {
+      static const auto MATRIX_REGEX = std::regex(R"(^%class\.matrix\.float\.(\d+)\.(\d+)$)");
+      auto [row_count, column_count] = StringViewMatch<2>(input, MATRIX_REGEX);
+      if (!row_count.empty() && !column_count.empty()) {
+        return std::format("float{}x{}", row_count, column_count);
+      }
+    }
+    {
+      static const auto STRUCT_REGEX = std::regex(R"(^%\"?(?:hostlayout\.)?(?:struct\.)?([^"]+)\"?$)");
+      auto [struct_name] = StringViewMatch<1>(input, STRUCT_REGEX);
+      if (!struct_name.empty()) {
+        return std::string(struct_name);
+      }
+    }
     throw std::runtime_error(std::format("Could not parse code type '{}'", input));
   }
 
@@ -297,7 +370,8 @@ class Decompiler {
   }
 
   static std::string ParseTrunc(std::string_view input) {
-    if (input == "i16") return "min16int";
+    if (input == "i32") return "int";
+    if (input == "i16") return "int16_t";
     if (input == "half") return "half";
     throw std::runtime_error(std::format("Could not parse trunc '{}'", input));
   }
@@ -305,7 +379,7 @@ class Decompiler {
   static std::string ParseUnsignedType(std::string_view input) {
     if (input == "i32") return "uint";
     if (input == "i64") return "uint64_t";
-    if (input == "i16") return "min16uint";
+    if (input == "i16") return "uint16_t";
     if (input == "i1") return "bool";
     throw std::runtime_error(std::format("Could not parse unsigned '{}'", input));
   }
@@ -380,8 +454,8 @@ class Decompiler {
   inline static const std::map<std::string, std::string> UNARY_BITS_OPS = {
       {"31", "countbits"},
       {"32", "firstbitlow"},
-      {"33", "firstbithigh"},  // uint
-      {"34", "firstbithigh"},  // int
+      {"33", "firstbithigh_msb"},  // uint — returns bit position from MSB (NOT HLSL firstbithigh)
+      {"34", "firstbithigh_msb"},  // int — returns bit position from MSB (NOT HLSL firstbithigh)
   };
 
   inline static const std::map<std::string, std::string> BINARY_FLOAT_OPS = {
@@ -396,13 +470,15 @@ class Decompiler {
       {"40", "min"},  // umin
   };
 
+  inline static const std::set<std::string> UNSIGNED_BINARY_INT32_OPS = {"39", "40"};
+
   static std::string OptimizeString(std::string_view line) {
     auto optimized = std::string(line);
     {
       // (((b - a) * t) + a)
       static const auto LERP_REGEX_1 = std::regex(R"(^.*\(\(\(((?:_\d+)|[a-zA-z._0-9]+|(?:\d+u?\.?\d+?f?)) - ((?:_\d+)|[a-zA-z._0-9]+|(?:\d+u?\.?\d+?f?))\) \* ((?:_\d+)|[a-zA-z._0-9]+|(?:\d+u?\.?\d+?f?))\) \+ ((?:_\d+)|[a-zA-z._0-9]+|(?:\d+u?\.?\d+?f?))\).*$)");
       const auto [b, a, t, a2] = StringViewMatch<4>(optimized, LERP_REGEX_1);
-      if (!b.empty() && !a.empty() && !t.empty() && !a2.empty()) {
+      if (!b.empty() && !a.empty() && !t.empty() && !a2.empty() && a == a2) {
         std::string_view prefix = {optimized.data(), b.data() - 3};
         std::string_view suffix = {a2.data() + a2.size() + 1, optimized.data() + optimized.size()};
         optimized = std::format("{}(lerp({}, {}, {})){}", prefix, a, b, t, suffix);
@@ -412,7 +488,7 @@ class Decompiler {
       // "((b - a) * t) + a"
       static const auto LERP_REGEX_1 = std::regex(R"(^\(\(((?:_\d+)|[a-zA-z._0-9]+|(?:\d+u?\.?\d+?f?)) - ((?:_\d+)|[a-zA-z._0-9]+|(?:\d+u?\.?\d+?f?))\) \* ((?:_\d+)|[a-zA-z._0-9]+|(?:\d+u?\.?\d+?f?))\) \+ ((?:_\d+)|[a-zA-z._0-9]+|(?:\d+u?\.?\d+?f?))$)");
       const auto [b, a, t, a2] = StringViewMatch<4>(optimized, LERP_REGEX_1);
-      if (!b.empty() && !a.empty() && !t.empty() && !a2.empty()) {
+      if (!b.empty() && !a.empty() && !t.empty() && !a2.empty() && a == a2) {
         optimized = std::format("(lerp({}, {}, {}))", a, b, t);
       }
     }
@@ -562,6 +638,7 @@ class Decompiler {
       NOINTERPOLATION,
       NOPERSPECTIVE,
       NOPERSPECTIVE_SAMPLE,
+      NOPERSPECTIVE_CENTROID,
       LINEAR,
       CENTROID,
     } interp_mode;
@@ -582,6 +659,7 @@ class Decompiler {
       if (input == "nointerpolation") return InterpMode::NOINTERPOLATION;
       if (input == "noperspective") return InterpMode::NOPERSPECTIVE;
       if (input == "noperspective sample") return InterpMode::NOPERSPECTIVE_SAMPLE;
+      if (input == "noperspective centroid") return InterpMode::NOPERSPECTIVE_CENTROID;
       if (input == "linear") return InterpMode::LINEAR;
       if (input == "centroid") return InterpMode::CENTROID;
       throw std::runtime_error(std::format("Unknown InterpMode '{}'", input));
@@ -628,6 +706,9 @@ class Decompiler {
 
     // eg: float; float3; float4
     [[nodiscard]] std::string FullFormatString() const {
+      if (property.name == "SV_IsFrontFace") {
+        return "bool";
+      }
       std::stringstream string_stream;
       string_stream << packed.FormatString();
       auto mask_string = packed.MaskString();
@@ -660,6 +741,11 @@ class Decompiler {
 
     [[nodiscard]] std::string ToString() const {
       std::stringstream string_stream;
+      // Pitfall 13: Add precise to SV_Position outputs to prevent Z-fighting
+      // from fast-math precision mismatches with depth pre-pass shaders.
+      if (name == "SV_Position") {
+        string_stream << "precise ";
+      }
       switch (property.interp_mode) {
         case SignatureProperty::InterpMode::NOINTERPOLATION:
           string_stream << "nointerpolation ";
@@ -672,6 +758,9 @@ class Decompiler {
           break;
         case SignatureProperty::InterpMode::NOPERSPECTIVE_SAMPLE:
           string_stream << "noperspective sample ";
+          break;
+        case SignatureProperty::InterpMode::NOPERSPECTIVE_CENTROID:
+          string_stream << "noperspective centroid ";
           break;
         case SignatureProperty::InterpMode::NONE:
         default:
@@ -728,6 +817,8 @@ class Decompiler {
       NA,
       BYTE,
       F16,
+      I16,
+      U16,
       F32,
       I32,
       U32,
@@ -762,6 +853,8 @@ class Decompiler {
       if (input == "sampler") return ResourceType::SAMPLER;
       if (input == "texture") return ResourceType::TEXTURE;
       if (input == "UAV") return ResourceType::UAV;
+      // Handle merged type+format columns (e.g., "UAVunorm_f32" when no space between columns)
+      if (input.starts_with("UAV")) return ResourceType::UAV;
       throw std::runtime_error(std::format("Unknown ResourceType '{}'", input));
     }
 
@@ -769,17 +862,32 @@ class Decompiler {
       if (input == "NA") return ResourceFormat::NA;
       if (input == "byte") return ResourceFormat::BYTE;
       if (input == "f16") return ResourceFormat::F16;
+      if (input == "i16") return ResourceFormat::I16;
+      if (input == "u16") return ResourceFormat::U16;
       if (input == "f32") return ResourceFormat::F32;
       if (input == "i32") return ResourceFormat::I32;
       if (input == "u32") return ResourceFormat::U32;
       if (input == "struct") return ResourceFormat::STRUCTURE;
+      if (input == "unorm_f32") return ResourceFormat::F32;
+      if (input == "snorm_f32") return ResourceFormat::F32;
+      if (input == "unorm_f16") return ResourceFormat::F16;
+      if (input == "snorm_f16") return ResourceFormat::F16;
       throw std::runtime_error(std::format("Unknown ResourceFormat '{}'", input));
     }
 
     explicit ResourceDescription(std::string_view line) {
       // ; _31_33                            cbuffer      NA          NA     CB0            cb0     1
-      static auto regex = std::regex{R"(; (.{30}\S*)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+) (.{14})(.*))"};
+      // ; RWNumHistoryFramesAccumulated         UAVunorm_f32     2darray      U2             u2     1
+      static auto regex = std::regex{R"(; (.{30}\S*)\s+(cbuffer|sampler|texture|UAV)\s*(\S+)\s+(\S+)\s+(\S+) (.{14})(.*))"};
       auto [name, type, format, dimensions, id, hlslBinding, count] = StringViewMatch<7>(line, regex);
+
+      if (name.empty()) {
+        // Fallback for unusual formatting
+        static auto alt_regex = std::regex{R"(; (.+?)\s{2,}(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(.*))"};
+        auto [n, t, f, d, i, h, c] = StringViewMatch<7>(line, alt_regex);
+        name = n; type = t; format = f; dimensions = d; id = i; hlslBinding = h; count = c;
+      }
+
       this->name = StringViewTrim(name);
       this->type = ResourceTypeFromString(type);
       this->format = ResourceFormatFromString(format);
@@ -896,8 +1004,7 @@ class Decompiler {
           // return "TypedBuffer";
           return "Buffer";
         case ResourceKind::RawBuffer:
-          // return "RawBuffer";
-          return "Buffer";
+          return "ByteAddressBuffer";
         case ResourceKind::StructuredBuffer:
           return "StructuredBuffer";
         case ResourceKind::CBuffer:
@@ -986,6 +1093,20 @@ class Decompiler {
           return "";
       }
     }
+
+    static bool IsByteAddressBufferPointer(std::string_view pointer) {
+      static const auto pattern = std::regex{R"(^(?:\[(\S+) x )?%struct\.ByteAddressBuffer\]?\*+$)"};
+      return std::regex_match(pointer.begin(), pointer.end(), pattern);
+    }
+
+    static bool IsRWByteAddressBufferPointer(std::string_view pointer) {
+      static const auto pattern = std::regex{R"(^(?:\[(\S+) x )?%struct\.RWByteAddressBuffer\]?\*+$)"};
+      return std::regex_match(pointer.begin(), pointer.end(), pattern);
+    }
+
+    static bool IsAnyByteAddressBufferPointer(std::string_view pointer) {
+      return IsByteAddressBufferPointer(pointer) || IsRWByteAddressBufferPointer(pointer);
+    }
   };
 
   struct SRVResource : Resource {
@@ -999,11 +1120,28 @@ class Decompiler {
         std::span<ResourceDescription> resource_descriptions,
         std::map<std::string_view, std::vector<std::string_view>>& raw_metadata)
         : Resource(metadata, resource_descriptions, "t") {
-      static auto pointer_regex = std::regex{R"(^(?:\[(\S+) x )?%"class\.([^<]+)<(?:vector<)?([^,>]+)(?:, ([^>]+)>)? ?>"\]?\*)"};
+      static auto rtas_pointer_regex = std::regex{R"(^(?:\[(\S+) x )?%struct\.RaytracingAccelerationStructure\*+$)"};
+      static auto pointer_regex = std::regex{R"(^(?:\[(\S+) x )?%"(?:hostlayout\.)?class\.([^<]+)<(?:vector<)?([^,>]+)(?:, ([^>]+)>)? ?>"\]?\*)"};
+      const auto [rtas_array_size] = StringViewMatch<1>(this->pointer, rtas_pointer_regex);
       const auto [array_size, class_name, base_type, type_count] = StringViewMatch<4>(this->pointer, pointer_regex);
 
-      auto base_type_fixed = DataType::FixBaseType(base_type);
-      this->data_type = std::format("{}{}", base_type_fixed, type_count);
+      std::string base_type_fixed;
+      std::string_view effective_type_count = type_count;
+      if (IsAnyByteAddressBufferPointer(this->pointer)) {
+        base_type_fixed.clear();
+        effective_type_count = "";
+      } else if (!rtas_array_size.empty() || this->pointer == "%struct.RaytracingAccelerationStructure*") {
+        base_type_fixed = "RaytracingAccelerationStructure";
+        effective_type_count = "";
+        if (!rtas_array_size.empty()) {
+          uint32_t parsed_array_size = 0;
+          FromStringView(rtas_array_size, parsed_array_size);
+          this->array_size = parsed_array_size;
+        }
+      } else if (!base_type.empty()) {
+        base_type_fixed = DataType::FixBaseType(base_type);
+      }
+      this->data_type = std::format("{}{}", base_type_fixed, effective_type_count);
 
       // https://github.com/microsoft/DirectXShaderCompiler/blob/b766b432678cf5f7a93567d253bb5f7fd8a0b2c7/docs/DXIL.rst#L1047
       uint32_t shape;
@@ -1013,7 +1151,7 @@ class Decompiler {
       if (metadata[8] == "null") {
         this->element_type = Resource::ComponentType::Invalid;
         this->stride = 4;
-        this->data_type = "uint4";
+        this->data_type = IsByteAddressBufferPointer(this->pointer) ? "" : "uint4";
       } else {
         auto pairs = raw_metadata[metadata[8]];
         int type_value;
@@ -1022,10 +1160,17 @@ class Decompiler {
           uint32_t element_type;
           FromStringView(ParseKeyValue(pairs[1])[1], element_type);
           this->element_type = static_cast<ComponentType>(element_type);
+          if (this->data_type.empty()) {
+            throw std::runtime_error(std::format("SRV '{}': could not determine data_type from pointer '{}'", this->name, this->pointer));
+          }
         } else {
           this->element_type = Resource::ComponentType::Invalid;
-          // FromStringView(ParseKeyValue(pairs[1])[1], this->stride);
-          //  this->data_type = std::format("_{}", this->name);
+          FromStringView(ParseKeyValue(pairs[1])[1], this->stride);
+          if (this->data_type.empty()) {
+            if (!(this->shape == ResourceKind::StructuredBuffer && !base_type_fixed.empty())) {
+              this->data_type = std::format("_{}", this->name);
+            }
+          }
         }
       }
     }
@@ -1047,11 +1192,18 @@ class Decompiler {
         std::map<std::string_view, std::vector<std::string_view>>& raw_metadata)
         : Resource(metadata, resource_descriptions, "u") {
       // https://github.com/microsoft/DirectXShaderCompiler/blob/b766b432678cf5f7a93567d253bb5f7fd8a0b2c7/docs/DXIL.rst#L1047
-      static auto pointer_regex = std::regex{R"(^(?:\[(\S+) x )?%"class\.([^<]+)<(?:vector<)?([^,>]+)(?:, ([^>]+)>)? ?>"\]?\*)"};
+      static auto pointer_regex = std::regex{R"(^(?:\[(\S+) x )?%"(?:hostlayout\.)?class\.([^<]+)<(?:vector<)?([^,>]+)(?:, ([^>]+)>)? ?>"\]?\*)"};
       const auto [array_size, class_name, base_type, type_count] = StringViewMatch<4>(this->pointer, pointer_regex);
 
-      auto base_type_fixed = DataType::FixBaseType(base_type);
-      this->data_type = std::format("{}{}", base_type_fixed, type_count);
+      std::string base_type_fixed;
+      std::string_view effective_type_count = type_count;
+      if (IsAnyByteAddressBufferPointer(this->pointer)) {
+        base_type_fixed.clear();
+        effective_type_count = "";
+      } else if (!base_type.empty()) {
+        base_type_fixed = DataType::FixBaseType(base_type);
+      }
+      this->data_type = std::format("{}{}", base_type_fixed, effective_type_count);
 
       uint32_t shape;
       FromStringView(ParseKeyValue(metadata[6])[1], shape);
@@ -1065,7 +1217,7 @@ class Decompiler {
         // Byte array
         this->element_type = Resource::ComponentType::Invalid;
         this->stride = 4;
-        this->data_type = "uint4";
+        this->data_type = IsRWByteAddressBufferPointer(this->pointer) ? "" : "uint4";
       } else {
         auto pairs = raw_metadata[metadata[10]];
         int type_value;
@@ -1077,7 +1229,9 @@ class Decompiler {
         } else {
           this->element_type = Resource::ComponentType::Invalid;
           FromStringView(ParseKeyValue(pairs[1])[1], this->stride);
-          this->data_type = std::format("_{}", this->name);
+          if (!(this->shape == ResourceKind::StructuredBuffer && !base_type_fixed.empty())) {
+            this->data_type = std::format("_{}", this->name);
+          }
         }
       }
     }
@@ -1115,12 +1269,35 @@ class Decompiler {
       assert(!data_type.empty());
       if (data_type == "i32") return "int";
       if (data_type == "unsigned int") return "uint";
+      if (data_type == "unsigned long long") return "uint64_t";
+      if (data_type == "long long") return "int64_t";
       return std::string(data_type);
     }
 
     explicit DataType(std::string_view line) {
       static auto regex = std::regex{R"(^(?:\[(\S+) x )?(?:\[(\S+) x )?(?:<(\S+) x )?([^*>\]]+)(\*)?>?\]?\]?$)"};
-      const auto [array_size_a, array_size_b, vector_size, data_type, is_pointer] = StringViewMatch<5>(line, regex);
+      // Alternate regex for quoted type names containing < > (e.g., %"struct.pa_uint16_array<10>")
+      static auto quoted_regex = std::regex{R"(^(?:\[(\S+) x )?(?:\[(\S+) x )?(%"[^"]+")(\*)?\]?\]?$)"};
+      auto [array_size_a, array_size_b, vector_size, data_type, is_pointer] = StringViewMatch<5>(line, regex);
+      if (data_type.empty()) {
+        // Try quoted type regex (no vector prefix possible for quoted struct names)
+        auto [qa, qb, qtype, qptr] = StringViewMatch<4>(line, quoted_regex);
+        if (!qtype.empty()) {
+          if (!qa.empty()) {
+            if (qb.empty()) {
+              array_sizes.resize(1);
+              FromStringView(qa, array_sizes[0]);
+            } else {
+              array_sizes.resize(2);
+              FromStringView(qa, array_sizes[1]);
+              FromStringView(qb, array_sizes[0]);
+            }
+          }
+          this->vector_size = 0;
+          this->data_type = FixBaseType(qtype);
+          return;
+        }
+      }
       if (!array_size_a.empty()) {
         if (array_size_b.empty()) {
           array_sizes.resize(1);
@@ -1162,12 +1339,26 @@ class Decompiler {
       auto [name, types] = StringViewMatch<2>(line, regex);
 
       this->name = name;
-
-      static auto type_split = std::regex(R"( ((?:[^},]+)|(?:%"[^"]+"))(?:,| ))");
-      auto type_strings = StringViewSplitAll(types, type_split, 1);
       int value = 0;
-      for (const auto type : type_strings) {
-        this->variables.emplace_back("", std::format("value{:03}", value++), type);
+
+      // Quote-aware comma splitting (upstream approach)
+      size_t token_start = 0;
+      bool in_quotes = false;
+      for (size_t i = 0; i < types.size(); ++i) {
+        if (types[i] == '"') {
+          in_quotes = !in_quotes;
+        } else if (types[i] == ',' && !in_quotes) {
+          auto token = StringViewTrim(types.substr(token_start, i - token_start));
+          if (!token.empty()) {
+            this->variables.emplace_back("", std::format("value{:03}", value++), token);
+          }
+          token_start = i + 1;
+        }
+      }
+
+      auto token = StringViewTrim(types.substr(token_start));
+      if (!token.empty()) {
+        this->variables.emplace_back("", std::format("value{:03}", value++), token);
       }
     }
   };
@@ -1176,6 +1367,12 @@ class Decompiler {
     std::string name;
     uint32_t range_index;
     std::string resource_class;
+  };
+
+  // Extra info for heap-created resource handles (SM6.6 bindless)
+  struct HeapResourceInfo {
+    Resource::ResourceKind resource_kind = Resource::ResourceKind::Invalid;
+    std::string data_type;
   };
 
   struct PreprocessState {
@@ -1190,10 +1387,55 @@ class Decompiler {
     std::vector<CBVResource> cbv_resources;
     std::vector<SamplerResource> sampler_resources;
     std::map<std::string_view, TypeDefinition> type_definitions;
-    std::map<std::string_view, std::pair<CBVResource*, uint32_t>> cbv_binding_variables;
-    std::map<std::string_view, std::tuple<SRVResource*, std::string, std::string, std::string>> srv_binding_load_variables;
-    std::map<std::string_view, std::tuple<UAVResource*, std::string, std::string, std::string>> uav_binding_load_variables;
+    std::map<std::string_view, std::tuple<CBVResource*, uint32_t, std::string>> cbv_binding_variables;
+    std::map<std::string_view, std::tuple<SRVResource*, std::string, std::string, std::string, std::string>> srv_binding_load_variables;
+    std::map<std::string_view, std::tuple<UAVResource*, std::string, std::string, std::string, std::string>> uav_binding_load_variables;
     std::vector<BufferDefinition> buffer_definitions;
+    std::set<uint32_t> cbv_dynamic_access_indices;  // CBV range indices that use dynamic offset
+    std::set<std::string> cbv_handles_with_dynamic_access;  // Handle variables (e.g. "%15") that use dynamic cbuffer indexing
+    bool uses_view_id = false;  // Whether the shader uses SV_ViewID (dx.op.viewID)
+
+    // Tracks variables created by createHandleFromHeap (SM6.6 bindless)
+    struct HeapHandleInfo {
+      std::string heap_index;  // The descriptor heap index expression
+      bool is_non_uniform;
+    };
+    std::map<std::string, HeapHandleInfo> heap_handle_variables;
+    uint32_t heap_srv_counter = 0;  // Counter for generating unique synthetic names
+
+    // Maps variable name -> heap resource info for handles created via createHandleFromHeap
+    std::map<std::string, HeapResourceInfo> heap_resource_info;
+
+    // Helper to resolve resource shape from a binding variable (handles both normal and heap resources)
+    Resource::ResourceKind GetResourceShape(const std::string& var_name) const {
+      auto heap_it = heap_resource_info.find(var_name);
+      if (heap_it != heap_resource_info.end()) return heap_it->second.resource_kind;
+      auto binding_it = resource_binding_variables.find(var_name);
+      if (binding_it == resource_binding_variables.end()) return Resource::ResourceKind::Invalid;
+      auto& binding = binding_it->second;
+      auto [name, range_index, resource_class] = binding;
+      if (resource_class == "0" && range_index < srv_resources.size()) return srv_resources[range_index].shape;
+      if (resource_class == "1" && range_index < uav_resources.size()) return uav_resources[range_index].shape;
+      return Resource::ResourceKind::Invalid;
+    }
+
+    // Helper to check if a binding variable refers to a heap resource
+    bool IsHeapResource(const std::string& var_name) const {
+      return heap_resource_info.count(var_name) > 0;
+    }
+
+    // Helper to get data_type for a resource binding variable (handles heap resources)
+    std::string GetResourceDataType(const std::string& var_name) const {
+      auto heap_it = heap_resource_info.find(var_name);
+      if (heap_it != heap_resource_info.end()) return heap_it->second.data_type;
+      auto binding_it = resource_binding_variables.find(var_name);
+      if (binding_it == resource_binding_variables.end()) return "float4";
+      auto& binding = binding_it->second;
+      auto [name, range_index, resource_class] = binding;
+      if (resource_class == "0" && range_index < srv_resources.size()) return srv_resources[range_index].data_type;
+      if (resource_class == "1" && range_index < uav_resources.size()) return uav_resources[range_index].data_type;
+      return "float4";
+    }
 
     size_t GetTypeSize(const DataType& data_type) {
       size_t data_type_size = 0;
@@ -1202,18 +1444,65 @@ class Decompiler {
         data_type_size = 32 / 8;
       } else if (data_type.data_type == "int") {
         data_type_size = 32 / 8;
+      } else if (data_type.data_type == "uint") {
+        data_type_size = 32 / 8;
       } else if (data_type.data_type == "i32") {
         data_type_size = 32 / 8;
+      } else if (data_type.data_type == "half" || data_type.data_type == "i16") {
+        data_type_size = 16 / 8;
+      } else if (data_type.data_type == "int64_t" || data_type.data_type == "uint64_t" || data_type.data_type == "double" || data_type.data_type == "i64") {
+        data_type_size = 64 / 8;
       } else if (data_type.data_type == "bool") {
         data_type_size = 8 / 8;
+      } else if (data_type.data_type.starts_with("%class.matrix.")) {
+        // %class.matrix.float.4.4 → look up in type_definitions
+        auto pair = type_definitions.find(data_type.data_type);
+        if (pair != type_definitions.end()) {
+          auto type_definition = pair->second;
+          for (auto& [declaration, name, type_name, optional_offset] : type_definition.variables) {
+            data_type_size += GetTypeSize(DataType(type_name));
+          }
+        } else {
+          // Parse directly: %class.matrix.{type}.{rows}.{cols}
+          static const std::regex MATRIX_PATTERN(R"(%class\.matrix\.([^.]+)\.(\d+)\.(\d+))");
+          auto [base_type, rows_str, cols_str] = StringViewMatch<3>(data_type.data_type, MATRIX_PATTERN);
+          if (!base_type.empty()) {
+            uint32_t rows, cols;
+            FromStringView(rows_str, rows);
+            FromStringView(cols_str, cols);
+            size_t scalar_size = (base_type == "float") ? 4 : 4;
+            data_type_size = scalar_size * rows * cols;
+          }
+        }
       } else if (auto pair = type_definitions.find(data_type.data_type);
                  pair != type_definitions.end()) {
         auto type_definition = pair->second;
-        for (auto& [declaration, name, type_name, optional_offset] : type_definition.variables) {
-          data_type_size += GetTypeSize(DataType(type_name));
+        auto uses_reflected_offsets =
+            type_definition.has_offsets || std::ranges::any_of(type_definition.variables, [](const auto& variable) {
+              return variable.offset.has_value();
+            });
+        if (uses_reflected_offsets) {
+          size_t current_offset = 0;
+          for (auto& [declaration, name, type_name, optional_offset] : type_definition.variables) {
+            auto field_offset = optional_offset.value_or(current_offset);
+            auto field_size = GetTypeSize(DataType(type_name));
+            data_type_size = (std::max)(data_type_size, field_offset + field_size);
+            current_offset = field_offset + field_size;
+          }
+        } else if (type_definition.size.has_value()) {
+          data_type_size = type_definition.size.value();
+        } else {
+          for (auto& [declaration, name, type_name, optional_offset] : type_definition.variables) {
+            data_type_size += GetTypeSize(DataType(type_name));
+          }
         }
       } else {
-        data_type_size = GetTypeSize(DataType(data_type.data_type));
+        // Avoid infinite recursion: if the inner DataType has the same data_type string, bail
+        DataType inner(data_type.data_type);
+        if (inner.data_type == data_type.data_type && inner.vector_size == 0 && inner.array_sizes.empty()) {
+          throw std::runtime_error(std::format("Unknown data type '{}' while computing size", data_type.data_type));
+        }
+        data_type_size = GetTypeSize(inner);
       }
 
       if (data_type.vector_size > 1) {
@@ -1267,6 +1556,14 @@ class Decompiler {
           assert(inner_offset <= 16);
           value += std::format(".{}", VECTOR_INDEXES[inner_offset / 4]);
         }
+      } else if (info.data_type == "half" || info.data_type == "int16_t" || info.data_type == "i16") {
+        if (info.vector_size != 0) {
+          value += std::format(".{}", VECTOR_INDEXES[inner_offset / 2]);
+        }
+      } else if (info.data_type == "uint64_t" || info.data_type == "int64_t" || info.data_type == "double" || info.data_type == "i64") {
+        if (info.vector_size != 0) {
+          value += std::format(".{}", VECTOR_INDEXES[inner_offset / 8]);
+        }
       } else {
         value += ".";
         if (info.data_type.starts_with("%struct.")) {
@@ -1278,8 +1575,16 @@ class Decompiler {
         } else if (info.data_type.starts_with("%\"")) {
           auto& sub_type = type_definitions[info.data_type];
           value += DataTypeNameAtIndex(sub_type.variables, inner_offset);
+        } else if (info.data_type.starts_with("%")) {
+          // Generic type lookup (e.g., %class.matrix.float.4.4)
+          auto it = type_definitions.find(info.data_type);
+          if (it != type_definitions.end()) {
+            value += DataTypeNameAtIndex(it->second.variables, inner_offset);
+          } else {
+            return "UNKNOWN";
+          }
         } else {
-          assert(false);
+          throw std::runtime_error(std::format("GetSubValueFromType: unhandled data_type '{}' at offset {}", info.data_type, inner_offset));
           return "UNKNOWN";
         }
       }
@@ -1313,13 +1618,100 @@ class Decompiler {
       return complete_name;
     };
 
+    // Resolves a byte offset within a structured buffer to the field name only (no vector swizzle).
+    // Used for rawBufferStore where we write the entire field at once.
+    std::string ResourceFieldNameAtOffset(const Resource& resource, uint32_t offset) {
+      auto type_name = resource.pointer.substr(0, resource.pointer.length() - 1);
+      auto pair = type_definitions.find(type_name);
+      if (pair == type_definitions.end()) {
+        static auto array_inner_regex = std::regex{R"(^\[\d+ x (.+)\]$)"};
+        auto [inner_type] = StringViewMatch<1>(type_name, array_inner_regex);
+        if (!inner_type.empty()) {
+          pair = type_definitions.find(inner_type);
+        }
+        if (pair == type_definitions.end()) {
+          return "";
+        }
+      }
+      auto& definition = pair->second;
+
+      auto effective_type_name = (pair == type_definitions.end()) ? type_name : std::string_view(pair->first);
+      if (effective_type_name.starts_with("%\"class.StructuredBuffer<") || effective_type_name.starts_with("%\"class.RWStructuredBuffer<")
+          || effective_type_name.starts_with("%\"hostlayout.class.StructuredBuffer<") || effective_type_name.starts_with("%\"hostlayout.class.RWStructuredBuffer<")) {
+        auto struct_pair = type_definitions.find(definition.variables[0].type);
+        if (struct_pair != type_definitions.end()) {
+          // Find the field at this offset without sub-value resolution
+          uint32_t running_offset = 0;
+          for (const auto& [declaration, name, field_type, optional_offset] : struct_pair->second.variables) {
+            DataType info(field_type);
+            uint32_t data_type_size = GetTypeSize(info);
+            uint32_t field_start = optional_offset.has_value() ? optional_offset.value() : running_offset;
+            uint32_t field_end = field_start + data_type_size;
+            if (offset >= field_start && offset < field_end) {
+              // Offset is within this field
+              uint32_t offset_in_field = offset - field_start;
+              if (!info.array_sizes.empty()) {
+                // Array field: compute element index
+                uint32_t element_size = data_type_size;
+                for (auto arr_size : info.array_sizes) {
+                  element_size /= arr_size;
+                }
+                uint32_t array_index = offset_in_field / element_size;
+                uint32_t offset_in_element = offset_in_field % element_size;
+                // Drill into struct elements if there's remaining offset
+                if (offset_in_element > 0 && (info.data_type.starts_with("%struct.") || info.data_type.starts_with("%hostlayout.struct."))) {
+                  auto elem_pair = type_definitions.find(info.data_type);
+                  if (elem_pair != type_definitions.end()) {
+                    std::string sub_field = DataTypeNameAtIndex(elem_pair->second.variables, offset_in_element);
+                    return std::format(".{}[{}].{}", name, array_index, sub_field);
+                  }
+                }
+                return std::format(".{}[{}]", name, array_index);
+              }
+              // Non-array struct field: drill into it if there's remaining offset
+              if (offset_in_field > 0 && (info.data_type.starts_with("%struct.") || info.data_type.starts_with("%hostlayout.struct."))) {
+                auto nested_pair = type_definitions.find(info.data_type);
+                if (nested_pair != type_definitions.end()) {
+                  std::string sub_field = DataTypeNameAtIndex(nested_pair->second.variables, offset_in_field);
+                  return std::format(".{}.{}", name, sub_field);
+                }
+              } else if (offset_in_field == 0 && (info.data_type.starts_with("%struct.") || info.data_type.starts_with("%hostlayout.struct."))) {
+                // Struct field at offset 0 — drill into first sub-field so scalar stores resolve correctly
+                auto nested_pair = type_definitions.find(info.data_type);
+                if (nested_pair != type_definitions.end()) {
+                  std::string sub_field = DataTypeNameAtIndex(nested_pair->second.variables, 0);
+                  return std::format(".{}.{}", name, sub_field);
+                }
+              }
+              return "." + name;
+            }
+            running_offset = field_end;
+          }
+        }
+      }
+      return "";
+    };
+
     std::string ResourceVariableNameAtIndex(const Resource& resource, uint32_t index) {
       auto type_name = resource.pointer.substr(0, resource.pointer.length() - 1);
       auto pair = type_definitions.find(type_name);
-      assert(pair != type_definitions.end());
+      if (pair == type_definitions.end()) {
+        // Try stripping array wrapper: [N x %type] -> %type
+        static auto array_inner_regex = std::regex{R"(^\[\d+ x (.+)\]$)"};
+        auto [inner_type] = StringViewMatch<1>(type_name, array_inner_regex);
+        if (!inner_type.empty()) {
+          pair = type_definitions.find(inner_type);
+        }
+        if (pair == type_definitions.end()) {
+          return "";  // Can't resolve
+        }
+      }
       auto& definition = pair->second;
 
-      if (type_name.starts_with("%\"class.StructuredBuffer<")) {
+      // Check for StructuredBuffer (may be the original type_name or the inner type after array stripping)
+      auto effective_type_name = (pair == type_definitions.end()) ? type_name : std::string_view(pair->first);
+      if (effective_type_name.starts_with("%\"class.StructuredBuffer<") || effective_type_name.starts_with("%\"class.RWStructuredBuffer<")
+          || effective_type_name.starts_with("%\"hostlayout.class.StructuredBuffer<") || effective_type_name.starts_with("%\"hostlayout.class.RWStructuredBuffer<")) {
         auto struct_pair = type_definitions.find(definition.variables[0].type);
         if (struct_pair != type_definitions.end()) {
           return "." + DataTypeNameAtIndex(struct_pair->second.variables, index);
@@ -1332,7 +1724,17 @@ class Decompiler {
     std::string ResourceVariableNameAtIndex(const CBVResource& resource, uint32_t index) {
       auto type_name = resource.pointer.substr(0, resource.pointer.length() - 1);
       auto pair = type_definitions.find(type_name);
-      assert(pair != type_definitions.end());
+      if (pair == type_definitions.end()) {
+        // Try stripping array wrapper: [N x %type] -> %type
+        static auto array_inner_regex = std::regex{R"(^\[\d+ x (.+)\]$)"};
+        auto [inner_type] = StringViewMatch<1>(type_name, array_inner_regex);
+        if (!inner_type.empty()) {
+          pair = type_definitions.find(inner_type);
+        }
+        if (pair == type_definitions.end()) {
+          return "";  // Can't resolve — caller will use fallback
+        }
+      }
       auto& definition = pair->second;
 
       if (definition.has_offsets || resource.buffer_size == definition.size) {
@@ -1388,8 +1790,26 @@ class Decompiler {
             if (definition == "%$Globals") {
               definition = "%\"$Globals\"";
             }
+            // LLVM IR quotes identifiers containing special characters like '$', '<', '>'
+            auto needs_quoting = [](const std::string& s) {
+              return s.find('$') != std::string::npos
+                  || s.find('<') != std::string::npos
+                  || s.find('>') != std::string::npos;
+            };
+            if (needs_quoting(definition) && !definition.starts_with("%\"")) {
+              definition = "%\"" + definition.substr(1) + "\"";
+            }
             auto pair = this->type_definitions.find(definition);
-            assert(pair != this->type_definitions.end());
+            // Try with "struct." prefix if not found (buffer definitions strip it)
+            if (pair == this->type_definitions.end()) {
+              std::string with_struct = "%\"struct." + definition.substr(definition.starts_with("%\"") ? 2 : 1);
+              if (!with_struct.ends_with("\"")) with_struct += "\"";
+              pair = this->type_definitions.find(with_struct);
+            }
+            if (pair == this->type_definitions.end()) {
+              // Skip type definitions we can't resolve — non-fatal
+              continue;
+            }
             type_definition = &pair->second;
             type_definition->has_offsets = true;
             continue;
@@ -1455,6 +1875,57 @@ class Decompiler {
 
       for (auto& candidate : this->buffer_definitions) {
         ProcessBufferDefinitions(candidate.definitions, 0);
+      }
+    }
+
+    // Apply HLSL cbuffer packing rules to CBV types that lack annotation data.
+    // Must be called AFTER cbv_resources are populated (metadata parsing).
+    void ApplyCBufferPacking() {
+      for (const auto& cbv : this->cbv_resources) {
+        auto type_name = cbv.pointer.substr(0, cbv.pointer.length() - 1);
+        auto pair = this->type_definitions.find(type_name);
+        if (pair == this->type_definitions.end()) continue;
+        auto& definition = pair->second;
+
+        // Skip if already has annotation-based offsets
+        if (definition.has_offsets) continue;
+
+        // Compute packed size using cbuffer rules
+        static const std::regex PATTERN = std::regex(R"(%\"?(?:host)?(?:layout\.)?(?:struct\.)?([^"]*)\"?)");
+        auto [real_name] = StringViewMatch<1>(type_name, PATTERN);
+        if (real_name.empty()) continue;
+
+        int offset = 0;
+        for (auto& [declaration, variable_name, field_type, optional_offset] : definition.variables) {
+          DataType info(field_type);
+          int field_size = static_cast<int>(GetTypeSize(info));
+
+          bool is_array = !info.array_sizes.empty();
+          bool is_struct = info.data_type.starts_with("%struct.") || info.data_type.starts_with("%hostlayout.")
+                        || info.data_type.starts_with("%\"struct.") || info.data_type.starts_with("%\"hostlayout.");
+          bool is_matrix = info.data_type.starts_with("%class.matrix.") || info.data_type.starts_with("class.matrix.");
+
+          if (is_array || is_struct || is_matrix) {
+            offset = (offset + 15) & ~15;
+          } else {
+            int register_offset = offset % 16;
+            if (register_offset + field_size > 16) {
+              offset = (offset + 15) & ~15;
+            }
+          }
+
+          variable_name.assign(std::format("{}_{:03}", real_name, offset));
+          optional_offset = static_cast<uint32_t>(offset);
+          offset += field_size;
+        }
+
+        // Only apply if packed size matches the declared buffer size
+        if (static_cast<uint32_t>(offset) == cbv.buffer_size) {
+          definition.size = offset;
+          definition.has_offsets = true;
+        }
+        // If sizes don't match, leave the original tight-packed layout
+        // (the per-component fallback will be used)
       }
     }
   };
@@ -1530,6 +2001,12 @@ class Decompiler {
     int current_code_block_number = 0;
     std::map<uint32_t, std::string> variable_assignments;
     std::unordered_map<std::string_view, std::string> stored_pointers;
+    // Tracks the underlying element type (LLVM type) that a pointer alias
+    // actually refers to in HLSL-land. When a pointer bitcast reinterprets
+    // the element type (e.g. i32* -> float*), this map keeps the ORIGINAL
+    // type so that stores/loads can emit asuint()/asfloat() to preserve bits.
+    // Key: variable name (e.g. "193"). Value: LLVM scalar type (e.g. "i32").
+    std::unordered_map<std::string, std::string> stored_pointer_element_types;
     std::map<std::string, std::pair<std::string, std::string>> variable_aliases;
     std::vector<std::string_view> threads;
     std::map<uint32_t, uint32_t> variable_counter;
@@ -1537,19 +2014,57 @@ class Decompiler {
     std::map<uint32_t, uint32_t> variable_declaration;  // variable _codeblocknumber
     std::map<uint32_t, uint32_t> assignment_values;
     std::set<uint32_t> single_use_variables;
+    std::vector<std::string> ray_query_declarations;  // RayQuery declarations to hoist to function scope
 
-    std::vector<std::string> ComputePhiAssignments(CodeBlock* code_block, int branch_code_function) {
+    std::vector<std::string> ComputePhiAssignments(CodeBlock* code_block, int branch_code_function,
+                                                    const std::set<std::string>& bool_forwarding_phis = {}) {
       std::vector<std::string> phi_lines;
       for (const auto& [variable, type, value, predecessor, code_function, is_assign] : code_block->phi_lines) {
         // add phi lines
         if (code_function == branch_code_function && is_assign) {
+          auto var_name = std::format("_{}", variable);
           auto assignment_value = std::format("{}", this->ParseByType(value, type));
           std::string optimized = OptimizeString(assignment_value);
+          // For boolean forwarding phis (true/false constants that DXC
+          // constant-folds), emit as uint to prevent branch elimination.
+          if (bool_forwarding_phis.contains(var_name)) {
+            if (optimized == "true") optimized = "1u";
+            else if (optimized == "false") optimized = "0u";
+          }
           auto phi_line = std::format("_{} = {};", variable, optimized);
           phi_lines.push_back(phi_line);
         }
       }
       return phi_lines;
+    }
+
+    // Detect boolean forwarding phis: phi i1 [true from A, false from B]
+    // DXC constant-folds these when used as branch conditions, eliminating
+    // code paths. Returns set of variable names that need uint treatment.
+    std::set<std::string> DetectBooleanForwardingPhis(int convergence_block) {
+      std::set<std::string> result;
+      if (!code_blocks.contains(convergence_block)) return result;
+      auto& block = code_blocks[convergence_block];
+      
+      std::map<std::string, std::vector<std::pair<int, std::string>>> phi_groups;
+      for (const auto& [variable, type, value, predecessor, code_function, is_assign] : block.phi_lines) {
+        if (type == "i1" && is_assign) {
+          phi_groups[std::string(variable)].emplace_back(code_function, std::string(value));
+        }
+      }
+      
+      for (auto& [variable, entries] : phi_groups) {
+        if (entries.size() != 2) continue;
+        bool has_true = false, has_false = false;
+        for (auto& [cf, val] : entries) {
+          if (val == "true") has_true = true;
+          if (val == "false") has_false = true;
+        }
+        if (has_true && has_false) {
+          result.insert(std::format("_{}", variable));
+        }
+      }
+      return result;
     }
 
     void IncrementVariableCounter(std::string_view variable) {
@@ -1578,9 +2093,20 @@ class Decompiler {
           static constexpr const auto* SAFE_CHARACTERS = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_.";
           // static constexpr const auto *UNSAFE_CHARACTERS = " *+-/&^|";
           bool needs_wrap = !is_function && alias_value.find_first_not_of(SAFE_CHARACTERS) != std::string_view::npos;
-          auto new_value = (expected_type != alias_type)
-                               ? CastType(alias_type, alias_value)
-                               : alias_value;
+          std::string new_value;
+          if (expected_type != alias_type) {
+            // When caller explicitly requests int or uint, cast to the requested
+            // type to preserve signedness semantics (e.g., udiv needs uint operands).
+            // For other cases (float default, bool), preserve the source type annotation
+            // so that reinterpret casts like asfloat() see the correct input type.
+            if (expected_type == "int" || expected_type == "uint") {
+              new_value = CastType(expected_type, alias_value);
+            } else {
+              new_value = CastType(alias_type, alias_value);
+            }
+          } else {
+            new_value = std::string(alias_value);
+          }
           return needs_wrap ? ParseWrapped(new_value) : new_value;
         }
       }
@@ -1634,6 +2160,10 @@ class Decompiler {
       if (type == "i32") return ParseInt(input);
       if (type == "int") return ParseInt(input);
       if (type == "uint") return ParseUint(input);
+      // Pitfall 9: i16 must be parsed as integer, not float.
+      // Negative i16 constants (e.g., -25536) parsed as float produce (uint)-25536.0f which is UB.
+      if (type == "i16") return ParseInt(input);
+      if (type == "i64") return ParseInt64(input);
       if (type == "half") return ParseHalf(input);
       return ParseFloat(input);
     }
@@ -1695,23 +2225,39 @@ class Decompiler {
           std::string hint;
           Resource* resource;
           if (resource_class == "0") {
+            if (range_id_value >= preprocess_state.srv_resources.size()) {
+              throw std::runtime_error(std::format("createHandle: SRV rangeId {} out of bounds (size={})", range_id_value, preprocess_state.srv_resources.size()));
+            }
             resource = &preprocess_state.srv_resources[range_id_value];
             hint = "texture";
           } else if (resource_class == "1") {
+            if (range_id_value >= preprocess_state.uav_resources.size()) {
+              throw std::runtime_error(std::format("createHandle: UAV rangeId {} out of bounds (size={})", range_id_value, preprocess_state.uav_resources.size()));
+            }
             resource = &preprocess_state.uav_resources[range_id_value];
             hint = "rwtexture";
           } else if (resource_class == "2") {
+            if (range_id_value >= preprocess_state.cbv_resources.size()) {
+              throw std::runtime_error(std::format("createHandle: CBV rangeId {} out of bounds (size={})", range_id_value, preprocess_state.cbv_resources.size()));
+            }
             resource = &preprocess_state.cbv_resources[range_id_value];
             hint = "cbuffer";
           } else if (resource_class == "3") {
+            if (range_id_value >= preprocess_state.sampler_resources.size()) {
+              throw std::runtime_error(std::format("createHandle: Sampler rangeId {} out of bounds (size={})", range_id_value, preprocess_state.sampler_resources.size()));
+            }
             resource = &preprocess_state.sampler_resources[range_id_value];
             hint = "SamplerState";
           } else {
-            throw std::runtime_error("Unknown resource type");
+            throw std::runtime_error(std::format("Unknown resource class '{}' in createHandle", resource_class));
           }
           std::string name = resource->name;
           if (resource->array_size.has_value()) {
-            name = std::format("{}[{}]", name, ParseUint(index));
+            bool is_non_uniform_old = (nonUniformIndex.find("true") != std::string_view::npos);
+            auto idx = ParseUint(index);
+            name = is_non_uniform_old
+                ? std::format("{}[NonUniformResourceIndex({})]", name, idx)
+                : std::format("{}[{}]", name, idx);
           }
           preprocess_state.resource_binding_variables[std::string(variable)] = {
               .name = name,
@@ -1743,6 +2289,7 @@ class Decompiler {
           int bind_start_value;
           FromStringView(space, space_value);
           FromStringView(bind_start, bind_start_value);
+          bool is_non_uniform = (nonUniformIndex.find("true") != std::string_view::npos);
           std::string name;
           uint32_t range_index;
           std::string hint;
@@ -1753,7 +2300,10 @@ class Decompiler {
             range_index = srv - preprocess_state.srv_resources.begin();
             name = srv->name;
             if (srv->array_size.has_value()) {
-              name = std::format("{}[{}]", name, ParseInt(index));
+              auto idx = ParseInt(index);
+              name = is_non_uniform
+                  ? std::format("{}[NonUniformResourceIndex({})]", name, idx)
+                  : std::format("{}[{}]", name, idx);
             }
             hint = "texture";
           } else if (resource_class == "1") {
@@ -1763,7 +2313,10 @@ class Decompiler {
             range_index = uav - preprocess_state.uav_resources.begin();
             name = uav->name;
             if (uav->array_size.has_value()) {
-              name = std::format("{}[{}]", name, ParseInt(index));
+              auto idx = ParseInt(index);
+              name = is_non_uniform
+                  ? std::format("{}[NonUniformResourceIndex({})]", name, idx)
+                  : std::format("{}[{}]", name, idx);
             }
             hint = "rwtexture";
           } else if (resource_class == "2") {
@@ -1773,7 +2326,10 @@ class Decompiler {
             range_index = cbv - preprocess_state.cbv_resources.begin();
             name = cbv->name;
             if (cbv->array_size.has_value()) {
-              name = std::format("{}[{}]", name, ParseInt(index));
+              auto idx = ParseInt(index);
+              name = is_non_uniform
+                  ? std::format("{}[NonUniformResourceIndex({})]", name, idx)
+                  : std::format("{}[{}]", name, idx);
             }
             hint = "cbuffer";
           } else if (resource_class == "3") {
@@ -1783,7 +2339,10 @@ class Decompiler {
             range_index = sampler - preprocess_state.sampler_resources.begin();
             name = sampler->name;
             if (sampler->array_size.has_value()) {
-              name = std::format("{}[{}]", name, ParseInt(index));
+              auto idx = ParseInt(index);
+              name = is_non_uniform
+                  ? std::format("{}[NonUniformResourceIndex({})]", name, idx)
+                  : std::format("{}[{}]", name, idx);
             }
             hint = "SamplerState";
           } else {
@@ -1799,27 +2358,158 @@ class Decompiler {
           assignment_value = name;
           use_comment = true;
           // decompiled = std::format("// {} _{} = {};", hint, variable, name);
+        } else if (functionName == "@dx.op.createHandleFromHeap") {
+          // %21 = call %dx.types.Handle @dx.op.createHandleFromHeap(i32 218, i32 %14, i1 false, i1 true)  ; CreateHandleFromHeap(index,samplerHeap,nonUniformIndex)
+          auto [opNumber, index, samplerHeap, nonUniformIndex] = StringViewSplit<4>(functionParamsString, param_regex, 2);
+          bool is_non_uniform = (nonUniformIndex.find("true") != std::string_view::npos);
+          std::string heap_index = ParseInt(index);
+          preprocess_state.heap_handle_variables[std::string(variable)] = {
+              .heap_index = heap_index,
+              .is_non_uniform = is_non_uniform,
+          };
+          assignment_type = "auto";
+          assignment_value = std::format("/* heap[{}] */", heap_index);
+          use_comment = true;
         } else if (functionName == "@dx.op.annotateHandle") {
           // %4 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %3, %dx.types.ResourceProperties { i32 13, i32 644 })  ; AnnotateHandle(res,props)  resource: CBuffer
           auto [opNumber, res, props] = StringViewSplit<3>(functionParamsString, param_regex, 2);
           auto ref = std::string{res.substr(1)};
-          preprocess_state.resource_binding_variables[std::string(variable)] = preprocess_state.resource_binding_variables.at(ref);
-          assignment_type = "auto";
-          assignment_value = std::format("_{}", ref);
-          use_comment = true;
+
+          // Check if this annotates a heap-created handle (SM6.6 bindless)
+          auto heap_it = preprocess_state.heap_handle_variables.find(ref);
+          if (heap_it != preprocess_state.heap_handle_variables.end()) {
+            // Parse ResourceProperties { i32 <kind_bits>, i32 <extra> }
+            // kind_bits low 12 bits = ResourceKind, bit 12 = isUAV
+            static auto props_regex = std::regex{R"(\{\s*i32\s+(\d+)\s*,\s*i32\s+(\d+)\s*\})"};
+            auto [kind_bits_str, extra_str] = StringViewMatch<2>(props, props_regex);
+            uint32_t kind_bits = 0;
+            if (!kind_bits_str.empty()) FromStringView(kind_bits_str, kind_bits);
+            uint32_t resource_kind = kind_bits & 0xFF;
+            bool is_uav = (kind_bits >> 11) & 1;
+
+            auto& heap_info = heap_it->second;
+            std::string synth_name = std::format("_HeapResource_{}", preprocess_state.heap_srv_counter++);
+            std::string resource_class;
+            uint32_t range_index;
+
+            if (is_uav) {
+              // Create synthetic UAV
+              range_index = static_cast<uint32_t>(preprocess_state.uav_resources.size());
+              resource_class = "1";
+              // We don't add to uav_resources — just track the binding variable
+              // The downstream code will need to handle this via the resource_class
+            } else {
+              // Create synthetic SRV entry for tracking
+              range_index = static_cast<uint32_t>(preprocess_state.srv_resources.size());
+              resource_class = "0";
+            }
+
+            // Determine the HLSL type name for the heap resource
+            std::string hint;
+            std::string data_type;
+            auto rk = static_cast<Resource::ResourceKind>(resource_kind);
+            if (rk == Resource::ResourceKind::RawBuffer) {
+              hint = is_uav ? "RWByteAddressBuffer" : "ByteAddressBuffer";
+              data_type = "";
+            } else if (rk == Resource::ResourceKind::RTAccelerationStructure) {
+              hint = "RaytracingAccelerationStructure";
+              data_type = "RaytracingAccelerationStructure";
+            } else if (rk == Resource::ResourceKind::StructuredBuffer) {
+              hint = is_uav ? "rwtexture" : "texture";
+              data_type = "uint4";  // StructuredBuffer accessed via raw loads
+            } else {
+              // Texture types — parse element type from second props word
+              // Second word: low 8 bits = component type, bits 8+ = component count
+              uint32_t extra = 0;
+              if (!extra_str.empty()) FromStringView(extra_str, extra);
+              uint32_t comp_type = extra & 0xFF;
+              uint32_t comp_count = (extra >> 8) & 0xFF;
+              if (comp_count == 0) comp_count = 1;  // fallback
+              std::string base;
+              switch (comp_type) {
+                case 1: base = "bool"; break;    // I1
+                case 2: base = "int16_t"; break; // I16
+                case 3: base = "uint16_t"; break;// U16
+                case 4: base = "int"; break;     // I32
+                case 5: base = "uint"; break;    // U32
+                case 6: base = "int64_t"; break; // I64
+                case 7: base = "uint64_t"; break;// U64
+                case 8: base = "half"; break;    // F16
+                case 9: base = "float"; break;   // F32
+                case 10: base = "double"; break; // F64
+                default: base = "float"; break;
+              }
+              data_type = (comp_count == 1) ? base : std::format("{}{}", base, comp_count);
+              hint = is_uav ? "rwtexture" : "texture";
+            }
+
+            preprocess_state.resource_binding_variables[std::string(variable)] = {
+                .name = synth_name,
+                .range_index = range_index,
+                .resource_class = resource_class,
+            };
+            preprocess_state.heap_resource_info[std::string(variable)] = {
+                .resource_kind = rk,
+                .data_type = data_type,
+            };
+
+            // Emit actual variable declaration using ResourceDescriptorHeap
+            std::string hlsl_type;
+            if (rk == Resource::ResourceKind::RawBuffer) {
+              hlsl_type = is_uav ? "RWByteAddressBuffer" : "ByteAddressBuffer";
+            } else if (rk == Resource::ResourceKind::StructuredBuffer) {
+              hlsl_type = is_uav ? "RWByteAddressBuffer" : "ByteAddressBuffer";
+            } else if (rk == Resource::ResourceKind::RTAccelerationStructure) {
+              hlsl_type = "RaytracingAccelerationStructure";
+            } else {
+              // Texture types
+              std::string rk_str = Resource::ResourceKindString(rk);
+              if (is_uav) rk_str = "RW" + rk_str;
+              hlsl_type = data_type.empty() ? rk_str : std::format("{}<{}>", rk_str, data_type);
+            }
+            assignment_type = hlsl_type;
+            std::string heap_idx = heap_info.is_non_uniform
+                ? std::format("NonUniformResourceIndex({})", heap_info.heap_index)
+                : heap_info.heap_index;
+            assignment_value = std::format("ResourceDescriptorHeap[{}]", heap_idx);
+            // Override the variable name to use the synthetic name
+            decompiled = std::format("{} {} = {};", hlsl_type, synth_name, assignment_value);
+            assignment_type.clear();
+            assignment_value.clear();
+          } else {
+            preprocess_state.resource_binding_variables[std::string(variable)] = preprocess_state.resource_binding_variables.at(ref);
+            // Check if this annotated handle has dynamic cbuffer access
+            if (preprocess_state.cbv_handles_with_dynamic_access.contains(std::format("%{}", variable))) {
+              auto& binding = preprocess_state.resource_binding_variables[std::string(variable)];
+              if (binding.resource_class == "2") {  // CBV
+                preprocess_state.cbv_dynamic_access_indices.insert(binding.range_index);
+              }
+            }
+            assignment_type = "auto";
+            assignment_value = std::format("_{}", ref);
+            use_comment = true;
+          }
           // decompiled = std::format("// _{} = _{};", variable, ref);
         } else if (functionName == "@dx.op.loadInput.f32") {
           //   @dx.op.loadInput.f32(i32 4, i32 3, i32 0, i8 0, i32 undef)  ; LoadInput(inputSigId,rowIndex,colIndex,gsVertexAxis)
           auto [opNumber, inputSigId, rowIndex, colIndex, gsVertexAxis] = StringViewSplit<5>(functionParamsString, param_regex, 2);
           int input_signature_index;
           FromStringView(inputSigId, input_signature_index);
-          auto signature = preprocess_state.input_signature[input_signature_index];
+          // rowIndex offsets within array signatures (e.g., TEXCOORD 1-16)
+          int row_index = 0;
+          FromStringView(rowIndex, row_index);
+          auto sig_index = input_signature_index + row_index;
+          if (sig_index >= static_cast<int>(preprocess_state.input_signature.size())) {
+            sig_index = input_signature_index;  // fallback
+          }
+          auto signature = preprocess_state.input_signature[sig_index];
           assignment_type = "float";
           is_identity = true;
           if (signature.packed.MaskString() == "1") {
-            if (ParseIndex(colIndex) != "x") {
-              throw std::runtime_error("Unexpected index.");
-            }
+            // Single-component signature — use the variable directly.
+            // The colIndex may not be "x" when the signature occupies a
+            // non-x component of a shared register (e.g., SV_RenderTargetArrayIndex
+            // at mask y sharing a register with PRIMITIVE_ID at mask x).
             assignment_value = signature.VariableString();
             // decompiled = std::format("float _{} = {};", variable, value);
             // preprocess_state.variable_aliases.emplace(variable, assignment_value);
@@ -1828,18 +2518,40 @@ class Decompiler {
             // decompiled = std::format("float _{} = {};", variable, value);
             // preprocess_state.variable_aliases.emplace(variable, assignment_value);
           }
+        } else if (functionName == "@dx.op.loadInput.f16") {
+          //   @dx.op.loadInput.f16(i32 4, i32 5, i32 0, i8 0, i32 undef)  ; LoadInput(inputSigId,rowIndex,colIndex,gsVertexAxis)
+          auto [opNumber, inputSigId, rowIndex, colIndex, gsVertexAxis] = StringViewSplit<5>(functionParamsString, param_regex, 2);
+          int input_signature_index;
+          FromStringView(inputSigId, input_signature_index);
+          int row_index = 0;
+          FromStringView(rowIndex, row_index);
+          auto sig_index = input_signature_index + row_index;
+          if (sig_index >= static_cast<int>(preprocess_state.input_signature.size())) {
+            sig_index = input_signature_index;
+          }
+          auto signature = preprocess_state.input_signature[sig_index];
+          assignment_type = "half";
+          is_identity = true;
+          if (signature.packed.MaskString() == "1") {
+            assignment_value = signature.VariableString();
+          } else {
+            assignment_value = std::format("{}.{}", signature.VariableString(), ParseIndex(colIndex));
+          }
         } else if (functionName == "@dx.op.loadInput.i32") {
           //   @dx.op.loadInput.i32(i32 4, i32 2, i32 0, i8 0, i32 undef)  ; LoadInput(inputSigId,rowIndex,colIndex,gsVertexAxis)
           auto [opNumber, inputSigId, rowIndex, colIndex, gsVertexAxis] = StringViewSplit<5>(functionParamsString, param_regex, 2);
           int input_signature_index;
           FromStringView(inputSigId, input_signature_index);
-          auto signature = preprocess_state.input_signature[input_signature_index];
+          int row_index = 0;
+          FromStringView(rowIndex, row_index);
+          auto sig_index = input_signature_index + row_index;
+          if (sig_index >= static_cast<int>(preprocess_state.input_signature.size())) {
+            sig_index = input_signature_index;
+          }
+          auto signature = preprocess_state.input_signature[sig_index];
           assignment_type = "int";
           is_identity = true;
           if (signature.packed.MaskString() == "1") {
-            if (ParseIndex(colIndex) != "x") {
-              throw std::runtime_error("Unexpected index.");
-            }
             assignment_value = signature.VariableString();
             // decompiled = std::format("uint _{} = {};", variable, value);
             // preprocess_state.variable_aliases.emplace(variable, value);
@@ -1856,14 +2568,20 @@ class Decompiler {
           auto& cbv_resource = preprocess_state.cbv_resources[range_index];
 
           if (regIndex.starts_with("%")) {
-            throw std::exception("Unexpected dynamic cbuffer offset.");
-          }
-          uint32_t cbv_variable_index;
-          FromStringView(regIndex, cbv_variable_index);
-          // auto name = preprocess_state.ResourceVariableNameAtIndex(cbv_resource, cbv_variable_index);
+            // Dynamic cbuffer offset — emit as array-style access via raw uint4 view
+            preprocess_state.cbv_dynamic_access_indices.insert(range_index);
+            assignment_type = "float4";
+            assignment_value = std::format("asfloat({}_raw[{}])", cbv_resource.name, ParseVariable(regIndex));
+            is_identity = false;
+            use_comment = false;
+          } else {
+            uint32_t cbv_variable_index;
+            FromStringView(regIndex, cbv_variable_index);
+            // auto name = preprocess_state.ResourceVariableNameAtIndex(cbv_resource, cbv_variable_index);
 
-          // decompiled = std::format("// float4 _{} = {}[{}u];", variable, cbv_resource.name, cbv_variable_index);
-          preprocess_state.cbv_binding_variables[variable] = {&cbv_resource, cbv_variable_index};
+            // decompiled = std::format("// float4 _{} = {}[{}u];", variable, cbv_resource.name, cbv_variable_index);
+            preprocess_state.cbv_binding_variables[variable] = {&cbv_resource, cbv_variable_index, binding_name};
+          }
 
         } else if (functionName == "@dx.op.cbufferLoadLegacy.i32") {
           // %18 = call %dx.types.CBufRet.i32 @dx.op.cbufferLoadLegacy.i32(i32 59, %dx.types.Handle %4, i32 40)  ; CBufferLoadLegacy(handle,regIndex)
@@ -1873,15 +2591,35 @@ class Decompiler {
           assert(resource_class == "2");
           auto& cbv_resource = preprocess_state.cbv_resources[range_index];
 
-          uint32_t cbv_variable_index;
-          FromStringView(regIndex, cbv_variable_index);
           if (regIndex.starts_with("%")) {
-            throw std::exception("Unexpected dynamic cbuffer offset.");
-          }
-          // auto name = preprocess_state.ResourceVariableNameAtIndex(cbv_resource, cbv_variable_index);
+            // Dynamic cbuffer offset — emit as array-style access via raw float4 view
+            preprocess_state.cbv_dynamic_access_indices.insert(range_index);
+            assignment_type = "int4";
+            assignment_value = std::format("asint({}_raw[{}])", cbv_resource.name, ParseVariable(regIndex));
+            is_identity = false;
+            use_comment = false;
+          } else {
+            uint32_t cbv_variable_index;
+            FromStringView(regIndex, cbv_variable_index);
+            // auto name = preprocess_state.ResourceVariableNameAtIndex(cbv_resource, cbv_variable_index);
 
-          // decompiled = std::format("// int4 _{} = {}[{}u];", variable, cbv_resource.name, cbv_variable_index);
-          preprocess_state.cbv_binding_variables[variable] = {&cbv_resource, cbv_variable_index};
+            // decompiled = std::format("// int4 _{} = {}[{}u];", variable, cbv_resource.name, cbv_variable_index);
+            preprocess_state.cbv_binding_variables[variable] = {&cbv_resource, cbv_variable_index, binding_name};
+          }
+        } else if (functionName == "@dx.op.cbufferLoadLegacy.f16") {
+          auto [opNumber, handle, regIndex] = StringViewSplit<3>(functionParamsString, param_regex, 2);
+          auto ref = std::string{handle.substr(1)};
+          auto [binding_name, range_index, resource_class] = preprocess_state.resource_binding_variables.at(ref);
+          assert(resource_class == "2");
+          auto& cbv_resource = preprocess_state.cbv_resources[range_index];
+
+          if (regIndex.starts_with("%")) {
+            throw std::runtime_error("Unsupported dynamic @dx.op.cbufferLoadLegacy.f16");
+          } else {
+            uint32_t cbv_variable_index;
+            FromStringView(regIndex, cbv_variable_index);
+            preprocess_state.cbv_binding_variables[variable] = {&cbv_resource, cbv_variable_index, binding_name};
+          }
         } else if (functionName == "@dx.op.unary.f32") {
           auto [opNumber, value] = StringViewSplit<2>(functionParamsString, param_regex, 2);
           if (auto pair = UNARY_FLOAT_OPS.find(std::string(opNumber));
@@ -1916,14 +2654,23 @@ class Decompiler {
           auto [opNumber, value] = StringViewSplit<2>(functionParamsString, param_regex, 2);
           if (auto pair = UNARY_BITS_OPS.find(std::string(opNumber));
               pair != UNARY_BITS_OPS.end()) {
-            if (opNumber == "33") {
+            if (opNumber == "33" || opNumber == "34") {
               assignment_type = "uint";
-              // decompiled = std::format("uint _{} = {}({});", variable, pair->second, ParseFloat(value));
             } else {
               assignment_type = ParseType(type);
-              // decompiled = std::format("{} _{} = {}({});", ParseType(type), variable, pair->second, ParseFloat(value));
             }
-            assignment_value = CastType(pair->second, ParseFloat(value));
+            // Opcode 33 = FirstbitHi (unsigned input) — must cast to uint
+            // Opcode 34 = FirstbitSHi (signed input) — must cast to int
+            // Other opcodes (countbits, firstbitlow) use generic parse
+            std::string parsed_arg;
+            if (opNumber == "33") {
+              parsed_arg = ParseUint(value);
+            } else if (opNumber == "34") {
+              parsed_arg = ParseInt(value);
+            } else {
+              parsed_arg = ParseFloat(value);
+            }
+            assignment_value = std::format("{}{}", pair->second, ParseWrapped(parsed_arg));
           } else {
             throw std::runtime_error("Unknown @dx.op.unaryBits.i32");
           }
@@ -1953,12 +2700,61 @@ class Decompiler {
           if (auto pair = BINARY_INT32_OPS.find(std::string(opNumber));
               pair != BINARY_INT32_OPS.end()) {
             assignment_type = ParseType(type);
-            assignment_value = std::format("{}({}, {})", pair->second, ParseInt(a), ParseInt(b));
-            // decompiled = std::format("{} _{} = {}({}, {});", ParseType(type), variable, pair->second, ParseInt(a), ParseInt(b));
+            if (UNSIGNED_BINARY_INT32_OPS.contains(std::string(opNumber))) {
+              // UMin/UMax require unsigned comparison semantics
+              auto a_str = std::string(ParseInt(a));
+              auto b_str = std::string(ParseInt(b));
+              // Wrap in (uint) cast if not already uint
+              auto cast_uint = [](const std::string& s) -> std::string {
+                if (s.starts_with("(uint)") || (s.size() > 0 && s.back() == 'u')) return s;
+                return std::format("(uint)({})", s);
+              };
+              assignment_value = std::format("(int){}({}, {})", pair->second, cast_uint(a_str), cast_uint(b_str));
+            } else {
+              // Pitfall 5: IMax/IMin (opcodes 37/38) require signed comparison semantics.
+              // Without (int) casts, max(uint_value, 0u) is a no-op since uint >= 0 always.
+              // The original intent is signed clamping: if unsigned subtraction wraps,
+              // the signed interpretation is negative, and IMax with 0 clamps to 0.
+              auto a_str = std::string(ParseInt(a));
+              auto b_str = std::string(ParseInt(b));
+              auto cast_int = [](const std::string& s) -> std::string {
+                if (s.starts_with("(int)")) return s;
+                return std::format("(int)({})", s);
+              };
+              assignment_value = std::format("{}({}, {})", pair->second, cast_int(a_str), cast_int(b_str));
+            }
           } else {
             throw std::runtime_error("Unknown @dx.op.binary.i32");
           }
-        } else if (functionName == "@dx.op.textureLoad.f32" || functionName == "@dx.op.textureLoad.i32") {
+        } else if (functionName == "@dx.op.binary.i16") {
+          // call i16 @dx.op.binary.i16(i32 38, i16 %365, i16 4)  ; IMin(a,b)
+          auto [opNumber, a, b] = StringViewSplit<3>(functionParamsString, param_regex, 2);
+          if (auto pair = BINARY_INT32_OPS.find(std::string(opNumber));
+              pair != BINARY_INT32_OPS.end()) {
+            assignment_type = "int16_t";
+            if (UNSIGNED_BINARY_INT32_OPS.contains(std::string(opNumber))) {
+              // UMin/UMax require unsigned comparison semantics
+              auto a_str = std::string(ParseInt(a));
+              auto b_str = std::string(ParseInt(b));
+              auto cast_uint16 = [](const std::string& s) -> std::string {
+                if (s.starts_with("(uint16_t)")) return s;
+                return std::format("(uint16_t)({})", s);
+              };
+              assignment_value = std::format("(int16_t){}({}, {})", pair->second, cast_uint16(a_str), cast_uint16(b_str));
+            } else {
+              // IMax/IMin require signed comparison semantics
+              auto a_str = std::string(ParseInt(a));
+              auto b_str = std::string(ParseInt(b));
+              auto cast_int16 = [](const std::string& s) -> std::string {
+                if (s.starts_with("(int16_t)")) return s;
+                return std::format("(int16_t)({})", s);
+              };
+              assignment_value = std::format("{}({}, {})", pair->second, cast_int16(a_str), cast_int16(b_str));
+            }
+          } else {
+            throw std::runtime_error("Unknown @dx.op.binary.i16");
+          }
+        } else if (functionName == "@dx.op.textureLoad.f32" || functionName == "@dx.op.textureLoad.i32" || functionName == "@dx.op.textureLoad.f16" || functionName == "@dx.op.textureLoad.i16") {
           // %dx.types.ResRet.f32 @dx.op.textureLoad.f32(i32 66, %dx.types.Handle %40, i32 0, i32 %38, i32 %39, i32 undef, i32 undef, i32 undef, i32 undef)  ; TextureLoad(srv,mipLevelOrSampleCount,coord0,coord1,coord2,offset0,offset1,offset2)
           // %dx.types.ResRet.f32 @dx.op.textureLoad.f32(i32 66, %dx.types.Handle %442, i32 undef, i32 %440, i32 %441, i32 undef, i32 undef, i32 undef, i32 undef)  ; TextureLoad(srv,mipLevelOrSampleCount,coord0,coord1,coord2,offset0,offset1,offset2)
           auto [opNumber, srv, mipLevelOrSampleCount, coord0, coord1, coord2, offset0, offset1, offset2] = StringViewSplit<9>(functionParamsString, param_regex, 2);
@@ -1970,10 +2766,9 @@ class Decompiler {
           const bool has_mip_level = mipLevelOrSampleCount != "undef";
           std::string coords;
           auto [binding_name, range_index, resource_class] = preprocess_state.resource_binding_variables.at(ref_resource);
-          Resource::ResourceKind shape;
+          Resource::ResourceKind shape = preprocess_state.GetResourceShape(ref_resource);
           if (resource_class == "0") {
-            shape = preprocess_state.srv_resources[range_index].shape;
-            assignment_type = preprocess_state.srv_resources[range_index].data_type;
+            assignment_type = preprocess_state.GetResourceDataType(ref_resource);
           } else if (resource_class == "1") {
             shape = preprocess_state.uav_resources[range_index].shape;
             assignment_type = preprocess_state.uav_resources[range_index].data_type;
@@ -2059,10 +2854,9 @@ class Decompiler {
 
           auto [srv_name, srv_range_index, srv_resource_class] = preprocess_state.resource_binding_variables.at(ref_resource);
           assert(srv_resource_class == "0");
-          auto srv_resource = preprocess_state.srv_resources[srv_range_index];
           auto [sampler_name, sampler_range_index, sampler_resource_class] = preprocess_state.resource_binding_variables.at(ref_sampler);
           auto sampler_resource = preprocess_state.sampler_resources[sampler_range_index];
-          assignment_type = srv_resource.data_type;
+          assignment_type = preprocess_state.GetResourceDataType(ref_resource);
           if (offset == "0" || offset == "int2(0, 0)" || offset == "int3(0, 0, 0)") {
             assignment_value = std::format("{}.Sample({}, {})", srv_name, sampler_name, coords);
             // decompiled = std::format("{} _{} = {}.Sample({}, {});", srv_resource.data_type, variable, srv_name, sampler_name, coords);
@@ -2102,10 +2896,9 @@ class Decompiler {
           }
 
           auto [srv_name, srv_range_index, srv_resource_class] = preprocess_state.resource_binding_variables.at(ref_resource);
-          auto srv_resource = preprocess_state.srv_resources[srv_range_index];
           auto [sampler_name, sampler_range_index, sampler_resource_class] = preprocess_state.resource_binding_variables.at(ref_sampler);
           auto sampler_resource = preprocess_state.sampler_resources[sampler_range_index];
-          assignment_type = srv_resource.data_type;
+          assignment_type = preprocess_state.GetResourceDataType(ref_resource);
           if (offset == "" || offset == "0" || offset == "int2(0, 0)" || offset == "int3(0, 0, 0)") {
             assignment_value = std::format("{}.SampleLevel({}, {}, {})", srv_name,
                                            sampler_name, coords, ParseFloat(LOD));
@@ -2115,6 +2908,32 @@ class Decompiler {
                                            sampler_name, coords, ParseFloat(LOD), offset);
             // decompiled = std::format("{} _{} = {}.SampleLevel({}, {}, {}, {});", srv_resource.data_type, variable, srv_name, sampler_name, coords, ParseFloat(LOD), offset);
           }
+        } else if (functionName == "@dx.op.calculateLOD.f32") {
+          // call float @dx.op.calculateLOD.f32(i32 81, %dx.types.Handle %srv, %dx.types.Handle %sampler, float %coord0, float %coord1, float %coord2, i1 true)  ; CalculateLOD(handle,sampler,coord0,coord1,coord2,clamped)
+          auto [opNumber, srv, sampler, coord0, coord1, coord2, clamped] = StringViewSplit<7>(functionParamsString, param_regex, 2);
+          auto ref_resource = std::string{srv.substr(1)};
+          auto ref_sampler = std::string{sampler.substr(1)};
+          const bool has_coord_y = coord1 != "undef";
+          const bool has_coord_z = coord2 != "undef";
+
+          std::string coords;
+          if (has_coord_z) {
+            coords = std::format("float3({}, {}, {})", ParseFloat(coord0), ParseFloat(coord1), ParseFloat(coord2));
+          } else if (has_coord_y) {
+            coords = std::format("float2({}, {})", ParseFloat(coord0), ParseFloat(coord1));
+          } else {
+            coords = ParseFloat(coord0);
+          }
+
+          auto [srv_name, srv_range_index, srv_resource_class] = preprocess_state.resource_binding_variables.at(ref_resource);
+          auto [sampler_name, sampler_range_index, sampler_resource_class] = preprocess_state.resource_binding_variables.at(ref_sampler);
+          assignment_type = "float";
+          assignment_value = std::format(
+              "{}.{}({}, {})",
+              srv_name,
+              clamped == "true" ? "CalculateLevelOfDetail" : "CalculateLevelOfDetailUnclamped",
+              sampler_name,
+              coords);
         } else if (functionName == "@dx.op.dot2.f32") {
           auto [opNumber, ax, ay, bx, by] = StringViewSplit<5>(functionParamsString, param_regex, 2);
           assignment_type = "float";
@@ -2149,7 +2968,7 @@ class Decompiler {
           assignment_value = std::format("dot(half3({}, {}, {}), half3({}, {}, {}))",
                                          ParseHalf(ax), ParseHalf(ay), ParseHalf(az),
                                          ParseHalf(bx), ParseHalf(by), ParseHalf(bz));
-        } else if (functionName == "@dx.op.dot4.f32") {
+        } else if (functionName == "@dx.op.dot4.f16") {
           auto [opNumber, ax, ay, az, aw, bx, by, bz, bw] = StringViewSplit<9>(functionParamsString, param_regex, 2);
           assignment_type = "half";
           assignment_value = std::format("dot(half4({}, {}, {}, {}), half4({}, {}, {}, {}))",
@@ -2161,103 +2980,217 @@ class Decompiler {
           assignment_type = "float";
           assignment_value = std::format("mad({}, {}, {})",
                                          ParseFloat(a), ParseFloat(b), ParseFloat(c));
-        } else if (functionName == "@dx.op.rawBufferLoad.f32") {
+        } else if (functionName == "@dx.op.tertiary.f16") {
+          auto [opNumber, a, b, c] = StringViewSplit<4>(functionParamsString, param_regex, 2);
+          assignment_type = "half";
+          assignment_value = std::format("mad({}, {}, {})",
+                                         ParseHalf(a), ParseHalf(b), ParseHalf(c));
+        } else if (functionName == "@dx.op.tertiary.i32") {
+          // call i32 @dx.op.tertiary.i32(i32 48, i32 %x, i32 %y, i32 %z)  ; IMad(a,b,c)
+          auto [opNumber, a, b, c] = StringViewSplit<4>(functionParamsString, param_regex, 2);
+          assignment_type = "int";
+          assignment_value = std::format("mad({}, {}, {})",
+                                         ParseInt(a), ParseInt(b), ParseInt(c));
+        } else if (functionName == "@dx.op.rawBufferLoad.f32" || functionName == "@dx.op.rawBufferLoad.f16") {
           // call %dx.types.ResRet.f32 @dx.op.rawBufferLoad.f32(i32 139, %dx.types.Handle %21, i32 %20, i32 0, i8 15, i32 4)  ; RawBufferLoad(srv,index,elementOffset,mask,alignment)
           // call %dx.types.ResRet.f32 @dx.op.rawBufferLoad.f32(i32 139, %dx.types.Handle %21, i32 %20, i32 32, i8 1, i32 4)  ; RawBufferLoad(srv,index,elementOffset,mask,alignment)
 
           auto [opNumber, srv, index, elementOffset, mask, alignment] = StringViewSplit<6>(functionParamsString, param_regex, 2);
           auto ref = std::string{srv.substr(1)};
-          auto [res_name, range_index, resource_class] = preprocess_state.resource_binding_variables.at(ref);
-          bool is_raw_buffer = false;
-          if (resource_class == "0") {
-            is_raw_buffer = preprocess_state.srv_resources[range_index].shape == Resource::ResourceKind::RawBuffer;
-          } else if (resource_class == "1") {
-            is_raw_buffer = preprocess_state.uav_resources[range_index].shape == Resource::ResourceKind::RawBuffer;
-          } else {
-            throw std::runtime_error("Unknown @dx.op.rawBufferLoad.f32 resource");
-          }
+          auto binding = preprocess_state.resource_binding_variables.at(ref);
+          auto [res_name, range_index, resource_class] = binding;
+          bool is_raw_buffer = preprocess_state.GetResourceShape(ref) == Resource::ResourceKind::RawBuffer;
 
           if (is_raw_buffer) {
-            assignment_type = "float4";
             assert(elementOffset == "undef");
-            assignment_value = std::format("{}[{} / {}]",
-                                           res_name, ParseInt(index), ParseInt(alignment));
-          } else if (resource_class == "0") {
+            int mask_val;
+            FromStringView(mask, mask_val);
+            int component_count = 0;
+            if (mask_val & 1) component_count++;
+            if (mask_val & 2) component_count++;
+            if (mask_val & 4) component_count++;
+            if (mask_val & 8) component_count++;
+            std::string load_func = (component_count == 1) ? "Load" :
+                                    std::format("Load{}", component_count);
+            assignment_type = (component_count == 1) ? "float" :
+                              std::format("float{}", component_count);
+            assignment_value = std::format("asfloat({}.{}({}))",
+                                           res_name, load_func, ParseInt(index));
+            // Store in binding_load_variables with component_count so
+            // extractvalue knows whether to append .x/.y/.z/.w
+            std::string count_str = std::to_string(component_count);
+            if (resource_class == "0") {
+              preprocess_state.srv_binding_load_variables[variable] = {
+                  nullptr, assignment_value, count_str, "raw", ""};
+            } else {
+              preprocess_state.uav_binding_load_variables[variable] = {
+                  nullptr, assignment_value, count_str, "raw", ""};
+            }
+            use_comment = true;
+          } else if (!preprocess_state.IsHeapResource(ref) && resource_class == "0") {
             preprocess_state.srv_binding_load_variables[variable] = {
                 &preprocess_state.srv_resources[range_index],
                 ParseInt(index),
                 ParseInt(elementOffset),
                 ParseInt(alignment),
+                res_name,
             };
-          } else if (resource_class == "1") {
+          } else if (!preprocess_state.IsHeapResource(ref) && resource_class == "1") {
             preprocess_state.uav_binding_load_variables[variable] = {
                 &preprocess_state.uav_resources[range_index],
                 ParseInt(index),
                 ParseInt(elementOffset),
                 ParseInt(alignment),
+                res_name,
             };
+          } else if (preprocess_state.IsHeapResource(ref)) {
+            // Heap-created structured buffer — store with nullptr resource
+            if (resource_class == "0") {
+              preprocess_state.srv_binding_load_variables[variable] = {
+                  nullptr, ParseInt(index), ParseInt(elementOffset), ParseInt(alignment), res_name};
+            } else {
+              preprocess_state.uav_binding_load_variables[variable] = {
+                  nullptr, ParseInt(index), ParseInt(elementOffset), ParseInt(alignment), res_name};
+            }
           }
-        } else if (functionName == "@dx.op.rawBufferLoad.i32") {
+        } else if (functionName == "@dx.op.rawBufferLoad.i32" || functionName == "@dx.op.rawBufferLoad.i16") {
           auto [opNumber, srv, index, elementOffset, mask, alignment] = StringViewSplit<6>(functionParamsString, param_regex, 2);
           auto ref = std::string{srv.substr(1)};
-          auto [res_name, res_range_index, resource_class] = preprocess_state.resource_binding_variables.at(ref);
-          bool is_raw_buffer = false;
-          if (resource_class == "0") {
-            is_raw_buffer = preprocess_state.srv_resources[res_range_index].shape == Resource::ResourceKind::RawBuffer;
-          } else if (resource_class == "1") {
-            is_raw_buffer = preprocess_state.uav_resources[res_range_index].shape == Resource::ResourceKind::RawBuffer;
-          } else {
-            throw std::invalid_argument("Unknown @dx.op.rawBufferLoad.i32 resource");
-          }
+          auto binding = preprocess_state.resource_binding_variables.at(ref);
+          auto [res_name, res_range_index, resource_class] = binding;
+          bool is_raw_buffer = preprocess_state.GetResourceShape(ref) == Resource::ResourceKind::RawBuffer;
 
           if (is_raw_buffer) {
-            assignment_type = "int4";
             assert(elementOffset == "undef");
-            assignment_value = std::format("asint({}[{} / {}])",
-                                           res_name, ParseInt(index), ParseInt(alignment));
-          } else if (resource_class == "0") {
+            int mask_val;
+            FromStringView(mask, mask_val);
+            int component_count = 0;
+            if (mask_val & 1) component_count++;
+            if (mask_val & 2) component_count++;
+            if (mask_val & 4) component_count++;
+            if (mask_val & 8) component_count++;
+            std::string load_func = (component_count == 1) ? "Load" :
+                                    std::format("Load{}", component_count);
+            assignment_type = (component_count == 1) ? "int" :
+                              std::format("int{}", component_count);
+            assignment_value = std::format("asint({}.{}({}))",
+                                           res_name, load_func, ParseInt(index));
+            std::string count_str = std::to_string(component_count);
+            if (resource_class == "0") {
+              preprocess_state.srv_binding_load_variables[variable] = {
+                  nullptr, assignment_value, count_str, "raw", ""};
+            } else {
+              preprocess_state.uav_binding_load_variables[variable] = {
+                  nullptr, assignment_value, count_str, "raw", ""};
+            }
+            use_comment = true;
+          } else if (!preprocess_state.IsHeapResource(ref) && resource_class == "0") {
             preprocess_state.srv_binding_load_variables[variable] = {
                 &preprocess_state.srv_resources[res_range_index],
                 ParseInt(index),
                 ParseInt(elementOffset),
                 ParseInt(alignment),
+                res_name,
             };
-          } else if (resource_class == "1") {
+          } else if (!preprocess_state.IsHeapResource(ref) && resource_class == "1") {
             preprocess_state.uav_binding_load_variables[variable] = {
                 &preprocess_state.uav_resources[res_range_index],
                 ParseInt(index),
                 ParseInt(elementOffset),
                 ParseInt(alignment),
+                res_name,
             };
+          } else if (preprocess_state.IsHeapResource(ref)) {
+            if (resource_class == "0") {
+              preprocess_state.srv_binding_load_variables[variable] = {
+                  nullptr, ParseInt(index), ParseInt(elementOffset), ParseInt(alignment), res_name};
+            } else {
+              preprocess_state.uav_binding_load_variables[variable] = {
+                  nullptr, ParseInt(index), ParseInt(elementOffset), ParseInt(alignment), res_name};
+            }
           }
-        } else if (functionName == "@dx.op.bufferLoad.i32") {
+        } else if (functionName == "@dx.op.bufferLoad.i32" || functionName == "@dx.op.bufferLoad.i16") {
           // call %dx.types.ResRet.i32 @dx.op.bufferLoad.i32(i32 68, %dx.types.Handle %4, i32 6, i32 undef)  ; BufferLoad(srv,index,wot)
           // call %dx.types.ResRet.i32 @dx.op.bufferLoad.i32(i32 68, %dx.types.Handle %31, i32 %28, i32 undef)  ; BufferLoad(srv,index,wot)
           auto [opNumber, srv, index, wot] = StringViewSplit<4>(functionParamsString, param_regex, 2);
           auto ref = std::string{srv.substr(1)};
           auto [res_name, range_index, resource_class] = preprocess_state.resource_binding_variables.at(ref);
-          if (resource_class == "0") {
-            assignment_type = preprocess_state.srv_resources[range_index].data_type;
-          } else if (resource_class == "1") {
-            assignment_type = preprocess_state.uav_resources[range_index].data_type;
+          assignment_type = preprocess_state.GetResourceDataType(ref);
+          auto buffer_load_shape = preprocess_state.GetResourceShape(ref);
+          if (buffer_load_shape == Resource::ResourceKind::StructuredBuffer) {
+            // StructuredBuffer: register so extractvalue resolves struct field names
+            if (resource_class == "0") {
+              preprocess_state.srv_binding_load_variables[variable] = {
+                  &preprocess_state.srv_resources[range_index],
+                  ParseInt(index), "0", "4", ""};
+            } else {
+              preprocess_state.uav_binding_load_variables[variable] = {
+                  &preprocess_state.uav_resources[range_index],
+                  ParseInt(index), "0", "4", ""};
+            }
+          } else if (buffer_load_shape == Resource::ResourceKind::RawBuffer) {
+            // RawBuffer (ByteAddressBuffer): register as raw load so extractvalue
+            // emits component access directly without an intermediate variable.
+            assignment_value = std::format("{}.Load4{}", res_name, ParseWrapped(ParseInt(index)));
+            if (resource_class == "0") {
+              preprocess_state.srv_binding_load_variables[variable] = {
+                  nullptr, assignment_value, "4", "raw", ""};
+            } else {
+              preprocess_state.uav_binding_load_variables[variable] = {
+                  nullptr, assignment_value, "4", "raw", ""};
+            }
+            use_comment = true;
           } else {
-            throw std::runtime_error("Unknown @dx.op.bufferLoad.i32 resource");
+            // TypedBuffer (RWBuffer<T>): emit .Load() directly
+            assignment_value = std::format("{}.Load{}", res_name, ParseWrapped(ParseInt(index)));
           }
-          assignment_value = std::format("{}.Load{}", res_name, ParseWrapped(ParseInt(index)));
 
-        } else if (functionName == "@dx.op.bufferLoad.f32") {
+        } else if (functionName == "@dx.op.bufferLoad.f32" || functionName == "@dx.op.bufferLoad.f16") {
           // call %dx.types.ResRet.i32 @dx.op.bufferLoad.i32(i32 68, %dx.types.Handle %31, i32 %28, i32 undef)  ; BufferLoad(srv,index,wot)
           auto [opNumber, srv, index, wot] = StringViewSplit<4>(functionParamsString, param_regex, 2);
           auto ref = std::string{srv.substr(1)};
           auto [res_name, range_index, resource_class] = preprocess_state.resource_binding_variables.at(ref);
-          if (resource_class == "0") {
-            assignment_type = preprocess_state.srv_resources[range_index].data_type;
-          } else if (resource_class == "1") {
-            assignment_type = preprocess_state.uav_resources[range_index].data_type;
+          assignment_type = preprocess_state.GetResourceDataType(ref);
+          auto buffer_load_shape_f = preprocess_state.GetResourceShape(ref);
+          if (buffer_load_shape_f == Resource::ResourceKind::StructuredBuffer) {
+            // StructuredBuffer: register so extractvalue resolves struct field names
+            if (resource_class == "0") {
+              preprocess_state.srv_binding_load_variables[variable] = {
+                  &preprocess_state.srv_resources[range_index],
+                  ParseInt(index), "0", "4", ""};
+            } else {
+              preprocess_state.uav_binding_load_variables[variable] = {
+                  &preprocess_state.uav_resources[range_index],
+                  ParseInt(index), "0", "4", ""};
+            }
+          } else if (buffer_load_shape_f == Resource::ResourceKind::RawBuffer) {
+            // RawBuffer: register as raw load
+            assignment_value = std::format("asfloat({}.Load4{})", res_name, ParseWrapped(ParseInt(index)));
+            if (resource_class == "0") {
+              preprocess_state.srv_binding_load_variables[variable] = {
+                  nullptr, assignment_value, "4", "raw", ""};
+            } else {
+              preprocess_state.uav_binding_load_variables[variable] = {
+                  nullptr, assignment_value, "4", "raw", ""};
+            }
+            use_comment = true;
           } else {
-            throw std::runtime_error("Unknown @dx.op.bufferLoad.f32 resource");
+            // TypedBuffer: emit .Load() directly
+            assignment_value = std::format("{}.Load{}", res_name, ParseWrapped(ParseInt(index)));
           }
-          assignment_value = std::format("{}.Load{}", res_name, ParseWrapped(ParseInt(index)));
+        } else if (functionName == "@dx.op.bufferUpdateCounter") {
+          // %98 = call i32 @dx.op.bufferUpdateCounter(i32 70, %dx.types.Handle %2, i8 -1)  ; BufferUpdateCounter(uav,inc)
+          auto [opNumber, handle, inc] = StringViewSplit<3>(functionParamsString, param_regex, 2);
+          auto ref = std::string{handle.substr(1)};
+          auto [uav_name, range_index, resource_class] = preprocess_state.resource_binding_variables.at(ref);
+          int inc_value = 0;
+          FromStringView(inc, inc_value);
+          assignment_type = "uint";
+          if (inc_value == 1 || inc == "1") {
+            assignment_value = std::format("{}.IncrementCounter()", uav_name);
+          } else {
+            assignment_value = std::format("{}.DecrementCounter()", uav_name);
+          }
         } else if (functionName == "@dx.op.threadId.i32") {
           // call i32 @dx.op.threadId.i32(i32 93, i32 0)  ; ThreadId(component)
           auto [opNumber, component] = StringViewSplit<2>(functionParamsString, param_regex, 2);
@@ -2276,6 +3209,12 @@ class Decompiler {
           assignment_type = "uint";
           assignment_value = "SV_GroupIndex";
           is_identity = true;
+        } else if (functionName == "@dx.op.viewID.i32") {
+          // call i32 @dx.op.viewID.i32(i32 138)  ; ViewID()
+          assignment_type = "uint";
+          assignment_value = "SV_ViewID";
+          is_identity = true;
+          preprocess_state.uses_view_id = true;
         } else if (functionName == "@dx.op.groupId.i32") {
           // %10 = call i32 @dx.op.groupId.i32(i32 94, i32 0)  ; GroupId(component)
           auto [opNumber, component] = StringViewSplit<2>(functionParamsString, param_regex, 2);
@@ -2298,14 +3237,7 @@ class Decompiler {
 
           auto ref_resource = std::string{handle.substr(1)};
           auto [srv_name, range_index, resource_class] = preprocess_state.resource_binding_variables.at(ref_resource);
-          Resource::ResourceKind shape;
-          if (resource_class == "0") {
-            shape = preprocess_state.srv_resources[range_index].shape;
-          } else if (resource_class == "1") {
-            shape = preprocess_state.uav_resources[range_index].shape;
-          } else {
-            throw std::runtime_error("Unknown @dx.op.textureLoad.f32 resource");
-          }
+          Resource::ResourceKind shape = preprocess_state.GetResourceShape(ref_resource);
 
           std::string get_dimensions_arguments;
           switch (shape) {
@@ -2322,19 +3254,29 @@ class Decompiler {
               assignment_type = "uint3";
               get_dimensions_arguments = std::format("_{}.x, _{}.y, _{}.z", variable, variable, variable);
               break;
+            case SRVResource::ResourceKind::StructuredBuffer:
+            case SRVResource::ResourceKind::RawBuffer: {
+              // StructuredBuffer/ByteAddressBuffer: GetDimensions(numStructs, stride)
+              assignment_type = "uint2";
+              get_dimensions_arguments = std::format("_{}.x, _{}.y", variable, variable);
+              break;
+            }
             default:
               std::cerr << "Unexpected shape: " << Resource::ResourceKindString(shape) << "\n";
               throw std::runtime_error("Unexpected shape");
           }
 
-          if (mip_level != "0") {
+          bool has_mip_level = (mip_level != "0" && mip_level != "undef"
+                                && shape != SRVResource::ResourceKind::StructuredBuffer
+                                && shape != SRVResource::ResourceKind::RawBuffer);
+          if (has_mip_level) {
             decompiled = std::format("{} _{}; uint _{}_levels; {}.GetDimensions({}, {}, _{}_levels);",
                                      assignment_type, variable, variable, srv_name, ParseUint(mip_level), get_dimensions_arguments, variable);
           } else {
             decompiled = std::format("{} _{}; {}.GetDimensions({});", assignment_type, variable, srv_name, get_dimensions_arguments);
           }
           is_identity = false;  // Can never be identity
-        } else if (functionName == "@dx.op.sampleBias.f32") {
+        } else if (functionName == "@dx.op.sampleBias.f32" || functionName == "@dx.op.sampleBias.f16") {
           // call %dx.types.ResRet.f32 @dx.op.sampleBias.f32(i32 61, %dx.types.Handle %66, %dx.types.Handle %67, float %62, float %63, float undef, float undef, i32 0, i32 0, i32 undef, float %65, float undef)  ; SampleBias(srv,sampler,coord0,coord1,coord2,coord3,offset0,offset1,offset2,bias,clamp)
           auto [op, srv, sampler, coord0, coord1, coord2, coord3, offset0, offset1, offset2, bias, clamp] = StringViewSplit<12>(functionParamsString, param_regex, 2);
 
@@ -2363,11 +3305,10 @@ class Decompiler {
           }
 
           auto [srv_name, srv_range_index, srv_resource_class] = preprocess_state.resource_binding_variables.at(ref_resource);
-          auto srv_resource = preprocess_state.srv_resources[srv_range_index];
           auto [sampler_name, sampler_range_index, sampler_resource_class] = preprocess_state.resource_binding_variables.at(ref_sampler);
           auto sampler_resource = preprocess_state.sampler_resources[sampler_range_index];
 
-          assignment_type = srv_resource.data_type;
+          assignment_type = preprocess_state.GetResourceDataType(ref_resource);
           assignment_value = std::format("{}.SampleBias({}, {}, {}, {})",
                                          srv_name,
                                          sampler_name, coords, ParseFloat(bias), offset);
@@ -2424,11 +3365,10 @@ class Decompiler {
           }
 
           auto [srv_name, srv_range_index, srv_resource_class] = preprocess_state.resource_binding_variables.at(ref_resource);
-          auto srv_resource = preprocess_state.srv_resources[srv_range_index];
           auto [sampler_name, sampler_range_index, sampler_resource_class] = preprocess_state.resource_binding_variables.at(ref_sampler);
           auto sampler_resource = preprocess_state.sampler_resources[sampler_range_index];
 
-          assignment_type = srv_resource.data_type;
+          assignment_type = preprocess_state.GetResourceDataType(ref_resource);
           assignment_value = std::format("{}.SampleGrad({}, {}, {}, {}, {})",
                                          srv_name,
                                          sampler_name, coords, ddx, ddy, offset);
@@ -2462,13 +3402,12 @@ class Decompiler {
           }
 
           auto [srv_name, srv_range_index, srv_resource_class] = preprocess_state.resource_binding_variables.at(ref_resource);
-          auto srv_resource = preprocess_state.srv_resources[srv_range_index];
           auto [sampler_name, sampler_range_index, sampler_resource_class] = preprocess_state.resource_binding_variables.at(ref_sampler);
           auto sampler_resource = preprocess_state.sampler_resources[sampler_range_index];
 
-          assignment_type = srv_resource.data_type;
+          assignment_type = preprocess_state.GetResourceDataType(ref_resource);
           assignment_value = std::format("{}.SampleCmpLevelZero({}, {}, {})", srv_name, sampler_name, coords, ParseFloat(compareValue));
-        } else if (functionName == "@dx.op.textureGather.i32" || functionName == "@dx.op.textureGather.f32") {
+        } else if (functionName == "@dx.op.textureGather.i32" || functionName == "@dx.op.textureGather.f32" || functionName == "@dx.op.textureGather.i16") {
           // %67 = call %dx.types.ResRet.i32 @dx.op.textureGather.i32(i32 73, %dx.types.Handle %3, %dx.types.Handle %11, float %53, float %54, float undef, float undef, i32 0, i32 0, i32 0)  ; TextureGather(srv,sampler,coord0,coord1,coord2,coord3,offset0,offset1,channel)
           auto [op, srv, sampler, coord0, coord1, coord2, coord3, offset0, offset1, channel] = StringViewSplit<10>(functionParamsString, param_regex, 2);
           auto ref_resource = std::string{srv.substr(1)};
@@ -2493,7 +3432,6 @@ class Decompiler {
           }
 
           auto [srv_name, srv_range_index, srv_resource_class] = preprocess_state.resource_binding_variables.at(ref_resource);
-          auto srv_resource = preprocess_state.srv_resources[srv_range_index];
           auto [sampler_name, sampler_range_index, sampler_resource_class] = preprocess_state.resource_binding_variables.at(ref_sampler);
           auto sampler_resource = preprocess_state.sampler_resources[sampler_range_index];
           std::string channel_string;
@@ -2510,6 +3448,8 @@ class Decompiler {
           }
           if (functionName == "@dx.op.textureGather.i32") {
             assignment_type = "int4";
+          } else if (functionName == "@dx.op.textureGather.i16") {
+            assignment_type = "int16_t4";
           } else {
             assignment_type = "float4";
           }
@@ -2555,6 +3495,10 @@ class Decompiler {
           } else {
             throw std::runtime_error("Unknown wave active op");
           }
+        } else if (functionName == "@dx.op.waveIsFirstLane") {
+          // call i1 @dx.op.waveIsFirstLane(i32 110)  ; WaveIsFirstLane()
+          assignment_type = "bool";
+          assignment_value = "WaveIsFirstLane()";
         } else if (functionName == "@dx.op.waveAllTrue") {
           // call i1 @dx.op.waveAllTrue(i32 114, i1 %144)  ; WaveAllTrue(cond)
           auto [op, cond] = StringViewSplit<2>(functionParamsString, param_regex, 2);
@@ -2569,21 +3513,63 @@ class Decompiler {
           // %25 = call i32 @dx.op.waveAllOp(i32 135, i1 true)  ; WaveAllBitCount(value)
           auto [op, cond] = StringViewSplit<2>(functionParamsString, param_regex, 2);
           assignment_type = "int";
-          assignment_value = std::format("WaveAllBitCount{}", ParseWrapped(ParseBool(cond)));
+          assignment_value = std::format("WaveActiveCountBits{}", ParseWrapped(ParseBool(cond)));
         } else if (functionName == "@dx.op.wavePrefixOp") {
           // %26 = call i32 @dx.op.wavePrefixOp(i32 136, i1 true)  ; WavePrefixBitCount(value)
           auto [op, cond] = StringViewSplit<2>(functionParamsString, param_regex, 2);
           assignment_type = "int";
-          assignment_value = std::format("WavePrefixBitCount{}", ParseWrapped(ParseBool(cond)));
+          assignment_value = std::format("WavePrefixCountBits{}", ParseWrapped(ParseBool(cond)));
+        } else if (functionName == "@dx.op.wavePrefixOp.i32") {
+          // %213 = call i32 @dx.op.wavePrefixOp.i32(i32 121, i32 %212, i8 0, i8 1)  ; WavePrefixOp(value,op,sop)
+          auto [opNumber, value, op, sop] = StringViewSplit<4>(functionParamsString, param_regex, 2);
+          int op_val = 0, sop_val = 0;
+          FromStringView(op, op_val);
+          FromStringView(sop, sop_val);
+          bool is_unsigned = (sop_val == 1);
+          assignment_type = is_unsigned ? "uint" : "int";
+          std::string func_name = (op_val == 0) ? "WavePrefixSum" : "WavePrefixProduct";
+          if (is_unsigned) {
+            assignment_value = std::format("{}({})", func_name, ParseUint(value));
+          } else {
+            assignment_value = std::format("{}({})", func_name, ParseInt(value));
+          }
+        } else if (functionName == "@dx.op.wavePrefixOp.f32") {
+          // call float @dx.op.wavePrefixOp.f32(i32 121, float %val, i8 0, i8 0)  ; WavePrefixOp(value,op,sop)
+          auto [opNumber, value, op, sop] = StringViewSplit<4>(functionParamsString, param_regex, 2);
+          int op_val = 0;
+          FromStringView(op, op_val);
+          assignment_type = "float";
+          std::string func_name = (op_val == 0) ? "WavePrefixSum" : "WavePrefixProduct";
+          assignment_value = std::format("{}({})", func_name, ParseFloat(value));
         } else if (functionName == "@dx.op.waveAnyTrue") {
           // call i1 @dx.op.waveAnyTrue(i32 113, i1 %264)  ; WaveAnyTrue(cond)
           auto [op, cond] = StringViewSplit<2>(functionParamsString, param_regex, 2);
           assignment_type = "bool";
           assignment_value = std::format("WaveActiveAnyTrue{}", ParseWrapped(ParseBool(cond)));
+        } else if (functionName == "@dx.op.waveActiveBit.i32") {
+          // %2503 = call i32 @dx.op.waveActiveBit.i32(i32 120, i32 %2502, i8 1)  ; WaveActiveBit(value,op)
+          auto [op, value, bitOp] = StringViewSplit<3>(functionParamsString, param_regex, 2);
+          assignment_type = "uint";
+          // WaveActiveBit functions require uint argument — explicit cast
+          auto uint_arg = std::format("(uint)({})", ParseInt(value));
+          if (bitOp == "0") {
+            assignment_value = std::format("WaveActiveBitAnd{}", ParseWrapped(uint_arg));
+          } else if (bitOp == "1") {
+            assignment_value = std::format("WaveActiveBitOr{}", ParseWrapped(uint_arg));
+          } else if (bitOp == "2") {
+            assignment_value = std::format("WaveActiveBitXor{}", ParseWrapped(uint_arg));
+          } else {
+            throw std::runtime_error("Unknown wave active bit op");
+          }
         } else if (functionName == "@dx.op.waveGetLaneIndex") {
           // %347 = call i32 @dx.op.waveGetLaneIndex(i32 111)  ; WaveGetLaneIndex()
           assignment_type = "int";
           assignment_value = "WaveGetLaneIndex()";
+        } else if (functionName == "@dx.op.waveActiveBallot") {
+          // %X = call %dx.types.fouri32 @dx.op.waveActiveBallot(i32 116, i1 %cond)  ; WaveActiveBallot(cond)
+          auto [opNumber, cond] = StringViewSplit<2>(functionParamsString, param_regex, 2);
+          assignment_type = "uint4";
+          assignment_value = std::format("WaveActiveBallot{}", ParseWrapped(ParseBool(cond)));
         } else if (functionName == "@dx.op.waveGetLaneCount") {
           // %15 = call i32 @dx.op.waveGetLaneCount(i32 112)  ; WaveGetLaneCount()
           assignment_type = "uint";
@@ -2598,6 +3584,46 @@ class Decompiler {
           auto [op, value, lane] = StringViewSplit<3>(functionParamsString, param_regex, 2);
           assignment_type = "int";
           assignment_value = std::format("WaveReadLaneAt({},{})", ParseInt(value), ParseInt(lane));
+        } else if (functionName == "@dx.op.waveMatch.i32") {
+          // %928 = call %dx.types.fouri32 @dx.op.waveMatch.i32(i32 165, i32 %876)  ; WaveMatch(value)
+          auto [op, value] = StringViewSplit<2>(functionParamsString, param_regex, 2);
+          assignment_type = "uint4";
+          assignment_value = std::format("WaveMatch({})", ParseInt(value));
+        } else if (functionName.starts_with("@dx.op.waveMultiPrefixOp.")) {
+          // %942 = call half @dx.op.waveMultiPrefixOp.f16(i32 166, half %923, i32 %932, i32 %935, i32 %938, i32 %941, i8 0, i8 0)
+          // WaveMultiPrefixOp(value, mask0, mask1, mask2, mask3, op, sop)
+          auto [op_id, value, m0, m1, m2, m3, wave_op, sop] = StringViewSplit<8>(functionParamsString, param_regex, 2);
+          std::string val_parsed;
+          if (functionName.find(".f16") != std::string::npos || functionName.find(".f32") != std::string::npos) {
+            val_parsed = ParseFloat(value);
+            assignment_type = functionName.find(".f16") != std::string::npos ? "half" : "float";
+          } else {
+            val_parsed = ParseInt(value);
+            assignment_type = "int";
+          }
+          auto mask_str = std::format("uint4({}, {}, {}, {})", ParseInt(m0), ParseInt(m1), ParseInt(m2), ParseInt(m3));
+          std::string op_name;
+          if (wave_op == "0") op_name = "WaveMultiPrefixSum";
+          else if (wave_op == "1") op_name = "WaveMultiPrefixProduct";
+          else op_name = std::format("WaveMultiPrefixOp/*op={}*/", wave_op);
+          assignment_value = std::format("{}({}, {})", op_name, val_parsed, mask_str);
+        } else if (functionName == "@dx.op.quadReadLaneAt.f32") {
+          // call float @dx.op.quadReadLaneAt.f32(i32 122, float %val, i32 0)  ; QuadReadLaneAt(value,quadLane)
+          auto [op, value, quadLane] = StringViewSplit<3>(functionParamsString, param_regex, 2);
+          assignment_type = "float";
+          assignment_value = std::format("QuadReadLaneAt({}, {})", ParseFloat(value), ParseInt(quadLane));
+        } else if (functionName == "@dx.op.quadReadLaneAt.f16") {
+          auto [op, value, quadLane] = StringViewSplit<3>(functionParamsString, param_regex, 2);
+          assignment_type = "half";
+          assignment_value = std::format("QuadReadLaneAt({}, {})", ParseHalf(value), ParseInt(quadLane));
+        } else if (functionName == "@dx.op.quadReadLaneAt.i32") {
+          auto [op, value, quadLane] = StringViewSplit<3>(functionParamsString, param_regex, 2);
+          assignment_type = "int";
+          assignment_value = std::format("QuadReadLaneAt({}, {})", ParseInt(value), ParseInt(quadLane));
+        } else if (functionName == "@dx.op.quadReadLaneAt.i16") {
+          auto [op, value, quadLane] = StringViewSplit<3>(functionParamsString, param_regex, 2);
+          assignment_type = "int16_t";
+          assignment_value = std::format("QuadReadLaneAt({}, {})", ParseInt(value), ParseInt(quadLane));
         } else if (functionName == "@dx.op.legacyF32ToF16") {
           //   %1390 = call i32 @dx.op.legacyF32ToF16(i32 130, float %115)  ; LegacyF32ToF16(value)
           auto [op, value] = StringViewSplit<2>(functionParamsString, param_regex, 2);
@@ -2612,18 +3638,54 @@ class Decompiler {
           // %78 = call i32 @dx.op.atomicBinOp.i32(i32 78, %dx.types.Handle %1, i32 7, i32 %62, i32 %63, i32 0, i32 %77)  ; AtomicBinOp(handle,atomicOp,offset0,offset1,offset2,newValue)
           auto [op, handle, atomicOp, offset0, offset1, offset2, newValue] = StringViewSplit<7>(functionParamsString, param_regex, 2);
           auto ref_resource = std::string{handle.substr(1)};
-          const bool has_offset_y = offset1 != "undef";
-          const bool has_offset_z = offset2 != "undef";
-          std::string offset;
-          if (has_offset_z) {
-            offset = std::format("int3({}, {}, {})", ParseInt(offset0), ParseInt(offset1), ParseInt(offset2));
-          } else if (has_offset_y) {
-            offset = std::format("int2({}, {})", ParseInt(offset0), ParseInt(offset1));
-          } else {
-            offset = std::format("{}", ParseInt(offset0));
-          }
           auto [uav_name, uav_range_index, resource_class] = preprocess_state.resource_binding_variables.at(ref_resource);
           auto uav_resource = preprocess_state.uav_resources[uav_range_index];
+
+          const bool has_offset_y = offset1 != "undef";
+          const bool has_offset_z = offset2 != "undef";
+          const bool is_raw_buffer = (uav_resource.shape == Resource::ResourceKind::RawBuffer);
+          const bool is_structured = (uav_resource.shape == Resource::ResourceKind::StructuredBuffer);
+          std::string target;
+          bool use_method_syntax = false;
+          std::string byte_addr;
+          if (is_raw_buffer) {
+            // RWByteAddressBuffer: use method syntax buffer.InterlockedAdd(byteAddress, value, original)
+            use_method_syntax = true;
+            byte_addr = ParseInt(offset0);
+          } else if (is_structured && has_offset_y) {
+            // StructuredBuffer: offset0 = element index, offset1 = byte offset within element
+            int byte_offset = 0;
+            FromStringView(offset1, byte_offset);
+            // Try to resolve byte offset to struct field access
+            // The data_type may be a plain name like "SharcAccumulationData" — try %struct. prefix
+            std::string lookup_type = uav_resource.data_type;
+            if (!lookup_type.starts_with("%") && !lookup_type.starts_with("_")) {
+              auto struct_key = std::format("%struct.{}", lookup_type);
+              if (preprocess_state.type_definitions.contains(struct_key)) {
+                lookup_type = struct_key;
+              }
+            }
+            std::string field_access;
+            try {
+              field_access = preprocess_state.GetSubValueFromType(lookup_type, DataType(lookup_type), byte_offset);
+            } catch (...) {
+              // Fallback: compute swizzle from byte offset assuming 4-byte components
+              static const char* swizzles[] = {"x", "y", "z", "w"};
+              int comp_idx = byte_offset / 4;
+              if (comp_idx < 4) {
+                field_access = std::format(".{}", swizzles[comp_idx]);
+              }
+            }
+            target = std::format("{}[{}]{}", uav_name, ParseInt(offset0), field_access);
+          } else if (is_structured) {
+            target = std::format("{}[{}]", uav_name, ParseInt(offset0));
+          } else if (has_offset_z) {
+            target = std::format("{}[int3({}, {}, {})]", uav_name, ParseInt(offset0), ParseInt(offset1), ParseInt(offset2));
+          } else if (has_offset_y) {
+            target = std::format("{}[int2({}, {})]", uav_name, ParseInt(offset0), ParseInt(offset1));
+          } else {
+            target = std::format("{}[{}]", uav_name, ParseInt(offset0));
+          }
           // assignment_type = "int";
           std::string atomic_func;
 
@@ -2648,24 +3710,59 @@ class Decompiler {
           } else {
             throw std::runtime_error("Unknown atomicOp for AtomicBinOp");
           }
-          assignment_type = uav_resource.data_type;
-          decompiled = std::format("{} _{}; {}({}[{}], {}, _{});", assignment_type, variable, atomic_func, uav_name, offset, ParseInt(newValue), variable);
+          assignment_type = "int";
+          if (use_method_syntax) {
+            decompiled = std::format("int _{}; {}.{}({}, {}, _{});", variable, uav_name, atomic_func, byte_addr, ParseInt(newValue), variable);
+          } else {
+            decompiled = std::format("int _{}; {}({}, {}, _{});", variable, atomic_func, target, ParseInt(newValue), variable);
+          }
         } else if (functionName == "@dx.op.atomicBinOp.i64") {
           // %2646 = call i64 @dx.op.atomicBinOp.i64(i32 78, %dx.types.Handle %2537, i32 7, i32 %2530, i32 %2489, i32 undef, i64 %2645)  ; AtomicBinOp(handle,atomicOp,offset0,offset1,offset2,newValue)
           auto [op, handle, atomicOp, offset0, offset1, offset2, newValue] = StringViewSplit<7>(functionParamsString, param_regex, 2);
           auto ref_resource = std::string{handle.substr(1)};
-          const bool has_offset_y = offset1 != "undef";
-          const bool has_offset_z = offset2 != "undef";
-          std::string offset;
-          if (has_offset_z) {
-            offset = std::format("int3({}, {}, {})", ParseInt(offset0), ParseInt(offset1), ParseInt(offset2));
-          } else if (has_offset_y) {
-            offset = std::format("int2({}, {})", ParseInt(offset0), ParseInt(offset1));
-          } else {
-            offset = std::format("{}", ParseInt(offset0));
-          }
           auto [uav_name, uav_range_index, resource_class] = preprocess_state.resource_binding_variables.at(ref_resource);
           auto uav_resource = preprocess_state.uav_resources[uav_range_index];
+
+          const bool has_offset_y = offset1 != "undef";
+          const bool has_offset_z = offset2 != "undef";
+          const bool is_raw_buffer = (uav_resource.shape == Resource::ResourceKind::RawBuffer);
+          const bool is_structured = (uav_resource.shape == Resource::ResourceKind::StructuredBuffer);
+          std::string target;
+          bool use_method_syntax = false;
+          std::string byte_addr;
+          if (is_raw_buffer) {
+            use_method_syntax = true;
+            byte_addr = ParseInt(offset0);
+          } else if (is_structured && has_offset_y) {
+            int byte_offset = 0;
+            FromStringView(offset1, byte_offset);
+            std::string lookup_type = uav_resource.data_type;
+            if (!lookup_type.starts_with("%") && !lookup_type.starts_with("_")) {
+              auto struct_key = std::format("%struct.{}", lookup_type);
+              if (preprocess_state.type_definitions.contains(struct_key)) {
+                lookup_type = struct_key;
+              }
+            }
+            std::string field_access;
+            try {
+              field_access = preprocess_state.GetSubValueFromType(lookup_type, DataType(lookup_type), byte_offset);
+            } catch (...) {
+              static const char* swizzles[] = {"x", "y", "z", "w"};
+              int comp_idx = byte_offset / 8;  // 8 bytes for i64
+              if (comp_idx < 4) {
+                field_access = std::format(".{}", swizzles[comp_idx]);
+              }
+            }
+            target = std::format("{}[{}]{}", uav_name, ParseInt(offset0), field_access);
+          } else if (is_structured) {
+            target = std::format("{}[{}]", uav_name, ParseInt(offset0));
+          } else if (has_offset_z) {
+            target = std::format("{}[int3({}, {}, {})]", uav_name, ParseInt(offset0), ParseInt(offset1), ParseInt(offset2));
+          } else if (has_offset_y) {
+            target = std::format("{}[int2({}, {})]", uav_name, ParseInt(offset0), ParseInt(offset1));
+          } else {
+            target = std::format("{}[{}]", uav_name, ParseInt(offset0));
+          }
           // assignment_type = "int64_t";
           std::string atomic_func;
 
@@ -2690,8 +3787,157 @@ class Decompiler {
           } else {
             throw std::runtime_error("Unknown atomicOp for AtomicBinOp");
           }
-          assignment_type = uav_resource.data_type;
-          decompiled = std::format("{} _{}; {}({}[{}], {}, _{});", assignment_type, variable, atomic_func, uav_name, offset, ParseInt64(newValue), variable);
+          assignment_type = "int64_t";
+          if (use_method_syntax) {
+            decompiled = std::format("int64_t _{}; {}.{}({}, {}, _{});", variable, uav_name, atomic_func, byte_addr, ParseInt64(newValue), variable);
+          } else {
+            decompiled = std::format("int64_t _{}; {}({}, {}, _{});", variable, atomic_func, target, ParseInt64(newValue), variable);
+          }
+
+        } else if (functionName == "@dx.op.atomicCompareExchange.i32"
+                   || functionName == "@dx.op.atomicCompareExchange.i64") {
+          // %4482 = call i64 @dx.op.atomicCompareExchange.i64(i32 79, %dx.types.Handle %4481, i32 %4480, i32 0, i32 undef, i64 0, i64 %4435)
+          // AtomicCompareExchange(handle,offset0,offset1,offset2,compareValue,newValue)
+          auto [op, handle, offset0, offset1, offset2, compareValue, newValue] = StringViewSplit<7>(functionParamsString, param_regex, 2);
+          auto ref_resource = std::string{handle.substr(1)};
+          auto [uav_name, uav_range_index, resource_class] = preprocess_state.resource_binding_variables.at(ref_resource);
+
+          bool is_64 = functionName.find("i64") != std::string_view::npos;
+          std::string value_type = is_64 ? "int64_t" : "int";
+
+          auto uav_resource = preprocess_state.uav_resources[uav_range_index];
+          const bool has_offset_y = offset1 != "undef";
+          const bool is_raw_buffer = (uav_resource.shape == Resource::ResourceKind::RawBuffer);
+          const bool is_structured = (uav_resource.shape == Resource::ResourceKind::StructuredBuffer);
+          std::string target;
+          bool use_method_syntax = false;
+          std::string byte_addr;
+          if (is_raw_buffer) {
+            use_method_syntax = true;
+            byte_addr = ParseInt(offset0);
+          } else if (is_structured && has_offset_y) {
+            int byte_offset = 0;
+            FromStringView(offset1, byte_offset);
+            std::string lookup_type = uav_resource.data_type;
+            if (!lookup_type.starts_with("%") && !lookup_type.starts_with("_")) {
+              auto struct_key = std::format("%struct.{}", lookup_type);
+              if (preprocess_state.type_definitions.contains(struct_key)) {
+                lookup_type = struct_key;
+              }
+            }
+            std::string field_access;
+            try {
+              field_access = preprocess_state.GetSubValueFromType(lookup_type, DataType(lookup_type), byte_offset);
+            } catch (...) {
+              static const char* swizzles[] = {"x", "y", "z", "w"};
+              int scalar_size = is_64 ? 8 : 4;
+              int comp_idx = byte_offset / scalar_size;
+              if (comp_idx < 4) {
+                field_access = std::format(".{}", swizzles[comp_idx]);
+              }
+            }
+            target = std::format("{}[{}]{}", uav_name, ParseInt(offset0), field_access);
+          } else if (is_structured) {
+            target = std::format("{}[{}]", uav_name, ParseInt(offset0));
+          } else if (has_offset_y) {
+            target = std::format("{}[int2({}, {})]", uav_name, ParseInt(offset0), ParseInt(offset1));
+          } else {
+            target = std::format("{}[{}]", uav_name, ParseInt(offset0));
+          }
+
+          assignment_type = value_type;
+          if (use_method_syntax) {
+            decompiled = std::format("{} _{}; {}.InterlockedCompareExchange({}, {}, {}, _{});",
+                                     value_type, variable, uav_name, byte_addr,
+                                     is_64 ? ParseInt64(compareValue) : ParseInt(compareValue),
+                                     is_64 ? ParseInt64(newValue) : ParseInt(newValue),
+                                     variable);
+          } else {
+            decompiled = std::format("{} _{}; InterlockedCompareExchange({}, {}, {}, _{});",
+                                     value_type, variable, target,
+                                     is_64 ? ParseInt64(compareValue) : ParseInt(compareValue),
+                                     is_64 ? ParseInt64(newValue) : ParseInt(newValue),
+                                     variable);
+          }
+
+        // --- Ray Query operations (DXR Tier 1.1 inline raytracing) ---
+        } else if (functionName == "@dx.op.allocateRayQuery") {
+          // %154 = call i32 @dx.op.allocateRayQuery(i32 178, i32 512)  ; AllocateRayQuery(constRayFlags)
+          auto [opNumber, constRayFlags] = StringViewSplit<2>(functionParamsString, param_regex, 2);
+          // Track for hoisting to function scope (avoids scoping issues with deferred blocks)
+          ray_query_declarations.push_back(std::format("RayQuery<{}> _{};", ParseInt(constRayFlags), variable));
+          assignment_type = "auto";
+          assignment_value = std::format("/* RayQuery<{}> */", ParseInt(constRayFlags));
+          use_comment = true;
+        } else if (functionName == "@dx.op.rayQuery_Proceed.i1") {
+          // %156 = call i1 @dx.op.rayQuery_Proceed.i1(i32 180, i32 %154)  ; RayQuery_Proceed(rayQueryHandle)
+          auto [opNumber, rayQueryHandle] = StringViewSplit<2>(functionParamsString, param_regex, 2);
+          assignment_type = "bool";
+          assignment_value = std::format("_{}.Proceed()", ParseVariable(rayQueryHandle).substr(1));
+        } else if (functionName == "@dx.op.rayQuery_StateScalar.i32") {
+          // %159 = call i32 @dx.op.rayQuery_StateScalar.i32(i32 185, i32 %154)  ; RayQuery_CandidateType(rayQueryHandle)
+          auto [opNumber, rayQueryHandle] = StringViewSplit<2>(functionParamsString, param_regex, 2);
+          int op_code = 0;
+          FromStringView(opNumber, op_code);
+          std::string rq_var = std::format("_{}", ParseVariable(rayQueryHandle).substr(1));
+          assignment_type = "uint";
+          // Map DXIL opcodes to HLSL RayQuery methods
+          switch (op_code) {
+            case 184: assignment_value = std::format("{}.CommittedStatus()", rq_var); break;
+            case 185: assignment_value = std::format("{}.CandidateType()", rq_var); break;
+            case 201: assignment_value = std::format("{}.CandidateInstanceIndex()", rq_var); break;
+            case 202: assignment_value = std::format("{}.CandidateInstanceID()", rq_var); break;
+            case 203: assignment_value = std::format("{}.CandidateGeometryIndex()", rq_var); break;
+            case 204: assignment_value = std::format("{}.CandidatePrimitiveIndex()", rq_var); break;
+            case 207: assignment_value = std::format("{}.CommittedInstanceIndex()", rq_var); break;
+            case 208: assignment_value = std::format("{}.CommittedInstanceID()", rq_var); break;
+            case 209: assignment_value = std::format("{}.CommittedGeometryIndex()", rq_var); break;
+            case 210: assignment_value = std::format("{}.CommittedPrimitiveIndex()", rq_var); break;
+            default: throw std::runtime_error(std::format("Unknown rayQuery_StateScalar.i32 opcode {}", op_code));
+          }
+        } else if (functionName == "@dx.op.rayQuery_StateScalar.f32") {
+          // %1396 = call float @dx.op.rayQuery_StateScalar.f32(i32 200, i32 %154)  ; RayQuery_CommittedRayT(rayQueryHandle)
+          auto [opNumber, rayQueryHandle] = StringViewSplit<2>(functionParamsString, param_regex, 2);
+          int op_code = 0;
+          FromStringView(opNumber, op_code);
+          std::string rq_var = std::format("_{}", ParseVariable(rayQueryHandle).substr(1));
+          assignment_type = "float";
+          switch (op_code) {
+            case 195: assignment_value = std::format("{}.CandidateTriangleRayT()", rq_var); break;
+            case 198: assignment_value = std::format("{}.RayTMin()", rq_var); break;
+            case 199: assignment_value = std::format("{}.CandidateRayT()", rq_var); break;
+            case 200: assignment_value = std::format("{}.CommittedRayT()", rq_var); break;
+            default: throw std::runtime_error(std::format("Unknown rayQuery_StateScalar.f32 opcode {}", op_code));
+          }
+        } else if (functionName == "@dx.op.rayQuery_StateScalar.i1") {
+          // %198 = call i1 @dx.op.rayQuery_StateScalar.i1(i32 192, i32 %177)  ; RayQuery_CommittedTriangleFrontFace(rayQueryHandle)
+          auto [opNumber, rayQueryHandle] = StringViewSplit<2>(functionParamsString, param_regex, 2);
+          int op_code = 0;
+          FromStringView(opNumber, op_code);
+          std::string rq_var = std::format("_{}", ParseVariable(rayQueryHandle).substr(1));
+          assignment_type = "bool";
+          switch (op_code) {
+            case 191: assignment_value = std::format("{}.CandidateTriangleFrontFace()", rq_var); break;
+            case 192: assignment_value = std::format("{}.CommittedTriangleFrontFace()", rq_var); break;
+            default: throw std::runtime_error(std::format("Unknown rayQuery_StateScalar.i1 opcode {}", op_code));
+          }
+        } else if (functionName == "@dx.op.rayQuery_StateVector.f32") {
+          // %168 = call float @dx.op.rayQuery_StateVector.f32(i32 193, i32 %154, i8 0)  ; RayQuery_CandidateTriangleBarycentrics(rayQueryHandle,component)
+          auto [opNumber, rayQueryHandle, component] = StringViewSplit<3>(functionParamsString, param_regex, 2);
+          int op_code = 0;
+          FromStringView(opNumber, op_code);
+          std::string rq_var = std::format("_{}", ParseVariable(rayQueryHandle).substr(1));
+          int comp = 0;
+          FromStringView(component, comp);
+          std::string swizzle = (comp == 0) ? ".x" : ".y";
+          assignment_type = "float";
+          switch (op_code) {
+            case 186: assignment_value = std::format("{}.WorldRayOrigin(){}", rq_var, swizzle); break;
+            case 187: assignment_value = std::format("{}.WorldRayDirection(){}", rq_var, swizzle); break;
+            case 193: assignment_value = std::format("{}.CandidateTriangleBarycentrics(){}", rq_var, swizzle); break;
+            case 194: assignment_value = std::format("{}.CommittedTriangleBarycentrics(){}", rq_var, swizzle); break;
+            default: throw std::runtime_error(std::format("Unknown rayQuery_StateVector.f32 opcode {}", op_code));
+          }
         } else {
           std::cerr << line << "\n";
           std::cerr << "Function name: " << functionName << "\n";
@@ -2701,82 +3947,200 @@ class Decompiler {
         // extractvalue %dx.types.ResRet.f32 %448, 0
         // extractvalue %dx.types.CBufRet.i32 %19, 0
         auto [type, input, index] = StringViewMatch<3>(assignment, std::regex{R"(extractvalue (\S+) (\S+), (\S+))"});
+        // Use raw variable number for binding lookups (not ParseVariable which may
+        // return an inlined expression when flatten mode is active)
+        auto raw_source_variable = std::string(input.substr(1));
         if (type == R"(%dx.types.CBufRet.f32)") {
-          auto source_variable = ParseVariable(input).substr(1);
-          const auto& [cbv_resource, cbv_variable_index] = preprocess_state.cbv_binding_variables[source_variable];
-          int literal_index;
-          FromStringView(index, literal_index);
-
-          auto value_from_reflection = preprocess_state.ResourceVariableNameAtIndex(*cbv_resource, (cbv_variable_index * 16) + (literal_index * 4));
-
-          if (value_from_reflection.empty()) {
-            int real_index = cbv_variable_index;
-            char sub_index = VECTOR_INDEXES[literal_index];
-            std::string suffix = std::format("{:03}{}", real_index, sub_index);
-            assignment_value = std::format("{}_{}", cbv_resource->name, suffix);
-            cbv_resource->data_types[suffix] = "float";
+          auto source_variable = raw_source_variable;
+          if (preprocess_state.cbv_binding_variables.find(source_variable) == preprocess_state.cbv_binding_variables.end()) {
+            // Dynamic cbuffer access — use swizzle on the float4 value
+            int literal_index;
+            FromStringView(index, literal_index);
+            assignment_type = "float";
+            assignment_value = std::format("{}.{}", ParseVariable(input), ParseIndex(index));
+            is_identity = true;
           } else {
-            assignment_value = value_from_reflection;
-          }
+            const auto& [cbv_resource, cbv_variable_index, cbv_binding_name] = preprocess_state.cbv_binding_variables[source_variable];
+            int literal_index;
+            FromStringView(index, literal_index);
 
-          assignment_type = "float";
-          is_identity = true;
+            // Check if this cbuffer uses dynamic access (float4 array only)
+            auto cbv_range_idx = static_cast<uint32_t>(cbv_resource - preprocess_state.cbv_resources.data());
+            if (preprocess_state.cbv_dynamic_access_indices.count(cbv_range_idx)) {
+              // Use raw array access: cbuffer_raw[regIndex].component (uint4, reinterpret as float)
+              assignment_value = std::format("asfloat({}_raw[{}u].{})", cbv_resource->name, cbv_variable_index, ParseIndex(index));
+            } else {
+              auto value_from_reflection = preprocess_state.ResourceVariableNameAtIndex(*cbv_resource, (cbv_variable_index * 16) + (literal_index * 4));
+
+              if (value_from_reflection.empty()) {
+                int real_index = cbv_variable_index;
+                char sub_index = VECTOR_INDEXES[literal_index];
+                std::string suffix = std::format("{:03}{}", real_index, sub_index);
+                assignment_value = std::format("{}_{}", cbv_binding_name, suffix);
+                cbv_resource->data_types[suffix] = "float";
+              } else {
+                // Use binding name for array cbuffers (includes array index), direct for regular
+                if (cbv_resource->array_size.has_value()) {
+                  assignment_value = std::format("{}.{}", cbv_binding_name, value_from_reflection);
+                } else {
+                  assignment_value = value_from_reflection;
+                }
+              }
+            }
+
+            assignment_type = "float";
+            is_identity = true;
+          }
           // decompiled = std::format("float _{} = {};", variable, value);
           // preprocess_state.variable_aliases.emplace(variable, value);
         } else if (type == R"(%dx.types.CBufRet.i32)") {
-          auto source_variable = ParseVariable(input).substr(1);
-          const auto& [cbv_resource, cbv_variable_index] = preprocess_state.cbv_binding_variables[source_variable];
-          int literal_index;
-          FromStringView(index, literal_index);
-
-          auto value_from_reflection = preprocess_state.ResourceVariableNameAtIndex(*cbv_resource, (cbv_variable_index * 16) + (literal_index * 4));
-
-          if (value_from_reflection.empty()) {
-            int real_index = cbv_variable_index;
-            char sub_index = VECTOR_INDEXES[literal_index];
-            std::string suffix = std::format("{:03}{}", real_index, sub_index);
-            assignment_value = std::format("{}_{}", cbv_resource->name, suffix);
-            cbv_resource->data_types[suffix] = "int";
+          auto source_variable = raw_source_variable;
+          if (preprocess_state.cbv_binding_variables.find(source_variable) == preprocess_state.cbv_binding_variables.end()) {
+            // Dynamic cbuffer access — use swizzle on the int4 value
+            int literal_index;
+            FromStringView(index, literal_index);
+            assignment_type = "int";
+            assignment_value = std::format("{}.{}", ParseVariable(input), ParseIndex(index));
+            is_identity = true;
           } else {
-            assignment_value = value_from_reflection;
-          }
+            const auto& [cbv_resource, cbv_variable_index, cbv_binding_name] = preprocess_state.cbv_binding_variables[source_variable];
+            int literal_index;
+            FromStringView(index, literal_index);
 
-          assignment_type = "int";
-          is_identity = true;
+            // Check if this cbuffer uses dynamic access (float4 array only)
+            auto cbv_range_idx = static_cast<uint32_t>(cbv_resource - preprocess_state.cbv_resources.data());
+            if (preprocess_state.cbv_dynamic_access_indices.count(cbv_range_idx)) {
+              // Use raw array access: cbuffer_raw[regIndex].component
+              assignment_value = std::format("asint({}_raw[{}u].{})", cbv_resource->name, cbv_variable_index, ParseIndex(index));
+            } else {
+              auto value_from_reflection = preprocess_state.ResourceVariableNameAtIndex(*cbv_resource, (cbv_variable_index * 16) + (literal_index * 4));
+
+              if (value_from_reflection.empty()) {
+                int real_index = cbv_variable_index;
+                char sub_index = VECTOR_INDEXES[literal_index];
+                std::string suffix = std::format("{:03}{}", real_index, sub_index);
+                assignment_value = std::format("{}_{}", cbv_binding_name, suffix);
+                cbv_resource->data_types[suffix] = "int";
+              } else {
+                if (cbv_resource->array_size.has_value()) {
+                  assignment_value = std::format("{}.{}", cbv_binding_name, value_from_reflection);
+                } else {
+                  assignment_value = value_from_reflection;
+                }
+              }
+            }
+
+            assignment_type = "int";
+            is_identity = true;
+          }
           // preprocess_state.variable_aliases.emplace(variable, value);
+        } else if (type == R"(%dx.types.CBufRet.f16.8)") {
+          auto source_variable = raw_source_variable;
+          if (preprocess_state.cbv_binding_variables.find(source_variable) == preprocess_state.cbv_binding_variables.end()) {
+            throw std::runtime_error("Unsupported extractvalue from %dx.types.CBufRet.f16.8 without CBV binding");
+          } else {
+            const auto& [cbv_resource, cbv_variable_index, cbv_binding_name] = preprocess_state.cbv_binding_variables[source_variable];
+            int literal_index;
+            FromStringView(index, literal_index);
+
+            // Pitfall 11: Check if this cbuffer uses raw uint4 array (due to 16-bit field packing)
+            auto cbv_range_idx = static_cast<uint32_t>(cbv_resource - preprocess_state.cbv_resources.data());
+            if (preprocess_state.cbv_dynamic_access_indices.count(cbv_range_idx)) {
+              // Extract half from raw uint4 array using f16tof32.
+              // CBufRet.f16.8 packs 8 halves per register:
+              //   indices 0-3 = low 16 bits of xyzw
+              //   indices 4-7 = high 16 bits of xyzw
+              int component = literal_index % 4;
+              bool high_half = literal_index >= 4;
+              if (high_half) {
+                assignment_value = std::format("f16tof32({}_raw[{}u].{} >> 16u)", cbv_resource->name, cbv_variable_index, VECTOR_INDEXES[component]);
+              } else {
+                assignment_value = std::format("f16tof32({}_raw[{}u].{})", cbv_resource->name, cbv_variable_index, VECTOR_INDEXES[component]);
+              }
+            } else {
+              auto value_from_reflection = preprocess_state.ResourceVariableNameAtIndex(*cbv_resource, (cbv_variable_index * 16) + (literal_index * 2));
+
+              if (value_from_reflection.empty()) {
+                int real_index = cbv_variable_index;
+                char sub_index = VECTOR_INDEXES[literal_index % 4];
+                std::string suffix = std::format("{:03}{}", real_index, sub_index);
+                assignment_value = std::format("{}_{}", cbv_binding_name, suffix);
+                cbv_resource->data_types[suffix] = "half";
+              } else {
+                if (cbv_resource->array_size.has_value()) {
+                  assignment_value = std::format("{}.{}", cbv_binding_name, value_from_reflection);
+                } else {
+                  assignment_value = value_from_reflection;
+                }
+              }
+            }
+          }
+          assignment_type = "half";
+          is_identity = true;
         } else if (type == R"(%dx.types.ResRet.f32)") {
-          auto source_variable = ParseVariable(input).substr(1);
+          auto source_variable = raw_source_variable;
           assignment_type = "float";
           if (auto pair = preprocess_state.srv_binding_load_variables.find(source_variable);
               pair != preprocess_state.srv_binding_load_variables.end()) {
-            const auto& [srv_resource, srv_index, element_offset, alignment] = pair->second;
-            int literal_index;
-            FromStringView(index, literal_index);
-            int literal_element_offset;
-            FromStringView(element_offset, literal_element_offset);
-            int literal_alignment;
-            FromStringView(alignment, literal_alignment);
-            assignment_value = std::format("{}[{}]{}",
-                                           srv_resource->name,
-                                           ParseInt(srv_index),
-                                           preprocess_state.ResourceVariableNameAtIndex(*srv_resource, (literal_element_offset) + (literal_index * 4)));
-            is_identity = false;
-            use_comment = false;
+            const auto& [srv_resource, srv_index, element_offset, alignment, srv_binding_name] = pair->second;
+            if (alignment == "raw") {
+              // Raw buffer load — srv_index has the full expression, element_offset has component count
+              int comp_count = 0;
+              FromStringView(element_offset, comp_count);
+              int literal_index;
+              FromStringView(index, literal_index);
+              if (comp_count == 1) {
+                assignment_value = srv_index;  // scalar, no component access
+              } else {
+                assignment_value = std::format("{}.{}", srv_index, ParseIndex(index));
+              }
+              is_identity = false;
+              use_comment = false;
+            } else {
+              int literal_index;
+              FromStringView(index, literal_index);
+              int literal_element_offset;
+              FromStringView(element_offset, literal_element_offset);
+              int literal_alignment;
+              FromStringView(alignment, literal_alignment);
+              // Use binding name (includes array index for unbounded arrays) instead of resource name
+              auto& access_name = srv_binding_name.empty() ? srv_resource->name : srv_binding_name;
+              assignment_value = std::format("{}[{}]{}",
+                                             access_name,
+                                             ParseInt(srv_index),
+                                             preprocess_state.ResourceVariableNameAtIndex(*srv_resource, (literal_element_offset) + (literal_index * 4)));
+              is_identity = false;
+              use_comment = false;
+            }
           } else if (auto pair = preprocess_state.uav_binding_load_variables.find(source_variable);
                      pair != preprocess_state.uav_binding_load_variables.end()) {
-            const auto& [uav_resource, srv_index, element_offset, alignment] = pair->second;
-            int literal_index;
-            FromStringView(index, literal_index);
-            int literal_element_offset;
-            FromStringView(element_offset, literal_element_offset);
-            int literal_alignment;
-            FromStringView(alignment, literal_alignment);
-            assignment_value = std::format("{}[{}]{}",
-                                           uav_resource->name,
-                                           ParseInt(srv_index),
-                                           preprocess_state.ResourceVariableNameAtIndex(*uav_resource, (literal_element_offset) + (literal_index * 4)));
-            is_identity = false;
-            use_comment = false;
+            const auto& [uav_resource, srv_index, element_offset, alignment, uav_binding_name] = pair->second;
+            if (alignment == "raw") {
+              int comp_count = 0;
+              FromStringView(element_offset, comp_count);
+              int literal_index;
+              FromStringView(index, literal_index);
+              if (comp_count == 1) {
+                assignment_value = srv_index;
+              } else {
+                assignment_value = std::format("{}.{}", srv_index, ParseIndex(index));
+              }
+              is_identity = false;
+              use_comment = false;
+            } else {
+              int literal_index;
+              FromStringView(index, literal_index);
+              int literal_element_offset;
+              FromStringView(element_offset, literal_element_offset);
+              int literal_alignment;
+              FromStringView(alignment, literal_alignment);
+              assignment_value = std::format("{}[{}]{}",
+                                             (uav_binding_name.empty() ? uav_resource->name : uav_binding_name),
+                                             ParseInt(srv_index),
+                                             preprocess_state.ResourceVariableNameAtIndex(*uav_resource, (literal_element_offset) + (literal_index * 4)));
+              is_identity = false;
+              use_comment = false;
+            }
           } else {
             assignment_value = std::format("{}.{}", ParseVariable(input), ParseIndex(index));
             is_identity = true;
@@ -2784,64 +4148,216 @@ class Decompiler {
 
           // decompiled = std::format("float _{} = {};", variable, value);
           // preprocess_state.variable_aliases.emplace(variable, value);
+          // preprocess_state.variable_aliases.emplace(variable, value);
         } else if (type == R"(%dx.types.ResRet.f16)") {
-          auto source_variable = ParseVariable(input).substr(1);
+          auto source_variable = raw_source_variable;
           assignment_type = "half";
           if (auto pair = preprocess_state.srv_binding_load_variables.find(source_variable);
               pair != preprocess_state.srv_binding_load_variables.end()) {
-            throw std::invalid_argument("Unsupported half in SRV.");
+            const auto& [srv_resource, srv_index, element_offset, alignment, srv_binding_name] = pair->second;
+            if (alignment == "raw") {
+              int comp_count = 0;
+              FromStringView(element_offset, comp_count);
+              int literal_index;
+              FromStringView(index, literal_index);
+              if (comp_count == 1) {
+                assignment_value = srv_index;
+              } else {
+                assignment_value = std::format("{}.{}", srv_index, ParseIndex(index));
+              }
+              is_identity = false;
+              use_comment = false;
+            } else {
+              int literal_index;
+              FromStringView(index, literal_index);
+              int literal_element_offset;
+              FromStringView(element_offset, literal_element_offset);
+              int literal_alignment;
+              FromStringView(alignment, literal_alignment);
+              auto& access_name = srv_binding_name.empty() ? srv_resource->name : srv_binding_name;
+              assignment_value = std::format("{}[{}]{}",
+                                             access_name,
+                                             ParseInt(srv_index),
+                                             preprocess_state.ResourceVariableNameAtIndex(*srv_resource, (literal_element_offset) + (literal_index * 2)));
+              is_identity = false;
+              use_comment = false;
+            }
           } else if (auto pair = preprocess_state.uav_binding_load_variables.find(source_variable);
                      pair != preprocess_state.uav_binding_load_variables.end()) {
-            throw std::invalid_argument("Unsupported half in UAV.");
+            const auto& [uav_resource, srv_index, element_offset, alignment, uav_binding_name] = pair->second;
+            if (alignment == "raw") {
+              int comp_count = 0;
+              FromStringView(element_offset, comp_count);
+              int literal_index;
+              FromStringView(index, literal_index);
+              if (comp_count == 1) {
+                assignment_value = srv_index;
+              } else {
+                assignment_value = std::format("{}.{}", srv_index, ParseIndex(index));
+              }
+              is_identity = false;
+              use_comment = false;
+            } else {
+              int literal_index;
+              FromStringView(index, literal_index);
+              int literal_element_offset;
+              FromStringView(element_offset, literal_element_offset);
+              int literal_alignment;
+              FromStringView(alignment, literal_alignment);
+              assignment_value = std::format("{}[{}]{}",
+                                             (uav_binding_name.empty() ? uav_resource->name : uav_binding_name),
+                                             ParseInt(srv_index),
+                                             preprocess_state.ResourceVariableNameAtIndex(*uav_resource, (literal_element_offset) + (literal_index * 2)));
+              is_identity = false;
+              use_comment = false;
+            }
           } else {
             assignment_value = std::format("{}.{}", ParseVariable(input), ParseIndex(index));
             is_identity = true;
           }
         } else if (type == R"(%dx.types.ResRet.i32)") {
-          auto source_variable = ParseVariable(input).substr(1);
+          auto source_variable = raw_source_variable;
           assignment_type = "int";
           if (auto pair = preprocess_state.srv_binding_load_variables.find(source_variable);
               pair != preprocess_state.srv_binding_load_variables.end()) {
-            const auto& [srv_resource, srv_index, element_offset, alignment] = pair->second;
-            int literal_index;
-            FromStringView(index, literal_index);
-            int literal_element_offset;
-            FromStringView(element_offset, literal_element_offset);
-            int literal_alignment;
-            FromStringView(alignment, literal_alignment);
-            assignment_value = std::format("{}[{}]{}",
-                                           srv_resource->name,
-                                           ParseInt(srv_index),
-                                           preprocess_state.ResourceVariableNameAtIndex(*srv_resource, (literal_element_offset) + (literal_index * 4)));
-            is_identity = false;
-            use_comment = false;
+            const auto& [srv_resource, srv_index, element_offset, alignment, srv_binding_name] = pair->second;
+            if (alignment == "raw") {
+              int comp_count = 0;
+              FromStringView(element_offset, comp_count);
+              int literal_index;
+              FromStringView(index, literal_index);
+              if (comp_count == 1) {
+                assignment_value = srv_index;
+              } else {
+                assignment_value = std::format("{}.{}", srv_index, ParseIndex(index));
+              }
+              is_identity = false;
+              use_comment = false;
+            } else {
+              int literal_index;
+              FromStringView(index, literal_index);
+              int literal_element_offset;
+              FromStringView(element_offset, literal_element_offset);
+              int literal_alignment;
+              FromStringView(alignment, literal_alignment);
+              auto& access_name = srv_binding_name.empty() ? srv_resource->name : srv_binding_name;
+              assignment_value = std::format("{}[{}]{}",
+                                             access_name,
+                                             ParseInt(srv_index),
+                                             preprocess_state.ResourceVariableNameAtIndex(*srv_resource, (literal_element_offset) + (literal_index * 4)));
+              is_identity = false;
+              use_comment = false;
+            }
           } else if (auto pair = preprocess_state.uav_binding_load_variables.find(source_variable);
                      pair != preprocess_state.uav_binding_load_variables.end()) {
-            const auto& [uav_resource, srv_index, element_offset, alignment] = pair->second;
-            int literal_index;
-            FromStringView(index, literal_index);
-            int literal_element_offset;
-            FromStringView(element_offset, literal_element_offset);
-            int literal_alignment;
-            FromStringView(alignment, literal_alignment);
-            assignment_value = std::format("{}[{}]{}",
-                                           uav_resource->name,
-                                           ParseInt(srv_index),
-                                           preprocess_state.ResourceVariableNameAtIndex(*uav_resource, (literal_element_offset) + (literal_index * 4)));
-            is_identity = false;
-            use_comment = false;
+            const auto& [uav_resource, srv_index, element_offset, alignment, uav_binding_name] = pair->second;
+            if (alignment == "raw") {
+              int comp_count = 0;
+              FromStringView(element_offset, comp_count);
+              int literal_index;
+              FromStringView(index, literal_index);
+              if (comp_count == 1) {
+                assignment_value = srv_index;
+              } else {
+                assignment_value = std::format("{}.{}", srv_index, ParseIndex(index));
+              }
+              is_identity = false;
+              use_comment = false;
+            } else {
+              int literal_index;
+              FromStringView(index, literal_index);
+              int literal_element_offset;
+              FromStringView(element_offset, literal_element_offset);
+              int literal_alignment;
+              FromStringView(alignment, literal_alignment);
+              assignment_value = std::format("{}[{}]{}",
+                                             (uav_binding_name.empty() ? uav_resource->name : uav_binding_name),
+                                             ParseInt(srv_index),
+                                             preprocess_state.ResourceVariableNameAtIndex(*uav_resource, (literal_element_offset) + (literal_index * 4)));
+              is_identity = false;
+              use_comment = false;
+            }
           } else {
             assignment_value = std::format("{}.{}", ParseVariable(input), ParseIndex(index));
             is_identity = true;
           }
           // decompiled = std::format("int _{} = {};", variable, value);
           // preprocess_state.variable_aliases.emplace(variable, value);
+        } else if (type == R"(%dx.types.ResRet.i16)") {
+          auto source_variable = raw_source_variable;
+          assignment_type = "int16_t";
+          if (auto pair = preprocess_state.srv_binding_load_variables.find(source_variable);
+              pair != preprocess_state.srv_binding_load_variables.end()) {
+            const auto& [srv_resource, srv_index, element_offset, alignment, srv_binding_name] = pair->second;
+            if (alignment == "raw") {
+              int comp_count = 0;
+              FromStringView(element_offset, comp_count);
+              int literal_index;
+              FromStringView(index, literal_index);
+              if (comp_count == 1) {
+                assignment_value = srv_index;
+              } else {
+                assignment_value = std::format("{}.{}", srv_index, ParseIndex(index));
+              }
+              is_identity = false;
+              use_comment = false;
+            } else {
+              int literal_index;
+              FromStringView(index, literal_index);
+              int literal_element_offset;
+              FromStringView(element_offset, literal_element_offset);
+              int literal_alignment;
+              FromStringView(alignment, literal_alignment);
+              auto& access_name = srv_binding_name.empty() ? srv_resource->name : srv_binding_name;
+              assignment_value = std::format("{}[{}]{}",
+                                             access_name,
+                                             ParseInt(srv_index),
+                                             preprocess_state.ResourceVariableNameAtIndex(*srv_resource, (literal_element_offset) + (literal_index * 2)));
+              is_identity = false;
+              use_comment = false;
+            }
+          } else if (auto pair = preprocess_state.uav_binding_load_variables.find(source_variable);
+                     pair != preprocess_state.uav_binding_load_variables.end()) {
+            const auto& [uav_resource, srv_index, element_offset, alignment, uav_binding_name] = pair->second;
+            if (alignment == "raw") {
+              int comp_count = 0;
+              FromStringView(element_offset, comp_count);
+              int literal_index;
+              FromStringView(index, literal_index);
+              if (comp_count == 1) {
+                assignment_value = srv_index;
+              } else {
+                assignment_value = std::format("{}.{}", srv_index, ParseIndex(index));
+              }
+              is_identity = false;
+              use_comment = false;
+            } else {
+              int literal_index;
+              FromStringView(index, literal_index);
+              int literal_element_offset;
+              FromStringView(element_offset, literal_element_offset);
+              int literal_alignment;
+              FromStringView(alignment, literal_alignment);
+              assignment_value = std::format("{}[{}]{}",
+                                             (uav_binding_name.empty() ? uav_resource->name : uav_binding_name),
+                                             ParseInt(srv_index),
+                                             preprocess_state.ResourceVariableNameAtIndex(*uav_resource, (literal_element_offset) + (literal_index * 2)));
+              is_identity = false;
+              use_comment = false;
+            }
+          } else {
+            assignment_value = std::format("{}.{}", ParseVariable(input), ParseIndex(index));
+            is_identity = true;
+          }
         } else if (type == R"(%dx.types.Dimensions)") {
           assignment_type = "uint";
           assignment_value = std::format("{}.{}", ParseVariable(input), ParseIndex(index));
           is_identity = true;
-          // decompiled = std::format("uint _{} = {};", variable, value);
-          // preprocess_state.variable_aliases.emplace(variable, value);
+        } else if (type == R"(%dx.types.fouri32)") {
+          // extractvalue %dx.types.fouri32 %928, 0  — from WaveMatch
+          assignment_type = "uint";
+          assignment_value = std::format("{}.{}", ParseVariable(input), ParseIndex(index));
+          is_identity = true;
         } else {
           std::cerr << type << "\n";
           throw std::runtime_error("Unknown extractvalue type");
@@ -2862,16 +4378,19 @@ class Decompiler {
       } else if (instruction == "ashr") {
         // %95 = ashr i32 %68, 2
         // %36 = exact i32 %35, 16
+        // Pitfall 10: ashr is arithmetic right shift — result MUST be signed (int)
+        // so that HLSL >> performs sign-extension, not zero-fill.
         auto [exact, no_unsigned_wrap, no_signed_wrap, variable_type, a, b] = StringViewMatch<6>(assignment, std::regex{R"(ashr (exact )?(nuw )?(nsw )?(\S+) (\S+), (\S+))"});
         assignment_type = ParseType(variable_type);
-        if (no_signed_wrap.empty()) {
-          if (assignment_type == "int") {
-            assignment_type = "uint";
-          } else if (assignment_type == "min16int") {
-            assignment_type = "min16uint";
-          }
+        // Force signed type for ashr — HLSL >> on int is arithmetic shift
+        if (assignment_type == "uint") {
+          assignment_type = "int";
+        } else if (assignment_type == "min16uint") {
+          assignment_type = "min16int";
+        } else if (assignment_type == "uint16_t") {
+          assignment_type = "int16_t";
         }
-        assignment_value = std::format("{} >> {}", ParseInt(a), ParseInt(b));
+        assignment_value = std::format("(int){} >> {}", ParseWrapped(ParseInt(a)), ParseInt(b));
       } else if (instruction == "xor") {
         // %173 = xor i1 %100, true
         // %347 = xor i32 %344, %339
@@ -2913,7 +4432,7 @@ class Decompiler {
         // %39 = fcmp fast ogt float %37, 0.000000e+00
         auto [fast, op, value_type, a, b] = StringViewMatch<5>(assignment, std::regex{R"(fcmp (fast )?(\S+) (\S+) (\S+), (\S+))"});
 
-        // Missing fast support
+        bool is_fast = !fast.empty();
         assignment_type = "bool";
 
         auto a_parsed = ParseByType(a, value_type);
@@ -2935,17 +4454,42 @@ class Decompiler {
         } else if (op == "ord") {
           assignment_value = std::format("(!isnan{} && !isnan{})", ParseWrapped(a_parsed), ParseWrapped(b_parsed));
         } else if (op == "ueq") {
-          assignment_value = std::format("!({} != {})", a_parsed, b_parsed);
+          // With fast: unordered == ordered, emit direct comparison
+          if (is_fast) {
+            assignment_value = std::format("({} == {})", a_parsed, b_parsed);
+          } else {
+            assignment_value = std::format("!({} != {})", a_parsed, b_parsed);
+          }
         } else if (op == "ugt") {
-          assignment_value = std::format("!({} <= {})", a_parsed, b_parsed);
+          if (is_fast) {
+            assignment_value = std::format("({} > {})", a_parsed, b_parsed);
+          } else {
+            assignment_value = std::format("!({} <= {})", a_parsed, b_parsed);
+          }
         } else if (op == "uge") {
-          assignment_value = std::format("!({} > {})", a_parsed, b_parsed);
+          if (is_fast) {
+            assignment_value = std::format("({} >= {})", a_parsed, b_parsed);
+          } else {
+            assignment_value = std::format("!({} < {})", a_parsed, b_parsed);
+          }
         } else if (op == "ult") {
-          assignment_value = std::format("!({} >= {})", a_parsed, b_parsed);
+          if (is_fast) {
+            assignment_value = std::format("({} < {})", a_parsed, b_parsed);
+          } else {
+            assignment_value = std::format("!({} >= {})", a_parsed, b_parsed);
+          }
         } else if (op == "ule") {
-          assignment_value = std::format("!({} > {})", a_parsed, b_parsed);
+          if (is_fast) {
+            assignment_value = std::format("({} <= {})", a_parsed, b_parsed);
+          } else {
+            assignment_value = std::format("!({} > {})", a_parsed, b_parsed);
+          }
         } else if (op == "une") {
-          assignment_value = std::format("!({} == {})", a_parsed, b_parsed);
+          if (is_fast) {
+            assignment_value = std::format("({} != {})", a_parsed, b_parsed);
+          } else {
+            assignment_value = std::format("!({} == {})", a_parsed, b_parsed);
+          }
         } else if (op == "uno") {
           assignment_value = std::format("(isnan{} || isnan{})", ParseWrapped(a_parsed), ParseWrapped(b_parsed));
         } else {
@@ -2964,21 +4508,30 @@ class Decompiler {
           cast = "(int)";
         }
 
+        // Pitfall 9: For unsigned comparisons, convert negative constants to their
+        // unsigned equivalents based on DXIL type width. e.g., i16 -25536 → 40000u.
+        auto parse_icmp_operand = [&](std::string_view operand) -> std::string {
+          if (op.starts_with("u") && !operand.empty() && operand[0] == '-') {
+            return ParseUnsignedConstant(operand, type);
+          }
+          return ParseByType(operand, type);
+        };
+
         assignment_type = "bool";
         if (op == "false") {
           assignment_value = "false";
         } else if (op == "eq") {
-          assignment_value = std::format("({} == {})", ParseByType(a, type), ParseByType(b, type));
+          assignment_value = std::format("({} == {})", parse_icmp_operand(a), parse_icmp_operand(b));
         } else if (op == "ne") {
-          assignment_value = std::format("({} != {})", ParseByType(a, type), ParseByType(b, type));
+          assignment_value = std::format("({} != {})", parse_icmp_operand(a), parse_icmp_operand(b));
         } else if (op == "ugt" || op == "sgt") {
-          assignment_value = std::format("({}{} > {}{})", cast, ParseByType(a, type), cast, ParseByType(b, type));
+          assignment_value = std::format("({}{} > {}{})", cast, parse_icmp_operand(a), cast, parse_icmp_operand(b));
         } else if (op == "uge" || op == "sge") {
-          assignment_value = std::format("({}{} >= {}{})", cast, ParseByType(a, type), cast, ParseByType(b, type));
+          assignment_value = std::format("({}{} >= {}{})", cast, parse_icmp_operand(a), cast, parse_icmp_operand(b));
         } else if (op == "ult" || op == "slt") {
-          assignment_value = std::format("({}{} < {}{})", cast, ParseByType(a, type), cast, ParseByType(b, type));
+          assignment_value = std::format("({}{} < {}{})", cast, parse_icmp_operand(a), cast, parse_icmp_operand(b));
         } else if (op == "ule" || op == "sle") {
-          assignment_value = std::format("({}{} <= {}{})", cast, ParseByType(a, type), cast, ParseByType(b, type));
+          assignment_value = std::format("({}{} <= {}{})", cast, parse_icmp_operand(a), cast, parse_icmp_operand(b));
         } else {
           std::cerr << op << "\n";
           throw std::runtime_error("Could not parse code assignment operator");
@@ -2990,14 +4543,21 @@ class Decompiler {
         assignment_value = std::format("{} + {}", ParseByType(a, assignment_type), ParseByType(b, assignment_type));
       } else if (instruction == "sub") {
         // sub nsw i32 %43, %45
-        auto [no_signed_wrap, a, b] = StringViewMatch<3>(assignment, std::regex{R"(sub (nsw )?(?:\S+) (\S+), (\S+))"});
+        // sub nuw nsw i32 3, %885
+        auto [no_unsigned_wrap, no_signed_wrap, a, b] = StringViewMatch<4>(assignment, std::regex{R"(sub (nuw )?(nsw )?(?:\S+) (\S+), (\S+))"});
         assignment_type = (no_signed_wrap.empty()) ? "uint" : "int";
         assignment_value = std::format("{} - {}", ParseByType(a, assignment_type), ParseByType(b, assignment_type));
       } else if (instruction == "sext") {
         // %43 = sext i1 %324 to i32
         auto [from_type, a, to_type] = StringViewMatch<3>(assignment, std::regex{R"(sext (?:fast )?(\S+) (\S+) to (\S+))"});
         assignment_type = ParseType(to_type);
-        assignment_value = std::format("{}(({}){})", assignment_type, ParseUnsignedType(from_type), ParseInt(a));
+        if (from_type == "i1") {
+          // Sign-extending i1: true → -1 (all bits set), false → 0
+          // int((bool)x) gives 1 for true, so negate it.
+          assignment_value = std::format("-{}(({}){})", assignment_type, ParseUnsignedType(from_type), ParseInt(a));
+        } else {
+          assignment_value = std::format("{}(({}){})", assignment_type, ParseUnsignedType(from_type), ParseInt(a));
+        }
       } else if (instruction == "zext") {
         // %43 = zext i1 %39 to i32
         auto [from_type, a, to_type] = StringViewMatch<3>(assignment, std::regex{R"(zext (?:fast )?(\S+) (\S+) to (\S+))"});
@@ -3030,7 +4590,16 @@ class Decompiler {
         auto [type, a, b] = StringViewMatch<3>(assignment, std::regex{R"(and (\S+) (\S+), (\S+))"});
         if (type == "i1") {
           assignment_type = "bool";
-          assignment_value = std::format("{} && {}", ParseInt(a), ParseInt(b));
+          // Use ParseBool (not ParseInt) so operands stay in the bool domain.
+          // Otherwise each bool alias gets wrapped in (int)(...) which exposes
+          // integer-level structure to DXC's InstCombine. That can fuse a bool
+          // flag (e.g. derived from `X & (1<<N)`) with its underlying bit
+          // extraction (`lshr X, N`), letting DXC CSE independent gated
+          // branches that share such a flag into one integer expression and
+          // eliminate per-branch floating-point work. Keeping the operands as
+          // pure bool expressions preserves the original `and i1 / br i1`
+          // structure on recompilation.
+          assignment_value = std::format("{} && {}", ParseBool(a), ParseBool(b));
         } else {
           assignment_type = ParseType(type);
           assignment_value = std::format("{} & {}", ParseInt(a), ParseInt(b));
@@ -3048,21 +4617,42 @@ class Decompiler {
       } else if (instruction == "udiv") {
         // %16 = udiv i32 %14, 38
         auto [type, a, b] = StringViewMatch<3>(assignment, std::regex{R"(udiv (\S+) (\S+), (\S+))"});
+        assignment_type = "uint";
+        assignment_value = std::format("{} / {}", ParseUint(a), ParseUint(b));
+      } else if (instruction == "sdiv") {
+        // %215 = sdiv i32 %193, 2
+        auto [type, a, b] = StringViewMatch<3>(assignment, std::regex{R"(sdiv (\S+) (\S+), (\S+))"});
         assignment_type = "int";
         assignment_value = std::format("{} / {}", ParseInt(a), ParseInt(b));
       } else if (instruction == "or") {
         auto [type, a, b] = StringViewMatch<3>(assignment, std::regex{R"(or (\S+) (\S+), (\S+))"});
         if (type == "i1") {
           assignment_type = "bool";
-          assignment_value = std::format("{} || {}", ParseInt(a), ParseInt(b));
+          // See `and i1` above for rationale: stay in the bool domain so DXC
+          // does not fuse the bool flag with its underlying bit extraction.
+          assignment_value = std::format("{} || {}", ParseBool(a), ParseBool(b));
         } else {
           assignment_type = ParseType(type);
           assignment_value = std::format("{} | {}", ParseInt(a), ParseInt(b));
         }
       } else if (instruction == "alloca") {
         // alloca [6 x float], align 4
-        auto [size, type, align] = StringViewMatch<3>(assignment, std::regex{R"(alloca \[(\S+) x (\S+)\], align (\S+))"});
-        decompiled = std::format("{} _{}[{}];", ParseType(type), variable, ParseInt(size));
+        // alloca i32, align 4
+        static auto alloca_array_regex = std::regex{R"(alloca \[(\S+) x (\S+)\], align (\S+))"};
+        static auto alloca_scalar_regex = std::regex{R"(alloca (\S+), align (\S+))"};
+        auto [size, type, align] = StringViewMatch<3>(assignment, alloca_array_regex);
+        if (!size.empty()) {
+          decompiled = std::format("{} _{}[{}];", ParseType(type), variable, ParseInt(size));
+        } else {
+          auto [scalar_type, scalar_align] = StringViewMatch<2>(assignment, alloca_scalar_regex);
+          if (!scalar_type.empty()) {
+            // Scalar alloca: declare a local variable and register it in stored_pointers
+            // so that subsequent store/load through this pointer resolve correctly.
+            // Note: `variable` is a string_view into persistent line data, safe as map key.
+            decompiled = std::format("{} _{};", ParseType(scalar_type), variable);
+            stored_pointers[variable] = std::format("_{}", variable);
+          }
+        }
       } else if (instruction == "select") {
         // select i1 %26, float 1.000000e+00, float 0x3FFB47E420000000
         // %88 = select i1 %84, i1 %86, i1 %87
@@ -3083,6 +4673,12 @@ class Decompiler {
         } else if (type_a == "half" && type_b == "half") {
           assignment_type = "half";
           assignment_value = std::format("select({}, {}, {})", ParseBool(condition), ParseFloat(value_a), ParseFloat(value_b));
+        } else if (type_a == "i64" && type_b == "i64") {
+          assignment_type = "int64_t";
+          assignment_value = std::format("select({}, {}, {})", ParseBool(condition), ParseInt64(value_a), ParseInt64(value_b));
+        } else if (type_a == "i16" && type_b == "i16") {
+          assignment_type = "int16_t";
+          assignment_value = std::format("select({}, {}, {})", ParseBool(condition), ParseInt(value_a), ParseInt(value_b));
         } else {
           std::cerr << line << "\n";
           throw std::runtime_error("Unrecognized code assignment");
@@ -3094,7 +4690,20 @@ class Decompiler {
         bool declared = false;
         auto pairs = StringViewSplitAll(arguments, std::regex{R"((\[ (\S+), %(\S+) \]),?)"}, {2, 3});
 
+        // Find the first non-undef value to use as a substitute for undef entries.
+        // LLVM undef means "don't care" — the path is unreachable or the value unused.
+        // We skip emitting assignments for undef phi entries entirely, leaving the variable
+        // uninitialized on that path. This lets DXC optimize the same way LLVM does —
+        // it can assume any value for the uninitialized variable and eliminate dead paths.
+
         for (const auto& [value, predecessor] : pairs) {
+          if (value == "undef") {
+            // Don't emit an assignment — leave variable uninitialized on this path
+            int predecessor_int;
+            FromStringView(predecessor, predecessor_int);
+            // Still need to parse to register the predecessor block, but skip the phi_line
+            continue;
+          }
           ParseByType(value, type);
           int predecessor_int;
           FromStringView(predecessor, predecessor_int);
@@ -3120,19 +4729,87 @@ class Decompiler {
 
         // this->code_blocks[0].phi_lines.push_back(
         //     std::format("{} _{};", ParseType(type), variable));
-        // phi_variables.emplace(variable);
+        phi_variables.emplace(std::string(variable));
 
       } else if (instruction == "load") {
         // load float, float* %1681, align 4, !tbaa !26
         // load float, float addrspace(3)* %64, align 4, !tbaa !27
-        auto [source] = StringViewMatch<1>(assignment, std::regex{R"(load \S+, [^*]+\* %(\S+),.*)"});
-        assignment_type = "float";
-        assignment_value = stored_pointers[source];
+        // load i32, i32* %1376, align 4, !tbaa !60
+        // load i32, i32 addrspace(3)* @"\01?NumSphericalHarmonics@@3IA", align 4
+        // load float, float addrspace(3)* getelementptr inbounds ([1024 x float], [1024 x float] addrspace(3)* @"...", i32 0, i32 0), align 4
+        static auto load_local_regex = std::regex{R"(load (\S+), [^*]+\* %(\S+),.*)"};
+        static auto load_global_regex = std::regex{R"(load (\S+), [^*]+\* (@[^,]+),.*)"};
+        static auto load_inline_gep_regex = std::regex{R"(load (\S+), [^*]+\* getelementptr inbounds \([^,]+, [^*]+\* (@[^,]+), i32 \S+, i32 (\S+)\)(?:,.*)?)"};
+        auto [load_type, source] = StringViewMatch<2>(assignment, load_local_regex);
+        if (source.empty()) {
+          auto [load_type_gep, gep_global, gep_index] = StringViewMatch<3>(assignment, load_inline_gep_regex);
+          if (!gep_global.empty()) {
+            // Inline GEP load from shared memory: array[index]
+            if (load_type_gep == "i32") {
+              assignment_type = "int";
+            } else {
+              assignment_type = "float";
+            }
+            if (auto pair = preprocess_state.global_variables.find(std::string(gep_global));
+                pair != preprocess_state.global_variables.end()) {
+              assignment_value = std::format("{}[{}]", pair->second, gep_index);
+            } else {
+              assignment_value = std::format("/* {} */[{}]", gep_global, gep_index);
+            }
+            is_identity = true;
+          } else {
+            auto [load_type_g, global_source] = StringViewMatch<2>(assignment, load_global_regex);
+            if (!global_source.empty()) {
+              if (load_type_g == "i32") {
+                assignment_type = "int";
+              } else {
+                assignment_type = "float";
+              }
+              if (auto pair = preprocess_state.global_variables.find(std::string(global_source));
+                  pair != preprocess_state.global_variables.end()) {
+                assignment_value = pair->second;
+              } else {
+                assignment_value = std::format("/* {} */", global_source);
+              }
+              is_identity = true;
+            }
+          }
+        } else {
+          if (load_type == "i32") {
+            assignment_type = "int";
+          } else if (load_type == "i16") {
+            assignment_type = "int";
+          } else {
+            assignment_type = "float";
+          }
+          assignment_value = stored_pointers[source];
+        }
       } else if (instruction == "bitcast") {
         // %63 = bitcast i32 %62 to float
-        auto [source_type, source_variable, dest_type] = StringViewMatch<3>(assignment, std::regex{R"(bitcast (\S+) (\S+) to (\S+))"});
+        // %1323 = bitcast i32* %1322 to float*
+        // %193 = bitcast i32 addrspace(3)* %192 to float addrspace(3)*
+        static auto bitcast_regex = std::regex{R"(bitcast (\S+(?:\s+addrspace\(\d+\))?\*?) (\S+) to (\S+(?:\s+addrspace\(\d+\))?\*?))"};
+        auto [source_type, source_variable, dest_type] = StringViewMatch<3>(assignment, bitcast_regex);
         if (source_type.empty()) {
           // decompiled = std::format("// {}", line);
+        } else if (dest_type.find('*') != std::string_view::npos) {
+          // Pointer bitcast — propagate the stored pointer alias.
+          // Preserve the ORIGINAL element type of the source pointer so
+          // that subsequent stores/loads through this alias know when the
+          // value type differs from the actual HLSL array element type
+          // (e.g. storing a float through an i32* that was bitcast to
+          // float* — must emit asuint() to preserve the bits).
+          auto source_ref = std::string(source_variable.substr(1));
+          if (stored_pointers.count(source_ref)) {
+            stored_pointers[variable] = stored_pointers[source_ref];
+          } else {
+            stored_pointers[variable] = std::format("_{}", source_ref);
+          }
+          auto it = stored_pointer_element_types.find(source_ref);
+          if (it != stored_pointer_element_types.end()) {
+            stored_pointer_element_types[std::string(variable)] = it->second;
+          }
+          IncrementVariableCounter(variable);
         } else {
           assignment_type = ParseType(dest_type);
           assignment_value = std::format("{}({})", ParseBitcast(dest_type), ParseVariable(source_variable, ParseType(source_type)));
@@ -3169,11 +4846,16 @@ class Decompiler {
           // IncrementVariableCounter(source_variable);
         }
       } else if (instruction == "getelementptr") {
-        auto [source, index] = StringViewMatch<2>(
+        auto [array_size_str, element_type, source, index] = StringViewMatch<4>(
             assignment,
-            std::regex{R"(getelementptr (?:inbounds )?\[[^\]]+\], \[[^\]]+\](?: addrspace\(\d+\))?\* (\S+), i32 \S+, i32 (\S+).*)"});
+            std::regex{R"(getelementptr (?:inbounds )?\[(\d+) x ([^\]]+)\], \[[^\]]+\](?: addrspace\(\d+\))?\* (\S+), i32 \S+, i32 (\S+).*)"});
         // %1369 = getelementptr inbounds [6 x float], [6 x float]* %10, i32 0, i32 0
         // %58 = getelementptr [128 x float], [128 x float] addrspace(3)* @"\01?g_ToneMapRadianceSamples@@3PAMA", i32 0, i32 %57
+        int array_size = 0;
+        if (!array_size_str.empty()) {
+          FromStringView(array_size_str, array_size);
+        }
+        
         std::string parsed_source;
         if (source.starts_with('%')) {
           parsed_source = std::format("_{}", source.substr(1));
@@ -3182,14 +4864,147 @@ class Decompiler {
               pair != preprocess_state.global_variables.end()) {
             parsed_source = pair->second;
           } else {
-            throw std::invalid_argument("Unknown global variable");
+            // Try stripping .N.N... suffix (sub-element access into global struct)
+            // The suffix is inside the quotes: @"\01?name@@...A.0.0" -> @"\01?name@@...A"
+            auto source_str = std::string(source);
+            bool found_base = false;
+            // Try progressively stripping .N suffixes from inside the closing quote
+            auto last_quote = source_str.rfind('"');
+            if (last_quote != std::string::npos && last_quote > 0) {
+              auto inner = source_str.substr(0, last_quote);  // everything before closing "
+              while (!found_base) {
+                auto last_dot = inner.rfind('.');
+                if (last_dot == std::string::npos) break;
+                // Check if everything after the dot is digits
+                auto suffix = inner.substr(last_dot + 1);
+                bool all_digits = !suffix.empty() && std::ranges::all_of(suffix, [](char c) { return c >= '0' && c <= '9'; });
+                if (!all_digits) break;
+                inner = inner.substr(0, last_dot);
+                auto candidate = inner + "\"";
+                if (auto pair2 = preprocess_state.global_variables.find(candidate);
+                    pair2 != preprocess_state.global_variables.end()) {
+                  parsed_source = pair2->second;
+                  found_base = true;
+                }
+              }
+            }
+            if (!found_base) {
+              throw std::invalid_argument(std::format("Unknown global variable: {}", source));
+            }
           }
         } else {
           throw std::invalid_argument("Unknown pointer source");
         }
-        const auto pointer_value = std::format("{}[{}]", parsed_source, ParseInt(index));
+        // Clamp dynamic indices to array bounds to prevent OOB access.
+        // The original DXIL guarantees in-bounds via control flow, but the
+        // decompiler's opaque condition mechanism can't preserve that guarantee
+        // for all possible values of __opaque_false. DXC's validator checks
+        // all possible paths including the opaque-flipped ones.
+        auto parsed_index = ParseInt(index);
+        bool is_dynamic_index = index.starts_with('%');
+        std::string clamped_index;
+        if (is_dynamic_index && array_size > 0) {
+          clamped_index = std::format("min((uint)({}), {}u)", parsed_index, array_size - 1);
+        } else {
+          clamped_index = parsed_index;
+        }
+        const auto pointer_value = std::format("{}[{}]", parsed_source, clamped_index);
         stored_pointers[variable] = pointer_value;
+        if (!element_type.empty()) {
+          stored_pointer_element_types[std::string(variable)] = std::string(element_type);
+        }
         IncrementVariableCounter(variable);
+      } else if (instruction == "atomicrmw") {
+        // %259 = atomicrmw add i32 addrspace(3)* @"\01?NumSphericalHarmonics@@3IA", i32 1 seq_cst
+        // %X   = atomicrmw add i32 addrspace(3)* getelementptr inbounds ([N x i32], [N x i32] addrspace(3)* @"name", i32 0, i32 INDEX), i32 %val seq_cst
+        std::string op_str;
+        std::string parsed_pointer;
+        std::string operand_str_raw;
+        auto assignment_str = std::string(assignment);
+        bool is_inline_gep = assignment_str.find("getelementptr inbounds") != std::string::npos
+                              && assignment_str.find("addrspace(") != std::string::npos;
+        if (is_inline_gep) {
+          // Parse: atomicrmw OP TYPE addrspace(N)* getelementptr inbounds (..., addrspace(N)* @"NAME", i32 0, i32 INDEX), TYPE OPERAND ...
+          auto rmw_pos = assignment_str.find("atomicrmw ") + 10;
+          auto op_end = assignment_str.find(' ', rmw_pos);
+          op_str = assignment_str.substr(rmw_pos, op_end - rmw_pos);
+          auto at_pos = assignment_str.find("@\"");
+          auto close_quote = (at_pos != std::string::npos) ? assignment_str.find("\"", at_pos + 2) : std::string::npos;
+          // Find the GEP closing ")," — the last "i32 N)" before the comma
+          auto gep_close = (close_quote != std::string::npos) ? assignment_str.find(")", close_quote) : std::string::npos;
+          // Find the index: last "i32 N" before gep_close
+          auto last_i32 = (gep_close != std::string::npos) ? assignment_str.rfind("i32 ", gep_close) : std::string::npos;
+          // Find the operand: after "), TYPE "
+          auto post_gep = (gep_close != std::string::npos) ? assignment_str.find(", ", gep_close) : std::string::npos;
+          if (!op_str.empty() && at_pos != std::string::npos && close_quote != std::string::npos
+              && last_i32 != std::string::npos && post_gep != std::string::npos
+              && gep_close > last_i32 + 4) {
+            auto gep_global = assignment_str.substr(at_pos, close_quote - at_pos + 1);
+            auto index_str = assignment_str.substr(last_i32 + 4, gep_close - (last_i32 + 4));
+            // Operand is after "), TYPE " — skip the type word
+            auto operand_start = assignment_str.find(' ', post_gep + 2) + 1;
+            auto operand_end = assignment_str.find(' ', operand_start);
+            if (operand_end == std::string::npos) operand_end = assignment_str.size();
+            operand_str_raw = assignment_str.substr(operand_start, operand_end - operand_start);
+            
+            std::string base_pointer;
+            if (auto pair = preprocess_state.global_variables.find(gep_global);
+                pair != preprocess_state.global_variables.end()) {
+              base_pointer = pair->second;
+            } else {
+              base_pointer = std::format("/* {} */", gep_global);
+            }
+            int index = 0;
+            FromStringView(index_str, index);
+            parsed_pointer = std::format("{}[{}]", base_pointer, index);
+          }
+        }
+        
+        if (parsed_pointer.empty()) {
+          // Fall back to simple pointer regex
+          static auto atomicrmw_regex = std::regex{R"(atomicrmw (\S+) \S+(?: addrspace\(\d+\))?\* (\S+), \S+ (\S+).*)"};
+          auto [op, pointer, operand] = StringViewMatch<3>(assignment, atomicrmw_regex);
+          if (op.empty()) {
+            throw std::runtime_error(std::format("Could not parse atomicrmw: {}", assignment));
+          }
+          op_str = std::string(op);
+          operand_str_raw = std::string(operand);
+          if (pointer.starts_with('%')) {
+            parsed_pointer = stored_pointers.count(pointer.substr(1)) ? stored_pointers[pointer.substr(1)] : std::format("_{}", pointer.substr(1));
+          } else if (pointer.starts_with('@')) {
+            if (auto pair = preprocess_state.global_variables.find(std::string(pointer));
+                pair != preprocess_state.global_variables.end()) {
+              parsed_pointer = pair->second;
+            } else {
+              parsed_pointer = std::format("/* {} */", pointer);
+            }
+          } else {
+            parsed_pointer = std::string(pointer);
+          }
+        }
+        
+        std::string atomic_func;
+        if (op_str == "add") atomic_func = "InterlockedAdd";
+        else if (op_str == "sub") atomic_func = "InterlockedAdd";  // sub with negated value
+        else if (op_str == "and") atomic_func = "InterlockedAnd";
+        else if (op_str == "or") atomic_func = "InterlockedOr";
+        else if (op_str == "xor") atomic_func = "InterlockedXor";
+        else if (op_str == "max") atomic_func = "InterlockedMax";
+        else if (op_str == "min") atomic_func = "InterlockedMin";
+        else if (op_str == "umax") atomic_func = "InterlockedMax";
+        else if (op_str == "umin") atomic_func = "InterlockedMin";
+        else if (op_str == "xchg") atomic_func = "InterlockedExchange";
+        else atomic_func = std::format("InterlockedOp/* {} */", op_str);
+
+        assignment_type = "uint";
+        std::string operand_str = ParseInt(std::string_view(operand_str_raw));
+        if (op_str == "sub") {
+          operand_str = std::format("-{}", operand_str);
+        }
+        assignment_value = std::format("{}({}, {})", atomic_func, parsed_pointer, operand_str);
+        is_identity = false;
+        use_comment = false;
+        decompiled = std::format("uint _{}; {}({}, {}, _{});", variable, atomic_func, parsed_pointer, operand_str, variable);
       } else {
         std::cerr << line << "\n";
         throw std::runtime_error("Unrecognized code assignment");
@@ -3197,14 +5012,29 @@ class Decompiler {
 
       if (decompiled.empty() && !assignment_value.empty()) {
         if (is_identity) {
-          variable_aliases.emplace(variable, std::pair<std::string, std::string>(assignment_type, OptimizeString(assignment_value)));
-          use_comment = true;
+          // Refuse to inline wave intrinsics. Wave ops (WaveActiveCountBits,
+          // WavePrefixCountBits, WaveReadLaneFirst, WaveIsFirstLane, etc.) rely
+          // on the active-lane mask at the point of call. If a wave op is
+          // inlined into a use-site that lives under a deeper branch (e.g.,
+          // inside `if (WaveIsFirstLane())`), the active mask differs from
+          // where the original DXIL called it, producing wrong results.
+          // Keep the assignment as a named local so the wave op executes at
+          // its original control-flow position.
+          static const auto IS_WAVE_INTRINSIC = std::regex(
+              R"(\bWave(Active|Prefix|Read|Is|Match|MultiPrefix|All|Any)\w*\s*\()");
+          if (std::regex_search(assignment_value, IS_WAVE_INTRINSIC)) {
+            use_comment = false;
+            decompiled = std::format("{} _{} = {};", assignment_type, variable, assignment_value);
+          } else {
+            variable_aliases.emplace(variable, std::pair<std::string, std::string>(assignment_type, OptimizeString(assignment_value)));
+            use_comment = true;
+          }
         }
         if (use_comment) {
 #if DECOMPILER_DXC_DEBUG >= 1
           decompiled = std::format("// {} _{} = {};", assignment_type, variable, assignment_value);
 #endif
-        } else {
+        } else if (decompiled.empty()) {
           decompiled = std::format("{} _{} = {};", assignment_type, variable, assignment_value);
         }
       }
@@ -3273,7 +5103,7 @@ class Decompiler {
 
       while (true) {
         auto& current_line = *(++iterator);
-        if (StringViewTrim(current_line) == "]") break;
+        if (StringViewTrim(current_line).starts_with("]")) break;
         //     i32 2, label %25
         static const auto SWITCH_CASE_REGEX = std::regex{R"(^    i32 (\S+), label %(\S+).*$)"};
         const auto [case_value, case_function] = StringViewMatch<2>(current_line, SWITCH_CASE_REGEX);
@@ -3310,75 +5140,316 @@ class Decompiler {
         }
       } else if (functionName == "@dx.op.barrier") {
         // @dx.op.barrier(i32 80, i32 9)  ; Barrier(barrierMode)
+        // Barrier mode is a bitmask: bit0=SyncThreadGroup, bit1=UAVFenceGlobal, bit2=UAVFenceThreadGroup, bit3=TGSMFence
         auto [opNumber, barrierMode] = StringViewSplit<2>(functionParamsString, param_regex, 2);
-        if (barrierMode == "9") {
+        int mode = 0;
+        FromStringView(barrierMode, mode);
+        bool has_sync = (mode & 1) != 0;
+        bool has_uav_global = (mode & 2) != 0;
+        bool has_uav_thread_group = (mode & 4) != 0;
+        bool has_tgsm = (mode & 8) != 0;
+        
+        if (has_tgsm && has_sync && !has_uav_global) {
           decompiled = "GroupMemoryBarrierWithGroupSync();";
+        } else if (has_tgsm && !has_sync && !has_uav_global) {
+          decompiled = "GroupMemoryBarrier();";
+        } else if (has_uav_global && has_sync && !has_tgsm) {
+          decompiled = "DeviceMemoryBarrierWithGroupSync();";
+        } else if (has_uav_global && !has_sync && !has_tgsm) {
+          decompiled = "DeviceMemoryBarrier();";
+        } else if (has_uav_global && has_tgsm && has_sync) {
+          decompiled = "AllMemoryBarrierWithGroupSync();";
+        } else if (has_uav_global && has_tgsm && !has_sync) {
+          decompiled = "AllMemoryBarrier();";
+        } else if (mode == 0) {
+          decompiled = "// barrier(0) - no-op";
         } else {
-          throw std::runtime_error("Unknown barrier mode.");
+          // Fallback: emit AllMemoryBarrierWithGroupSync for any unrecognized combo with sync
+          decompiled = has_sync ? "AllMemoryBarrierWithGroupSync();" : "AllMemoryBarrier();";
         }
-      } else if (functionName == "@dx.op.rawBufferStore.f32") {
+      } else if (functionName == "@dx.op.rawBufferStore.f32" || functionName == "@dx.op.rawBufferStore.f16") {
         // call void @dx.op.rawBufferStore.f32(i32 140, %dx.types.Handle %1751, i32 0, i32 0, float %884, float %885, float %821, float %833, i8 15, i32 4)  ; RawBufferStore(uav,index,elementOffset,value0,value1,value2,value3,mask,alignment)
 
         auto [opNumber, uav, index, elementOffset, value0, value1, value2, value3, mask, alignment] = StringViewSplit<10>(functionParamsString, param_regex, 2);
         auto ref = std::string{uav.substr(1)};
-        auto [res_name, range_index, resource_class] = preprocess_state.resource_binding_variables.at(ref);
-        bool is_raw_buffer = false;
-        if (resource_class == "0") {
-          is_raw_buffer = preprocess_state.srv_resources[range_index].shape == Resource::ResourceKind::RawBuffer;
-        } else if (resource_class == "1") {
-          is_raw_buffer = preprocess_state.uav_resources[range_index].shape == Resource::ResourceKind::RawBuffer;
-        } else {
-          throw std::runtime_error("Unknown @dx.op.rawBufferStore.f32 resource");
-        }
+        auto binding_store_f32 = preprocess_state.resource_binding_variables.at(ref);
+        auto [res_name, range_index, resource_class] = binding_store_f32;
+        bool is_raw_buffer = preprocess_state.GetResourceShape(ref) == Resource::ResourceKind::RawBuffer;
 
         const bool has_value_y = value1 != "undef";
         const bool has_value_z = value2 != "undef";
         const bool has_value_w = value3 != "undef";
         std::string value;
-        if (has_value_w) {
-          value = std::format("float4({}, {}, {}, {})", ParseFloat(value0), ParseFloat(value1), ParseFloat(value2), ParseFloat(value3));
-        } else if (has_value_z) {
-          value = std::format("float3({}, {}, {})", ParseFloat(value0), ParseFloat(value1), ParseFloat(value2));
-        } else if (has_value_y) {
-          value = std::format("float2({}, {})", ParseFloat(value0), ParseFloat(value1));
+        bool is_f16 = (functionName == "@dx.op.rawBufferStore.f16");
+        if (is_f16) {
+          if (has_value_w) {
+            value = std::format("half4({}, {}, {}, {})", ParseHalf(value0), ParseHalf(value1), ParseHalf(value2), ParseHalf(value3));
+          } else if (has_value_z) {
+            value = std::format("half3({}, {}, {})", ParseHalf(value0), ParseHalf(value1), ParseHalf(value2));
+          } else if (has_value_y) {
+            value = std::format("half2({}, {})", ParseHalf(value0), ParseHalf(value1));
+          } else {
+            value = std::format("{}", ParseHalf(value0));
+          }
         } else {
-          value = std::format("{}", ParseFloat(value0));
+          if (has_value_w) {
+            value = std::format("float4({}, {}, {}, {})", ParseFloat(value0), ParseFloat(value1), ParseFloat(value2), ParseFloat(value3));
+          } else if (has_value_z) {
+            value = std::format("float3({}, {}, {})", ParseFloat(value0), ParseFloat(value1), ParseFloat(value2));
+          } else if (has_value_y) {
+            value = std::format("float2({}, {})", ParseFloat(value0), ParseFloat(value1));
+          } else {
+            value = std::format("{}", ParseFloat(value0));
+          }
         }
 
         // assert(is_raw_buffer);
 
         // assert(elementOffset == "undef");
-        decompiled = std::format("{}[{} / {}] = {};",
-                                 res_name, ParseInt(index), ParseInt(alignment), value);
-      } else if (functionName == "@dx.op.rawBufferStore.i32") {
+        if (is_raw_buffer) {
+          int component_count = 1;
+          if (has_value_w) component_count = 4;
+          else if (has_value_z) component_count = 3;
+          else if (has_value_y) component_count = 2;
+          std::string store_func = (component_count == 1) ? "Store" :
+                                   std::format("Store{}", component_count);
+          decompiled = std::format("{}.{}({}, asuint({}));",
+                                   res_name, store_func, ParseInt(index), value);
+        } else if (elementOffset.starts_with("%")) {
+          // Dynamic element offset on a StructuredBuffer — resolve using struct layout.
+          auto& uav_resource = preprocess_state.uav_resources[range_index];
+          auto offset_var = std::string(elementOffset.substr(1));  // strip '%'
+
+          uint32_t constant_field_offset = 0;
+          std::string array_index_expr;
+
+          // Scan source lines for the definition of this offset variable
+          static const auto or_ir_regex_f = std::regex(R"(^\s+%(\d+) = or i32 (%\d+), (\d+))");
+          static const auto add_ir_regex_f = std::regex(R"(^\s+%(\d+) = add (?:nuw )?(?:nsw )?i32 (%\d+), (\d+))");
+          for (const auto& src_line : this->lines) {
+            std::match_results<std::string_view::const_iterator> m;
+            if (std::regex_search(src_line.begin(), src_line.end(), m, or_ir_regex_f) || std::regex_search(src_line.begin(), src_line.end(), m, add_ir_regex_f)) {
+              if (m[1].str() == offset_var) {
+                FromStringView(std::string_view(m[3].str()), constant_field_offset);
+                array_index_expr = ParseInt(std::string_view(m[2].str()));
+                break;
+              }
+            }
+          }
+          if (array_index_expr.empty()) {
+            array_index_expr = ParseInt(elementOffset);
+          }
+
+          std::string field_access = preprocess_state.ResourceFieldNameAtOffset(uav_resource, constant_field_offset);
+          if (!field_access.empty()) {
+            auto type_name = uav_resource.pointer.substr(0, uav_resource.pointer.length() - 1);
+            auto type_pair = preprocess_state.type_definitions.find(type_name);
+            if (type_pair == preprocess_state.type_definitions.end()) {
+              static auto array_inner_regex2 = std::regex{R"(^\[\d+ x (.+)\]$)"};
+              auto [inner_type] = StringViewMatch<1>(type_name, array_inner_regex2);
+              if (!inner_type.empty()) type_pair = preprocess_state.type_definitions.find(inner_type);
+            }
+            bool resolved_dynamic = false;
+            if (type_pair != preprocess_state.type_definitions.end()) {
+              auto& def = type_pair->second;
+              auto effective_tn = std::string_view(type_pair->first);
+              if (effective_tn.starts_with("%\"class.RWStructuredBuffer<") || effective_tn.starts_with("%\"hostlayout.class.RWStructuredBuffer<")) {
+                auto struct_pair = preprocess_state.type_definitions.find(def.variables[0].type);
+                if (struct_pair != preprocess_state.type_definitions.end()) {
+                  for (const auto& [decl, fname, ftype, foffset] : struct_pair->second.variables) {
+                    DataType finfo(ftype);
+                    if (!finfo.array_sizes.empty()) {
+                      uint32_t total_size = static_cast<uint32_t>(preprocess_state.GetTypeSize(finfo));
+                      uint32_t element_size = total_size;
+                      for (auto arr_sz : finfo.array_sizes) element_size /= arr_sz;
+                      std::string sub_field;
+                      if (finfo.data_type.starts_with("%struct.") || finfo.data_type.starts_with("%hostlayout.struct.")) {
+                        auto sub_pair = preprocess_state.type_definitions.find(finfo.data_type);
+                        if (sub_pair != preprocess_state.type_definitions.end()) {
+                          sub_field = "." + preprocess_state.DataTypeNameAtIndex(sub_pair->second.variables, constant_field_offset);
+                        }
+                      } else {
+                        DataType elem_info(finfo.data_type);
+                        if (elem_info.vector_size > 0 && constant_field_offset > 0) {
+                          uint32_t scalar_size = (elem_info.data_type == "double" || elem_info.data_type == "int64_t" || elem_info.data_type == "uint64_t") ? 8 : 4;
+                          sub_field = std::format(".{}", VECTOR_INDEXES[constant_field_offset / scalar_size]);
+                        }
+                      }
+                      decompiled = std::format("{}[{}].{}[{} / {}]{} = {};",
+                                               res_name, ParseInt(index), fname, array_index_expr, element_size, sub_field, value);
+                      resolved_dynamic = true;
+                      break;
+                    }
+                  }
+                }
+              }
+            }
+            if (!resolved_dynamic) {
+              decompiled = std::format("{}[{}]{} = {};",
+                                       res_name, ParseInt(index), field_access, value);
+            }
+          } else {
+            decompiled = std::format("{}[{}] = {};",
+                                     res_name, ParseInt(index), value);
+          }
+        } else {
+          // Structured buffer store: resolve byte offset to struct field
+          int literal_element_offset = 0;
+          if (elementOffset != "undef") {
+            FromStringView(elementOffset, literal_element_offset);
+          }
+          auto& uav_resource = preprocess_state.uav_resources[range_index];
+          std::string field_access = preprocess_state.ResourceFieldNameAtOffset(uav_resource, literal_element_offset);
+          if (!field_access.empty()) {
+            decompiled = std::format("{}[{}]{} = {};",
+                                     res_name, ParseInt(index), field_access, value);
+          } else {
+            // Fallback: can't resolve field, use raw offset notation
+            decompiled = std::format("{}[{}] = {};",
+                                     res_name, ParseInt(index), value);
+          }
+        }
+      } else if (functionName == "@dx.op.rawBufferStore.i32" || functionName == "@dx.op.rawBufferStore.i16") {
         // call void @dx.op.rawBufferStore.i32(i32 140, %dx.types.Handle %3114, i32 %3113, i32 0, i32 %2310, i32 undef, i32 undef, i32 undef, i8 1, i32 4)  ; RawBufferStore(uav,index,elementOffset,value0,value1,value2,value3,mask,alignment)
 
         auto [opNumber, uav, index, elementOffset, value0, value1, value2, value3, mask, alignment] = StringViewSplit<10>(functionParamsString, param_regex, 2);
         auto ref = std::string{uav.substr(1)};
-        auto [res_name, range_index, resource_class] = preprocess_state.resource_binding_variables.at(ref);
-        bool is_raw_buffer = false;
-        if (resource_class == "0") {
-          is_raw_buffer = preprocess_state.srv_resources[range_index].shape == Resource::ResourceKind::RawBuffer;
-        } else if (resource_class == "1") {
-          is_raw_buffer = preprocess_state.uav_resources[range_index].shape == Resource::ResourceKind::RawBuffer;
-        } else {
-          throw std::runtime_error("Unknown @dx.op.rawBufferStore.i32 resource");
-        }
+        auto binding_store_i32 = preprocess_state.resource_binding_variables.at(ref);
+        auto [res_name, range_index, resource_class] = binding_store_i32;
+        bool is_raw_buffer = preprocess_state.GetResourceShape(ref) == Resource::ResourceKind::RawBuffer;
 
         const bool has_value_y = value1 != "undef";
         const bool has_value_z = value2 != "undef";
         const bool has_value_w = value3 != "undef";
         std::string value;
-        if (has_value_w) {
-          value = std::format("int4({}, {}, {}, {})", ParseInt(value0), ParseInt(value1), ParseInt(value2), ParseInt(value3));
-        } else if (has_value_z) {
-          value = std::format("int3({}, {}, {})", ParseInt(value0), ParseInt(value1), ParseInt(value2));
-        } else if (has_value_y) {
-          value = std::format("int2({}, {})", ParseInt(value0), ParseInt(value1));
+        bool is_i16 = (functionName == "@dx.op.rawBufferStore.i16");
+        if (is_i16) {
+          if (has_value_w) {
+            value = std::format("int16_t4({}, {}, {}, {})", ParseInt(value0), ParseInt(value1), ParseInt(value2), ParseInt(value3));
+          } else if (has_value_z) {
+            value = std::format("int16_t3({}, {}, {})", ParseInt(value0), ParseInt(value1), ParseInt(value2));
+          } else if (has_value_y) {
+            value = std::format("int16_t2({}, {})", ParseInt(value0), ParseInt(value1));
+          } else {
+            value = std::format("(int16_t)({})", ParseInt(value0));
+          }
         } else {
-          value = std::format("{}", ParseInt(value0));
+          if (has_value_w) {
+            value = std::format("int4({}, {}, {}, {})", ParseInt(value0), ParseInt(value1), ParseInt(value2), ParseInt(value3));
+          } else if (has_value_z) {
+            value = std::format("int3({}, {}, {})", ParseInt(value0), ParseInt(value1), ParseInt(value2));
+          } else if (has_value_y) {
+            value = std::format("int2({}, {})", ParseInt(value0), ParseInt(value1));
+          } else {
+            value = std::format("{}", ParseInt(value0));
+          }
         }
-      } else if (functionName == "@dx.op.storeOutput.f32") {
+
+        if (is_raw_buffer) {
+          decompiled = std::format("{}.{}({}, asuint({}));",
+                                   res_name,
+                                   has_value_w ? "Store4" : has_value_z ? "Store3" : has_value_y ? "Store2" : "Store",
+                                   ParseInt(index), value);
+        } else if (elementOffset.starts_with("%")) {
+          // Dynamic element offset on a StructuredBuffer — resolve using struct layout.
+          // Extract the constant field offset from the IR definition of the offset variable.
+          // Pattern: %N = or i32 %base, CONSTANT  →  field offset = CONSTANT
+          // Pattern: %N = shl ... (no constant add)  →  field offset = 0
+          auto& uav_resource = preprocess_state.uav_resources[range_index];
+          auto offset_var = std::string(elementOffset.substr(1));  // strip '%'
+
+          uint32_t constant_field_offset = 0;
+          std::string array_index_expr;
+
+          // Scan source lines for the definition of this offset variable
+          static const auto or_ir_regex = std::regex(R"(^\s+%(\d+) = or i32 (%\d+), (\d+))");
+          static const auto add_ir_regex = std::regex(R"(^\s+%(\d+) = add (?:nuw )?(?:nsw )?i32 (%\d+), (\d+))");
+          for (const auto& src_line : this->lines) {
+            std::match_results<std::string_view::const_iterator> m;
+            if (std::regex_search(src_line.begin(), src_line.end(), m, or_ir_regex) || std::regex_search(src_line.begin(), src_line.end(), m, add_ir_regex)) {
+              if (m[1].str() == offset_var) {
+                FromStringView(std::string_view(m[3].str()), constant_field_offset);
+                array_index_expr = ParseInt(std::string_view(m[2].str()));
+                break;
+              }
+            }
+          }
+          // If no or/add found, the offset itself is the base (field offset = 0)
+          if (array_index_expr.empty()) {
+            array_index_expr = ParseInt(elementOffset);
+          }
+
+          std::string field_access = preprocess_state.ResourceFieldNameAtOffset(uav_resource, constant_field_offset);
+          if (!field_access.empty()) {
+            // Find the array field and its element size to emit proper indexing
+            auto type_name = uav_resource.pointer.substr(0, uav_resource.pointer.length() - 1);
+            auto type_pair = preprocess_state.type_definitions.find(type_name);
+            if (type_pair == preprocess_state.type_definitions.end()) {
+              static auto array_inner_regex3 = std::regex{R"(^\[\d+ x (.+)\]$)"};
+              auto [inner_type] = StringViewMatch<1>(type_name, array_inner_regex3);
+              if (!inner_type.empty()) type_pair = preprocess_state.type_definitions.find(inner_type);
+            }
+            bool resolved_dynamic = false;
+            if (type_pair != preprocess_state.type_definitions.end()) {
+              auto& def = type_pair->second;
+              auto effective_tn = std::string_view(type_pair->first);
+              if (effective_tn.starts_with("%\"class.RWStructuredBuffer<") || effective_tn.starts_with("%\"hostlayout.class.RWStructuredBuffer<")) {
+                auto struct_pair = preprocess_state.type_definitions.find(def.variables[0].type);
+                if (struct_pair != preprocess_state.type_definitions.end()) {
+                  for (const auto& [decl, fname, ftype, foffset] : struct_pair->second.variables) {
+                    DataType finfo(ftype);
+                    if (!finfo.array_sizes.empty()) {
+                      uint32_t total_size = static_cast<uint32_t>(preprocess_state.GetTypeSize(finfo));
+                      uint32_t element_size = total_size;
+                      for (auto arr_sz : finfo.array_sizes) element_size /= arr_sz;
+                      std::string sub_field;
+                      if (finfo.data_type.starts_with("%struct.") || finfo.data_type.starts_with("%hostlayout.struct.")) {
+                        auto sub_pair = preprocess_state.type_definitions.find(finfo.data_type);
+                        if (sub_pair != preprocess_state.type_definitions.end()) {
+                          sub_field = "." + preprocess_state.DataTypeNameAtIndex(sub_pair->second.variables, constant_field_offset);
+                        }
+                      } else {
+                        DataType elem_info(finfo.data_type);
+                        if (elem_info.vector_size > 0 && constant_field_offset > 0) {
+                          uint32_t scalar_size = (elem_info.data_type == "double" || elem_info.data_type == "int64_t" || elem_info.data_type == "uint64_t") ? 8 : 4;
+                          sub_field = std::format(".{}", VECTOR_INDEXES[constant_field_offset / scalar_size]);
+                        }
+                      }
+                      decompiled = std::format("{}[{}].{}[{} / {}]{} = {};",
+                                               res_name, ParseInt(index), fname, array_index_expr, element_size, sub_field, value);
+                      resolved_dynamic = true;
+                      break;
+                    }
+                  }
+                }
+              }
+            }
+            if (!resolved_dynamic) {
+              decompiled = std::format("{}[{}]{} = {};",
+                                       res_name, ParseInt(index), field_access, value);
+            }
+          } else {
+            decompiled = std::format("{}[{}] = {};",
+                                     res_name, ParseInt(index), value);
+          }
+        } else {
+          // Structured buffer store: resolve byte offset to struct field
+          int literal_element_offset = 0;
+          if (elementOffset != "undef") {
+            FromStringView(elementOffset, literal_element_offset);
+          }
+          auto& uav_resource = preprocess_state.uav_resources[range_index];
+          std::string field_access = preprocess_state.ResourceFieldNameAtOffset(uav_resource, literal_element_offset);
+          if (!field_access.empty()) {
+            decompiled = std::format("{}[{}]{} = {};",
+                                     res_name, ParseInt(index), field_access, value);
+          } else {
+            // Fallback: can't resolve field, use raw offset notation
+            decompiled = std::format("{}[{}] = {};",
+                                     res_name, ParseInt(index), value);
+          }
+        }
+      } else if (functionName == "@dx.op.storeOutput.f32" || functionName == "@dx.op.storeOutput.f16") {
         // call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float %2772)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
         auto [opNumber, outputSigId, rowIndex, colIndex, value] = StringViewSplit<5>(functionParamsString, param_regex, 2);
         int output_signature_index;
@@ -3388,14 +5459,26 @@ class Decompiler {
           throw std::runtime_error("Row index not supported.");
         }
         if (signature.packed.MaskString() == "1") {
-          if (ParseIndex(colIndex) != "x") {
-            throw std::runtime_error("Unexpected index.");
-          }
           decompiled = std::format("{} = {};", signature.VariableString(), ParseFloat(value));
         } else {
           decompiled = std::format("{}.{} = {};", signature.VariableString(), ParseIndex(colIndex), ParseFloat(value));
         }
-      } else if (functionName == "@dx.op.textureStore.f32") {
+      } else if (functionName == "@dx.op.storeOutput.i32") {
+        // call void @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 0, i32 %532)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+        auto [opNumber, outputSigId, rowIndex, colIndex, value] = StringViewSplit<5>(functionParamsString, param_regex, 2);
+        int output_signature_index;
+        FromStringView(outputSigId, output_signature_index);
+        auto signature = preprocess_state.output_signature[output_signature_index];
+        if (rowIndex != "0") {
+          throw std::runtime_error("Row index not supported.");
+        }
+        auto parsed_value = signature.packed.format == SignaturePacked::Format::UINT ? ParseUint(value) : ParseInt(value);
+        if (signature.packed.MaskString() == "1") {
+          decompiled = std::format("{} = {};", signature.VariableString(), parsed_value);
+        } else {
+          decompiled = std::format("{}.{} = {};", signature.VariableString(), ParseIndex(colIndex), parsed_value);
+        }
+      } else if (functionName == "@dx.op.textureStore.f32" || functionName == "@dx.op.textureStore.f16") {
         //   call void @dx.op.textureStore.f32(i32 67, %dx.types.Handle %558, i32 %16, i32 %17, i32 undef, float %555, float %556, float %557, float 1.000000e+00, i8 15)  ; TextureStore(srv,coord0,coord1,coord2,value0,value1,value2,value3,mask)
         auto [opNumber, uav, coord0, coord1, coord2, value0, value1, value2, value3, mask] = StringViewSplit<10>(functionParamsString, param_regex, 2);
         auto ref_resource = std::string{uav.substr(1)};
@@ -3436,7 +5519,7 @@ class Decompiler {
         }
 
         decompiled = std::format("{}[{}] = {};", uav_name, coords, value);
-      } else if (functionName == "@dx.op.textureStore.i32") {
+      } else if (functionName == "@dx.op.textureStore.i32" || functionName == "@dx.op.textureStore.i16") {
         //     call void @dx.op.textureStore.i32(i32 67, %dx.types.Handle %1, i32 %12, i32 %13, i32 undef, i32 %1392, i32 %1405, i32 %1392, i32 %1392, i8 15)  ; TextureStore(srv,coord0,coord1,coord2,value0,value1,value2,value3,mask)
         auto [opNumber, uav, coord0, coord1, coord2, value0, value1, value2, value3, mask] = StringViewSplit<10>(functionParamsString, param_regex, 2);
         auto ref_resource = std::string{uav.substr(1)};
@@ -3477,7 +5560,70 @@ class Decompiler {
         }
 
         decompiled = std::format("{}[{}] = {};", uav_name, coords, value);
-      } else if (functionName == "@dx.op.bufferStore.i32") {
+      } else if (functionName == "@dx.op.bufferStore.f32" || functionName == "@dx.op.bufferStore.f16") {
+        // call void @dx.op.bufferStore.f32(i32 69, %dx.types.Handle %593, i32 %584, i32 undef, float %592, float %592, float %592, float %592, i8 15)  ; BufferStore(uav,coord0,coord1,value0,value1,value2,value3,mask)
+
+        auto [opNumber, uav, coord0, coord1, value0, value1, value2, value3, mask] = StringViewSplit<9>(functionParamsString, param_regex, 2);
+        auto ref = std::string{uav.substr(1)};
+        const bool has_coord_y = coord1 != "undef";
+        std::string coords;
+        auto [uav_name, uav_range_index, resource_class] = preprocess_state.resource_binding_variables.at(ref);
+        auto uav_resource = preprocess_state.uav_resources[uav_range_index];
+        // For StructuredBuffer, coord0 is the element index and coord1 is the byte
+        // offset within the struct element. Use only coord0 as the HLSL index.
+        bool is_structured = (uav_resource.shape == Resource::ResourceKind::StructuredBuffer);
+        if (has_coord_y && !is_structured) {
+          coords = std::format("int2({}, {})", ParseInt(coord0), ParseInt(coord1));
+        } else {
+          coords = std::format("{}", ParseInt(coord0));
+        }
+
+        bool has_value_y = value1 != "undef";
+        bool has_value_z = value2 != "undef";
+        bool has_value_w = value3 != "undef";
+
+        if (has_value_w && value3 == value0 && uav_resource.data_type != "float4") {
+          has_value_w = false;
+        }
+        if (has_value_z && value2 == value0 && uav_resource.data_type != "float3") {
+          has_value_z = false;
+        }
+        if (has_value_y && value1 == value0 && uav_resource.data_type != "float2") {
+          has_value_y = false;
+        }
+        std::string value;
+        if (has_value_w) {
+          value = std::format("float4({}, {}, {}, {})", ParseFloat(value0), ParseFloat(value1), ParseFloat(value2), ParseFloat(value3));
+        } else if (has_value_z) {
+          value = std::format("float3({}, {}, {})", ParseFloat(value0), ParseFloat(value1), ParseFloat(value2));
+        } else if (has_value_y) {
+          value = std::format("float2({}, {})", ParseFloat(value0), ParseFloat(value1));
+        } else {
+          value = std::format("{}", ParseFloat(value0));
+        }
+
+        bool is_raw_buffer_f = (uav_resource.shape == Resource::ResourceKind::RawBuffer);
+        if (is_raw_buffer_f) {
+          int component_count = 1;
+          if (has_value_w) component_count = 4;
+          else if (has_value_z) component_count = 3;
+          else if (has_value_y) component_count = 2;
+          std::string store_func = (component_count == 1) ? "Store" :
+                                   std::format("Store{}", component_count);
+          decompiled = std::format("{}.{}({}, asuint({}));",
+                                   uav_name, store_func, coords, value);
+        } else if (is_structured) {
+          // Resolve byte offset to struct field name
+          int byte_offset = 0;
+          if (has_coord_y && coord1 != "undef") {
+            FromStringView(coord1, byte_offset);
+          }
+          std::string field_access = preprocess_state.ResourceFieldNameAtOffset(uav_resource, byte_offset);
+          decompiled = std::format("{}[{}]{} = {};", uav_name, coords, field_access, value);
+        } else {
+          decompiled = std::format("{}[{}] = {};", uav_name, coords, value);
+        }
+      } else if (functionName == "@dx.op.bufferStore.i32" || functionName == "@dx.op.bufferStore.i16") {
         // call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %1, i32 %17, i32 undef, i32 %438, i32 %438, i32 %438, i32 %438, i8 15)  ; BufferStore(uav,coord0,coord1,value0,value1,value2,value3,mask)
 
         auto [opNumber, uav, coord0, coord1, value0, value1, value2, value3, mask] = StringViewSplit<9>(functionParamsString, param_regex, 2);
@@ -3486,7 +5632,10 @@ class Decompiler {
         std::string coords;
         auto [uav_name, uav_range_index, resource_class] = preprocess_state.resource_binding_variables.at(ref);
         auto uav_resource = preprocess_state.uav_resources[uav_range_index];
-        if (has_coord_y) {
+        // For StructuredBuffer, coord0 is the element index and coord1 is the byte
+        // offset within the struct element. Use only coord0 as the HLSL index.
+        bool is_structured = (uav_resource.shape == Resource::ResourceKind::StructuredBuffer);
+        if (has_coord_y && !is_structured) {
           coords = std::format("int2({}, {})", ParseInt(coord0), ParseInt(coord1));
         } else {
           coords = std::format("{}", ParseInt(coord0));
@@ -3516,7 +5665,62 @@ class Decompiler {
           value = std::format("{}", ParseInt(value0));
         }
 
-        decompiled = std::format("{}[{}] = {};", uav_name, coords, value);
+        bool is_raw_buffer_i = (uav_resource.shape == Resource::ResourceKind::RawBuffer);
+        if (is_raw_buffer_i) {
+          int component_count = 1;
+          if (has_value_w) component_count = 4;
+          else if (has_value_z) component_count = 3;
+          else if (has_value_y) component_count = 2;
+          std::string store_func = (component_count == 1) ? "Store" :
+                                   std::format("Store{}", component_count);
+          decompiled = std::format("{}.{}({}, asuint({}));",
+                                   uav_name, store_func, coords, value);
+        } else if (is_structured) {
+          // Resolve byte offset to struct field name
+          int byte_offset = 0;
+          if (has_coord_y && coord1 != "undef") {
+            FromStringView(coord1, byte_offset);
+          }
+          std::string field_access = preprocess_state.ResourceFieldNameAtOffset(uav_resource, byte_offset);
+          decompiled = std::format("{}[{}]{} = {};", uav_name, coords, field_access, value);
+        } else {
+          decompiled = std::format("{}[{}] = {};", uav_name, coords, value);
+        }
+
+      // --- Ray Query void operations (DXR Tier 1.1 inline raytracing) ---
+      } else if (functionName == "@dx.op.rayQuery_TraceRayInline") {
+        // call void @dx.op.rayQuery_TraceRayInline(i32 179, i32 %154, %dx.types.Handle %155, i32 0, i32 128, float %133, float %135, float %137, float %153, float %147, float %148, float %149, float %146)
+        auto [opNumber, rayQueryHandle, accelStruct, rayFlags, instanceMask,
+              originX, originY, originZ, tMin,
+              directionX, directionY, directionZ, tMax] = StringViewSplit<13>(functionParamsString, param_regex, 2);
+        std::string rq_var = std::format("_{}", ParseVariable(rayQueryHandle).substr(1));
+        auto ref_as = std::string{accelStruct.substr(1)};
+        auto [as_name, as_range_index, as_resource_class] = preprocess_state.resource_binding_variables.at(ref_as);
+        // HLSL TraceRayInline takes 4 args: (accelStruct, rayFlags, instanceMask, rayDesc)
+        // Pack origin/tMin/direction/tMax into a RayDesc struct
+        std::string rd_var = std::format("_rd_{}", rq_var);
+        decompiled = std::format("RayDesc {}; {}.Origin = float3({}, {}, {}); {}.TMin = {}; {}.Direction = float3({}, {}, {}); {}.TMax = {}; {}.TraceRayInline({}, {}, {}, {});",
+                                  rd_var,
+                                  rd_var, ParseFloat(originX), ParseFloat(originY), ParseFloat(originZ),
+                                  rd_var, ParseFloat(tMin),
+                                  rd_var, ParseFloat(directionX), ParseFloat(directionY), ParseFloat(directionZ),
+                                  rd_var, ParseFloat(tMax),
+                                  rq_var, as_name, ParseInt(rayFlags), ParseInt(instanceMask), rd_var);
+      } else if (functionName == "@dx.op.rayQuery_CommitNonOpaqueTriangleHit") {
+        // call void @dx.op.rayQuery_CommitNonOpaqueTriangleHit(i32 182, i32 %154)
+        auto [opNumber, rayQueryHandle] = StringViewSplit<2>(functionParamsString, param_regex, 2);
+        std::string rq_var = std::format("_{}", ParseVariable(rayQueryHandle).substr(1));
+        decompiled = std::format("{}.CommitNonOpaqueTriangleHit();", rq_var);
+      } else if (functionName == "@dx.op.rayQuery_CommitProceduralPrimitiveHit") {
+        // call void @dx.op.rayQuery_CommitProceduralPrimitiveHit(i32 183, i32 %handle, float %tHit)
+        auto [opNumber, rayQueryHandle, tHit] = StringViewSplit<3>(functionParamsString, param_regex, 2);
+        std::string rq_var = std::format("_{}", ParseVariable(rayQueryHandle).substr(1));
+        decompiled = std::format("{}.CommitProceduralPrimitiveHit({});", rq_var, ParseFloat(tHit));
+      } else if (functionName == "@dx.op.rayQuery_Abort") {
+        // call void @dx.op.rayQuery_Abort(i32 181, i32 %handle)
+        auto [opNumber, rayQueryHandle] = StringViewSplit<2>(functionParamsString, param_regex, 2);
+        std::string rq_var = std::format("_{}", ParseVariable(rayQueryHandle).substr(1));
+        decompiled = std::format("{}.Abort();", rq_var);
       } else {
         std::cerr << line << "\n";
         std::cerr << "Function name: " << functionName << "\n";
@@ -3535,11 +5739,137 @@ class Decompiler {
     }
 
     void AddCodeStore(std::string_view line, PreprocessState& preprocess_state) {
-      // store float %1358, float* %1369, align 4, !tbaa !26, !alias.scope !30
-      static auto regex = std::regex{R"(^  store \S+ ([^,]+), [^*]+\* %([A-Za-z0-9]+),?.*)"};
-      auto [value, pointer] = StringViewMatch<2>(line, regex);
+      // Handle stores with inline getelementptr to shared memory FIRST (before other regexes):
+      // store i32 %val, i32 addrspace(3)* getelementptr inbounds ([N x type], [N x type] addrspace(3)* @"name", i32 0, i32 INDEX), ...
+      {
+        auto line_str = std::string(line);
+        if (line_str.find("getelementptr inbounds") != std::string::npos
+            && line_str.find("addrspace(3)") != std::string::npos) {
+          // Parse store type and value manually: "  store TYPE VALUE, ..."
+          auto store_start = line_str.find("store ") + 6;  // skip "  store "
+          auto type_end = line_str.find(' ', store_start);
+          auto gep_store_type = line_str.substr(store_start, type_end - store_start);
+          auto value_start = type_end + 1;
+          auto value_end = line_str.find(',', value_start);
+          auto gep_value = line_str.substr(value_start, value_end - value_start);
+          auto at_pos = line_str.find("@\"");
+          auto close_quote = (at_pos != std::string::npos) ? line_str.find("\"", at_pos + 2) : std::string::npos;
+          auto last_i32 = line_str.rfind("i32 ");
+          auto close_paren = (last_i32 != std::string::npos) ? line_str.find(")", last_i32) : std::string::npos;
+          
+          if (!gep_store_type.empty() && !gep_value.empty()
+              && at_pos != std::string::npos && close_quote != std::string::npos
+              && last_i32 != std::string::npos && close_paren != std::string::npos
+              && close_paren > last_i32 + 4) {
+            auto gep_global = line_str.substr(at_pos, close_quote - at_pos + 1);
+            auto index_str = std::string_view(line_str).substr(last_i32 + 4, close_paren - (last_i32 + 4));
+            
+            std::string parsed_pointer;
+            if (auto pair = preprocess_state.global_variables.find(gep_global);
+                pair != preprocess_state.global_variables.end()) {
+              parsed_pointer = pair->second;
+            } else {
+              parsed_pointer = std::format("/* {} */", gep_global);
+            }
+            std::string parsed_value;
+            if (gep_store_type == "i32" || gep_store_type == "i16") {
+              parsed_value = ParseInt(std::string_view(gep_value));
+            } else {
+              parsed_value = ParseFloat(std::string_view(gep_value));
+            }
+            int index = 0;
+            FromStringView(index_str, index);
+            std::string decompiled = std::format("{}[{}] = {};", parsed_pointer, index, parsed_value);
+            this->current_code_block.hlsl_lines.push_back(decompiled);
+            return;
+          }
+        }
+      }
 
-      std::string decompiled = std::format("{} = {};", stored_pointers[pointer], ParseFloat(value));
+      // store float %1358, float* %1369, align 4, !tbaa !26, !alias.scope !30
+      // store i32 %62, i32 addrspace(3)* %ptr, align 4
+      // Pitfall 2/6: Parse the store type to use correct value parser.
+      // Float stores to int groupshared need asuint(); int stores should not use ParseFloat.
+      static auto regex = std::regex{R"(^  store (\S+) ([^,]+), [^*]+\* %([A-Za-z0-9]+),?.*)"};
+      auto [store_type, value, pointer] = StringViewMatch<3>(line, regex);
+
+      // Returns the HLSL reinterpret-cast helper needed when storing `stored_type`
+      // through a pointer whose underlying element type is `element_type`.
+      // Returns empty string when no cast is needed.
+      auto get_reinterpret_for_mismatch = [](std::string_view stored_type, std::string_view element_type) -> std::string {
+        if (element_type.empty() || stored_type == element_type) return "";
+        // float -> integer storage: preserve bits via asuint/asint
+        if (stored_type == "float" || stored_type == "half" || stored_type == "double") {
+          if (element_type == "i32" || element_type == "i16" || element_type == "i64") {
+            return "asuint";
+          }
+        }
+        // integer -> float storage
+        if (stored_type == "i32" || stored_type == "i16" || stored_type == "i64") {
+          if (element_type == "float" || element_type == "half" || element_type == "double") {
+            return "asfloat";
+          }
+        }
+        return "";
+      };
+
+      if (pointer.empty()) {
+        // Handle stores to global/addrspace variables (e.g., shared memory)
+        // store i32 0, i32 addrspace(3)* @"...", align 4
+        // store float %val, float addrspace(3)* @"...", align 4
+        static auto global_regex = std::regex{R"(^  store (\S+) ([^,]+), [^*]+\* (@[^,]+),?.*)"};
+        auto [global_store_type, global_value, global_pointer] = StringViewMatch<3>(line, global_regex);
+        if (!global_pointer.empty()) {
+          std::string parsed_pointer;
+          if (auto pair = preprocess_state.global_variables.find(std::string(global_pointer));
+              pair != preprocess_state.global_variables.end()) {
+            parsed_pointer = pair->second;
+          } else {
+            parsed_pointer = std::format("/* {} */", global_pointer);
+          }
+          // Use type-appropriate parser for the stored value
+          std::string parsed_value;
+          if (global_store_type == "i32" || global_store_type == "i16") {
+            parsed_value = ParseInt(global_value);
+          } else {
+            parsed_value = ParseFloat(global_value);
+          }
+          std::string decompiled = std::format("{} = {};", parsed_pointer, parsed_value);
+#if DECOMPILER_DXC_DEBUG >= 1
+          this->current_code_block.hlsl_lines.push_back(std::format("// {}", StringViewTrim(line)));
+#endif
+          this->current_code_block.hlsl_lines.push_back(decompiled);
+          return;
+        }
+
+        // Unknown store format — skip with comment
+        std::cerr << "WARNING: Unhandled store instruction: " << StringViewTrim(line) << "\n";
+        this->current_code_block.hlsl_lines.push_back(std::format("// UNHANDLED: {}", StringViewTrim(line)));
+        return;
+      }
+
+      // Use type-appropriate parser for the stored value
+      std::string parsed_value;
+      if (store_type == "i32" || store_type == "i16") {
+        parsed_value = ParseInt(value);
+      } else {
+        parsed_value = ParseFloat(value);
+      }
+
+      // If the pointer was reinterpret-bitcast to a different scalar type
+      // (e.g. i32* -> float*), the underlying HLSL array element type still
+      // follows the original declaration. Plain HLSL assignment would
+      // perform a numeric conversion (float -> uint truncation), which is
+      // WRONG when the DXIL intent is a bit-level reinterpret. Emit
+      // asuint()/asfloat() to preserve the raw bits.
+      auto element_type_it = stored_pointer_element_types.find(std::string(pointer));
+      if (element_type_it != stored_pointer_element_types.end()) {
+        std::string cast = get_reinterpret_for_mismatch(store_type, element_type_it->second);
+        if (!cast.empty()) {
+          parsed_value = std::format("{}({})", cast, parsed_value);
+        }
+      }
+      std::string decompiled = std::format("{} = {};", stored_pointers[pointer], parsed_value);
 
 #if DECOMPILER_DXC_DEBUG >= 3
       std::cout << decompiled << "\n";
@@ -3603,6 +5933,11 @@ class Decompiler {
         }
       }
 
+      // Single-pass transitive closure (ascending key order).
+      // Because std::map iterates in ascending order and we modify
+      // in-place, earlier entries expand before later entries read them,
+      // effectively computing a multi-level closure. The post-dominator
+      // validation in the convergence search corrects any over-inclusion.
       for (auto& [line_number, convergence_set] : convergences) {
         const auto temp_convergence_set = convergence_set;
         for (const auto convergence : temp_convergence_set) {
@@ -3616,7 +5951,7 @@ class Decompiler {
       return convergences;
     }
 
-    auto ListRecursions() {
+    auto ListRecursions() const {
       std::map<int, std::set<int>> recursions;
 
       for (const auto& [line_number, code_block] : code_blocks) {
@@ -3644,6 +5979,784 @@ class Decompiler {
 
       return recursions;
     }
+
+    // Compute predecessors for each block
+    auto ComputePredecessors() {
+      std::map<int, std::set<int>> preds;
+      for (const auto& [line_number, code_block] : code_blocks) {
+        if (code_block.code_branch.branch_condition_true > 0) {
+          preds[code_block.code_branch.branch_condition_true].insert(line_number);
+        }
+        if (code_block.code_branch.branch_condition_false > 0) {
+          preds[code_block.code_branch.branch_condition_false].insert(line_number);
+        }
+        if (!code_block.code_switch.switch_condition.empty()) {
+          preds[code_block.code_switch.case_default].insert(line_number);
+          for (const auto& [case_value, case_function] : code_block.code_switch.case_values) {
+            preds[case_function].insert(line_number);
+          }
+        }
+      }
+      return preds;
+    }
+
+    // Compute immediate dominators using iterative dataflow algorithm
+    // Returns map: block -> immediate dominator
+    auto ComputeDominators() {
+      std::map<int, int> idom;
+      auto preds = ComputePredecessors();
+
+      // Get sorted block numbers
+      std::vector<int> block_order;
+      for (const auto& [line_number, _] : code_blocks) {
+        block_order.push_back(line_number);
+      }
+      std::sort(block_order.begin(), block_order.end());
+
+      if (block_order.empty()) return idom;
+
+      int entry = block_order[0];
+      idom[entry] = entry;  // entry dominates itself
+
+      // Intersect function for dominator computation
+      auto intersect = [&](int b1, int b2) -> int {
+        auto finger1 = b1;
+        auto finger2 = b2;
+        while (finger1 != finger2) {
+          while (finger1 > finger2) {
+            finger1 = idom[finger1];
+          }
+          while (finger2 > finger1) {
+            finger2 = idom[finger2];
+          }
+        }
+        return finger1;
+      };
+
+      bool changed = true;
+      while (changed) {
+        changed = false;
+        for (int b : block_order) {
+          if (b == entry) continue;
+          int new_idom = -1;
+          if (preds.contains(b)) {
+            for (int p : preds[b]) {
+              if (!idom.contains(p)) continue;  // not yet processed
+              if (new_idom == -1) {
+                new_idom = p;
+              } else {
+                new_idom = intersect(new_idom, p);
+              }
+            }
+          }
+          if (new_idom != -1 && (!idom.contains(b) || idom[b] != new_idom)) {
+            idom[b] = new_idom;
+            changed = true;
+          }
+        }
+      }
+
+      return idom;
+    }
+
+    // Compute full dominator sets for every block.
+    // Returns map: block -> set of all blocks that dominate it (including itself).
+    auto ListDominators() {
+      std::map<int, std::set<int>> dom_sets;
+      auto idom = ComputeDominators();
+      for (const auto& [block, _] : code_blocks) {
+        std::set<int>& s = dom_sets[block];
+        int cur = block;
+        while (true) {
+          s.insert(cur);
+          if (!idom.contains(cur)) break;
+          int next = idom.at(cur);
+          if (next == cur) break;
+          cur = next;
+        }
+      }
+      return dom_sets;
+    }
+
+    // Check if block 'a' dominates block 'b'
+    static bool Dominates(const std::map<int, int>& idom, int a, int b) {
+      int current = b;
+      while (current != a) {
+        if (!idom.contains(current)) return false;
+        int next = idom.at(current);
+        if (next == current) return false;  // reached entry without finding 'a'
+        current = next;
+      }
+      return true;
+    }
+
+    // Compute successors for each block
+    auto ComputeSuccessors() {
+      std::map<int, std::set<int>> succs;
+      for (const auto& [line_number, code_block] : code_blocks) {
+        if (code_block.code_branch.branch_condition_true > 0) {
+          succs[line_number].insert(code_block.code_branch.branch_condition_true);
+        }
+        if (code_block.code_branch.branch_condition_false > 0) {
+          succs[line_number].insert(code_block.code_branch.branch_condition_false);
+        }
+        if (!code_block.code_switch.switch_condition.empty()) {
+          succs[line_number].insert(code_block.code_switch.case_default);
+          for (const auto& [case_value, case_function] : code_block.code_switch.case_values) {
+            succs[line_number].insert(case_function);
+          }
+        }
+      }
+      return succs;
+    }
+
+    // Compute immediate post-dominators using iterative dataflow on reverse CFG.
+    // Returns map: block -> immediate post-dominator.
+    // loop_back_edges: map of loop_header -> set of back-edge source blocks.
+    // Back edges are removed from the successor graph so that post-dominators
+    // are meaningful inside infinite loops (while(true)).
+    auto ComputePostDominators(const std::map<int, std::set<int>>& loop_back_edges = {}) {
+      std::map<int, int> ipdom;
+      auto succs = ComputeSuccessors();
+
+      // Remove back edges from the successor graph.
+      // A back edge is source -> header where source is in loop_back_edges[header].
+      for (const auto& [header, sources] : loop_back_edges) {
+        for (int src : sources) {
+          if (succs.contains(src)) {
+            succs[src].erase(header);
+          }
+        }
+      }
+
+      std::vector<int> block_order;
+      for (const auto& [line_number, _] : code_blocks) {
+        block_order.push_back(line_number);
+      }
+      std::sort(block_order.begin(), block_order.end());
+
+      if (block_order.empty()) return ipdom;
+
+      // Find exit blocks (blocks with no successors after back-edge removal)
+      std::set<int> exit_blocks;
+      for (int b : block_order) {
+        if (!succs.contains(b) || succs[b].empty()) {
+          exit_blocks.insert(b);
+        }
+      }
+      // If no natural exits, use the last block
+      if (exit_blocks.empty()) {
+        exit_blocks.insert(block_order.back());
+      }
+
+      // Add a virtual exit node that all exit blocks point to
+      int virtual_exit = block_order.back() + 1;
+      ipdom[virtual_exit] = virtual_exit;
+      for (int e : exit_blocks) {
+        ipdom[e] = virtual_exit;
+      }
+
+      // Intersect on reverse post-order (descending block numbers)
+      auto intersect = [&](int b1, int b2) -> int {
+        auto finger1 = b1;
+        auto finger2 = b2;
+        while (finger1 != finger2) {
+          while (finger1 < finger2) {
+            if (!ipdom.contains(finger1)) return -1;
+            finger1 = ipdom[finger1];
+          }
+          while (finger2 < finger1) {
+            if (!ipdom.contains(finger2)) return -1;
+            finger2 = ipdom[finger2];
+          }
+        }
+        return finger1;
+      };
+
+      bool changed = true;
+      while (changed) {
+        changed = false;
+        // Process in ascending order for post-dominators
+        // (reverse post-order of the reverse CFG ≈ ascending block numbers)
+        for (int i = 0; i < static_cast<int>(block_order.size()); i++) {
+          int b = block_order[i];
+          if (exit_blocks.contains(b)) continue;
+          int new_ipdom = -1;
+          if (succs.contains(b)) {
+            for (int s : succs[b]) {
+              if (!ipdom.contains(s)) continue;
+              if (new_ipdom == -1) {
+                new_ipdom = s;
+              } else {
+                new_ipdom = intersect(new_ipdom, s);
+                if (new_ipdom == -1) break;
+              }
+            }
+          }
+          if (new_ipdom != -1 && (!ipdom.contains(b) || ipdom[b] != new_ipdom)) {
+            ipdom[b] = new_ipdom;
+            changed = true;
+          }
+        }
+      }
+
+      // Remove virtual exit from results
+      ipdom.erase(virtual_exit);
+      for (auto& [b, pd] : ipdom) {
+        if (pd == virtual_exit) pd = -1;
+      }
+
+      return ipdom;
+    }
+
+    // Find the nearest common post-dominator of two blocks.
+    static int NearestCommonPostDominator(const std::map<int, int>& ipdom, int a, int b) {
+      // Walk up both post-dominator chains until they meet
+      std::set<int> a_chain;
+      int current = a;
+      while (current != -1) {
+        a_chain.insert(current);
+        if (!ipdom.contains(current)) break;
+        int next = ipdom.at(current);
+        if (next == current) break;
+        current = next;
+      }
+      current = b;
+      while (current != -1) {
+        if (a_chain.contains(current)) return current;
+        if (!ipdom.contains(current)) break;
+        int next = ipdom.at(current);
+        if (next == current) break;
+        current = next;
+      }
+      return -1;
+    }
+
+    // Check if block 'start' can bypass block 'candidate' — i.e., reach a
+    // block after 'candidate' without going through 'candidate'.
+    // Uses the successor graph with back edges removed.
+    // Returns true if 'start' can bypass 'candidate'.
+    bool CanBypass(int start, int candidate,
+                   const std::map<int, std::set<int>>& succs_no_backedge) {
+      if (start == candidate) return false;
+
+      // Find successors of candidate (what's "after" it)
+      std::set<int> after_candidate;
+      if (succs_no_backedge.contains(candidate)) {
+        for (int s : succs_no_backedge.at(candidate)) {
+          after_candidate.insert(s);
+        }
+      }
+      if (after_candidate.empty()) return false;
+
+      // BFS from start, avoiding candidate
+      std::set<int> visited;
+      std::vector<int> queue = {start};
+      while (!queue.empty()) {
+        int node = queue.back();
+        queue.pop_back();
+        if (node == candidate) continue;  // don't go through candidate
+        if (visited.contains(node)) continue;
+        visited.insert(node);
+        if (after_candidate.contains(node)) return true;  // bypassed!
+        if (succs_no_backedge.contains(node)) {
+          for (int s : succs_no_backedge.at(node)) {
+            queue.push_back(s);
+          }
+        }
+      }
+      return false;
+    }
+
+    // Find the convergence point for two branches using BFS on the
+    // back-edge-free CFG. Returns the first block reachable from both
+    // branches, which is the correct convergence point.
+    static int FindPairConvergence(
+        int branch_a, int branch_b,
+        const std::map<int, std::set<int>>& succs_no_backedge) {
+      if (branch_a == branch_b) return branch_a;
+
+      // BFS from both branches simultaneously
+      std::map<int, int> reached_by;  // block -> bitmask (1=a, 2=b, 3=both)
+      std::deque<std::pair<int, int>> queue;  // (block, origin_bit)
+
+      auto enqueue = [&](int block, int origin) {
+        int prev = reached_by.count(block) ? reached_by[block] : 0;
+        if ((prev & origin) == origin) return;  // already reached by this origin
+        reached_by[block] = prev | origin;
+        if (reached_by[block] == 3) return;  // both reached — don't expand further
+        queue.push_back({block, origin});
+      };
+
+      // Helper: check if 'src' can reach 'target' without going through 'avoid'
+      auto can_reach_avoiding = [&](int src, int target, int avoid) -> bool {
+        std::set<int> visited;
+        std::deque<int> q;
+        q.push_back(src);
+        while (!q.empty()) {
+          int n = q.front(); q.pop_front();
+          if (n == target) return true;
+          if (n == avoid || visited.count(n)) continue;
+          visited.insert(n);
+          if (succs_no_backedge.contains(n)) {
+            for (int s : succs_no_backedge.at(n)) {
+              q.push_back(s);
+            }
+          }
+        }
+        return false;
+      };
+
+      enqueue(branch_a, 1);
+      enqueue(branch_b, 2);
+
+      while (!queue.empty()) {
+        auto [node, origin] = queue.front();
+        queue.pop_front();
+        if (succs_no_backedge.contains(node)) {
+          for (int s : succs_no_backedge.at(node)) {
+            enqueue(s, origin);
+            if (reached_by.count(s) && reached_by[s] == 3) {
+              // If the convergence candidate is one of the branch targets,
+              // check if the other branch can bypass it. If so, the candidate
+              // is not a true convergence — one path can skip it entirely.
+              if (s == branch_a && succs_no_backedge.contains(branch_a)) {
+                // Check if branch_b can reach any successor of branch_a
+                // without going through branch_a itself
+                bool can_bypass = false;
+                for (int succ_a : succs_no_backedge.at(branch_a)) {
+                  if (can_reach_avoiding(branch_b, succ_a, branch_a)) {
+                    can_bypass = true;
+                    break;
+                  }
+                }
+                if (can_bypass) continue;  // skip this candidate
+              }
+              if (s == branch_b && succs_no_backedge.contains(branch_b)) {
+                bool can_bypass = false;
+                for (int succ_b : succs_no_backedge.at(branch_b)) {
+                  if (can_reach_avoiding(branch_a, succ_b, branch_b)) {
+                    can_bypass = true;
+                    break;
+                  }
+                }
+                if (can_bypass) continue;
+              }
+              return s;
+            }
+          }
+        }
+      }
+      return -1;
+    }
+
+    // Compute natural loops using dominator info
+    // Only back edges where the header dominates the source form natural loops
+    // Returns: map of loop_header -> set of back-edge source blocks (same format as ListRecursions)
+    auto ListNaturalLoops() {
+      auto idom = ComputeDominators();
+      std::map<int, std::set<int>> natural_loops;
+
+      for (const auto& [line_number, code_block] : code_blocks) {
+        auto check_back_edge = [&](int target) {
+          if (target <= 0 || target > line_number) return;  // not a back edge
+          // It's a back edge: line_number -> target (backward)
+          // Natural loop only if target dominates line_number
+          if (Dominates(idom, target, line_number)) {
+            natural_loops[target].insert(line_number);
+          }
+        };
+
+        if (code_block.code_branch.branch_condition_true != -1) {
+          check_back_edge(code_block.code_branch.branch_condition_true);
+        }
+        if (code_block.code_branch.branch_condition_false != -1) {
+          check_back_edge(code_block.code_branch.branch_condition_false);
+        }
+        if (!code_block.code_switch.switch_condition.empty()) {
+          check_back_edge(code_block.code_switch.case_default);
+          for (const auto& [case_value, case_function] : code_block.code_switch.case_values) {
+            check_back_edge(case_function);
+          }
+        }
+      }
+
+      return natural_loops;
+    }
+
+    // Compute the set of blocks belonging to each natural loop body.
+    // A block is in the loop body if it's on a path from the header to any
+    // back-edge source. Uses the standard reverse-walk algorithm: start from
+    // each back-edge source and walk predecessors until reaching the header.
+    // Returns: map of loop_header -> set of blocks in the loop body (includes header).
+    auto ComputeLoopBodies(const std::map<int, std::set<int>>& natural_loops) {
+      std::map<int, std::set<int>> loop_bodies;
+      auto preds = ComputePredecessors();
+
+      for (const auto& [header, back_edge_sources] : natural_loops) {
+        std::set<int>& body = loop_bodies[header];
+        body.insert(header);
+
+        // Reverse walk from each back-edge source
+        std::vector<int> worklist;
+        for (int src : back_edge_sources) {
+          if (src != header) {
+            body.insert(src);
+            worklist.push_back(src);
+          }
+        }
+
+        while (!worklist.empty()) {
+          int block = worklist.back();
+          worklist.pop_back();
+          if (!preds.contains(block)) continue;
+          for (int pred : preds[block]) {
+            if (!body.contains(pred)) {
+              body.insert(pred);
+              worklist.push_back(pred);
+            }
+          }
+        }
+      }
+
+      return loop_bodies;
+    }
+
+    // ===== Methods needed for --structural code path =====
+
+    std::vector<int> ListSuccessors(const CodeBlock& code_block) const {
+      std::vector<int> successors;
+      if (code_block.code_branch.branch_condition_true != -1) {
+        successors.push_back(code_block.code_branch.branch_condition_true);
+      }
+      if (code_block.code_branch.branch_condition_false != -1) {
+        successors.push_back(code_block.code_branch.branch_condition_false);
+      }
+      if (!code_block.code_switch.switch_condition.empty()) {
+        successors.push_back(code_block.code_switch.case_default);
+        for (const auto& [case_value, case_function] : code_block.code_switch.case_values) {
+          successors.push_back(case_function);
+        }
+      }
+      return successors;
+    }
+
+    std::vector<int> ListNormalizedSuccessors(const CodeBlock& code_block) const {
+      auto successors = ListSuccessors(code_block);
+      std::erase_if(successors, [&](int successor) {
+        return successor < 0 || !code_blocks.contains(successor);
+      });
+      std::ranges::sort(successors);
+      successors.erase(std::unique(successors.begin(), successors.end()), successors.end());
+      return successors;
+    }
+
+    auto ListPredecessorsVec() const {
+      std::map<int, std::vector<int>> predecessors;
+      for (const auto& [line_number, code_block] : code_blocks) {
+        predecessors[line_number];
+      }
+      for (const auto& [line_number, code_block] : code_blocks) {
+        for (const auto successor : ListNormalizedSuccessors(code_block)) {
+          predecessors[successor].push_back(line_number);
+        }
+      }
+      return predecessors;
+    }
+
+    auto ListPostDominators() const {
+      std::map<int, std::set<int>> postdominators;
+      std::set<int> all_blocks;
+      for (const auto& [line_number, code_block] : code_blocks) {
+        all_blocks.emplace(line_number);
+      }
+      for (const auto& [line_number, code_block] : code_blocks) {
+        auto successors = ListNormalizedSuccessors(code_block);
+        if (successors.empty()) {
+          postdominators[line_number] = {line_number};
+        } else {
+          postdominators[line_number] = all_blocks;
+        }
+      }
+      bool changed = true;
+      while (changed) {
+        changed = false;
+        for (const auto& [line_number, code_block] : code_blocks) {
+          auto successors = ListNormalizedSuccessors(code_block);
+          std::set<int> next_postdominators = {line_number};
+          if (!successors.empty()) {
+            auto intersection = postdominators.at(successors.front());
+            for (auto successor_it = successors.begin() + 1; successor_it != successors.end(); ++successor_it) {
+              std::set<int> next_intersection;
+              const auto& successor_postdominators = postdominators.at(*successor_it);
+              std::set_intersection(intersection.begin(), intersection.end(),
+                                    successor_postdominators.begin(), successor_postdominators.end(),
+                                    std::inserter(next_intersection, next_intersection.begin()));
+              intersection = std::move(next_intersection);
+            }
+            next_postdominators.insert(intersection.begin(), intersection.end());
+          }
+          if (next_postdominators != postdominators[line_number]) {
+            postdominators[line_number] = std::move(next_postdominators);
+            changed = true;
+          }
+        }
+      }
+      return postdominators;
+    }
+
+    auto ListImmediatePostDominators(const std::map<int, std::set<int>>& postdominators) const {
+      std::map<int, int> immediate_postdominators;
+      for (const auto& [line_number, dominator_set] : postdominators) {
+        std::vector<int> strict_postdominators;
+        strict_postdominators.reserve(dominator_set.size());
+        for (const auto postdominator : dominator_set) {
+          if (postdominator != line_number) {
+            strict_postdominators.push_back(postdominator);
+          }
+        }
+        for (const auto candidate : strict_postdominators) {
+          const auto& candidate_set = postdominators.at(candidate);
+          bool is_immediate = true;
+          for (const auto other : strict_postdominators) {
+            if (other == candidate) continue;
+            if (!candidate_set.contains(other)) {
+              is_immediate = false;
+              break;
+            }
+          }
+          if (is_immediate) {
+            immediate_postdominators[line_number] = candidate;
+            break;
+          }
+        }
+      }
+      return immediate_postdominators;
+    }
+
+    bool RegionNeedsConvergenceWrapper(
+        int start_line_number,
+        int region_convergence,
+        const std::vector<int>& outer_convergences) const {
+      if (outer_convergences.empty() || start_line_number < 0) {
+        return false;
+      }
+      std::set<int> visited;
+      std::vector<int> pending = {start_line_number};
+      while (!pending.empty()) {
+        int current_line_number = pending.back();
+        pending.pop_back();
+        if (current_line_number == region_convergence) {
+          continue;
+        }
+        if (std::ranges::find(outer_convergences, current_line_number) != outer_convergences.end()) {
+          return true;
+        }
+        if (!visited.emplace(current_line_number).second) {
+          continue;
+        }
+        auto code_block = code_blocks.find(current_line_number);
+        if (code_block == code_blocks.end()) {
+          continue;
+        }
+        for (const auto successor : ListSuccessors(code_block->second)) {
+          if (successor == -1 || successor == region_convergence) {
+            continue;
+          }
+          if (std::ranges::find(outer_convergences, successor) != outer_convergences.end()) {
+            return true;
+          }
+          pending.push_back(successor);
+        }
+      }
+      return false;
+    }
+
+    struct BranchLadderPlan {
+      int root = -1;
+      bool false_chain = false;
+      std::vector<int> blocks;
+      std::vector<int> exits;
+    };
+
+    struct BranchLadderIndex {
+      std::map<int, BranchLadderPlan> ladders;
+      std::unordered_map<int, int> owner;
+    };
+
+    std::optional<BranchLadderPlan> DetectBranchLadder(
+        int root,
+        bool false_chain,
+        const std::map<int, std::vector<int>>& predecessors,
+        const std::map<int, int>& immediate_postdominators) const {
+      auto root_it = code_blocks.find(root);
+      if (root_it == code_blocks.end()) {
+        return std::nullopt;
+      }
+      if (root_it->second.code_branch.branch_condition.empty()) {
+        return std::nullopt;
+      }
+      auto ipdom_it = immediate_postdominators.find(root);
+      if (ipdom_it == immediate_postdominators.end()) {
+        return std::nullopt;
+      }
+      const auto root_ipdom = ipdom_it->second;
+      BranchLadderPlan ladder{.root = root, .false_chain = false_chain};
+      std::set<int> visited;
+      int current = root;
+      while (true) {
+        if (!visited.emplace(current).second) {
+          return std::nullopt;
+        }
+        auto current_it = code_blocks.find(current);
+        if (current_it == code_blocks.end()) {
+          return std::nullopt;
+        }
+        const auto& code_block = current_it->second;
+        if (code_block.code_branch.branch_condition.empty()) {
+          return std::nullopt;
+        }
+        ladder.blocks.push_back(current);
+        int chain_target = false_chain ? code_block.code_branch.branch_condition_false : code_block.code_branch.branch_condition_true;
+        int side_target = false_chain ? code_block.code_branch.branch_condition_true : code_block.code_branch.branch_condition_false;
+        ladder.exits.push_back(side_target);
+        auto next_it = code_blocks.find(chain_target);
+        if (next_it == code_blocks.end() || next_it->second.code_branch.branch_condition.empty()) {
+          ladder.exits.push_back(chain_target);
+          break;
+        }
+        auto predecessor_it = predecessors.find(chain_target);
+        if (predecessor_it == predecessors.end() || predecessor_it->second.size() != 1) {
+          ladder.exits.push_back(chain_target);
+          break;
+        }
+        auto next_ipdom_it = immediate_postdominators.find(chain_target);
+        if (next_ipdom_it == immediate_postdominators.end() || next_ipdom_it->second != root_ipdom) {
+          ladder.exits.push_back(chain_target);
+          break;
+        }
+        current = chain_target;
+      }
+      if (ladder.blocks.size() < 3) {
+        return std::nullopt;
+      }
+      return ladder;
+    }
+
+    BranchLadderIndex BuildBranchLadderIndex(
+        const std::map<int, std::vector<int>>& predecessors,
+        const std::map<int, int>& immediate_postdominators) const {
+      BranchLadderIndex index;
+      for (const auto& [line_number, code_block] : code_blocks) {
+        if (index.owner.contains(line_number) || code_block.code_branch.branch_condition.empty()) {
+          continue;
+        }
+        auto false_ladder = DetectBranchLadder(line_number, true, predecessors, immediate_postdominators);
+        auto true_ladder = DetectBranchLadder(line_number, false, predecessors, immediate_postdominators);
+        auto chosen = [&]() -> std::optional<BranchLadderPlan> {
+          if (false_ladder.has_value() && true_ladder.has_value()) {
+            return false_ladder->blocks.size() >= true_ladder->blocks.size() ? false_ladder : true_ladder;
+          }
+          if (false_ladder.has_value()) return false_ladder;
+          if (true_ladder.has_value()) return true_ladder;
+          return std::nullopt;
+        }();
+        if (!chosen.has_value()) {
+          continue;
+        }
+        bool overlaps = false;
+        for (const auto block : chosen->blocks) {
+          if (index.owner.contains(block)) {
+            overlaps = true;
+            break;
+          }
+        }
+        if (overlaps) {
+          continue;
+        }
+        index.ladders.emplace(line_number, *chosen);
+        for (const auto block : chosen->blocks) {
+          index.owner.emplace(block, line_number);
+        }
+      }
+      return index;
+    }
+
+    struct BranchStructurePlan {
+      std::string shape;
+      int convergence = -1;
+      int then_target = -1;
+      int else_target = -1;
+      size_t test_count = 0;
+      size_t else_if_count = 0;
+      size_t arm_count = 0;
+      bool has_else = false;
+      std::set<int> exits;
+    };
+
+    std::optional<BranchStructurePlan> AnalyzeBranchStructure(
+        int line_number,
+        const std::map<int, int>& immediate_postdominators,
+        const BranchLadderIndex& ladder_index) const {
+      auto code_block_it = code_blocks.find(line_number);
+      if (code_block_it == code_blocks.end()) {
+        return std::nullopt;
+      }
+      const auto& code_block = code_block_it->second;
+      if (code_block.code_branch.branch_condition.empty()) {
+        return std::nullopt;
+      }
+      BranchStructurePlan plan;
+      if (auto ipdom_it = immediate_postdominators.find(line_number);
+          ipdom_it != immediate_postdominators.end()) {
+        plan.convergence = ipdom_it->second;
+      }
+      if (auto ladder_it = ladder_index.ladders.find(line_number);
+          ladder_it != ladder_index.ladders.end()) {
+        const auto& ladder = ladder_it->second;
+        std::set<int> member_blocks(ladder.blocks.begin(), ladder.blocks.end());
+        for (const auto block : ladder.blocks) {
+          for (const auto successor : ListNormalizedSuccessors(code_blocks.at(block))) {
+            if (!member_blocks.contains(successor)) {
+              plan.exits.emplace(successor);
+            }
+          }
+        }
+        plan.shape = "if-ladder";
+        plan.test_count = ladder.blocks.size();
+        plan.else_if_count = plan.test_count > 0 ? plan.test_count - 1 : 0;
+        plan.arm_count = plan.test_count;
+        if (!ladder.exits.empty()) {
+          auto final_exit = ladder.exits.back();
+          if (final_exit > 0 && final_exit != plan.convergence) {
+            plan.has_else = true;
+            ++plan.arm_count;
+          }
+        }
+        return plan;
+      }
+      plan.then_target = code_block.code_branch.branch_condition_true;
+      plan.else_target = code_block.code_branch.branch_condition_false;
+      if (plan.then_target == plan.convergence && plan.else_target == plan.convergence) {
+        plan.shape = "if";
+        plan.test_count = 1;
+        plan.arm_count = 0;
+        return plan;
+      }
+      if (plan.then_target == plan.convergence || plan.else_target == plan.convergence) {
+        plan.shape = "if";
+        plan.test_count = 1;
+        plan.arm_count = 1;
+        return plan;
+      }
+      plan.shape = "if/else";
+      plan.test_count = 1;
+      plan.arm_count = 2;
+      plan.has_else = true;
+      return plan;
+    }
+
+#include "shader_decompiler/mermaid.hpp"
   };
 
   PreprocessState preprocess_state;
@@ -3673,20 +6786,31 @@ class Decompiler {
       std::span<SignatureProperty> src_property,
       std::vector<Signature>& destination) {
     destination.clear();
-    for (const auto property : src_property) {
-      SignaturePacked packed;
+    // DXIL inputSigId/outputSigId indexes by property order, not packed order.
+    // Iterate property entries and find the matching packed entry for each.
+    for (const auto& property : src_property) {
+      SignaturePacked best_packed;
       bool found = false;
-      for (const auto candidate_packed : src_packed) {
-        if (candidate_packed.name != property.name) continue;
-        if (candidate_packed.index != property.index) continue;
-        destination.emplace_back(candidate_packed, property);
-        found = true;
-        break;
+      for (const auto& packed : src_packed) {
+        if (packed.name != property.name) continue;
+        if (packed.index == property.index) {
+          // Exact match
+          best_packed = packed;
+          found = true;
+          break;
+        }
+        if (packed.index >= property.index) {
+          // Array match — this property covers a range of packed indices
+          if (!found || packed.index < best_packed.index) {
+            best_packed = packed;
+            found = true;
+          }
+        }
       }
-
       if (!found) {
-        throw std::runtime_error(std::format("Could not find packed signature: {}", property.ToString()));
+        throw std::runtime_error(std::format("Could not find packed signature for property: {} index {}", property.name, property.index));
       }
+      destination.emplace_back(best_packed, property);
     }
   }
 
@@ -3720,14 +6844,58 @@ class Decompiler {
   struct DecompileOptions {
     bool flatten = false;
     bool use_do_while = false;
+    bool stackify = false;
+    bool structural = false;  // ShortFuse-style structural analysis
+    bool mermaid = false;     // Output Mermaid flowchart instead of HLSL
+    bool annotate = false;    // Emit developer-friendly annotation comments
+    bool annotate_mermaid = false;  // Emit full graph IR dump (nodes, edges, phi assignments)
+    bool mermaid_decompile = false;  // Mermaid-based region decompilation strategy
+    bool no_single_use_inline = false;  // Disable single-use variable inlining (keeps expressions readable and matches original DXIL SSA structure)
   };
 
-  std::string Decompile(std::string_view disassembly, const DecompileOptions& decompile_options = {
+  std::string Decompile(std::string_view disassembly, DecompileOptions decompile_options = {
                                                           .flatten = false,
                                                           .use_do_while = false,
+                                                          .stackify = false,
+                                                          .structural = false,
+                                                          .mermaid = false,
+                                                          .annotate = false,
+                                                          .annotate_mermaid = false,
+                                                          .mermaid_decompile = false,
+                                                          .no_single_use_inline = false,
                                                       }) {
     Init();
+    // --structural implies --use-do-while for convergence wrappers and --flatten
+    if (decompile_options.structural) {
+      decompile_options.use_do_while = true;
+      decompile_options.flatten = true;
+    }
+    // --mermaid-decompile implies --flatten for OptimizeString (lerp/pow patterns)
+    // but NOT single-use variable inlining, which conflicts with region functions
+    // (inlined variables become unavailable across function boundaries).
+    if (decompile_options.mermaid_decompile) {
+      decompile_options.flatten = true;
+    }
+    // --annotate-mermaid implies --annotate (block annotations are a superset)
+    if (decompile_options.annotate_mermaid) {
+      decompile_options.annotate = true;
+    }
     this->source_lines = StringViewSplitAll(disassembly, '\n');
+
+    // Pre-scan: identify handle variables that are used with dynamic cbuffer access
+    // This is needed because extractvalue on a static cbuffer load may appear before
+    // the dynamic load that marks the cbuffer as needing raw access
+    {
+      static auto dynamic_cbuf_regex = std::regex(
+          R"(call %dx\.types\.CBufRet\.\w+ @dx\.op\.cbufferLoadLegacy\.\w+\(i32 \d+, %dx\.types\.Handle (%\d+), i32 %)"
+      );
+      for (const auto& src_line : this->source_lines) {
+        std::match_results<std::string_view::const_iterator> match;
+        if (std::regex_search(src_line.begin(), src_line.end(), match, dynamic_cbuf_regex)) {
+          preprocess_state.cbv_handles_with_dynamic_access.insert(match[1].str());
+        }
+      }
+    }
 
     const std::string_view line;
     while (state != TokenizerState::COMPLETE) {
@@ -4038,32 +7206,43 @@ class Decompiler {
             // @"\01?shPixelsY@@3PAY0CG@$$CAMA.1dim" = addrspace(3) global [1444 x float] undef, align 4
             // @"\01?pixelOffsets@?1??DirectionalObscuranceCommon@@YA?AUSSDOOutput@@USSAOParams@@@Z@3QBV?$vector@M$01@@B.v.1dim" = internal constant [8 x float] [float -1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float 1.000000e+00, float -1.000000e+00, float -1.000000e+00, float -1.000000e+00], align 4
 
-            static auto regex = std::regex{R"(^(\S+) = (?:(internal|external) )?(?:(unnamed_addr|addrspace\(\d+\)) )?(constant|global) (?:\[(\S+) x ([^\]]+)\]|(\S+))(?:,|(?: \[([^\]]+)\])| undef).*)"};
+            static auto regex = std::regex{R"(^(\S+) = (?:(internal|external) )?(?:unnamed_addr )?(?:(addrspace\(\d+\)) )?(constant|global) (?:\[(\S+) x ([^\]]+)\]|(\S+))(?:,| \S+,| \S+$|(?: \[([^\]]+)\])| undef| zeroinitializer).*)"};
             auto [variable_name, scope, addr, qualifier, array_size, array_type, value_type, entries] = StringViewMatch<8>(line, regex);
 
             std::string output_name = std::format("_global_{}", preprocess_state.global_variables.size());
 
             std::stringstream decompiled;
 
-            if (scope == "internal") {
+            bool has_addrspace3 = (addr == "addrspace(3)");
+            if (scope == "internal" && !has_addrspace3) {
               decompiled << "static const ";
-            } else if (scope == "external" || scope == "") {
+            } else if (scope == "external" || scope == "" || has_addrspace3) {
               decompiled << "groupshared ";
             } else {
               throw std::runtime_error("Unknown global variable scope.");
             }
+            bool is_groupshared = (scope == "external" || scope == "" || has_addrspace3);
             if (!array_type.empty()) {
-              decompiled << array_type << " ";
+              // Pitfall 3: Use uint for i32 groupshared arrays so InterlockedAdd
+              // and other atomic intrinsics get a valid l-value of the correct type.
+              // Keep int for static const arrays (they don't need atomic access).
+              auto hlsl_array_type = (array_type == "i32") ? (is_groupshared ? std::string_view("uint") : std::string_view("int"))
+                                   : (array_type == "i16") ? std::string_view("int16_t")
+                                   : array_type;
+              decompiled << hlsl_array_type << " ";
               decompiled << output_name;
               decompiled << "[" << array_size << "]";
             } else {
-              decompiled << value_type << " ";
+              auto hlsl_value_type = (value_type == "i32") ? (is_groupshared ? std::string_view("uint") : std::string_view("int"))
+                                   : (value_type == "i16") ? std::string_view("int16_t")
+                                   : value_type;
+              decompiled << hlsl_value_type << " ";
               decompiled << output_name;
             }
             if (entries.empty()) {
               decompiled << ";";
             } else {
-              auto values = StringViewSplitAll(entries, std::regex{R"((\s*(\S+) (\S+)),?)"}, {2, 3});
+              auto values = StringViewSplitAll(entries, std::regex{R"((\s*(\S+) ([^\s,]+)),?)"}, {2, 3});
               decompiled << " = { ";
 
               int array_size_number;
@@ -4073,6 +7252,12 @@ class Decompiler {
                   decompiled << ParseSuffixedString(values[i].second, 'f');
                 } else if (array_type == "half") {
                   decompiled << ParseSuffixedString(values[i].second, 'h');
+                } else if (array_type == "i32") {
+                  decompiled << std::string(values[i].second);
+                } else if (array_type == "i16") {
+                  decompiled << std::string(values[i].second);
+                } else {
+                  decompiled << std::string(values[i].second);
                 }
                 if (i != array_size_number - 1) {
                   decompiled << ", ";
@@ -4231,13 +7416,270 @@ class Decompiler {
       }
     }
 
+    // Apply cbuffer packing rules to CBV types without annotation data.
+    // This must happen after resources are parsed (metadata) but before DecompileLines.
+    preprocess_state.ApplyCBufferPacking();
+
+    // Pitfall 11: Pre-detect cbuffers with half/min16float fields and mark them for
+    // raw uint4 array access. This must happen before DecompileLines() so the extractvalue
+    // handlers use asfloat/asint on the raw array instead of named field access.
+    {
+      std::function<bool(std::string_view)> type_uses_native_16bit = [&](std::string_view raw_type_name) -> bool {
+        DataType info(raw_type_name);
+        if (info.data_type == "half") return true;
+        if (auto nested = preprocess_state.type_definitions.find(info.data_type);
+            nested != preprocess_state.type_definitions.end()) {
+          return std::ranges::any_of(nested->second.variables, [&](const auto& variable) {
+            return type_uses_native_16bit(variable.type);
+          });
+        }
+        return false;
+      };
+      for (size_t cbv_idx = 0; cbv_idx < preprocess_state.cbv_resources.size(); ++cbv_idx) {
+        const auto& cbv_resource = preprocess_state.cbv_resources[cbv_idx];
+        auto type_name = cbv_resource.pointer.substr(0, cbv_resource.pointer.length() - 1);
+        auto def_it = preprocess_state.type_definitions.find(type_name);
+        if (def_it != preprocess_state.type_definitions.end()) {
+          const auto& definition = def_it->second;
+          // Note: 16-bit fields (half/min16float) are handled normally with packoffset.
+          // The decompiler always compiles with -enable-16bit-types, so layout is consistent.
+        }
+      }
+    }
+
     // Decompilation also notes
+
+    // Pre-pass: resolve cbufferLoad extractvalues that may be used before their
+    // defining block is processed (forward references in block-number order).
+    // This ensures ParseVariable() can resolve them regardless of processing order.
+    // Store pre-pass aliases separately so they can be seeded into replacement functions.
+    std::map<std::string, std::pair<std::string, std::string>> cbuffer_prepass_aliases;
+    {
+      static const auto create_handle_regex = std::regex(
+          R"(^\s+%(\d+) = call %dx\.types\.Handle @dx\.op\.createHandle\(i32 \d+, i8 2, i32 (\d+), i32 (\d+), i1 (?:true|false)\))");
+      static const auto cbuf_load_regex = std::regex(
+          R"(^\s+%(\d+) = call %dx\.types\.CBufRet\.(f32|i32) @dx\.op\.cbufferLoadLegacy\.\w+\(i32 \d+, %dx\.types\.Handle %(\d+), i32 (\d+)\))");
+      static const auto extractvalue_regex = std::regex(
+          R"(^\s+%(\d+) = extractvalue %dx\.types\.CBufRet\.(f32|i32) %(\d+), (\d+))");
+
+      // First: find createHandle calls for CBVs (resourceClass=2)
+      std::map<std::string, std::pair<uint32_t, uint32_t>> cbv_handles;  // handle_var -> (range_index, register_bind)
+      for (const auto& src_line : current_code_function->lines) {
+        std::match_results<std::string_view::const_iterator> m;
+        if (std::regex_search(src_line.begin(), src_line.end(), m, create_handle_regex)) {
+          std::string handle_var = m[1].str();
+          uint32_t range_id = 0, bind_index = 0;
+          FromStringView(std::string_view(m[2].str()), range_id);
+          FromStringView(std::string_view(m[3].str()), bind_index);
+          cbv_handles[handle_var] = {range_id, bind_index};
+        }
+      }
+
+      // Second: find cbufferLoadLegacy calls with static register index
+      std::map<std::string, std::tuple<uint32_t, uint32_t, std::string>> cbuf_load_map;  // var -> (range_index, regIndex, binding_name)
+      for (const auto& src_line : current_code_function->lines) {
+        std::match_results<std::string_view::const_iterator> m;
+        if (std::regex_search(src_line.begin(), src_line.end(), m, cbuf_load_regex)) {
+          std::string var = m[1].str();
+          std::string handle_ref = m[3].str();
+          uint32_t reg_index = 0;
+          FromStringView(std::string_view(m[4].str()), reg_index);
+
+          auto handle_it = cbv_handles.find(handle_ref);
+          if (handle_it == cbv_handles.end()) continue;
+          auto [range_index, bind_index] = handle_it->second;
+          if (range_index >= preprocess_state.cbv_resources.size()) continue;
+
+          // Skip if this cbuffer handle has dynamic access (uses raw array style)
+          if (preprocess_state.cbv_handles_with_dynamic_access.contains(std::format("%{}", handle_ref))) continue;
+          if (preprocess_state.cbv_dynamic_access_indices.count(range_index)) continue;
+
+          auto& cbv_resource = preprocess_state.cbv_resources[range_index];
+          cbuf_load_map[var] = {range_index, reg_index, cbv_resource.name};
+        }
+      }
+
+      // Third: resolve extractvalues from those cbufferLoads
+      for (const auto& src_line : current_code_function->lines) {
+        std::match_results<std::string_view::const_iterator> m;
+        if (std::regex_search(src_line.begin(), src_line.end(), m, extractvalue_regex)) {
+          std::string var = m[1].str();
+          std::string ret_type = m[2].str();
+          std::string source_var = m[3].str();
+          uint32_t component_index = 0;
+          FromStringView(std::string_view(m[4].str()), component_index);
+
+          auto cbuf_it = cbuf_load_map.find(source_var);
+          if (cbuf_it == cbuf_load_map.end()) continue;
+
+          auto& [range_index, reg_index, binding_name] = cbuf_it->second;
+          auto& cbv_resource = preprocess_state.cbv_resources[range_index];
+
+          std::string assignment_type;
+          std::string assignment_value;
+
+          if (ret_type == "f32") {
+            assignment_type = "float";
+            auto value_from_reflection = preprocess_state.ResourceVariableNameAtIndex(cbv_resource, (reg_index * 16) + (component_index * 4));
+            if (value_from_reflection.empty()) {
+              char sub_index = VECTOR_INDEXES[component_index];
+              std::string suffix = std::format("{:03}{}", reg_index, sub_index);
+              assignment_value = std::format("{}_{}", binding_name, suffix);
+            } else {
+              if (cbv_resource.array_size.has_value()) {
+                assignment_value = std::format("{}.{}", binding_name, value_from_reflection);
+              } else {
+                assignment_value = value_from_reflection;
+              }
+            }
+          } else if (ret_type == "i32") {
+            assignment_type = "int";
+            auto value_from_reflection = preprocess_state.ResourceVariableNameAtIndex(cbv_resource, (reg_index * 16) + (component_index * 4));
+            if (value_from_reflection.empty()) {
+              char sub_index = VECTOR_INDEXES[component_index];
+              std::string suffix = std::format("{:03}{}", reg_index, sub_index);
+              assignment_value = std::format("{}_{}", binding_name, suffix);
+            } else {
+              if (cbv_resource.array_size.has_value()) {
+                assignment_value = std::format("{}.{}", binding_name, value_from_reflection);
+              } else {
+                assignment_value = value_from_reflection;
+              }
+            }
+          }
+
+          if (!assignment_value.empty()) {
+            cbuffer_prepass_aliases.emplace(var, std::pair<std::string, std::string>(assignment_type, assignment_value));
+          }
+        }
+      }
+
+      // Seed the pre-pass aliases into the current code function
+      for (const auto& [key, value] : cbuffer_prepass_aliases) {
+        current_code_function->variable_aliases.emplace(key, value);
+      }
+    }
+
     current_code_function->DecompileLines(preprocess_state);
 
     if (decompile_options.flatten) {
-      for (const auto& [variable, count] : current_code_function->variable_counter) {
-        if (count == 1) {
-          current_code_function->single_use_variables.insert(variable);
+      // Single-use variable inlining: replace variables used only once with
+      // their defining expression. This is critical for preventing DXC from
+      // merging paths at multi-way convergence points — when phi assignments
+      // reference the same SSA variable from different predecessors, inlining
+      // expands them to different expressions that DXC can't prove equivalent.
+      if (!decompile_options.no_single_use_inline) {
+      {
+        // Propagate use counts through identity aliases. When an identity alias
+        // (e.g., extractvalue _460 = _459.x) is used multiple times, the source
+        // variable (_459) should NOT be considered single-use, because inlining
+        // it would duplicate the source expression (e.g., a SampleLevel call)
+        // at each use site. DXC cannot always CSE these duplicates back together,
+        // especially when they appear in short-circuit conditions vs else branches.
+        std::map<uint32_t, uint32_t> propagated_counter = current_code_function->variable_counter;
+        for (const auto& [alias_var_str, alias_pair] : current_code_function->variable_aliases) {
+          // Parse the alias variable number
+          uint32_t alias_var_num;
+          if (alias_var_str.empty() || !std::all_of(alias_var_str.begin(), alias_var_str.end(),
+                  [](char c) { return c >= '0' && c <= '9'; })) {
+            continue;
+          }
+          FromStringView(alias_var_str, alias_var_num);
+          // Get the alias's use count
+          auto alias_count_it = propagated_counter.find(alias_var_num);
+          if (alias_count_it == propagated_counter.end() || alias_count_it->second <= 1) {
+            continue;  // alias is single-use or unused, no propagation needed
+          }
+          // Find the source variable referenced in the alias expression.
+          // Identity aliases have the form "_SOURCE.component" or "(type)(_SOURCE)"
+          const auto& alias_expr = alias_pair.second;
+          // Look for _N pattern (variable reference) in the alias expression
+          static const auto SOURCE_VAR_REGEX = std::regex(R"(^_(\d+)\.)");
+          std::smatch match;
+          if (std::regex_search(alias_expr, match, SOURCE_VAR_REGEX)) {
+            uint32_t source_var_num;
+            FromStringView(std::string_view(match[1].first, match[1].second), source_var_num);
+            // Propagate: source gets additional uses from the alias (minus the 1 already counted)
+            propagated_counter[source_var_num] += (alias_count_it->second - 1);
+          }
+        }
+        for (const auto& [variable, count] : propagated_counter) {
+          if (count == 1) {
+            current_code_function->single_use_variables.insert(variable);
+          }
+        }
+
+        // Exclude variables that are forward-referenced (used in a block before their
+        // definition block). Inlining these would produce undeclared identifiers because
+        // the definition hasn't been processed when the use-site is emitted.
+        {
+          // Build a map: variable_number -> definition_block_number
+          std::map<uint32_t, int> var_definition_block;
+          // Build a map: variable_number -> earliest_use_block_number
+          std::map<uint32_t, int> var_earliest_use_block;
+
+          static const auto def_regex = std::regex(R"(^\s+%(\d+)\s*=)");
+          static const auto use_regex = std::regex(R"(%(\d+))");
+
+          int current_block = 0;
+          static const auto block_label_regex = std::regex(R"(^; <label>:(\d+))");
+          for (const auto& src_line : current_code_function->lines) {
+            std::match_results<std::string_view::const_iterator> bm;
+            if (std::regex_search(src_line.begin(), src_line.end(), bm, block_label_regex)) {
+              FromStringView(std::string_view(bm[1].first, bm[1].second), current_block);
+              continue;
+            }
+            // Check for definition
+            std::match_results<std::string_view::const_iterator> dm;
+            if (std::regex_search(src_line.begin(), src_line.end(), dm, def_regex)) {
+              uint32_t var_num = 0;
+              FromStringView(std::string_view(dm[1].first, dm[1].second), var_num);
+              var_definition_block.try_emplace(var_num, current_block);
+              // Also scan RHS for uses
+              auto rhs_start = dm[0].second;
+              auto search_start = rhs_start;
+              std::match_results<std::string_view::const_iterator> um;
+              while (std::regex_search(search_start, src_line.end(), um, use_regex)) {
+                uint32_t use_var = 0;
+                FromStringView(std::string_view(um[1].first, um[1].second), use_var);
+                if (use_var != var_num) {
+                  auto it = var_earliest_use_block.find(use_var);
+                  if (it == var_earliest_use_block.end() || current_block < it->second) {
+                    var_earliest_use_block[use_var] = current_block;
+                  }
+                }
+                search_start = um[0].second;
+              }
+            } else {
+              // Non-definition line — all %N references are uses
+              auto search_start = src_line.begin();
+              std::match_results<std::string_view::const_iterator> um;
+              while (std::regex_search(search_start, src_line.end(), um, use_regex)) {
+                uint32_t use_var = 0;
+                FromStringView(std::string_view(um[1].first, um[1].second), use_var);
+                auto it = var_earliest_use_block.find(use_var);
+                if (it == var_earliest_use_block.end() || current_block < it->second) {
+                  var_earliest_use_block[use_var] = current_block;
+                }
+                search_start = um[0].second;
+              }
+            }
+          }
+
+          // Remove forward-referenced variables from single_use_variables
+          std::vector<uint32_t> to_remove;
+          for (uint32_t var : current_code_function->single_use_variables) {
+            auto def_it = var_definition_block.find(var);
+            auto use_it = var_earliest_use_block.find(var);
+            if (def_it != var_definition_block.end() && use_it != var_earliest_use_block.end()) {
+              if (use_it->second < def_it->second) {
+                to_remove.push_back(var);
+              }
+            }
+          }
+          for (uint32_t var : to_remove) {
+            current_code_function->single_use_variables.erase(var);
+          }
         }
       }
       if (!current_code_function->single_use_variables.empty()) {
@@ -4249,6 +7691,10 @@ class Decompiler {
         replacement_code_function.lines = current_code_function->lines;
         replacement_code_function.single_use_variables = current_code_function->single_use_variables;
         replacement_code_function.phi_variables = current_code_function->phi_variables;
+        // Seed cbuffer pre-pass aliases so forward-referenced cbuffer loads resolve correctly
+        for (const auto& [key, value] : cbuffer_prepass_aliases) {
+          replacement_code_function.variable_aliases.emplace(key, value);
+        }
         replacement_code_function.DecompileLines(preprocess_state);
         *current_code_function = replacement_code_function;
 
@@ -4282,6 +7728,40 @@ class Decompiler {
         };
 #endif
       }
+      }  // end of if (!no_single_use_inline)
+    }
+
+    // Mermaid diagram output — returns a flowchart instead of HLSL
+    if (decompile_options.mermaid) {
+      std::stringstream string_stream;
+      string_stream << "```mermaid\n";
+      string_stream << "%%{init: {'theme': 'base', 'themeVariables': {"
+                    << "'background': '#111827', "
+                    << "'mainBkg': '#111827', "
+                    << "'clusterBkg': '#111827', "
+                    << "'tertiaryColor': '#111827', "
+                    << "'lineColor': '#64748b', "
+                    << "'textColor': '#f8fafc', "
+                    << "'primaryTextColor': '#f8fafc'"
+                    << "}}}%%\n";
+      string_stream << "flowchart TD\n";
+      string_stream << "  classDef entry fill:#0f2233,stroke:#63b3ed,stroke-width:2px,color:#ebf8ff;\n";
+      string_stream << "  classDef branch fill:#1f2937,stroke:#94a3b8,stroke-width:1px,color:#f8fafc;\n";
+      string_stream << "  classDef join fill:#0f2a1f,stroke:#68d391,stroke-width:2px,color:#f0fff4;\n";
+      string_stream << "  classDef loop fill:#24163a,stroke:#b794f4,stroke-width:2px,color:#faf5ff;\n";
+      string_stream << "  classDef planentry fill:#0f2233,stroke:#63b3ed,stroke-width:2px,color:#ebf8ff;\n";
+      string_stream << "  classDef planbranch fill:#1f2937,stroke:#94a3b8,stroke-width:1px,color:#f8fafc;\n";
+      string_stream << "  classDef planjoin fill:#0f2a1f,stroke:#68d391,stroke-width:2px,color:#f0fff4;\n";
+      string_stream << "  classDef planloop fill:#24163a,stroke:#b794f4,stroke-width:2px,color:#faf5ff;\n";
+      string_stream << "  classDef planladder fill:#341326,stroke:#f687b3,stroke-width:2px,color:#fff5f7;\n";
+      string_stream << "  classDef planseq fill:#1a202c,stroke:#a0aec0,stroke-width:1px,color:#edf2f7;\n";
+      string_stream << "  classDef planexit fill:#3b1014,stroke:#fc8181,stroke-width:2px,color:#fff5f5;\n";
+      string_stream << "  classDef hidden fill:transparent,stroke:transparent,color:transparent;\n";
+      for (size_t function_index = 0; function_index < code_functions.size(); ++function_index) {
+        string_stream << code_functions[function_index].BuildMermaid(std::format("fn{}", function_index));
+      }
+      string_stream << "```\n";
+      return string_stream.str();
     }
 
     // Generate output
@@ -4312,17 +7792,17 @@ class Decompiler {
       if (added_definitions.contains(std::string(definition_name))) return;
       auto& definition = preprocess_state.type_definitions[definition_name];
 
-      static const std::regex STRUCT_PATTERN = std::regex(R"(%(?:hostlayout\.)?(?:struct\.)(.*))");
+      static const std::regex STRUCT_PATTERN = std::regex(R"xx(%"?(?:hostlayout\.)?(?:struct\.)?([^"]*)"?)xx");
       auto [struct_name] = StringViewMatch<1>(definition_name, STRUCT_PATTERN);
 
       if (struct_name.empty()) return;
       if (struct_name == "SamplerState") return;
+      if (struct_name == "ByteAddressBuffer") return;
 
       for (const auto& [declaration, name, type_name, optional_offset] : definition.variables) {
         // Check for nested structs
         DataType info(type_name);
-        static const std::regex STRUCT_PATTERN = std::regex(R"(%(?:hostlayout\.)(?:struct\.)(.*))");
-        auto [struct_name] = StringViewMatch<1>(info.data_type, STRUCT_PATTERN);
+        static const std::regex NESTED_STRUCT_PATTERN = std::regex(R"xx(%"?(?:hostlayout\.)?(?:struct\.)([^"]*)"?)xx");        auto [struct_name] = StringViewMatch<1>(info.data_type, NESTED_STRUCT_PATTERN);
         if (struct_name.empty()) continue;
 
         if (!added_definitions.contains(std::string(info.data_type))) {
@@ -4330,26 +7810,66 @@ class Decompiler {
         }
       }
 
-      string_stream << spacing << "struct " << struct_name << " {\n";
+      // Sanitize struct name for HLSL (replace <, >, spaces with underscores)
+      std::string sanitized_name(struct_name);
+      std::ranges::replace(sanitized_name, '<', '_');
+      std::ranges::replace(sanitized_name, '>', '_');
+      std::ranges::replace(sanitized_name, ' ', '_');
+      string_stream << spacing << "struct " << sanitized_name << " {\n";
       indent_spacing();
       for (const auto& [declaration, name, type_name, optional_offset] : definition.variables) {
         DataType info(type_name);
 
-        static const std::regex TYPE_NAME_PATTERN = std::regex(R"(%?(host)?(?:layout\.)?(struct\.)?(.*))");
+        static const std::regex TYPE_NAME_PATTERN = std::regex(R"xx(%?"?(host)?(?:layout\.)?(struct\.)?([^"]*)"?)xx");
         auto [is_host, is_struct, type_name_parsed] = StringViewMatch<3>(info.data_type, TYPE_NAME_PATTERN);
 
         assert(!type_name_parsed.empty());
 
         if (is_host.empty() && !is_struct.empty()) {
-          declare_definition(info.data_type, name);
-        } else {
-          if (declaration.starts_with("uint")) {
-            // use uint from declaration
-            assert(info.data_type == "int" || info.data_type == "uint");
-            string_stream << spacing << "uint";
+          // Sanitize struct name for HLSL
+          std::string sanitized_type(type_name_parsed);
+          std::ranges::replace(sanitized_type, '<', '_');
+          std::ranges::replace(sanitized_type, '>', '_');
+          std::ranges::replace(sanitized_type, ' ', '_');
+          if (added_definitions.contains(std::string(info.data_type))) {
+            // Struct already declared — emit as field reference
+            string_stream << spacing << sanitized_type << " " << name;
           } else {
-            string_stream << spacing << type_name_parsed;
+            declare_definition(info.data_type, name);
           }
+        } else {
+          // Determine the HLSL type name
+          std::string hlsl_type;
+          if (declaration.starts_with("uint")) {
+            assert(info.data_type == "int" || info.data_type == "uint" || info.data_type == "i16");
+            if (info.data_type == "i16") {
+              hlsl_type = "uint16_t";
+            } else {
+              hlsl_type = "uint";
+            }
+          } else if (info.data_type.starts_with("%class.matrix.") || std::string_view(type_name_parsed).starts_with("class.matrix.")) {
+            // Matrix type: class.matrix.{base}.{rows}.{cols}
+            static const std::regex MATRIX_PATTERN(R"((?:%)?class\.matrix\.([^.]+)\.(\d+)\.(\d+))");
+            auto [base_type, rows_str, cols_str] = StringViewMatch<3>(info.data_type, MATRIX_PATTERN);
+            if (!base_type.empty()) {
+              // Always emit row_major for struct fields because the decompiler's
+              // register-based cbuffer access assumes row-major layout.
+              hlsl_type = std::format("row_major {}{}x{}", base_type, rows_str, cols_str);
+            } else {
+              hlsl_type = std::string(type_name_parsed);
+            }
+          } else if (info.data_type == "i16" || type_name_parsed == "i16") {
+            hlsl_type = "int16_t";
+          } else if (info.data_type == "i32" || type_name_parsed == "i32") {
+            hlsl_type = "int";
+          } else if (info.data_type == "i64" || type_name_parsed == "i64") {
+            hlsl_type = "int64_t";
+          } else if (info.data_type == "f16" || type_name_parsed == "f16") {
+            hlsl_type = "half";
+          } else {
+            hlsl_type = std::string(type_name_parsed);
+          }
+          string_stream << spacing << hlsl_type;
           if (info.vector_size != 0) {
             string_stream << info.vector_size;
           }
@@ -4373,10 +7893,14 @@ class Decompiler {
     };
 
     for (auto& [name, definition] : preprocess_state.type_definitions) {
-      static const std::regex STRUCT_PATTERN = std::regex(R"(%(?:hostlayout\.)(?:struct\.)(.*))");
+      static const std::regex STRUCT_PATTERN = std::regex(R"(%(?:hostlayout\.)?(?:struct\.)(.*))");
       auto [struct_name] = StringViewMatch<1>(name, STRUCT_PATTERN);
       if (struct_name.empty()) continue;
       if (struct_name == "SamplerState") continue;
+      if (struct_name == "SamplerComparisonState") continue;
+      if (struct_name == "ByteAddressBuffer") continue;
+      if (struct_name == "RWByteAddressBuffer") continue;
+      if (struct_name == "RaytracingAccelerationStructure") continue;
 
       if (!added_definitions.contains(std::string(name))) {
         declare_definition(name, "");
@@ -4388,28 +7912,44 @@ class Decompiler {
     }
 
     for (const auto& srv_resource : preprocess_state.srv_resources) {
-      auto pair = preprocess_state.type_definitions.find(srv_resource.data_type);
-      if (pair != preprocess_state.type_definitions.end()) {
-        auto& resource_type_definition = pair->second;
+      // Skip struct definition for RaytracingAccelerationStructure — it's a built-in HLSL type
+      if (srv_resource.shape == SRVResource::ResourceKind::RTAccelerationStructure
+          || srv_resource.pointer == "%struct.RaytracingAccelerationStructure*") {
+        // Just emit the declaration, no struct needed
+      } else {
+        auto pair = preprocess_state.type_definitions.find(srv_resource.data_type);
+        if (pair != preprocess_state.type_definitions.end()) {
+          auto& resource_type_definition = pair->second;
 
-        if (resource_type_definition.name.starts_with("%\"class.StructuredBuffer<")) {
-          auto struct_pair = preprocess_state.type_definitions.find(resource_type_definition.variables[0].type);
-          if (struct_pair != preprocess_state.type_definitions.end()) {
-            resource_type_definition = struct_pair->second;
+          if (resource_type_definition.name.starts_with("%\"class.StructuredBuffer<")) {
+            auto struct_pair = preprocess_state.type_definitions.find(resource_type_definition.variables[0].type);
+            if (struct_pair != preprocess_state.type_definitions.end()) {
+              resource_type_definition = struct_pair->second;
+            }
           }
-        }
-        if (srv_resource.shape == SRVResource::ResourceKind::StructuredBuffer) {
-          declare_definition(resource_type_definition.name, "");
+          if (srv_resource.shape == SRVResource::ResourceKind::StructuredBuffer) {
+            declare_definition(resource_type_definition.name, "");
+          }
         }
       }
 
       static const std::regex TYPE_NAME_PATTERN = std::regex(R"(%?(?:host)?(?:layout\.)?(?:struct\.)?(.*))");
-      auto [type_name_parsed] = StringViewMatch<1>(srv_resource.data_type, TYPE_NAME_PATTERN);
-      assert(!type_name_parsed.empty());
 
-      string_stream << SRVResource::ResourceKindString(srv_resource.shape);
+      if (Resource::IsByteAddressBufferPointer(srv_resource.pointer)) {
+        string_stream << "ByteAddressBuffer";
+      } else if (srv_resource.shape == SRVResource::ResourceKind::RTAccelerationStructure
+                 || srv_resource.pointer == "%struct.RaytracingAccelerationStructure*") {
+        string_stream << "RaytracingAccelerationStructure";
+      } else {
+        auto [type_name_parsed] = StringViewMatch<1>(srv_resource.data_type, TYPE_NAME_PATTERN);
+        assert(!type_name_parsed.empty());
 
-      string_stream << "<" << type_name_parsed << ">";
+        string_stream << SRVResource::ResourceKindString(srv_resource.shape);
+
+        if (srv_resource.shape != SRVResource::ResourceKind::RawBuffer) {
+          string_stream << "<" << type_name_parsed << ">";
+        }
+      }
 
       string_stream << " " << srv_resource.name;
       if (srv_resource.array_size.has_value()) {
@@ -4429,16 +7969,37 @@ class Decompiler {
     // UAV
 
     for (const auto& uav_resource : preprocess_state.uav_resources) {
-      string_stream << "RW" << UAVResource::ResourceKindString(uav_resource.shape);
-      if (uav_resource.element_type != SRVResource::ComponentType::Invalid) {
-        static const std::regex TYPE_NAME_PATTERN = std::regex(R"(%?(?:host)?(?:layout\.)?(?:struct\.)?(.*))");
-        auto [type_name_parsed] = StringViewMatch<1>(uav_resource.data_type, TYPE_NAME_PATTERN);
-
-        assert(!type_name_parsed.empty());
-
-        string_stream << "<" << type_name_parsed << ">";
+      if (Resource::IsRWByteAddressBufferPointer(uav_resource.pointer)) {
+        string_stream << "RWByteAddressBuffer";
       } else {
-        string_stream << "< (" << uav_resource.stride << " bytes) >";
+        string_stream << "RW" << UAVResource::ResourceKindString(uav_resource.shape);
+      }
+      if (uav_resource.shape == UAVResource::ResourceKind::RawBuffer) {
+        // RWByteAddressBuffer has no template parameter
+      } else if (!uav_resource.data_type.empty()
+                 && (uav_resource.data_type != "uint4"
+                     || uav_resource.shape == UAVResource::ResourceKind::Texture2D
+                     || uav_resource.shape == UAVResource::ResourceKind::Texture2DArray
+                     || uav_resource.shape == UAVResource::ResourceKind::Texture3D
+                     || uav_resource.shape == UAVResource::ResourceKind::Texture1D
+                     || uav_resource.shape == UAVResource::ResourceKind::Texture1DArray
+                     || uav_resource.shape == UAVResource::ResourceKind::TextureCube
+                     || uav_resource.shape == UAVResource::ResourceKind::TextureCubeArray)) {
+        static const std::regex TYPE_NAME_PATTERN = std::regex(R"(%?(?:host)?(?:layout\.)?(?:struct\.)?(.*))");
+        std::string_view type_to_parse = uav_resource.data_type;
+        // Strip leading underscore from struct name references
+        if (type_to_parse.starts_with("_")) type_to_parse = type_to_parse.substr(1);
+        auto [type_name_parsed] = StringViewMatch<1>(type_to_parse, TYPE_NAME_PATTERN);
+
+        if (!type_name_parsed.empty()) {
+          string_stream << "<" << type_name_parsed << ">";
+        } else {
+          string_stream << "<" << type_to_parse << ">";
+        }
+      } else if (uav_resource.element_type != SRVResource::ComponentType::Invalid) {
+        string_stream << "<" << SRVResource::ComponentTypeString(uav_resource.element_type) << ">";
+      } else {
+        string_stream << "<uint4>";
       }
 
       string_stream << " " << uav_resource.name;
@@ -4458,15 +8019,72 @@ class Decompiler {
 
     // CBV
 
-    for (const auto& cbv_resource : preprocess_state.cbv_resources) {
-      string_stream << "cbuffer " << cbv_resource.name;
+    for (size_t cbv_idx = 0; cbv_idx < preprocess_state.cbv_resources.size(); ++cbv_idx) {
+      const auto& cbv_resource = preprocess_state.cbv_resources[cbv_idx];
+
+      // For cbuffers with dynamic access, emit as float4 array only
+      if (preprocess_state.cbv_dynamic_access_indices.count(static_cast<uint32_t>(cbv_idx))) {
+        uint32_t num_float4s = static_cast<uint32_t>(ceil(static_cast<float>(cbv_resource.buffer_size) / 16.f));
+        string_stream << "cbuffer " << cbv_resource.name << " : register(b" << cbv_resource.signature_index;
+        if (cbv_resource.space != 0u) {
+          string_stream << ", space" << cbv_resource.space;
+        }
+        string_stream << ") {\n";
+        string_stream << "  uint4 " << cbv_resource.name << "_raw[" << num_float4s << "];\n";
+        string_stream << "};\n\n";
+        continue;
+      }
+
+      // Array cbuffers (including unbounded) must use ConstantBuffer<Type> syntax
       if (cbv_resource.array_size.has_value()) {
-        string_stream << "[";
-        if (cbv_resource.array_size != 0) {
+        auto type_name = cbv_resource.pointer.substr(0, cbv_resource.pointer.length() - 1);
+        // Strip array wrapper: [N x %type] -> %type
+        static auto array_inner_regex = std::regex{R"(^\[\d+ x (.+)\]$)"};
+        auto [inner_type] = StringViewMatch<1>(type_name, array_inner_regex);
+        std::string_view lookup_type = inner_type.empty() ? type_name : inner_type;
+
+        // Find or declare the struct type
+        auto def_it = preprocess_state.type_definitions.find(lookup_type);
+        if (def_it != preprocess_state.type_definitions.end()) {
+          auto& definition = def_it->second;
+          // Declare the inner struct if it has reflected fields
+          if (definition.has_offsets) {
+            static const std::regex STRUCT_PATTERN = std::regex(R"(%(?:hostlayout\.)?(?:struct\.)?(.+))");
+            auto [struct_type_name] = StringViewMatch<1>(lookup_type, STRUCT_PATTERN);
+            if (!struct_type_name.empty() && !added_definitions.contains(std::string(lookup_type))) {
+              declare_definition(lookup_type, "");
+            }
+            // Check for name collision: if the struct type name equals the variable name,
+            // the ConstantBuffer<Type> Type[] declaration creates an ambiguous reference.
+            // Fix by appending _t to the struct type name in the template parameter.
+            // The struct declaration was already emitted by declare_definition above,
+            // so we also need to emit a typedef alias.
+            std::string cb_type_str = struct_type_name.empty() ? std::string(lookup_type) : std::string(struct_type_name);
+            if (cb_type_str == cbv_resource.name) {
+              std::string renamed = cb_type_str + "_t";
+              string_stream << "typedef " << cb_type_str << " " << renamed << ";\n";
+              cb_type_str = renamed;
+            }
+            string_stream << "ConstantBuffer<" << cb_type_str << "> " << cbv_resource.name << "[";
+          } else {
+            // Fallback: emit as float4 array
+            string_stream << "ConstantBuffer<float4> " << cbv_resource.name << "[";
+          }
+        } else {
+          string_stream << "ConstantBuffer<float4> " << cbv_resource.name << "[";
+        }
+        if (cbv_resource.array_size.value() != 0 && cbv_resource.array_size.value() != 0xFFFFFFFF) {
           string_stream << cbv_resource.array_size.value();
         }
-        string_stream << "]";
+        string_stream << "] : register(b" << cbv_resource.signature_index;
+        if (cbv_resource.space != 0u) {
+          string_stream << ", space" << cbv_resource.space;
+        }
+        string_stream << ");\n\n";
+        continue;
       }
+
+      string_stream << "cbuffer " << cbv_resource.name;
       string_stream << " : register(b" << cbv_resource.signature_index;
       if (cbv_resource.space != 0u) {
         string_stream << ", space" << cbv_resource.space;
@@ -4480,30 +8098,84 @@ class Decompiler {
       indent_spacing();
 
       bool use_cbuffer_float4 = false;
+
+      // Detect if any field uses native 16-bit types (half) — packoffset is not valid for these
+      std::function<bool(std::string_view)> type_uses_native_16bit = [&](std::string_view raw_type_name) -> bool {
+        DataType info(raw_type_name);
+        if (info.data_type == "half") return true;
+        if (auto nested = preprocess_state.type_definitions.find(info.data_type);
+            nested != preprocess_state.type_definitions.end()) {
+          return std::ranges::any_of(nested->second.variables, [&](const auto& variable) {
+            return type_uses_native_16bit(variable.type);
+          });
+        }
+        return false;
+      };
+      bool has_16bit_fields = definition.has_offsets && std::ranges::any_of(definition.variables, [&](const auto& variable) {
+        return type_uses_native_16bit(variable.type);
+      });
+
+      // 16-bit fields (half/min16float) are emitted as named fields with packoffset.
+      // The decompiler always compiles with -enable-16bit-types, so layout is consistent.
+
       if (use_cbuffer_float4) {
         string_stream << "  float4 " << cbv_resource.name;
         string_stream << "[" << ceil(static_cast<float>(cbv_resource.buffer_size) / 16.f) << "] : packoffset(c0);\n";
-      } else if (definition.size == cbv_resource.buffer_size || definition.has_offsets) {
+      } else if (definition.has_offsets || cbv_resource.buffer_size == definition.size) {
+        int padding_counter = 0;
         for (const auto& [declaration, name, type_name, optional_offset] : definition.variables) {
           DataType info(type_name);
-          assert(!name.empty());
 
-          if (type_name.starts_with("%class")) {
-            // known classes
-            if (type_name.starts_with("%class.matrix")) {
-              static const std::regex PATTERN = std::regex(R"(%class\.matrix\.([^.]+)\.(\d+)\.(\d+))");
-              auto [base_type, array_string, vector_string] = StringViewMatch<3>(type_name, PATTERN);
+          // Fields with no name are padding or unused — emit a placeholder
+          if (name.empty()) {
+            auto item_offset = offset;
+            if (optional_offset.has_value()) {
+              item_offset = optional_offset.value();
+              offset = item_offset;
+            }
+            auto field_size = preprocess_state.GetTypeSize(info);
+            // Emit padding as int (4 bytes per component)
+            uint32_t padding_components = static_cast<uint32_t>(field_size / 4);
+            if (padding_components == 0) padding_components = 1;
+            std::string padding_type = (padding_components > 1) ? std::format("int{}", padding_components) : "int";
+            string_stream << spacing << padding_type << " _padding_" << padding_counter++;
+            if (!has_16bit_fields) {
+              string_stream << std::format(" : packoffset(c{:03}.{})", item_offset / 16, VECTOR_INDEXES[item_offset % 16 / 4]);
+            }
+            string_stream << ";\n";
+            offset += static_cast<int>(field_size);
+            continue;
+          }
+
+          if (type_name.starts_with("%class") || info.data_type.starts_with("class.matrix.") || info.data_type.starts_with("%class.matrix.")) {
+            // known classes — handle both direct (%class.matrix...) and array ([N x %class.matrix...]) types
+            static const std::regex PATTERN = std::regex(R"((?:%)?class\.matrix\.([^.]+)\.(\d+)\.(\d+))");
+            auto [base_type, array_string, vector_string] = StringViewMatch<3>(info.data_type, PATTERN);
+            if (!base_type.empty()) {
               uint32_t array;
               FromStringView(array_string, array);
               uint32_t vector;
               FromStringView(vector_string, vector);
+              // Always emit row_major because the decompiler's register-based
+              // access pattern assumes row-major layout (mat[N] = reg base+N).
               string_stream << spacing << std::format("row_major {}{}x{} {}", base_type, array, vector, name);
             }
-          } else if (info.data_type == "float" || info.data_type == "uint" || info.data_type == "int") {
+          } else if (info.data_type == "float" || info.data_type == "uint" || info.data_type == "int"
+                     || info.data_type == "half" || info.data_type == "bool"
+                     || info.data_type == "double" || info.data_type == "i16"
+                     || info.data_type == "int16_t" || info.data_type == "uint16_t"
+                     || info.data_type == "int64_t" || info.data_type == "uint64_t"
+                     || info.data_type == "i64") {
             if (declaration.starts_with("uint")) {
               // use uint from declaration
               assert(info.data_type == "int" || info.data_type == "uint");
               string_stream << spacing << "uint";
+            } else if (info.data_type == "half") {
+              // half is not valid in cbuffer with packoffset — use min16float
+              string_stream << spacing << "min16float";
+            } else if (info.data_type == "i64") {
+              // i64 is LLVM IR type — emit as int64_t for HLSL
+              string_stream << spacing << "int64_t";
             } else {
               string_stream << spacing << info.data_type;
             }
@@ -4513,7 +8185,13 @@ class Decompiler {
             string_stream << " " << name;
 
           } else if (info.data_type.starts_with("%struct.")) {
-            declare_definition(info.data_type, name);
+            if (added_definitions.contains(std::string(info.data_type))) {
+              // Struct already declared — just reference it by name
+              auto struct_type_name = std::string(info.data_type.substr(8));  // strip "%struct."
+              string_stream << spacing << struct_type_name << " " << name;
+            } else {
+              declare_definition(info.data_type, name);
+            }
 
           } else if (info.data_type.starts_with("%hostlayout.struct.")) {
             // host struct
@@ -4525,6 +8203,13 @@ class Decompiler {
             static const std::regex PATTERN = std::regex(R"(%\"[^"]*\")");
             auto [struct_name] = StringViewMatch<1>(type_name, PATTERN);
             string_stream << spacing << struct_name << " " << name;
+          } else if (info.data_type.starts_with("%")) {
+            // Bare struct reference — emit type name directly
+            static const std::regex BARE_TYPE_PATTERN = std::regex(R"(%(?:hostlayout\.)?(?:struct\.)?(.+))");
+            auto [bare_name] = StringViewMatch<1>(info.data_type, BARE_TYPE_PATTERN);
+            if (!bare_name.empty()) {
+              string_stream << spacing << bare_name << " " << name;
+            }
           } else {
             assert(false);
           }
@@ -4538,7 +8223,11 @@ class Decompiler {
             item_offset = optional_offset.value();
             offset = item_offset;
           }
-          string_stream << std::format(" : packoffset(c{:03}.{});\n", item_offset / 16, VECTOR_INDEXES[item_offset % 16 / 4], item_offset);
+          if (has_16bit_fields) {
+            string_stream << ";\n";
+          } else {
+            string_stream << std::format(" : packoffset(c{:03}.{});\n", item_offset / 16, VECTOR_INDEXES[item_offset % 16 / 4], item_offset);
+          }
           offset += preprocess_state.GetTypeSize(info);
         }
       } else {
@@ -4562,12 +8251,21 @@ class Decompiler {
           auto marker = suffix.length() - 1;
           string_stream << " : packoffset(c" << std::format("{}.{}", suffix.substr(0, marker), suffix.substr(marker)) << ");\n";
         }
+        if (sorted.empty()) {
+          // No resolved fields — emit float4 array as fallback
+          uint32_t num_float4s = static_cast<uint32_t>(ceil(static_cast<float>(cbv_resource.buffer_size) / 16.f));
+          string_stream << "  float4 " << cbv_resource.name << "_data[" << num_float4s << "];\n";
+        }
       }
       unindent_spacing();
       // string_stream << "  } " << cbv_resource.name << " : packoffset(c0);\n";
 
       string_stream << "};\n\n";
     }
+
+    // Emit raw float4 array views for cbuffers with dynamic access
+    // (These are emitted inside the cbuffer block via packoffset overlap — no separate declaration needed)
+    // Dynamic access uses the _raw array which overlaps the named fields at packoffset(c0)
 
     // sampler
     for (const auto& sampler_resource : preprocess_state.sampler_resources) {
@@ -4587,6 +8285,12 @@ class Decompiler {
       string_stream << ");\n\n";
     }
 
+    // Helper for DXIL FirstbitHi — returns bit position from MSB (count of leading zeros)
+    // Unlike HLSL firstbithigh() which returns position from LSB
+    string_stream << "// DXIL FirstbitHi: returns bit position counting from MSB (leading zeros count)\n";
+    string_stream << "uint firstbithigh_msb(int value) { return (value == 0) ? 0xFFFFFFFF : (31u - firstbithigh(value)); }\n";
+    string_stream << "uint firstbithigh_msb(uint value) { return (value == 0) ? 0xFFFFFFFF : (31u - firstbithigh(value)); }\n\n";
+
     // for (const auto binding : preprocess_state.resource_bindings) {
     //   if (binding.type == ResourceDescription::ResourceType::CBUFFER) {
     //     string_stream << "cbuffer " << binding.NameString() << " : ";
@@ -4601,9 +8305,66 @@ class Decompiler {
     std::vector<int> pending_convergences = {};
     std::vector<std::set<int>> pending_recursions = {};
     std::vector<int> current_loops = {};
+    int loop_escape_counter = 0;
+    std::vector<std::string> loop_escape_flags = {};
+    std::vector<std::string> loop_exit_flags = {};  // separate flag for convergence-exit (exits loop without continue)
+    std::set<int> loops_needing_exit_flag;  // loop headers that need the exit flag
+    int do_while_depth = 0;
+    std::vector<int> loop_do_while_depth = {};  // do_while_depth when each while(true) opened
+    std::set<int> phi_predeclared_blocks;  // blocks whose phi vars were pre-declared for convergence
+    std::set<std::string> declared_vars;  // variables already declared (for convergence scope hoisting)
+    std::vector<std::string> convergence_bypass_flags = {};
+    std::vector<int> convergence_bypass_targets = {};
+    // Deferred branch targets — upstream mechanism. When a block is reached
+    // from multiple paths inside a convergence region, we defer it: emit a
+    // bool flag, set it to true on each reaching path, and process the block
+    // once after the convergence via `if (flag) { ... }`.
+    std::vector<std::pair<int, std::string>> deferred_branch_targets;
 
     auto convergences = current_code_function->ListConvergences();
-    auto recursions = current_code_function->ListRecursions();
+    auto recursions = current_code_function->ListNaturalLoops();
+    auto ipdom = current_code_function->ComputePostDominators(recursions);
+    auto loop_bodies = current_code_function->ComputeLoopBodies(recursions);
+    auto dominators = current_code_function->ListDominators();
+    auto predecessors = current_code_function->ComputePredecessors();
+
+    // Pre-compute which loops need a separate exit flag. A loop needs it if
+    // any block inside the loop body can branch to the loop's exit block
+    // (ipdom of back-edge source) and that exit block is a convergence target.
+    for (const auto& [header, back_edge_sources] : recursions) {
+      for (int src : back_edge_sources) {
+        if (!ipdom.contains(src)) continue;
+        int exit_block = ipdom.at(src);
+        // Check if any block in the loop body branches to the exit block
+        if (loop_bodies.contains(header)) {
+          const auto& body = loop_bodies.at(header);
+          auto& succs = current_code_function->code_blocks;
+          for (int blk : body) {
+            if (!succs.contains(blk)) continue;
+            auto& cb = succs.at(blk);
+            if (cb.code_branch.branch_condition_true == exit_block
+                || cb.code_branch.branch_condition_false == exit_block) {
+              // This block branches to the exit — and it's not the latch itself
+              if (blk != src) {
+                loops_needing_exit_flag.insert(header);
+                break;
+              }
+            }
+          }
+          if (loops_needing_exit_flag.contains(header)) break;
+        }
+      }
+    }
+
+    // Build successor graph with back edges removed for bypass detection.
+    auto succs_no_backedge = current_code_function->ComputeSuccessors();
+    for (const auto& [header, sources] : recursions) {
+      for (int src : sources) {
+        if (succs_no_backedge.contains(src)) {
+          succs_no_backedge[src].erase(header);
+        }
+      }
+    }
 
 #if DECOMPILER_DXC_DEBUG >= 2
     for (const auto& [a, b] : convergences) {
@@ -4641,9 +8402,21 @@ class Decompiler {
       if (using_recursion) {
         pending_recursions.push_back(recursions[line_number]);
         current_loops.push_back(line_number);
+        if (decompile_options.use_do_while) {
+          auto flag_name = std::format("_loop_break_{}", loop_escape_counter);
+          auto exit_flag_name = std::format("_loop_exit_{}", loop_escape_counter);
+          loop_escape_counter++;
+          loop_escape_flags.push_back(flag_name);
+          bool needs_exit = loops_needing_exit_flag.contains(line_number);
+          loop_exit_flags.push_back(needs_exit ? exit_flag_name : "");
+          loop_do_while_depth.push_back(do_while_depth);
+          string_stream << spacing << "bool " << flag_name << " = false;\n";
+          if (needs_exit) {
+            string_stream << spacing << "bool " << exit_flag_name << " = false;\n";
+          }
+        }
         string_stream << spacing << "while(true) {\n";
         indent_spacing();
-        // break at these
       }
 
       auto on_complete = [&]() {
@@ -4653,6 +8426,38 @@ class Decompiler {
           string_stream << spacing << "}\n";
           pending_recursions.pop_back();
           current_loops.pop_back();
+          if (decompile_options.use_do_while) {
+            loop_escape_flags.pop_back();
+            loop_exit_flags.pop_back();
+            loop_do_while_depth.pop_back();
+            if (!loop_escape_flags.empty()) {
+              auto& parent_flag = loop_escape_flags.back();
+              std::string outer_guard;
+              for (int i = static_cast<int>(loop_escape_flags.size()) - 2; i >= 0; i--) {
+                if (!outer_guard.empty()) outer_guard += " && ";
+                outer_guard += "!" + loop_escape_flags[i];
+              }
+              // Check if we're inside a do-while(false) that's between us and
+              // the parent while(true) loop. If so, 'continue' would target
+              // the do-while, not the parent while(true).
+              int parent_dw_depth = loop_do_while_depth.back();
+              bool inside_intermediate_do_while = (do_while_depth > parent_dw_depth);
+              if (inside_intermediate_do_while) {
+                // Emit break to propagate through the do-while, keeping flag set
+                if (outer_guard.empty()) {
+                  string_stream << spacing << "if (" << parent_flag << ") break;\n";
+                } else {
+                  string_stream << spacing << "if (" << parent_flag << " && " << outer_guard << ") break;\n";
+                }
+              } else {
+                if (outer_guard.empty()) {
+                  string_stream << spacing << "if (" << parent_flag << ") { " << parent_flag << " = false; continue; }\n";
+                } else {
+                  string_stream << spacing << "if (" << parent_flag << " && " << outer_guard << ") { " << parent_flag << " = false; continue; }\n";
+                }
+              }
+            }
+          }
         }
       };
 
@@ -4675,17 +8480,31 @@ class Decompiler {
 #if DECOMPILER_DXC_DEBUG >= 2
           string_stream << spacing << "// optimized: " << hlsl_line << "\n";
 #endif
-          string_stream << spacing << optimized_line << "\n";
-        } else {
-          string_stream << spacing << hlsl_line << "\n";
         }
+        auto& emit_line = (optimized_line != hlsl_line) ? optimized_line : hlsl_line;
+        // Check if this is a variable declaration that was already declared
+        // (from convergence scope hoisting). If so, strip the type prefix.
+        std::string final_line = emit_line;
+        static const std::regex decl_re(R"(^(float4|float3|float2|float|int64_t|uint64_t|int16_t|uint16_t|int|uint|bool|uint4|int4|int2|uint2|int3|uint3|double|half|min16float|min16int|min16uint)\s+(_\d+)\s*=)");
+        std::smatch m;
+        if (std::regex_search(final_line, m, decl_re)) {
+          std::string var_name = m[2].str();
+          if (declared_vars.contains(var_name)) {
+            // Already pre-declared at convergence scope — emit as assignment only
+            final_line = var_name + " =" + m.suffix().str();
+          }
+        }
+        string_stream << spacing << final_line << "\n";
       }
       for (const auto& [variable, type, value, predecessor, code_function, is_assign] : code_block.phi_lines) {
         auto assignment_type = ParseType(type);
         std::string phi_line;
         if (is_assign) continue;
+        // Skip if already pre-declared (convergence or function-level)
+        auto var_name = std::format("_{}", variable);
+        if (phi_predeclared_blocks.contains(line_number) || declared_vars.contains(var_name)) continue;
         // Declare variable now
-        phi_line = std::format("{} _{};", assignment_type, variable);
+        phi_line = std::format("{} {};", assignment_type, var_name);
         string_stream << spacing << phi_line << "\n";
       }
 
@@ -4694,6 +8513,11 @@ class Decompiler {
       if (code_block.code_branch.branch_condition_true <= 0 && code_block.code_switch.switch_condition.empty()) {
         return;
       }
+
+      // Wrap branch condition in opaque function to prevent DXC from proving
+      // it's constant and eliminating code paths (and their resource accesses)
+      auto branch_cond = code_block.code_branch.branch_condition;
+      auto branch_cond_neg = branch_cond.empty() ? std::string("") : std::string("!") + ParseWrapped(branch_cond);
 
       int next_convergence = pending_convergences.empty() ? -1 : pending_convergences.rbegin()[0];
 
@@ -4741,7 +8565,32 @@ class Decompiler {
           }
         }
         if (current_loop == branch_number) {
-          string_stream << spacing << "continue;\n";  // go back
+          if (decompile_options.use_do_while && do_while_depth > 0) {
+            // Inside a do { } while(false) — continue would target the do-while.
+            // Use loop escape flag + break to propagate through the do-while.
+            for (size_t i = 0; i < current_loops.size(); i++) {
+              if (current_loops[i] == branch_number) {
+                string_stream << spacing << loop_escape_flags[i] << " = true;\n";
+                string_stream << spacing << "break;\n";
+                break;
+              }
+            }
+          } else {
+            string_stream << spacing << "continue;\n";
+          }
+        } else if (std::ranges::find(current_loops, branch_number) != current_loops.end()) {
+          // Branch targets an outer natural loop header
+          if (decompile_options.use_do_while && current_loop != -1) {
+            for (size_t i = 0; i < current_loops.size(); i++) {
+              if (current_loops[i] == branch_number) {
+                string_stream << spacing << loop_escape_flags[i] << " = true;\n";
+                string_stream << spacing << "break;\n";
+                break;
+              }
+            }
+          } else {
+            string_stream << spacing << "continue;\n";
+          }
         } else if (next_convergence == branch_number) {
 #if DECOMPILER_DXC_DEBUG >= 1
           string_stream << spacing << "// fn:converge " << line_number << " => " << next_convergence << "\n";
@@ -4749,10 +8598,88 @@ class Decompiler {
           // noop
         } else if (std::ranges::find(pending_convergences, branch_number) != pending_convergences.end()) {
           if (decompile_options.use_do_while) {
+            // When a convergence break targets the loop exit block and we're
+            // inside a do-while nested within the while(true), the plain `break`
+            // only exits the do-while. We need an exit flag so the while(true)
+            // also exits (without triggering the loop-continue handler).
+            // The loop exit block is identified as the post-dominator of any
+            // back-edge source — i.e., where control goes when the latch
+            // doesn't loop back.
+            if (current_loop != -1 && !loop_do_while_depth.empty()) {
+              int current_loop_dw_depth = loop_do_while_depth.back();
+              if (do_while_depth > current_loop_dw_depth && !pending_recursions.empty()) {
+                const auto& back_edge_sources = pending_recursions.back();
+                bool is_loop_exit = false;
+                for (int src : back_edge_sources) {
+                  if (ipdom.contains(src) && ipdom.at(src) == branch_number) {
+                    is_loop_exit = true;
+                    break;
+                  }
+                }
+                if (is_loop_exit) {
+                  for (size_t i = 0; i < current_loops.size(); i++) {
+                    if (current_loops[i] == current_loop) {
+                      // Emit code and phi assignments for the chain of blocks
+                      // after the loop exit. Follow unconditional branches and
+                      // emit hlsl_lines + phis at each step until we hit a
+                      // conditional branch or a block that's already a pending
+                      // convergence.
+                      int chain_block = branch_number;
+                      while (chain_block > 0 && current_code_function->code_blocks.contains(chain_block)) {
+                        auto& cb = current_code_function->code_blocks.at(chain_block);
+                        int next_block = cb.code_branch.branch_condition_true;
+                        // Only follow unconditional branches (no condition string)
+                        if (next_block <= 0 || !cb.code_branch.branch_condition.empty()) break;
+                        // Emit the block's hlsl_lines (actual computations).
+                        // These may define variables referenced by the phi
+                        // assignments below. Without this, the phi assignments
+                        // would use stale values from a previous loop iteration.
+                        for (const auto& hlsl_line : cb.hlsl_lines) {
+                          auto& emit_line = hlsl_line;
+                          // Strip type prefix if variable was already declared
+                          std::string final_line = emit_line;
+                          static const std::regex decl_re(R"(^(float4|float3|float2|float|int64_t|uint64_t|int16_t|uint16_t|int|uint|bool|uint4|int4|int2|uint2|int3|uint3|double|half|min16float|min16int|min16uint)\s+(_\d+)\s*=)");
+                          std::smatch m;
+                          if (std::regex_search(final_line, m, decl_re)) {
+                            std::string var_name = m[2].str();
+                            if (declared_vars.contains(var_name)) {
+                              final_line = var_name + " =" + m.suffix().str();
+                            }
+                          }
+                          string_stream << spacing << final_line << "\n";
+                        }
+                        // Emit phi assignments stored in chain_block targeting next_block
+                        for (const auto& [variable, type, value, predecessor, code_function_id, is_assign_flag] : cb.phi_lines) {
+                          if (code_function_id == next_block && is_assign_flag) {
+                            auto assignment_value = current_code_function->ParseByType(value, type);
+                            std::string optimized = OptimizeString(assignment_value);
+                            string_stream << spacing << "_" << variable << " = " << optimized << ";\n";
+                          }
+                        }
+                        // Continue chain if next_block also has an unconditional branch
+                        chain_block = next_block;
+                      }
+                      string_stream << spacing << loop_exit_flags[i] << " = true;\n";
+                      break;
+                    }
+                  }
+                }
+              }
+            }
             string_stream << spacing << "break;\n";
           } else {
             throw std::runtime_error("Unexpected goto");
           }
+        } else if (auto deferred_it = std::ranges::find_if(
+                       deferred_branch_targets.rbegin(),
+                       deferred_branch_targets.rend(),
+                       [&](const auto& entry) {
+                         return entry.first == branch_number;
+                       });
+                   deferred_it != deferred_branch_targets.rend()) {
+          // Target is deferred — set the flag instead of inlining the block.
+          // The block will be emitted once after the convergence region closes.
+          string_stream << spacing << deferred_it->second << " = true;\n";
         } else {
           append_code_block(branch_number);
         }
@@ -4851,6 +8778,98 @@ class Decompiler {
 
       if (code_block.code_branch.branch_condition_false <= line_number
           && code_block.code_branch.branch_condition_true <= line_number) {
+        // Both branches point backwards — this is a conditional at the end of a loop body
+        // where both paths loop back (possibly to different loop headers)
+        if (current_loop != -1) {
+          // We're inside a loop — emit conditional continue/break
+          auto true_target = code_block.code_branch.branch_condition_true;
+          auto false_target = code_block.code_branch.branch_condition_false;
+
+          // Emit phi assignments for true branch
+          if (true_target == current_loop && false_target == current_loop) {
+            auto true_phis = current_code_function->ComputePhiAssignments(&current_code_function->code_blocks[line_number], true_target);
+            auto false_phis = current_code_function->ComputePhiAssignments(&current_code_function->code_blocks[line_number], false_target);
+            if (!true_phis.empty() || !false_phis.empty()) {
+              string_stream << spacing << "if (" << branch_cond << ") {\n";
+              indent_spacing();
+              for (const auto& phi : true_phis) {
+                string_stream << spacing << phi << "\n";
+              }
+              unindent_spacing();
+              string_stream << spacing << "} else {\n";
+              indent_spacing();
+              for (const auto& phi : false_phis) {
+                string_stream << spacing << phi << "\n";
+              }
+              unindent_spacing();
+              string_stream << spacing << "}\n";
+            }
+          } else if (true_target == current_loop) {
+            // true branch loops back, false branch exits the loop
+            string_stream << spacing << "if (" << branch_cond_neg << ") {\n";
+            indent_spacing();
+            for (const auto& phi : current_code_function->ComputePhiAssignments(&current_code_function->code_blocks[line_number], false_target)) {
+              string_stream << spacing << phi << "\n";
+            }
+            string_stream << spacing << "break;\n";
+            unindent_spacing();
+            auto true_phis = current_code_function->ComputePhiAssignments(&current_code_function->code_blocks[line_number], true_target);
+            if (!true_phis.empty()) {
+              string_stream << spacing << "} else {\n";
+              indent_spacing();
+              for (const auto& phi : true_phis) {
+                string_stream << spacing << phi << "\n";
+              }
+              unindent_spacing();
+            }
+            string_stream << spacing << "}\n";
+            on_complete();
+            on_branch(false_target, true);
+            return;
+          } else if (false_target == current_loop) {
+            // false branch loops back, true branch exits the loop
+            // Emit break for exit, continue for loop-back
+            string_stream << spacing << "if (" << branch_cond << ") {\n";
+            indent_spacing();
+            for (const auto& phi : current_code_function->ComputePhiAssignments(&current_code_function->code_blocks[line_number], true_target)) {
+              string_stream << spacing << phi << "\n";
+            }
+            string_stream << spacing << "break;\n";
+            unindent_spacing();
+            auto false_phis = current_code_function->ComputePhiAssignments(&current_code_function->code_blocks[line_number], false_target);
+            if (!false_phis.empty()) {
+              string_stream << spacing << "} else {\n";
+              indent_spacing();
+              for (const auto& phi : false_phis) {
+                string_stream << spacing << phi << "\n";
+              }
+              unindent_spacing();
+            }
+            string_stream << spacing << "}\n";
+            on_complete();
+            // After the loop closes, process the exit target
+            on_branch(true_target, true);
+            return;
+          } else {
+            string_stream << spacing << "if (" << branch_cond << ") {\n";
+            indent_spacing();
+            on_branch(true_target);
+            unindent_spacing();
+            // When the false target is the convergence point, use
+            // close_lonely_if to put phi assignments in an else block.
+            // Otherwise on_branch emits them unconditionally, overwriting
+            // values set by the true branch path.
+            if (false_target == next_convergence
+                || std::ranges::find(pending_convergences, false_target) != pending_convergences.end()) {
+              close_lonely_if(false_target);
+            } else {
+              string_stream << spacing << "}\n";
+              on_branch(false_target);
+            }
+          }
+          on_complete();
+          return;
+        }
         throw std::exception("Unsupported loop detected.");
       }
 
@@ -4858,7 +8877,7 @@ class Decompiler {
         if (code_block.code_branch.use_hint) {
           string_stream << spacing << "[branch]\n";
         }
-        string_stream << spacing << "if (!" << code_block.code_branch.branch_condition << ") {\n";
+        string_stream << spacing << "if (" << branch_cond_neg << ") {\n";
         indent_spacing();
         on_branch(code_block.code_branch.branch_condition_false);
         unindent_spacing();
@@ -4873,7 +8892,7 @@ class Decompiler {
         if (code_block.code_branch.use_hint) {
           string_stream << spacing << "[branch]\n";
         }
-        string_stream << spacing << std::format("if {} {{\n", ParseWrapped(code_block.code_branch.branch_condition));
+        string_stream << spacing << std::format("if {} {{\n", ParseWrapped(branch_cond));
         indent_spacing();
         on_branch(code_block.code_branch.branch_condition_true);
         unindent_spacing();
@@ -4884,53 +8903,271 @@ class Decompiler {
         return;
       }
 
-      // Find next convergence for these two items
+      // Find next convergence for these two items using BFS on the
+      // back-edge-free CFG. This finds the first block reachable from
+      // both branches, which is the correct convergence point.
       int pair_convergence = -1;
-      for (auto& [convergence_line_number, callers] : convergences) {
-        if (
-            (convergence_line_number == code_block.code_branch.branch_condition_true || callers.contains(code_block.code_branch.branch_condition_true))
-            && (convergence_line_number == code_block.code_branch.branch_condition_false || callers.contains(code_block.code_branch.branch_condition_false))) {
-          if (convergence_line_number == next_convergence) break;
-          pair_convergence = convergence_line_number;
-          if (!pending_convergences.empty()) {
-            if (decompile_options.use_do_while) {
-              string_stream << spacing << "do {\n";
-              indent_spacing();
+      std::vector<std::pair<int, std::string>> deferred_shared_targets;
+      auto branch_true_val = code_block.code_branch.branch_condition_true;
+      auto branch_false_val = code_block.code_branch.branch_condition_false;
+
+      int bfs_convergence = CodeFunction::FindPairConvergence(
+          branch_true_val, branch_false_val, succs_no_backedge);
+
+      // Use the BFS result if it's valid and not the current next_convergence
+      if (bfs_convergence != -1 && bfs_convergence != next_convergence) {
+        pair_convergence = bfs_convergence;
+
+        // Detect deferred shared targets BEFORE opening the do-while wrapper,
+        // so the flag declarations are at the outer scope and visible after
+        // the do-while closes.
+        if (!decompile_options.flatten) {
+          auto can_defer_shared_target = [&](int candidate_target, bool allow_phi = false) -> bool {
+            if (candidate_target <= 0
+                || candidate_target == pair_convergence
+                || candidate_target <= line_number
+                || !current_code_function->code_blocks.contains(candidate_target)
+                || recursions.contains(candidate_target)) {
+              return false;
+            }
+            // Reject candidates that are loop latches (branch back to a loop header).
+            // Deferring a loop latch breaks the loop structure.
+            auto& candidate_block = current_code_function->code_blocks.at(candidate_target);
+            if (candidate_block.code_branch.branch_condition_true > 0
+                && recursions.contains(candidate_block.code_branch.branch_condition_true)) {
+              return false;
+            }
+            if (candidate_block.code_branch.branch_condition_false > 0
+                && recursions.contains(candidate_block.code_branch.branch_condition_false)) {
+              return false;
+            }
+            // Reject candidates that are inside a loop body between line_number
+            // and pair_convergence. Deferring blocks inside loops causes the
+            // convergence guard (if(!flag)) to skip loop iterations.
+            for (const auto& [header, body] : loop_bodies) {
+              if (header > line_number && header < pair_convergence
+                  && body.contains(candidate_target)) {
+                return false;
+              }
+            }
+            auto pred_it = predecessors.find(candidate_target);
+            if (pred_it == predecessors.end() || pred_it->second.size() < 2) {
+              return false;
+            }
+            for (int pred : pred_it->second) {
+              if (!current_code_function->code_blocks.contains(pred)) return false;
+              auto dom_it = dominators.find(pred);
+              if (dom_it == dominators.end() || !dom_it->second.contains(line_number)) return false;
+              if (!allow_phi
+                  && !current_code_function->ComputePhiAssignments(
+                         &current_code_function->code_blocks.at(pred), candidate_target)
+                          .empty()) {
+                return false;
+              }
+            }
+            return true;
+          };
+
+          std::optional<int> best_deferred;
+          size_t best_pred_count = 0;
+          for (const auto& [candidate, _cb] : current_code_function->code_blocks) {
+            if (!can_defer_shared_target(candidate)) continue;
+            auto existing = std::ranges::find_if(
+                deferred_branch_targets.rbegin(), deferred_branch_targets.rend(),
+                [&](const auto& e) { return e.first == candidate; });
+            if (existing != deferred_branch_targets.rend()) continue;
+            size_t count = predecessors.at(candidate).size();
+            if (!best_deferred.has_value() || count > best_pred_count
+                || (count == best_pred_count && candidate > best_deferred.value())) {
+              best_deferred = candidate;
+              best_pred_count = count;
             }
           }
-          pending_convergences.push_back(pair_convergence);
-          break;
-        }
-      }
 
-      if (pair_convergence == code_block.code_branch.branch_condition_true) {
+          if (best_deferred.has_value()) {
+            auto existing = std::ranges::find_if(
+                deferred_branch_targets.rbegin(), deferred_branch_targets.rend(),
+                [&](const auto& e) { return e.first == best_deferred.value(); });
+            if (existing == deferred_branch_targets.rend()) {
+              auto flag_name = std::format("__defer_{}_{}", line_number, best_deferred.value());
+              string_stream << spacing << "bool " << flag_name << " = false;\n";
+              deferred_branch_targets.emplace_back(best_deferred.value(), flag_name);
+              deferred_shared_targets.emplace_back(best_deferred.value(), flag_name);
+            }
+          }
+
+          // Secondary deferred target with phi assignments spanning both sides.
+          auto candidate_spans_both_sides = [&](int candidate_target) -> bool {
+            auto pred_it = predecessors.find(candidate_target);
+            if (pred_it == predecessors.end() || pred_it->second.size() < 2) return false;
+            bool has_true = (candidate_target == branch_true_val);
+            bool has_false = (candidate_target == branch_false_val);
+            for (int pred : pred_it->second) {
+              auto dom_it = dominators.find(pred);
+              if (dom_it == dominators.end()) continue;
+              if (pred == branch_true_val || dom_it->second.contains(branch_true_val)) has_true = true;
+              if (pred == branch_false_val || dom_it->second.contains(branch_false_val)) has_false = true;
+            }
+            return has_true && has_false;
+          };
+
+          std::optional<int> secondary_deferred;
+          size_t secondary_pred_count = 0;
+          for (const auto& [candidate, _cb] : current_code_function->code_blocks) {
+            if (best_deferred.has_value() && candidate == best_deferred.value()) continue;
+            if (!candidate_spans_both_sides(candidate)) continue;
+            if (!can_defer_shared_target(candidate, true)) continue;
+            bool has_phi = false;
+            auto pred_it = predecessors.find(candidate);
+            if (pred_it != predecessors.end()) {
+              for (int pred : pred_it->second) {
+                if (!current_code_function->ComputePhiAssignments(
+                         &current_code_function->code_blocks.at(pred), candidate)
+                         .empty()) {
+                  has_phi = true;
+                  break;
+                }
+              }
+            }
+            if (!has_phi) continue;
+            auto existing = std::ranges::find_if(
+                deferred_branch_targets.rbegin(), deferred_branch_targets.rend(),
+                [&](const auto& e) { return e.first == candidate; });
+            if (existing != deferred_branch_targets.rend()) continue;
+            size_t count = predecessors.at(candidate).size();
+            if (!secondary_deferred.has_value() || count > secondary_pred_count
+                || (count == secondary_pred_count && candidate > secondary_deferred.value())) {
+              secondary_deferred = candidate;
+              secondary_pred_count = count;
+            }
+          }
+
+          if (secondary_deferred.has_value()) {
+            auto existing = std::ranges::find_if(
+                deferred_branch_targets.rbegin(), deferred_branch_targets.rend(),
+                [&](const auto& e) { return e.first == secondary_deferred.value(); });
+            if (existing == deferred_branch_targets.rend()) {
+              auto flag_name = std::format("__defer_{}_{}", line_number, secondary_deferred.value());
+              string_stream << spacing << "bool " << flag_name << " = false;\n";
+              deferred_branch_targets.emplace_back(secondary_deferred.value(), flag_name);
+              deferred_shared_targets.emplace_back(secondary_deferred.value(), flag_name);
+            }
+          }
+        }
+
+        if (!pending_convergences.empty()) {
+          if (decompile_options.use_do_while) {
+            convergence_bypass_flags.push_back("");
+            convergence_bypass_targets.push_back(-1);
+            do_while_depth++;
+            string_stream << spacing << "do {\n";
+            indent_spacing();
+          } else {
+            convergence_bypass_flags.push_back("");
+            convergence_bypass_targets.push_back(-1);
+          }
+        } else {
+          convergence_bypass_flags.push_back("");
+          convergence_bypass_targets.push_back(-1);
+        }
+        pending_convergences.push_back(pair_convergence);
+      } else if (bfs_convergence == next_convergence && next_convergence != -1) {
+        // Both branches converge at the already-pending convergence point.
+        // Emit if/else — both paths will reach next_convergence naturally.
         if (code_block.code_branch.use_hint) {
           string_stream << spacing << "[branch]\n";
         }
-        string_stream << spacing << "if (!" << code_block.code_branch.branch_condition << ") {\n";
+        if (branch_true_val < branch_false_val) {
+          string_stream << spacing << std::format("if {} {{\n", ParseWrapped(branch_cond));
+          indent_spacing();
+          on_branch(branch_true_val);
+          unindent_spacing();
+          string_stream << spacing << "} else {\n";
+          indent_spacing();
+          on_branch(branch_false_val);
+          unindent_spacing();
+          string_stream << spacing << "}\n";
+        } else {
+          string_stream << spacing << "if (" << branch_cond_neg << ") {\n";
+          indent_spacing();
+          on_branch(branch_false_val);
+          unindent_spacing();
+          string_stream << spacing << "} else {\n";
+          indent_spacing();
+          on_branch(branch_true_val);
+          unindent_spacing();
+          string_stream << spacing << "}\n";
+        }
+        on_complete();
+        return;
+      }
+
+      // Pre-declare phi variables for the convergence block.
+      if (pair_convergence != -1 && current_code_function->code_blocks.contains(pair_convergence)) {
+        for (const auto& [variable, type, value, predecessor, code_function, is_assign] : current_code_function->code_blocks[pair_convergence].phi_lines) {
+          if (is_assign) continue;
+          auto var_name = std::format("_{}", variable);
+          if (!declared_vars.contains(var_name)) {
+            string_stream << spacing << ParseType(type) << " " << var_name << ";\n";
+            declared_vars.insert(var_name);
+          }
+        }
+        phi_predeclared_blocks.insert(pair_convergence);
+      }
+
+      if (pair_convergence == code_block.code_branch.branch_condition_true) {
+        // When inside a do-while, pre-initialize phi variables with their
+        // else-branch (convergence) values before the if block. This avoids
+        // emitting if-else phi assignments that DXC can constant-fold through,
+        // which causes dead code elimination of reachable SampleLevel calls.
+        if (do_while_depth > 0) {
+          auto convergence_phis = current_code_function->ComputePhiAssignments(&code_block, pair_convergence);
+          for (const auto& phi_line : convergence_phis) {
+            string_stream << spacing << phi_line << "\n";
+          }
+        }
+        if (code_block.code_branch.use_hint) {
+          string_stream << spacing << "[branch]\n";
+        }
+        string_stream << spacing << "if (" << branch_cond_neg << ") {\n";
         indent_spacing();
         on_branch(code_block.code_branch.branch_condition_false);
         unindent_spacing();
 
-        close_lonely_if(pair_convergence);
+        if (do_while_depth > 0) {
+          string_stream << spacing << "}\n";
+        } else {
+          close_lonely_if(pair_convergence);
+        }
 
         // Only print else
       } else if (pair_convergence == code_block.code_branch.branch_condition_false) {
+        // Same do-while pre-initialization for the symmetric case.
+        if (do_while_depth > 0) {
+          auto convergence_phis = current_code_function->ComputePhiAssignments(&code_block, pair_convergence);
+          for (const auto& phi_line : convergence_phis) {
+            string_stream << spacing << phi_line << "\n";
+          }
+        }
         if (code_block.code_branch.use_hint) {
           string_stream << spacing << "[branch]\n";
         }
-        string_stream << spacing << std::format("if {} {{\n", ParseWrapped(code_block.code_branch.branch_condition));
+        string_stream << spacing << std::format("if {} {{\n", ParseWrapped(branch_cond));
         indent_spacing();
         on_branch(code_block.code_branch.branch_condition_true);
         unindent_spacing();
 
-        close_lonely_if(pair_convergence);
+        if (do_while_depth > 0) {
+          string_stream << spacing << "}\n";
+        } else {
+          close_lonely_if(pair_convergence);
+        }
 
       } else if (code_block.code_branch.branch_condition_true < code_block.code_branch.branch_condition_false) {
         if (code_block.code_branch.use_hint) {
           string_stream << spacing << "[branch]\n";
         }
-        string_stream << spacing << std::format("if {} {{\n", ParseWrapped(code_block.code_branch.branch_condition));
+        string_stream << spacing << std::format("if {} {{\n", ParseWrapped(branch_cond));
         indent_spacing();
         on_branch(code_block.code_branch.branch_condition_true);
         unindent_spacing();
@@ -4943,7 +9180,7 @@ class Decompiler {
         if (code_block.code_branch.use_hint) {
           string_stream << spacing << "[branch]\n";
         }
-        string_stream << spacing << "if (!" << code_block.code_branch.branch_condition << ") {\n";
+        string_stream << spacing << "if (" << branch_cond_neg << ") {\n";
         indent_spacing();
         on_branch(code_block.code_branch.branch_condition_false);
         unindent_spacing();
@@ -4957,14 +9194,91 @@ class Decompiler {
       if (pair_convergence != -1) {
         pending_convergences.pop_back();
         bool is_empty = pending_convergences.empty();
+        // Pop both stacks together to keep them in sync.
+        convergence_bypass_flags.pop_back();
+        convergence_bypass_targets.pop_back();
+        // If deferred targets exist, wrap the convergence block in if(!flag)
+        // so it's skipped when the bypass path was taken. This prevents the
+        // convergence code (which may include a loop) from executing when
+        // the bypass already computed the final values.
+        bool has_defer_guard = !deferred_shared_targets.empty() && decompile_options.use_do_while;
+        if (has_defer_guard) {
+          // Use the first deferred flag as the guard — if any deferred path
+          // was taken, the convergence block should be skipped.
+          string_stream << spacing << "if (!" << deferred_shared_targets.front().second << ") {\n";
+          indent_spacing();
+        }
         on_branch(pair_convergence, true);
+        if (has_defer_guard) {
+          unindent_spacing();
+          string_stream << spacing << "}\n";
+        }
         if (!is_empty) {
           if (decompile_options.use_do_while) {
+            do_while_depth--;
             unindent_spacing();
             string_stream << spacing << "} while (false);\n";
+            // After the do-while, propagate any loop escape flags that were set
+            // inside it. A continue inside the do-while targeted the do-while
+            // (exiting it), so we need to check flags and re-emit the continue
+            // for the correct while(true) loop.
+            if (!loop_escape_flags.empty()) {
+              auto& parent_flag = loop_escape_flags.back();
+              auto& exit_flag = loop_exit_flags.back();
+              // Build the flag condition: parent_flag, or (parent_flag || exit_flag) if exit flag exists
+              std::string flag_cond = exit_flag.empty()
+                  ? parent_flag
+                  : ("(" + parent_flag + " || " + exit_flag + ")");
+              // Build condition: flag is set AND no outer flags are set
+              std::string outer_guard;
+              for (int i = static_cast<int>(loop_escape_flags.size()) - 2; i >= 0; i--) {
+                if (!outer_guard.empty()) outer_guard += " && ";
+                outer_guard += "!" + loop_escape_flags[i];
+              }
+              // Check if we're still inside a do-while(false) between us and
+              // the target while(true). If so, 'continue' would target that
+              // intermediate do-while instead of the while(true).
+              int target_dw_depth = loop_do_while_depth.back();
+              bool inside_intermediate_do_while = (do_while_depth > target_dw_depth);
+              if (inside_intermediate_do_while) {
+                // Emit break to propagate through the next do-while level,
+                // keeping the flag set for the next handler.
+                if (outer_guard.empty()) {
+                  string_stream << spacing << "if (" << flag_cond << ") break;\n";
+                } else {
+                  string_stream << spacing << "if (" << flag_cond << " && " << outer_guard << ") break;\n";
+                }
+              } else {
+                // At the same do-while depth as the target while(true).
+                // For loop-continue (parent_flag): reset and continue.
+                // For loop-exit (exit_flag): the continue check only fires for parent_flag.
+                if (outer_guard.empty()) {
+                  string_stream << spacing << "if (" << parent_flag << ") { " << parent_flag << " = false; continue; }\n";
+                } else {
+                  string_stream << spacing << "if (" << parent_flag << " && " << outer_guard << ") { " << parent_flag << " = false; continue; }\n";
+                }
+              }
+            }
           }
         }
       };
+
+      // Process deferred shared targets: emit each deferred block once,
+      // guarded by its flag. This runs AFTER the convergence region closes,
+      // so DXC can't eliminate the code through SSA analysis of the
+      // convergence's control flow.
+      for (const auto& [deferred_target, deferred_flag] : deferred_shared_targets) {
+        string_stream << spacing << "if (" << deferred_flag << ") {\n";
+        indent_spacing();
+        append_code_block(deferred_target);
+        unindent_spacing();
+        string_stream << spacing << "}\n";
+      }
+      // Pop deferred targets that were registered for this convergence level.
+      for (size_t i = 0; i < deferred_shared_targets.size(); ++i) {
+        deferred_branch_targets.pop_back();
+      }
+
       on_complete();
     };
 
@@ -5003,6 +9317,9 @@ class Decompiler {
 
     string_stream << " main(";
     {
+      // For mermaid strategy, prefix input params with __
+      // to avoid conflict with static module-scope copies.
+      bool mermaid_rename = decompile_options.mermaid_decompile;
       if (threads.empty()) {
         auto len = preprocess_state.input_signature.size();
         if (len > 0) string_stream << "\n";
@@ -5018,18 +9335,55 @@ class Decompiler {
         auto end = sorted_inputs.end();
         for (; it != end; ++it) {
           const auto& signature = it->second;
-          string_stream << "  " << signature.ToString();
+          if (mermaid_rename) {
+            // Include interpolation mode in the renamed parameter declaration
+            // so DXIL validation passes (especially for SV_Position which requires
+            // specific interpolation modes).
+            string_stream << "  ";
+            // Emit interpolation mode prefix
+            switch (signature.property.interp_mode) {
+              case SignatureProperty::InterpMode::NOINTERPOLATION:
+                string_stream << "nointerpolation "; break;
+              case SignatureProperty::InterpMode::LINEAR:
+                string_stream << "linear "; break;
+              case SignatureProperty::InterpMode::NOPERSPECTIVE:
+                string_stream << "noperspective "; break;
+              case SignatureProperty::InterpMode::NOPERSPECTIVE_SAMPLE:
+                string_stream << "noperspective sample "; break;
+              case SignatureProperty::InterpMode::NOPERSPECTIVE_CENTROID:
+                string_stream << "noperspective centroid "; break;
+              case SignatureProperty::InterpMode::CENTROID:
+                string_stream << "centroid "; break;
+              default: break;
+            }
+            string_stream << signature.FullFormatString() << " __" << signature.VariableString()
+                          << " : " << signature.SemanticString();
+          } else {
+            string_stream << "  " << signature.ToString();
+          }
           if (std::next(it) != end) {
+            string_stream << ",";
+          } else if (preprocess_state.uses_view_id) {
             string_stream << ",";
           }
           string_stream << "\n";
         }
+        if (preprocess_state.uses_view_id) {
+          string_stream << "  uint SV_ViewID : SV_ViewID\n";
+        }
       } else {
         string_stream << "\n";
-        string_stream << "  uint3 SV_DispatchThreadID : SV_DispatchThreadID,\n";
-        string_stream << "  uint3 SV_GroupID : SV_GroupID,\n";
-        string_stream << "  uint3 SV_GroupThreadID : SV_GroupThreadID,\n";
-        string_stream << "  uint SV_GroupIndex : SV_GroupIndex\n";
+        if (mermaid_rename) {
+          string_stream << "  uint3 __SV_DispatchThreadID : SV_DispatchThreadID,\n";
+          string_stream << "  uint3 __SV_GroupID : SV_GroupID,\n";
+          string_stream << "  uint3 __SV_GroupThreadID : SV_GroupThreadID,\n";
+          string_stream << "  uint __SV_GroupIndex : SV_GroupIndex\n";
+        } else {
+          string_stream << "  uint3 SV_DispatchThreadID : SV_DispatchThreadID,\n";
+          string_stream << "  uint3 SV_GroupID : SV_GroupID,\n";
+          string_stream << "  uint3 SV_GroupThreadID : SV_GroupThreadID,\n";
+          string_stream << "  uint SV_GroupIndex : SV_GroupIndex\n";
+        }
       }
     }
     string_stream << ")";
@@ -5044,7 +9398,216 @@ class Decompiler {
     }
 
     indent_spacing();
-    append_code_block(0);
+
+    // For mermaid strategy, phi-barrier function declarations are collected here
+    // and spliced before main() after code generation.
+    std::stringstream mermaid_module_vars;       // Only used for PS input statics now
+    std::stringstream mermaid_pre_main_functions; // Phi-barrier functions
+
+    // For mermaid v2 strategy, emit input variable copies.
+    // Compute: copy __SV_* params to local vars at start of main()
+    // Pixel: copy __TEXCOORD etc. to local vars declared at function scope
+    // No more static module-scope — everything is local since there are no region functions.
+    if (decompile_options.mermaid_decompile) {
+      bool is_compute = !threads.empty();
+      if (is_compute) {
+        if (preprocess_state.input_signature.empty()) {
+          // Declare local copies and assign from renamed params
+          string_stream << spacing << "uint3 SV_DispatchThreadID = __SV_DispatchThreadID;\n";
+          string_stream << spacing << "uint3 SV_GroupID = __SV_GroupID;\n";
+          string_stream << spacing << "uint3 SV_GroupThreadID = __SV_GroupThreadID;\n";
+          string_stream << spacing << "uint SV_GroupIndex = __SV_GroupIndex;\n";
+        }
+      } else {
+        // Pixel shader: declare local copies and assign from renamed params.
+        // Interpolation modes are on the parameter declaration — by the time
+        // main() executes, interpolation is done and values are plain floats.
+        for (const auto& sig : preprocess_state.input_signature) {
+          std::string var = sig.VariableString();
+          std::string type = sig.FullFormatString();
+          string_stream << spacing << type << " " << var << " = __" << var << ";\n";
+        }
+      }
+    }
+
+    // Pre-declare all SSA variables at function scope to avoid scoping
+    // issues when convergence optimization eliminates node splitting.
+    // Variables defined inside if/else branches may be referenced by
+    // convergence fallthrough blocks at a higher scope level.
+    {
+      // Helper: zero-initializer for a given HLSL type name.
+      // Using zero for all types. The decompiler's structured HLSL should
+      // assign all variables on all reachable paths. Zero initialization
+      // passes DXIL validation and doesn't poison DXC's optimizer.
+      auto zero_init_for_type = [](const std::string& type_name) -> std::string {
+        if (type_name == "bool") return " = false";
+        if (type_name == "int" || type_name == "int16_t" || type_name == "int64_t") return " = 0";
+        if (type_name == "uint" || type_name == "uint16_t" || type_name == "uint64_t") return " = 0u";
+        if (type_name == "half" || type_name == "min16float") return " = 0.0h";
+        if (type_name == "double") return " = 0.0";
+        if (type_name == "float") return " = 0.0f";
+        if (type_name == "float2") return " = float2(0.0f, 0.0f)";
+        if (type_name == "float3") return " = float3(0.0f, 0.0f, 0.0f)";
+        if (type_name == "float4") return " = float4(0.0f, 0.0f, 0.0f, 0.0f)";
+        if (type_name == "int2") return " = int2(0, 0)";
+        if (type_name == "int3") return " = int3(0, 0, 0)";
+        if (type_name == "int4") return " = int4(0, 0, 0, 0)";
+        if (type_name == "uint2") return " = uint2(0u, 0u)";
+        if (type_name == "uint3") return " = uint3(0u, 0u, 0u)";
+        if (type_name == "uint4") return " = uint4(0u, 0u, 0u, 0u)";
+        return " = 0";
+      };
+      // For mermaid v2 strategy, declare variables at function scope (local)
+      // since everything is emitted inline in main(). No more static module-scope.
+      bool use_module_scope = false;
+
+      // Zero-initialize pre-declared variables to pass DXIL validation.
+      // DXC's validator rejects reads of uninitialized values. The structured
+      // HLSL may create paths where a variable isn't assigned (due to branch
+      // restructuring), so zero initialization is needed for validation.
+      // The opaque condition removal and convergence fixes prevent DXC from
+      // exploiting zero values at branch points in most cases.
+      bool use_zero_init = decompile_options.mermaid_decompile;
+      bool use_phi_zero_init = use_zero_init;
+
+      static const std::regex var_decl_re(R"(^(float4|float3|float2|float|int|uint|bool|uint4|int4|int2|uint2|int3|uint3|double|int64_t|uint64_t|int16_t[234]?|uint16_t[234]?|half[234]?|min16float[234]?|min16int[234]?|min16uint[234]?|[A-Z_]\w*)\s+(_\d+)\s*=)");
+      // Also match "Type _NNN;" declarations without assignment (e.g., from InterlockedAdd output params:
+      // "int _259; InterlockedAdd(..., _259);")
+      static const std::regex var_decl_noassign_re(R"(^(float4|float3|float2|float|int|uint|bool|uint4|int4|int2|uint2|int3|uint3|double|int64_t|uint64_t|int16_t[234]?|uint16_t[234]?|half[234]?|min16float[234]?|min16int[234]?|min16uint[234]?|[A-Z_]\w*)\s+(_\d+)\s*;)");
+      for (const auto& [block_num, cb] : current_code_function->code_blocks) {
+        for (const auto& hl : cb.hlsl_lines) {
+          std::smatch m;
+          if (std::regex_search(hl, m, var_decl_re)) {
+            std::string var_name = m[2].str();
+            if (!declared_vars.contains(var_name)) {
+              std::string type_name = m[1].str();
+              auto& target = use_module_scope ? mermaid_module_vars : string_stream;
+              std::string prefix = use_module_scope ? "static " : spacing;
+              if (use_zero_init) {
+                target << prefix << type_name << " " << var_name << zero_init_for_type(type_name) << ";\n";
+              } else {
+                target << prefix << type_name << " " << var_name << ";\n";
+              }
+              declared_vars.insert(var_name);
+            }
+          } else if (std::regex_search(hl, m, var_decl_noassign_re)) {
+            // Catch "Type _NNN; ..." declarations (e.g., atomic output params)
+            std::string var_name = m[2].str();
+            if (!declared_vars.contains(var_name)) {
+              std::string type_name = m[1].str();
+              auto& target = use_module_scope ? mermaid_module_vars : string_stream;
+              std::string prefix = use_module_scope ? "static " : spacing;
+              if (use_zero_init) {
+                target << prefix << type_name << " " << var_name << zero_init_for_type(type_name) << ";\n";
+              } else {
+                target << prefix << type_name << " " << var_name << ";\n";
+              }
+              declared_vars.insert(var_name);
+            }
+          }
+        }
+        // Also pre-declare phi variables
+        for (const auto& [variable, type, value, predecessor, code_function, is_assign] : cb.phi_lines) {
+          if (is_assign) continue;
+          auto var_name = std::format("_{}", variable);
+          if (!declared_vars.contains(var_name)) {
+            std::string hlsl_type = ParseType(type);
+            auto& target = use_module_scope ? mermaid_module_vars : string_stream;
+            std::string prefix = use_module_scope ? "static " : spacing;
+            if (use_phi_zero_init) {
+              target << prefix << hlsl_type << " " << var_name << zero_init_for_type(hlsl_type) << ";\n";
+            } else if (use_zero_init) {
+              target << prefix << hlsl_type << " " << var_name << zero_init_for_type(hlsl_type) << ";\n";
+            } else {
+              target << prefix << hlsl_type << " " << var_name << ";\n";
+            }
+            declared_vars.insert(var_name);
+          }
+        }
+      }
+
+      // For mermaid strategy, also pre-declare alloca arrays at function scope
+      // so they're available across all scopes within main().
+      if (decompile_options.mermaid_decompile) {
+        static const std::regex alloca_re(R"(^(float|int|uint)\s+(_\d+)\[(\d+)\])");
+        for (const auto& [block_num, cb] : current_code_function->code_blocks) {
+          for (const auto& hl : cb.hlsl_lines) {
+            std::smatch m;
+            if (std::regex_search(hl, m, alloca_re)) {
+              std::string var_name = m[2].str();
+              if (!declared_vars.contains(var_name)) {
+                string_stream << spacing << m[1].str() << " " << var_name << "[" << m[3].str() << "];\n";
+                declared_vars.insert(var_name);
+              }
+            }
+          }
+        }
+      }
+
+      // Pre-declare heap resource variables (_HeapResource_N) at function scope.
+      // ResourceDescriptorHeap[] declarations CANNOT be at module scope because
+      // DXC ignores initializers of external globals, causing "Explicit load/store
+      // type does not match pointee type" validation errors.
+      //
+      // For mermaid, we intentionally DO NOT hoist heap resource declarations to
+      // function scope. The declaration uses an SSA index variable (e.g., _404)
+      // that is zero-initialized at function scope and only assigned inside a
+      // guarded block. A function-scope hoist would read _404 = 0 and construct
+      // a handle to descriptor heap slot 0. The mermaid emitter re-declares the
+      // heap resource at the top of every block that uses it instead.
+      // (See heap_decls_to_inject in mermaid_decompile.hpp.)
+      if (decompile_options.mermaid_decompile) {
+        // intentional no-op
+      } else {
+        static const std::regex heap_re(R"(^(.+\s+_HeapResource_\d+\s*=\s*ResourceDescriptorHeap\[.+\]);)");
+        for (const auto& [block_num, cb] : current_code_function->code_blocks) {
+          for (const auto& hl : cb.hlsl_lines) {
+            std::smatch m;
+            if (std::regex_search(hl, m, heap_re)) {
+              static const std::regex name_re(R"((_HeapResource_\d+))");
+              std::smatch nm;
+              if (std::regex_search(hl, nm, name_re)) {
+                std::string var_name = nm[1].str();
+                if (!declared_vars.contains(var_name)) {
+                  string_stream << spacing << hl << "\n";
+                  declared_vars.insert(var_name);
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // Emit hoisted RayQuery declarations at function scope
+    // For mermaid v2, also at function scope (no more module scope needed)
+    for (const auto& rq_decl : current_code_function->ray_query_declarations) {
+      string_stream << spacing << rq_decl << "\n";
+    }
+
+    if (decompile_options.structural) {
+      // Attempt structural code generation; fall back to use-do-while on unsupported patterns.
+      auto stream_pos_before_structural = string_stream.tellp();
+      try {
+#include "shader_decompiler/structural.hpp"
+      } catch (const std::runtime_error& structural_error) {
+        // Reset stream to before structural output and fall back to use-do-while
+        std::cerr << "WARNING: Structural decompilation failed, falling back to use-do-while: "
+                  << structural_error.what() << "\n";
+        string_stream.seekp(stream_pos_before_structural);
+        std::string truncated = string_stream.str().substr(0, static_cast<size_t>(stream_pos_before_structural));
+        string_stream.str(truncated);
+        string_stream.seekp(0, std::ios_base::end);
+        string_stream << spacing << "// Structural fallback: " << structural_error.what() << "\n";
+        append_code_block(0);
+      }
+    } else if (decompile_options.mermaid_decompile) {
+#include "shader_decompiler/mermaid_decompile.hpp"
+    } else if (decompile_options.stackify) {
+#include "shader_decompiler/stackify.hpp"
+    } else {
+      append_code_block(0);
+    }
     unindent_spacing();
 
     if (output_signature_count == 0) {
@@ -5065,9 +9628,67 @@ class Decompiler {
 #if DECOMPILER_DXC_DEBUG == 3
     return "";
 #else
-    return string_stream.str();
+    auto output = string_stream.str();
+    if (!decompile_options.annotate && !decompile_options.mermaid_decompile) {
+      output = OptimizeWholeStructBufferStores(output);
+      output = OptimizeDeferredBoolBridgeBlocks(output);
+      output = OptimizeSingleUseBoolChains(output);
+      output = OptimizeUpperBoundGuardLoads(output);
+      output = OptimizeSentinelBoolIntGuards(output);
+      output = OptimizeBoolCarrierAssignments(output);
+      output = OptimizeTrailingBoolFallbackElse(output);
+      output = OptimizeSentinelBoolIntGuards(output);  // second pass
+      output = OptimizeVisibilityBindlessIndices(output);
+      output = OptimizeVisibilityParamIndexSelection(output);
+      output = OptimizeVectorComponentTempArrays(output);
+      output = OptimizeRepeatedStoreAddresses(output);
+      output = OptimizeUnusedLocalAssignments(output);
+      output = OptimizeDeferredSiblingGuards(output);
+      output = OptimizeDeferredSelectorSentinels(output);
+      output = OptimizeNestedReductionLoops(output);
+      output = OptimizeVectorMaskedDots(output);
+    }
+
+    // Mermaid-safe post-processing passes: struct buffer store/load optimization.
+    // These combine field-by-field stores into single struct stores and consecutive
+    // component loads into vector loads. Safe for mermaid output because they don't
+    // affect control flow or phi assignments.
+    if (decompile_options.mermaid_decompile && !decompile_options.annotate) {
+      output = OptimizeWholeStructBufferStores(output);
+      output = OptimizeStructuredResourceVectorLoads(output);
+    }
+
+    // Mermaid v2 post-processing: splice phi-barrier functions before main().
+    if (decompile_options.mermaid_decompile) {
+      std::string region_funcs = mermaid_pre_main_functions.str();
+
+      if (!region_funcs.empty()) {
+        auto main_pos = output.find(" main(");
+        if (main_pos != std::string::npos) {
+          auto line_start = output.rfind('\n', main_pos);
+          if (line_start == std::string::npos) line_start = 0;
+          else line_start += 1;
+          // Check if the previous line is a [numthreads] attribute
+          if (line_start > 1) {
+            auto prev_line_end = line_start - 1;
+            auto prev_line_start = output.rfind('\n', prev_line_end - 1);
+            if (prev_line_start == std::string::npos) prev_line_start = 0;
+            else prev_line_start += 1;
+            std::string prev_line = output.substr(prev_line_start, prev_line_end - prev_line_start);
+            if (prev_line.find("[numthreads") != std::string::npos) {
+              line_start = prev_line_start;
+            }
+          }
+          output.insert(line_start, region_funcs + "\n");
+        }
+      }
+    }
+
+    return output;
 #endif
   }
+
+#include "shader_decompiler/postprocess.hpp"
 };  // namespace Decompiler
 
 }  // namespace renodx::utils::shader::decompiler::dxc

--- a/src/utils/shader_decompiler_dxc.hpp
+++ b/src/utils/shader_decompiler_dxc.hpp
@@ -232,9 +232,7 @@ class Decompiler {
     return std::format("{}", input);
   }
 
-  // Pitfall 9: Convert negative integer constants to unsigned equivalents based on DXIL type width.
-  // DXIL uses two's complement, so i16 -25536 = uint16 40000, i32 -1 = uint32 4294967295.
-  // Without this, (uint)-25536.0f is UB in HLSL (produces 0), silently breaking comparisons.
+  // Convert negative constants to unsigned equivalents (two's complement)
   static std::string ParseUnsignedConstant(std::string_view input, std::string_view dxil_type) {
     if (input == "undef") return "0u";
     if (input.starts_with("%")) return std::string(input);  // variable, not a constant
@@ -295,8 +293,7 @@ class Decompiler {
       uint32_t float_bits = sign | (exponent << 23) | mantissa;
 
       float as_float;
-      memcpy(&as_float, &float_bits, sizeof(as_float));  // Reinterpret bits
-      // Pitfall 12: NaN has no HLSL literal — emit asfloat(0x7FC00000) instead
+      memcpy(&as_float, &float_bits, sizeof(as_float));
       if (std::isnan(as_float)) {
         return "asfloat(0x7FC00000u)";
       }
@@ -307,7 +304,6 @@ class Decompiler {
       uint64_t as_uint64 = unsigned_long;
       double_t as_double;
       memcpy(&as_double, &as_uint64, sizeof(as_double));
-      // Pitfall 12: NaN has no HLSL literal — emit asfloat(0x7FC00000) instead
       if (std::isnan(as_double)) {
         return "asfloat(0x7FC00000u)";
       }
@@ -317,12 +313,9 @@ class Decompiler {
       FromStringView(input, as_double);
       output = std::format("{}", as_double);
     }
-    // Pitfall 12: catch NaN from any path (e.g., non-hex NaN literals)
     if (output == "nan" || output == "-nan" || output == "nan(ind)") {
       return "asfloat(0x7FC00000u)";
     }
-    // Infinity fallback — std::format on double ±infinity produces "inf"/"-inf"
-    // which are not valid HLSL literals. Emit HLSL #INF forms instead.
     if (output == "inf" || output == "+inf") return "+1.#INF";
     if (output == "-inf") return "-1.#INF";
     bool has_dot = output.find('.') != std::string::npos;
@@ -741,8 +734,7 @@ class Decompiler {
 
     [[nodiscard]] std::string ToString() const {
       std::stringstream string_stream;
-      // Pitfall 13: Add precise to SV_Position outputs to prevent Z-fighting
-      // from fast-math precision mismatches with depth pre-pass shaders.
+      // Prevent Z-fighting from fast-math precision mismatches with depth pre-pass
       if (name == "SV_Position") {
         string_stream << "precise ";
       }
@@ -2160,8 +2152,6 @@ class Decompiler {
       if (type == "i32") return ParseInt(input);
       if (type == "int") return ParseInt(input);
       if (type == "uint") return ParseUint(input);
-      // Pitfall 9: i16 must be parsed as integer, not float.
-      // Negative i16 constants (e.g., -25536) parsed as float produce (uint)-25536.0f which is UB.
       if (type == "i16") return ParseInt(input);
       if (type == "i64") return ParseInt64(input);
       if (type == "half") return ParseHalf(input);
@@ -2711,10 +2701,7 @@ class Decompiler {
               };
               assignment_value = std::format("(int){}({}, {})", pair->second, cast_uint(a_str), cast_uint(b_str));
             } else {
-              // Pitfall 5: IMax/IMin (opcodes 37/38) require signed comparison semantics.
-              // Without (int) casts, max(uint_value, 0u) is a no-op since uint >= 0 always.
-              // The original intent is signed clamping: if unsigned subtraction wraps,
-              // the signed interpretation is negative, and IMax with 0 clamps to 0.
+              // IMax/IMin require signed comparison semantics
               auto a_str = std::string(ParseInt(a));
               auto b_str = std::string(ParseInt(b));
               auto cast_int = [](const std::string& s) -> std::string {
@@ -4043,13 +4030,9 @@ class Decompiler {
             int literal_index;
             FromStringView(index, literal_index);
 
-            // Pitfall 11: Check if this cbuffer uses raw uint4 array (due to 16-bit field packing)
             auto cbv_range_idx = static_cast<uint32_t>(cbv_resource - preprocess_state.cbv_resources.data());
             if (preprocess_state.cbv_dynamic_access_indices.count(cbv_range_idx)) {
-              // Extract half from raw uint4 array using f16tof32.
-              // CBufRet.f16.8 packs 8 halves per register:
-              //   indices 0-3 = low 16 bits of xyzw
-              //   indices 4-7 = high 16 bits of xyzw
+              // f16.8: indices 0-3 = low 16 bits of xyzw, 4-7 = high 16 bits
               int component = literal_index % 4;
               bool high_half = literal_index >= 4;
               if (high_half) {
@@ -4376,10 +4359,7 @@ class Decompiler {
         assignment_type = ParseType(variable_type);
         assignment_value = std::format("({}){} >> {}", ParseUnsignedType(variable_type), ParseWrapped(ParseUint(a)), ParseInt(b));
       } else if (instruction == "ashr") {
-        // %95 = ashr i32 %68, 2
-        // %36 = exact i32 %35, 16
-        // Pitfall 10: ashr is arithmetic right shift — result MUST be signed (int)
-        // so that HLSL >> performs sign-extension, not zero-fill.
+        // ashr: arithmetic right shift — result must be signed for sign-extension
         auto [exact, no_unsigned_wrap, no_signed_wrap, variable_type, a, b] = StringViewMatch<6>(assignment, std::regex{R"(ashr (exact )?(nuw )?(nsw )?(\S+) (\S+), (\S+))"});
         assignment_type = ParseType(variable_type);
         // Force signed type for ashr — HLSL >> on int is arithmetic shift
@@ -4508,8 +4488,7 @@ class Decompiler {
           cast = "(int)";
         }
 
-        // Pitfall 9: For unsigned comparisons, convert negative constants to their
-        // unsigned equivalents based on DXIL type width. e.g., i16 -25536 → 40000u.
+        // Convert negative constants to unsigned equivalents for unsigned comparisons
         auto parse_icmp_operand = [&](std::string_view operand) -> std::string {
           if (op.starts_with("u") && !operand.empty() && operand[0] == '-') {
             return ParseUnsignedConstant(operand, type);
@@ -5788,14 +5767,10 @@ class Decompiler {
 
       // store float %1358, float* %1369, align 4, !tbaa !26, !alias.scope !30
       // store i32 %62, i32 addrspace(3)* %ptr, align 4
-      // Pitfall 2/6: Parse the store type to use correct value parser.
-      // Float stores to int groupshared need asuint(); int stores should not use ParseFloat.
+      // Parse store type to use correct value parser (float stores to int groupshared need asuint)
       static auto regex = std::regex{R"(^  store (\S+) ([^,]+), [^*]+\* %([A-Za-z0-9]+),?.*)"};
       auto [store_type, value, pointer] = StringViewMatch<3>(line, regex);
 
-      // Returns the HLSL reinterpret-cast helper needed when storing `stored_type`
-      // through a pointer whose underlying element type is `element_type`.
-      // Returns empty string when no cast is needed.
       auto get_reinterpret_for_mismatch = [](std::string_view stored_type, std::string_view element_type) -> std::string {
         if (element_type.empty() || stored_type == element_type) return "";
         // float -> integer storage: preserve bits via asuint/asint
@@ -6882,9 +6857,8 @@ class Decompiler {
     }
     this->source_lines = StringViewSplitAll(disassembly, '\n');
 
-    // Pre-scan: identify handle variables that are used with dynamic cbuffer access
-    // This is needed because extractvalue on a static cbuffer load may appear before
-    // the dynamic load that marks the cbuffer as needing raw access
+    // Pre-scan: identify handle variables used with dynamic cbuffer access
+    // (extractvalue on a static load may appear before the dynamic load that marks it)
     {
       static auto dynamic_cbuf_regex = std::regex(
           R"(call %dx\.types\.CBufRet\.\w+ @dx\.op\.cbufferLoadLegacy\.\w+\(i32 \d+, %dx\.types\.Handle (%\d+), i32 %)"
@@ -7223,9 +7197,7 @@ class Decompiler {
             }
             bool is_groupshared = (scope == "external" || scope == "" || has_addrspace3);
             if (!array_type.empty()) {
-              // Pitfall 3: Use uint for i32 groupshared arrays so InterlockedAdd
-              // and other atomic intrinsics get a valid l-value of the correct type.
-              // Keep int for static const arrays (they don't need atomic access).
+              // Use uint for groupshared i32 arrays (atomic intrinsics need uint l-values)
               auto hlsl_array_type = (array_type == "i32") ? (is_groupshared ? std::string_view("uint") : std::string_view("int"))
                                    : (array_type == "i16") ? std::string_view("int16_t")
                                    : array_type;
@@ -7416,13 +7388,10 @@ class Decompiler {
       }
     }
 
-    // Apply cbuffer packing rules to CBV types without annotation data.
-    // This must happen after resources are parsed (metadata) but before DecompileLines.
+    // Apply cbuffer packing rules (must happen after metadata parse, before DecompileLines)
     preprocess_state.ApplyCBufferPacking();
 
-    // Pitfall 11: Pre-detect cbuffers with half/min16float fields and mark them for
-    // raw uint4 array access. This must happen before DecompileLines() so the extractvalue
-    // handlers use asfloat/asint on the raw array instead of named field access.
+    // Mark cbuffers with 16-bit fields for raw uint4 array access
     {
       std::function<bool(std::string_view)> type_uses_native_16bit = [&](std::string_view raw_type_name) -> bool {
         DataType info(raw_type_name);
@@ -7449,10 +7418,7 @@ class Decompiler {
 
     // Decompilation also notes
 
-    // Pre-pass: resolve cbufferLoad extractvalues that may be used before their
-    // defining block is processed (forward references in block-number order).
-    // This ensures ParseVariable() can resolve them regardless of processing order.
-    // Store pre-pass aliases separately so they can be seeded into replacement functions.
+    // Pre-pass: resolve cbufferLoad extractvalues for forward references
     std::map<std::string, std::pair<std::string, std::string>> cbuffer_prepass_aliases;
     {
       static const auto create_handle_regex = std::regex(
@@ -9560,6 +9526,7 @@ class Decompiler {
         // intentional no-op
       } else {
         static const std::regex heap_re(R"(^(.+\s+_HeapResource_\d+\s*=\s*ResourceDescriptorHeap\[.+\]);)");
+        std::set<std::string> hoisted_heap_lines;
         for (const auto& [block_num, cb] : current_code_function->code_blocks) {
           for (const auto& hl : cb.hlsl_lines) {
             std::smatch m;
@@ -9571,10 +9538,17 @@ class Decompiler {
                 if (!declared_vars.contains(var_name)) {
                   string_stream << spacing << hl << "\n";
                   declared_vars.insert(var_name);
+                  hoisted_heap_lines.insert(hl);
                 }
               }
             }
           }
+        }
+        // Remove hoisted declarations from code blocks to prevent duplication
+        for (auto& [block_num, cb] : current_code_function->code_blocks) {
+          std::erase_if(cb.hlsl_lines, [&](const std::string& line) {
+            return hoisted_heap_lines.contains(line);
+          });
         }
       }
     }

--- a/src/utils/shader_decompiler_dxc.hpp
+++ b/src/utils/shader_decompiler_dxc.hpp
@@ -362,6 +362,23 @@ class Decompiler {
     throw std::runtime_error(std::format("Could not parse bitcast '{}'", input));
   }
 
+  // Turn a DXIL-derived struct/type name into a valid HLSL identifier. LLVM allows
+  // characters such as '.', '<', '>', ',', and spaces in type names (e.g. the
+  // anonymous struct '%struct.anon.0' or template classes), none of which are
+  // legal in an HLSL identifier. Emitting them verbatim produces "expected
+  // unqualified-id" errors, so every site that prints a struct name routes
+  // through here to stay consistent between the declaration and its references.
+  static std::string SanitizeHlslTypeName(std::string_view input) {
+    std::string result(input);
+    for (char& character : result) {
+      if (character == '<' || character == '>' || character == ' '
+          || character == '.' || character == ',' || character == ':') {
+        character = '_';
+      }
+    }
+    return result;
+  }
+
   static std::string ParseTrunc(std::string_view input) {
     if (input == "i32") return "int";
     if (input == "i16") return "int16_t";
@@ -688,6 +705,7 @@ class Decompiler {
     std::string_view name;
     SignaturePacked packed;
     SignatureProperty property;
+    std::string variable_name_override;
 
     explicit Signature() = default;
 
@@ -713,6 +731,7 @@ class Decompiler {
 
     // eg: float; float3; float4
     [[nodiscard]] std::string VariableString() const {
+      if (!variable_name_override.empty()) return variable_name_override;
       if (property.index == 0) return std::string{this->name};
 
       std::stringstream string_stream;
@@ -874,10 +893,19 @@ class Decompiler {
       auto [name, type, format, dimensions, id, hlslBinding, count] = StringViewMatch<7>(line, regex);
 
       if (name.empty()) {
-        // Fallback for unusual formatting
+        // Fallback: split on 2+ space boundaries
         static auto alt_regex = std::regex{R"(; (.+?)\s{2,}(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(.*))"};
         auto [n, t, f, d, i, h, c] = StringViewMatch<7>(line, alt_regex);
         name = n; type = t; format = f; dimensions = d; id = i; hlslBinding = h; count = c;
+      }
+
+      // Handle merged type+format (e.g., "UAVunorm_f32" → type="UAV", format="unorm_f32")
+      if (name.empty() || type.empty()) {
+        static auto merged_regex = std::regex{R"(; (.+?)\s{2,}(UAV)(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(.*))"};
+        auto [n, t, f, d, i, h, c] = StringViewMatch<7>(line, merged_regex);
+        if (!n.empty()) {
+          name = n; type = t; format = f; dimensions = d; id = i; hlslBinding = h; count = c;
+        }
       }
 
       this->name = StringViewTrim(name);
@@ -1099,6 +1127,23 @@ class Decompiler {
     static bool IsAnyByteAddressBufferPointer(std::string_view pointer) {
       return IsByteAddressBufferPointer(pointer) || IsRWByteAddressBufferPointer(pointer);
     }
+
+    // Resolve a nested matrix template element such as
+    //   %"class.StructuredBuffer<matrix<float, 4, 4> >"
+    // into the HLSL element type "float4x4". The generic pointer_regex used by
+    // SRV/UAV parsing was written for vector<> elements and captures
+    // base_type="matrix<float", type_count="4, 4" for matrix elements, which
+    // concatenates into the invalid "matrix<float4, 4". This returns the proper
+    // "{scalar}{rows}x{cols}" spelling, or empty when the element is not a matrix.
+    static std::string ResolveMatrixBufferElement(std::string_view pointer) {
+      static const auto MATRIX_ELEMENT_REGEX =
+          std::regex{R"(<\s*matrix<\s*(\w+)\s*,\s*(\d+)\s*,\s*(\d+)\s*>)"};
+      std::cmatch match;
+      if (!std::regex_search(pointer.data(), pointer.data() + pointer.size(), match, MATRIX_ELEMENT_REGEX)) {
+        return {};
+      }
+      return std::format("{}{}x{}", match[1].str(), match[2].str(), match[3].str());
+    }
   };
 
   struct SRVResource : Resource {
@@ -1134,6 +1179,12 @@ class Decompiler {
         base_type_fixed = DataType::FixBaseType(base_type);
       }
       this->data_type = std::format("{}{}", base_type_fixed, effective_type_count);
+
+      // Matrix-element StructuredBuffers (e.g. StructuredBuffer<float4x4>) are not
+      // expressible via the vector-oriented base_type/type_count split above.
+      if (auto matrix_element = ResolveMatrixBufferElement(this->pointer); !matrix_element.empty()) {
+        this->data_type = matrix_element;
+      }
 
       // https://github.com/microsoft/DirectXShaderCompiler/blob/b766b432678cf5f7a93567d253bb5f7fd8a0b2c7/docs/DXIL.rst#L1047
       uint32_t shape;
@@ -1196,6 +1247,12 @@ class Decompiler {
         base_type_fixed = DataType::FixBaseType(base_type);
       }
       this->data_type = std::format("{}{}", base_type_fixed, effective_type_count);
+
+      // Matrix-element (RW)StructuredBuffers (e.g. RWStructuredBuffer<float4x4>)
+      // are not expressible via the vector-oriented base_type/type_count split.
+      if (auto matrix_element = ResolveMatrixBufferElement(this->pointer); !matrix_element.empty()) {
+        this->data_type = matrix_element;
+      }
 
       uint32_t shape;
       FromStringView(ParseKeyValue(metadata[6])[1], shape);
@@ -1316,6 +1373,38 @@ class Decompiler {
     std::string_view type;
     std::optional<uint32_t> offset;
   };
+
+  struct ReflectedMatrixDeclaration {
+    std::string major;
+    std::string scalar_type;
+    uint32_t row_count = 0;
+    uint32_t column_count = 0;
+    std::optional<uint32_t> array_size;
+  };
+
+  static std::optional<ReflectedMatrixDeclaration> ParseReflectedMatrixDeclaration(
+      std::string_view declaration,
+      std::string_view expected_name) {
+    if (declaration.empty()) return std::nullopt;
+
+    static const std::regex MATRIX_DECLARATION_PATTERN(
+        R"(^\s*(row_major|column_major)\s+(float|half|double)(\d+)x(\d+)\s+([A-Za-z_][A-Za-z0-9_]*)(?:\[(\d+)\])?\s*$)");
+    auto [major, scalar_type, rows, columns, name, array_size] = StringViewMatch<6>(declaration, MATRIX_DECLARATION_PATTERN);
+    if (name != expected_name || major != "row_major") return std::nullopt;
+
+    ReflectedMatrixDeclaration result;
+    result.major = major;
+    result.scalar_type = scalar_type;
+    FromStringView(rows, result.row_count);
+    FromStringView(columns, result.column_count);
+    if (!array_size.empty()) {
+      uint32_t parsed_array_size = 0;
+      FromStringView(array_size, parsed_array_size);
+      result.array_size = parsed_array_size;
+    }
+    return result;
+  }
+
   struct TypeDefinition {
     std::string_view name;
     std::vector<Variable> variables;
@@ -1326,7 +1415,10 @@ class Decompiler {
 
     explicit TypeDefinition(std::string_view line) {
       // %"class.Texture3D<vector<float, 4> >" = type { <4 x float>, %"class.Texture3D<vector<float, 4> >::mips_type" }
-      static auto regex = std::regex{R"(^(%(?:(?:"[^"]+")|\S+)) = type \{([^}]+)\}$)"};
+      // Use [^}]* (not +) so empty structs (`%struct.Foo = type {}`, size 0) are
+      // still registered; otherwise the regex fails, the definition is stored
+      // under an empty key, and GetTypeSize throws "Unknown data type".
+      static auto regex = std::regex{R"(^(%(?:(?:"[^"]+")|\S+)) = type \{([^}]*)\}$)"};
 
       auto [name, types] = StringViewMatch<2>(line, regex);
 
@@ -1365,6 +1457,7 @@ class Decompiler {
   struct HeapResourceInfo {
     Resource::ResourceKind resource_kind = Resource::ResourceKind::Invalid;
     std::string data_type;
+    uint32_t stride = 0;
   };
 
   struct PreprocessState {
@@ -1427,6 +1520,19 @@ class Decompiler {
       if (resource_class == "0" && range_index < srv_resources.size()) return srv_resources[range_index].data_type;
       if (resource_class == "1" && range_index < uav_resources.size()) return uav_resources[range_index].data_type;
       return "float4";
+    }
+
+    // Helper to get the byte stride for structured resource binding variables.
+    uint32_t GetResourceStride(const std::string& var_name) const {
+      auto heap_it = heap_resource_info.find(var_name);
+      if (heap_it != heap_resource_info.end()) return heap_it->second.stride;
+      auto binding_it = resource_binding_variables.find(var_name);
+      if (binding_it == resource_binding_variables.end()) return 0;
+      auto& binding = binding_it->second;
+      auto [name, range_index, resource_class] = binding;
+      if (resource_class == "0" && range_index < srv_resources.size()) return srv_resources[range_index].stride;
+      if (resource_class == "1" && range_index < uav_resources.size()) return uav_resources[range_index].stride;
+      return 0;
     }
 
     size_t GetTypeSize(const DataType& data_type) {
@@ -1604,6 +1710,23 @@ class Decompiler {
           }
         }
 
+        if (auto matrix_declaration = ParseReflectedMatrixDeclaration(declaration, name)) {
+          const uint32_t scalar_size = matrix_declaration->scalar_type == "double" ? 8u : 4u;
+          const uint32_t row_size = matrix_declaration->column_count * scalar_size;
+          const uint32_t matrix_size = matrix_declaration->row_count * row_size;
+          uint32_t offset_in_matrix = pending;
+          std::string array_index;
+
+          if (matrix_declaration->array_size.has_value()) {
+            array_index = std::format("[{}]", pending / matrix_size);
+            offset_in_matrix = pending % matrix_size;
+          }
+
+          const uint32_t row_index = offset_in_matrix / row_size;
+          const uint32_t component_index = (offset_in_matrix % row_size) / scalar_size;
+          return std::format("{}{}[{}].{}", name, array_index, row_index, VECTOR_INDEXES[component_index]);
+        }
+
         return name + GetSubValueFromType(type_name, info, pending);
       }
       assert(false);
@@ -1630,6 +1753,18 @@ class Decompiler {
       auto effective_type_name = (pair == type_definitions.end()) ? type_name : std::string_view(pair->first);
       if (effective_type_name.starts_with("%\"class.StructuredBuffer<") || effective_type_name.starts_with("%\"class.RWStructuredBuffer<")
           || effective_type_name.starts_with("%\"hostlayout.class.StructuredBuffer<") || effective_type_name.starts_with("%\"hostlayout.class.RWStructuredBuffer<")) {
+        // Matrix-element buffers (RWStructuredBuffer<float4x4>) store one matrix
+        // row per rawBufferStore, so resolve the byte offset to the row subscript.
+        if (std::string_view(definition.variables[0].type).starts_with("%class.matrix.float")) {
+          static const std::regex MATRIX_PATTERN(R"(%class\.matrix\.[^.]+\.(\d+)\.(\d+))");
+          auto [row_string, column_string] = StringViewMatch<2>(definition.variables[0].type, MATRIX_PATTERN);
+          uint32_t column_count = 0;
+          FromStringView(column_string, column_count);
+          if (column_count != 0) {
+            const uint32_t row_size = column_count * 4;
+            return std::format("[{}]", offset / row_size);
+          }
+        }
         auto struct_pair = type_definitions.find(definition.variables[0].type);
         if (struct_pair != type_definitions.end()) {
           // Find the field at this offset without sub-value resolution
@@ -1661,6 +1796,18 @@ class Decompiler {
                 return std::format(".{}[{}]", name, array_index);
               }
               // Non-array struct field: drill into it if there's remaining offset
+              if (info.data_type.starts_with("%class.matrix.float")) {
+                // Matrix struct field (e.g. float4x4 _transform): a rawBufferStore
+                // writes one row at a time, so resolve to the row subscript.
+                static const std::regex MATRIX_PATTERN(R"(%class\.matrix\.[^.]+\.(\d+)\.(\d+))");
+                auto [row_string, column_string] = StringViewMatch<2>(info.data_type, MATRIX_PATTERN);
+                uint32_t column_count = 0;
+                FromStringView(column_string, column_count);
+                if (column_count != 0) {
+                  const uint32_t row_size = column_count * 4;
+                  return std::format(".{}[{}]", name, offset_in_field / row_size);
+                }
+              }
               if (offset_in_field > 0 && (info.data_type.starts_with("%struct.") || info.data_type.starts_with("%hostlayout.struct."))) {
                 auto nested_pair = type_definitions.find(info.data_type);
                 if (nested_pair != type_definitions.end()) {
@@ -1704,9 +1851,16 @@ class Decompiler {
       auto effective_type_name = (pair == type_definitions.end()) ? type_name : std::string_view(pair->first);
       if (effective_type_name.starts_with("%\"class.StructuredBuffer<") || effective_type_name.starts_with("%\"class.RWStructuredBuffer<")
           || effective_type_name.starts_with("%\"hostlayout.class.StructuredBuffer<") || effective_type_name.starts_with("%\"hostlayout.class.RWStructuredBuffer<")) {
+        // Matrix-element buffers (StructuredBuffer<float4x4>) are declared with a
+        // bare matrix element, so resolve the byte offset to a matrix subscript
+        // ([row].col) rather than the synthetic wrapper-struct field name.
+        if (std::string_view(definition.variables[0].type).starts_with("%class.matrix.")) {
+          return GetSubValueFromType(definition.variables[0].type, DataType(definition.variables[0].type), index);
+        }
         auto struct_pair = type_definitions.find(definition.variables[0].type);
         if (struct_pair != type_definitions.end()) {
-          return "." + DataTypeNameAtIndex(struct_pair->second.variables, index);
+          auto field_name = DataTypeNameAtIndex(struct_pair->second.variables, index);
+          return field_name.empty() ? "" : "." + field_name;
         }
         return GetSubValueFromType(definition.variables[0].type, DataType(definition.variables[0].type), index);
       }
@@ -1729,11 +1883,87 @@ class Decompiler {
       }
       auto& definition = pair->second;
 
-      if (definition.has_offsets || resource.buffer_size == definition.size) {
-        return DataTypeNameAtIndex(definition.variables, index);
+      if (CBufferLayoutResolvable(resource, definition)) {
+        auto field_name = DataTypeNameAtIndex(definition.variables, index);
+        if (field_name.empty()) return "";
+        if (UsesCBufferStructView(resource, definition)) {
+          return std::format("{}.{}", CBufferStructViewName(resource), field_name);
+        }
+        return field_name;
       }
       return "";
     };
+
+    static bool HasDirectAggregateCBufferRoot(const TypeDefinition& definition) {
+      if (definition.variables.size() != 1u) return false;
+      const auto& variable = definition.variables.front();
+      if (variable.offset.has_value() && variable.offset.value() != 0u) return false;
+      DataType info(variable.type);
+      return info.data_type.starts_with("%struct.")
+          || info.data_type.starts_with("%hostlayout.struct.")
+          || info.data_type.starts_with("%\"struct.")
+          || info.data_type.starts_with("%\"hostlayout.struct.");
+    }
+
+    // True when the reconstructed struct layout can name the cbuffer's contents:
+    // it either carries reflected offsets or is a sized layout that fits within
+    // the declared buffer. When the layout is smaller than the buffer (no
+    // reflection annotation, trailing padding), the remaining bytes stay
+    // reachable through the raw views emitted for dynamic access.
+    [[nodiscard]] bool CBufferLayoutResolvable(const CBVResource& resource, const TypeDefinition& definition) const {
+      // Reflected layout, or a layout that exactly fills the buffer: always safe
+      // to name every field.
+      if (definition.has_offsets) return true;
+      if (resource.buffer_size == definition.size) return true;
+      // Undersized reconstructed layout (no reflection annotation / trailing
+      // padding): only safe when the cbuffer has dynamic access, because the raw
+      // views then cover every offset the struct can't name, and unresolved
+      // static loads route through those raw views instead of emitting an
+      // undeclared register accessor.
+      if (!definition.size.has_value()) return false;
+      const uint32_t layout_size = definition.size.value();
+      if (layout_size == 0u || layout_size > resource.buffer_size) return false;
+      const auto* first = this->cbv_resources.data();
+      const auto* last = first + this->cbv_resources.size();
+      if (&resource < first || &resource >= last) return false;
+      const auto index = static_cast<uint32_t>(&resource - first);
+      return this->cbv_dynamic_access_indices.count(index) != 0u;
+    }
+
+    [[nodiscard]] bool UsesCBufferStructView(const CBVResource& resource, const TypeDefinition& definition) const {
+      if (resource.array_size.has_value()) return false;
+      if (HasDirectAggregateCBufferRoot(definition)) return false;
+
+      const auto* first = this->cbv_resources.data();
+      const auto* last = first + this->cbv_resources.size();
+      if (&resource < first || &resource >= last) return false;
+      const auto index = static_cast<uint32_t>(&resource - first);
+      return this->cbv_dynamic_access_indices.count(index) != 0u
+          && CBufferLayoutResolvable(resource, definition);
+    }
+
+    // Whether the reflected field TYPES can be trusted to match how the shader
+    // loads each register. Real reflection (has_offsets) or an exact-size layout
+    // is reliable; a reconstructed/undersized layout is not — the same bytes may
+    // be loaded as int in one place and float in another, so callers must wrap
+    // such accesses in asint()/asfloat() to preserve the DXIL load's bit
+    // interpretation.
+    [[nodiscard]] bool CBufferFieldTypesReliable(const CBVResource& resource) const {
+      auto type_name = resource.pointer.substr(0, resource.pointer.length() - 1);
+      auto pair = type_definitions.find(type_name);
+      if (pair == type_definitions.end()) {
+        static auto array_inner_regex = std::regex{R"(^\[\d+ x (.+)\]$)"};
+        auto [inner_type] = StringViewMatch<1>(type_name, array_inner_regex);
+        if (!inner_type.empty()) pair = type_definitions.find(inner_type);
+        if (pair == type_definitions.end()) return false;
+      }
+      const auto& definition = pair->second;
+      return definition.has_offsets || resource.buffer_size == definition.size;
+    }
+
+    static std::string CBufferStructViewName(const CBVResource& resource) {
+      return std::format("{}_view", resource.name);
+    }
 
     void ProcessBufferDefinitions(
         std::span<std::string_view> buffer_definition_lines,
@@ -1832,9 +2062,29 @@ class Decompiler {
           candidate_name = candidate_name.substr(0, array_start_index);
         }
 
-        if (candidate_name.empty()) {
-          assert(!candidate_name.empty());
-          break;
+        if (candidate_name.empty()
+            || candidate_name == "bool"
+            || candidate_name == "uint"
+            || candidate_name == "uint2"
+            || candidate_name == "uint3"
+            || candidate_name == "uint4"
+            || candidate_name == "int"
+            || candidate_name == "int2"
+            || candidate_name == "int3"
+            || candidate_name == "int4"
+            || candidate_name == "float"
+            || candidate_name == "float2"
+            || candidate_name == "float3"
+            || candidate_name == "float4"
+            || candidate_name == "half"
+            || candidate_name == "half2"
+            || candidate_name == "half3"
+            || candidate_name == "half4"
+            || candidate_name == "double") {
+          // DXC reflection sometimes emits padding/anonymous fields as e.g. `uint ;`.
+          // Keep the generated offset-based name so subsequent reflected fields stay aligned.
+          item.offset = line_offset_number - base_offset;
+          continue;
         }
 
         item.name.assign(candidate_name);
@@ -2000,6 +2250,7 @@ class Decompiler {
     // Key: variable name (e.g. "193"). Value: LLVM scalar type (e.g. "i32").
     std::unordered_map<std::string, std::string> stored_pointer_element_types;
     std::map<std::string, std::pair<std::string, std::string>> variable_aliases;
+    std::map<std::string, std::string> aggregate_extract_types;
     std::vector<std::string_view> threads;
     std::map<uint32_t, uint32_t> variable_counter;
     std::set<std::string> phi_variables;
@@ -2064,6 +2315,44 @@ class Decompiler {
       FromStringView(variable, variable_number);
       auto& count = variable_counter[variable_number];
       ++count;
+    }
+
+    bool EnsureResourceBindingVariable(const std::string& ref, PreprocessState& preprocess_state) {
+      if (preprocess_state.resource_binding_variables.contains(ref)) return true;
+
+      static const auto annotate_handle_regex = std::regex{
+          R"(^  %([A-Za-z0-9]+) = call %dx\.types\.Handle @dx\.op\.annotateHandle\(i32 \d+, %dx\.types\.Handle %([A-Za-z0-9]+),.*)"};
+
+      for (const auto& line : this->lines) {
+        const auto [annotated_ref, source_ref] = StringViewMatch<2>(line, annotate_handle_regex);
+        if (annotated_ref != ref) continue;
+
+        const std::string source_key{source_ref};
+        if (!preprocess_state.resource_binding_variables.contains(source_key)) {
+          EnsureResourceBindingVariable(source_key, preprocess_state);
+        }
+
+        const auto source_binding = preprocess_state.resource_binding_variables.find(source_key);
+        if (source_binding == preprocess_state.resource_binding_variables.end()) return false;
+
+        preprocess_state.resource_binding_variables[ref] = source_binding->second;
+        if (preprocess_state.cbv_handles_with_dynamic_access.contains(std::format("%{}", ref))) {
+          auto& binding = preprocess_state.resource_binding_variables[ref];
+          if (binding.resource_class == "2") {
+            preprocess_state.cbv_dynamic_access_indices.insert(binding.range_index);
+          }
+        }
+        return true;
+      }
+
+      return false;
+    }
+
+    ResourceBindingVariable& GetResourceBindingVariable(const std::string& ref, PreprocessState& preprocess_state) {
+      if (!EnsureResourceBindingVariable(ref, preprocess_state)) {
+        throw std::runtime_error(std::format("Resource binding not found for handle %{}", ref));
+      }
+      return preprocess_state.resource_binding_variables.at(ref);
     }
 
     std::string ParseVariable(std::string_view input, const std::string& expected_type = "float") {
@@ -2156,6 +2445,123 @@ class Decompiler {
       if (type == "i64") return ParseInt64(input);
       if (type == "half") return ParseHalf(input);
       return ParseFloat(input);
+    }
+
+    int CountDxilMaskComponents(std::string_view mask) {
+      int mask_val = 0;
+      FromStringView(mask, mask_val);
+      int component_count = 0;
+      if (mask_val & 1) component_count++;
+      if (mask_val & 2) component_count++;
+      if (mask_val & 4) component_count++;
+      if (mask_val & 8) component_count++;
+      return component_count == 0 ? 1 : component_count;
+    }
+
+    std::string BuildStructuredByteAddress(std::string_view index, std::string_view element_offset, uint32_t stride) {
+      auto byte_address = ParseInt(index);
+      if (stride > 1) {
+        byte_address = std::format("({} * {})", byte_address, stride);
+      }
+      if (element_offset != "undef" && element_offset != "0") {
+        byte_address = std::format("({} + {})", byte_address, ParseInt(element_offset));
+      }
+      return byte_address;
+    }
+
+    std::string ResolveStoredPointer(std::string_view pointer, PreprocessState& preprocess_state) {
+      const auto pointer_key = std::string(pointer);
+      if (auto it = stored_pointers.find(pointer);
+          it != stored_pointers.end() && !it->second.empty()) {
+        return it->second;
+      }
+
+      const std::string assignment_prefix = std::format("  %{} = ", pointer_key);
+      for (const auto& source_line : this->lines) {
+        if (!source_line.starts_with(assignment_prefix)) continue;
+        auto assignment = source_line.substr(assignment_prefix.size());
+        if (auto comment_pos = assignment.find(';'); comment_pos != std::string_view::npos) {
+          assignment = StringViewTrim(assignment.substr(0, comment_pos));
+        }
+
+        auto [array_size_str, element_type, source, index] = StringViewMatch<4>(
+            assignment,
+            std::regex{R"(getelementptr (?:inbounds )?\[(\d+) x ([^\]]+)\], \[[^\]]+\](?: addrspace\(\d+\))?\* (\S+), i32 \S+, i32 (\S+).*)"});
+        if (!array_size_str.empty()) {
+          int array_size = 0;
+          FromStringView(array_size_str, array_size);
+
+          std::string parsed_source;
+          if (source.starts_with('%')) {
+            parsed_source = std::format("_{}", source.substr(1));
+          } else if (source.starts_with('@')) {
+            if (auto pair = preprocess_state.global_variables.find(std::string(source));
+                pair != preprocess_state.global_variables.end()) {
+              parsed_source = pair->second;
+            } else {
+              auto source_str = std::string(source);
+              bool found_base = false;
+              auto last_quote = source_str.rfind('"');
+              if (last_quote != std::string::npos && last_quote > 0) {
+                auto inner = source_str.substr(0, last_quote);
+                while (!found_base) {
+                  auto last_dot = inner.rfind('.');
+                  if (last_dot == std::string::npos) break;
+                  auto suffix = inner.substr(last_dot + 1);
+                  bool all_digits = !suffix.empty() && std::ranges::all_of(suffix, [](char c) { return c >= '0' && c <= '9'; });
+                  if (!all_digits) break;
+                  inner = inner.substr(0, last_dot);
+                  auto candidate = inner + "\"";
+                  if (auto pair2 = preprocess_state.global_variables.find(candidate);
+                      pair2 != preprocess_state.global_variables.end()) {
+                    parsed_source = pair2->second;
+                    found_base = true;
+                  }
+                }
+              }
+              if (!found_base) {
+                parsed_source = std::format("/* {} */", source);
+              }
+            }
+          }
+
+          if (!parsed_source.empty()) {
+            auto parsed_index = ParseInt(index);
+            bool is_dynamic_index = index.starts_with('%');
+            std::string clamped_index;
+            if (is_dynamic_index && array_size > 0) {
+              clamped_index = std::format("min((uint)({}), {}u)", parsed_index, array_size - 1);
+            } else {
+              clamped_index = parsed_index;
+            }
+            const auto pointer_value = std::format("{}[{}]", parsed_source, clamped_index);
+            stored_pointers[pointer] = pointer_value;
+            if (!element_type.empty()) {
+              stored_pointer_element_types[pointer_key] = std::string(element_type);
+            }
+            return pointer_value;
+          }
+        }
+
+        static auto bitcast_regex = std::regex{R"(bitcast (\S+(?:\s+addrspace\(\d+\))?\*?) (\S+) to (\S+(?:\s+addrspace\(\d+\))?\*?))"};
+        auto [source_type, source_variable, dest_type] = StringViewMatch<3>(assignment, bitcast_regex);
+        if (!source_type.empty() && dest_type.find('*') != std::string_view::npos && source_variable.starts_with('%')) {
+          auto source_ref = source_variable.substr(1);
+          auto pointer_value = ResolveStoredPointer(source_ref, preprocess_state);
+          stored_pointers[pointer] = pointer_value;
+          auto it = stored_pointer_element_types.find(std::string(source_ref));
+          if (it != stored_pointer_element_types.end()) {
+            stored_pointer_element_types[pointer_key] = it->second;
+          }
+          return pointer_value;
+        }
+      }
+
+      if (auto it = stored_pointers.find(pointer);
+          it != stored_pointers.end()) {
+        return it->second;
+      }
+      return std::format("_{}", pointer);
     }
 
     CodeFunction() = default;
@@ -2287,6 +2693,9 @@ class Decompiler {
             auto srv = std::ranges::find_if(preprocess_state.srv_resources, [&](SRVResource& resource) {
               return resource.space == space_value && resource.signature_index == bind_start_value;
             });
+            if (srv == preprocess_state.srv_resources.end()) {
+              throw std::runtime_error(std::format("createHandleFromBinding: SRV not found (space={}, index={})", space_value, bind_start_value));
+            }
             range_index = srv - preprocess_state.srv_resources.begin();
             name = srv->name;
             if (srv->array_size.has_value()) {
@@ -2300,6 +2709,9 @@ class Decompiler {
             auto uav = std::ranges::find_if(preprocess_state.uav_resources, [&](UAVResource& resource) {
               return resource.space == space_value && resource.signature_index == bind_start_value;
             });
+            if (uav == preprocess_state.uav_resources.end()) {
+              throw std::runtime_error(std::format("createHandleFromBinding: UAV not found (space={}, index={})", space_value, bind_start_value));
+            }
             range_index = uav - preprocess_state.uav_resources.begin();
             name = uav->name;
             if (uav->array_size.has_value()) {
@@ -2313,6 +2725,9 @@ class Decompiler {
             auto cbv = std::ranges::find_if(preprocess_state.cbv_resources, [&](CBVResource& resource) {
               return resource.space == space_value && resource.signature_index == bind_start_value;
             });
+            if (cbv == preprocess_state.cbv_resources.end()) {
+              throw std::runtime_error(std::format("createHandleFromBinding: CBV not found (space={}, index={})", space_value, bind_start_value));
+            }
             range_index = cbv - preprocess_state.cbv_resources.begin();
             name = cbv->name;
             if (cbv->array_size.has_value()) {
@@ -2326,6 +2741,9 @@ class Decompiler {
             auto sampler = std::find_if(preprocess_state.sampler_resources.begin(), preprocess_state.sampler_resources.end(), [&](SamplerResource& resource) {
               return resource.space == space_value && resource.signature_index == bind_start_value;
             });
+            if (sampler == preprocess_state.sampler_resources.end()) {
+              throw std::runtime_error(std::format("createHandleFromBinding: Sampler not found (space={}, index={})", space_value, bind_start_value));
+            }
             range_index = sampler - preprocess_state.sampler_resources.begin();
             name = sampler->name;
             if (sampler->array_size.has_value()) {
@@ -2375,7 +2793,7 @@ class Decompiler {
             uint32_t kind_bits = 0;
             if (!kind_bits_str.empty()) FromStringView(kind_bits_str, kind_bits);
             uint32_t resource_kind = kind_bits & 0xFF;
-            bool is_uav = (kind_bits >> 11) & 1;
+            bool is_uav = (kind_bits >> 12) & 1;
 
             auto& heap_info = heap_it->second;
             std::string synth_name = std::format("_HeapResource_{}", preprocess_state.heap_srv_counter++);
@@ -2398,6 +2816,8 @@ class Decompiler {
             std::string hint;
             std::string data_type;
             auto rk = static_cast<Resource::ResourceKind>(resource_kind);
+            uint32_t extra = 0;
+            if (!extra_str.empty()) FromStringView(extra_str, extra);
             if (rk == Resource::ResourceKind::RawBuffer) {
               hint = is_uav ? "RWByteAddressBuffer" : "ByteAddressBuffer";
               data_type = "";
@@ -2410,8 +2830,6 @@ class Decompiler {
             } else {
               // Texture types — parse element type from second props word
               // Second word: low 8 bits = component type, bits 8+ = component count
-              uint32_t extra = 0;
-              if (!extra_str.empty()) FromStringView(extra_str, extra);
               uint32_t comp_type = extra & 0xFF;
               uint32_t comp_count = (extra >> 8) & 0xFF;
               if (comp_count == 0) comp_count = 1;  // fallback
@@ -2441,6 +2859,7 @@ class Decompiler {
             preprocess_state.heap_resource_info[std::string(variable)] = {
                 .resource_kind = rk,
                 .data_type = data_type,
+              .stride = (rk == Resource::ResourceKind::StructuredBuffer) ? extra : 0,
             };
 
             // Emit actual variable declaration using ResourceDescriptorHeap
@@ -2558,10 +2977,10 @@ class Decompiler {
           auto& cbv_resource = preprocess_state.cbv_resources[range_index];
 
           if (regIndex.starts_with("%")) {
-            // Dynamic cbuffer offset — emit as array-style access via raw uint4 view
+            // Dynamic cbuffer offset — emit as array-style access via raw float4 view
             preprocess_state.cbv_dynamic_access_indices.insert(range_index);
             assignment_type = "float4";
-            assignment_value = std::format("asfloat({}_raw[{}])", cbv_resource.name, ParseVariable(regIndex));
+            assignment_value = std::format("{}_raw[{}]", cbv_resource.name, ParseVariable(regIndex));
             is_identity = false;
             use_comment = false;
           } else {
@@ -2582,10 +3001,10 @@ class Decompiler {
           auto& cbv_resource = preprocess_state.cbv_resources[range_index];
 
           if (regIndex.starts_with("%")) {
-            // Dynamic cbuffer offset — emit as array-style access via raw float4 view
+            // Dynamic cbuffer offset — emit as array-style access via overlapping raw uint4 view
             preprocess_state.cbv_dynamic_access_indices.insert(range_index);
             assignment_type = "int4";
-            assignment_value = std::format("asint({}_raw[{}])", cbv_resource.name, ParseVariable(regIndex));
+            assignment_value = std::format("asint({}_raw_uint[{}])", cbv_resource.name, ParseVariable(regIndex));
             is_identity = false;
             use_comment = false;
           } else {
@@ -2752,9 +3171,10 @@ class Decompiler {
           const bool has_offset_z = offset2 != "undef";
           const bool has_mip_level = mipLevelOrSampleCount != "undef";
           std::string coords;
-          auto [binding_name, range_index, resource_class] = preprocess_state.resource_binding_variables.at(ref_resource);
+          auto [binding_name, range_index, resource_class] = GetResourceBindingVariable(ref_resource, preprocess_state);
           Resource::ResourceKind shape = preprocess_state.GetResourceShape(ref_resource);
-          if (resource_class == "0") {
+          const bool is_heap_resource = preprocess_state.IsHeapResource(ref_resource);
+          if (resource_class == "0" || is_heap_resource) {
             assignment_type = preprocess_state.GetResourceDataType(ref_resource);
           } else if (resource_class == "1") {
             shape = preprocess_state.uav_resources[range_index].shape;
@@ -2801,12 +3221,27 @@ class Decompiler {
           } else {
             offset = std::format("{}", ParseInt(offset0));
           }
+          const bool is_uav_texture_load = resource_class == "1" && !is_heap_resource;
           if (offset == "undef" || offset == "0" || offset == "int2(0, 0)" || offset == "int3(0, 0, 0)") {
-            assignment_value = std::format("{}.Load({})", binding_name, coords);
+            assignment_value = is_uav_texture_load
+                                   ? std::format("{}[{}]", binding_name, coords)
+                                   : std::format("{}.Load({})", binding_name, coords);
             // decompiled = std::format("{} _{} = {}.Load({});", srv_resource.data_type, variable, binding_name, coords);
           } else {
-            assignment_value = std::format("{}.Load({}, {})", binding_name, coords, offset);
+            assignment_value = is_uav_texture_load
+                                   ? std::format("{}[{} + {}]", binding_name, coords, offset)
+                                   : std::format("{}.Load({}, {})", binding_name, coords, offset);
             // decompiled = std::format("{} _{} = {}.Load({}, {});", srv_resource.data_type, variable, binding_name, coords, offset);
+          }
+          if (is_uav_texture_load) {
+            int component_count = 1;
+            if (!assignment_type.empty()) {
+              char last_char = assignment_type.back();
+              if (last_char >= '2' && last_char <= '4') component_count = last_char - '0';
+            }
+            preprocess_state.uav_binding_load_variables[variable] = {
+                nullptr, assignment_value, std::to_string(component_count), "raw", ""};
+            use_comment = true;
           }
         } else if (functionName == "@dx.op.sample.f32" || functionName == "@dx.op.sample.f16") {
           //  call %dx.types.ResRet.f32 @dx.op.sample.f32(i32 60, %dx.types.Handle %1, %dx.types.Handle %2, float %4, float %5, float undef, float undef, i32 0, i32 0, i32 undef, float undef)  ; Sample(srv,sampler,coord0,coord1,coord2,coord3,offset0,offset1,offset2,clamp)
@@ -2835,21 +3270,25 @@ class Decompiler {
           } else {
             offset = std::format("{}", ParseInt(offset0));
           }
-          if (has_clamp) {
-            throw std::runtime_error("Unknown clamp");
-          }
-
-          auto [srv_name, srv_range_index, srv_resource_class] = preprocess_state.resource_binding_variables.at(ref_resource);
+          auto [srv_name, srv_range_index, srv_resource_class] = GetResourceBindingVariable(ref_resource, preprocess_state);
           assert(srv_resource_class == "0");
-          auto [sampler_name, sampler_range_index, sampler_resource_class] = preprocess_state.resource_binding_variables.at(ref_sampler);
+          auto [sampler_name, sampler_range_index, sampler_resource_class] = GetResourceBindingVariable(ref_sampler, preprocess_state);
           auto sampler_resource = preprocess_state.sampler_resources[sampler_range_index];
           assignment_type = preprocess_state.GetResourceDataType(ref_resource);
-          if (offset == "0" || offset == "int2(0, 0)" || offset == "int3(0, 0, 0)") {
+          const bool sample_offset_is_zero =
+              (offset == "0" || offset == "int2(0, 0)" || offset == "int3(0, 0, 0)");
+          if (has_clamp) {
+            // HLSL Sample(sampler, location, offset, clamp) requires an explicit
+            // offset argument whenever a clamp value is supplied.
+            std::string clamp_offset = offset;
+            if (sample_offset_is_zero) {
+              clamp_offset = has_coord_z ? "int3(0, 0, 0)" : "int2(0, 0)";
+            }
+            assignment_value = std::format("{}.Sample({}, {}, {}, {})", srv_name, sampler_name, coords, clamp_offset, ParseFloat(clamp));
+          } else if (sample_offset_is_zero) {
             assignment_value = std::format("{}.Sample({}, {})", srv_name, sampler_name, coords);
-            // decompiled = std::format("{} _{} = {}.Sample({}, {});", srv_resource.data_type, variable, srv_name, sampler_name, coords);
           } else {
             assignment_value = std::format("{}.Sample({}, {}, {})", srv_name, sampler_name, coords, offset);
-            // decompiled = std::format("{} _{} = {}.Sample({}, {}, {});", srv_resource.data_type, variable, srv_name, sampler_name, coords, offset);
           }
         } else if (functionName == "@dx.op.sampleLevel.f32" || functionName == "@dx.op.sampleLevel.f16") {
           // %427 = call %dx.types.ResRet.f32 @dx.op.sampleLevel.f32(i32 62, %dx.types.Handle %3, %dx.types.Handle %7, float %384, float %385, float %426, float undef, i32 undef, i32 undef, i32 undef, float 0.000000e+00)  ; SampleLevel(srv,sampler,coord0,coord1,coord2,coord3,offset0,offset1,offset2,LOD)
@@ -2882,8 +3321,8 @@ class Decompiler {
             offset = std::format("{}", ParseInt(offset0));
           }
 
-          auto [srv_name, srv_range_index, srv_resource_class] = preprocess_state.resource_binding_variables.at(ref_resource);
-          auto [sampler_name, sampler_range_index, sampler_resource_class] = preprocess_state.resource_binding_variables.at(ref_sampler);
+          auto [srv_name, srv_range_index, srv_resource_class] = GetResourceBindingVariable(ref_resource, preprocess_state);
+          auto [sampler_name, sampler_range_index, sampler_resource_class] = GetResourceBindingVariable(ref_sampler, preprocess_state);
           auto sampler_resource = preprocess_state.sampler_resources[sampler_range_index];
           assignment_type = preprocess_state.GetResourceDataType(ref_resource);
           if (offset == "" || offset == "0" || offset == "int2(0, 0)" || offset == "int3(0, 0, 0)") {
@@ -2912,8 +3351,8 @@ class Decompiler {
             coords = ParseFloat(coord0);
           }
 
-          auto [srv_name, srv_range_index, srv_resource_class] = preprocess_state.resource_binding_variables.at(ref_resource);
-          auto [sampler_name, sampler_range_index, sampler_resource_class] = preprocess_state.resource_binding_variables.at(ref_sampler);
+          auto [srv_name, srv_range_index, srv_resource_class] = GetResourceBindingVariable(ref_resource, preprocess_state);
+          auto [sampler_name, sampler_range_index, sampler_resource_class] = GetResourceBindingVariable(ref_sampler, preprocess_state);
           assignment_type = "float";
           assignment_value = std::format(
               "{}.{}({}, {})",
@@ -2961,6 +3400,19 @@ class Decompiler {
           assignment_value = std::format("dot(half4({}, {}, {}, {}), half4({}, {}, {}, {}))",
                                          ParseHalf(ax), ParseHalf(ay), ParseHalf(az), ParseHalf(aw),
                                          ParseHalf(bx), ParseHalf(by), ParseHalf(bz), ParseHalf(bw));
+        } else if (functionName == "@dx.op.dot4AddPacked.i32") {
+          // call i32 @dx.op.dot4AddPacked.i32(i32 163, i32 %acc, i32 %a, i32 %b)  ; Dot4AddI8Packed(acc,a,b)
+          // HLSL intrinsic order is dot4add_*8packed(a, b, acc).
+          auto [opNumber, acc, a, b] = StringViewSplit<4>(functionParamsString, param_regex, 2);
+          if (opNumber == "163") {
+            assignment_type = "int";
+            assignment_value = std::format("dot4add_i8packed({}, {}, {})", ParseUint(a), ParseUint(b), ParseInt(acc));
+          } else if (opNumber == "164") {
+            assignment_type = "uint";
+            assignment_value = std::format("dot4add_u8packed({}, {}, {})", ParseUint(a), ParseUint(b), ParseUint(acc));
+          } else {
+            throw std::runtime_error(std::format("Unknown @dx.op.dot4AddPacked.i32 opcode {}", opNumber));
+          }
         } else if (functionName == "@dx.op.tertiary.f32") {
           // call float @dx.op.tertiary.f32(i32 46, float 0xBFC4A8C160000000, float %210, float %217)  ; FMad(a,b,c)
           auto [opNumber, a, b, c] = StringViewSplit<4>(functionParamsString, param_regex, 2);
@@ -2990,13 +3442,7 @@ class Decompiler {
 
           if (is_raw_buffer) {
             assert(elementOffset == "undef");
-            int mask_val;
-            FromStringView(mask, mask_val);
-            int component_count = 0;
-            if (mask_val & 1) component_count++;
-            if (mask_val & 2) component_count++;
-            if (mask_val & 4) component_count++;
-            if (mask_val & 8) component_count++;
+            int component_count = CountDxilMaskComponents(mask);
             std::string load_func = (component_count == 1) ? "Load" :
                                     std::format("Load{}", component_count);
             assignment_type = (component_count == 1) ? "float" :
@@ -3031,14 +3477,23 @@ class Decompiler {
                 res_name,
             };
           } else if (preprocess_state.IsHeapResource(ref)) {
-            // Heap-created structured buffer — store with nullptr resource
+            // Heap-created structured buffers are declared as ByteAddressBuffer.
+            // DXIL rawBufferLoad uses element index + byte offset, so turn it
+            // into a byte address instead of invalid ByteAddressBuffer[index].x.
+            int component_count = CountDxilMaskComponents(mask);
+            std::string load_func = (component_count == 1) ? "Load" :
+                                    std::format("Load{}", component_count);
+            auto byte_address = BuildStructuredByteAddress(index, elementOffset, preprocess_state.GetResourceStride(ref));
+            assignment_value = std::format("asfloat({}.{}({}))", res_name, load_func, byte_address);
+            std::string count_str = std::to_string(component_count);
             if (resource_class == "0") {
               preprocess_state.srv_binding_load_variables[variable] = {
-                  nullptr, ParseInt(index), ParseInt(elementOffset), ParseInt(alignment), res_name};
+                  nullptr, assignment_value, count_str, "raw", ""};
             } else {
               preprocess_state.uav_binding_load_variables[variable] = {
-                  nullptr, ParseInt(index), ParseInt(elementOffset), ParseInt(alignment), res_name};
+                  nullptr, assignment_value, count_str, "raw", ""};
             }
+            use_comment = true;
           }
         } else if (functionName == "@dx.op.rawBufferLoad.i32" || functionName == "@dx.op.rawBufferLoad.i16") {
           auto [opNumber, srv, index, elementOffset, mask, alignment] = StringViewSplit<6>(functionParamsString, param_regex, 2);
@@ -3049,13 +3504,7 @@ class Decompiler {
 
           if (is_raw_buffer) {
             assert(elementOffset == "undef");
-            int mask_val;
-            FromStringView(mask, mask_val);
-            int component_count = 0;
-            if (mask_val & 1) component_count++;
-            if (mask_val & 2) component_count++;
-            if (mask_val & 4) component_count++;
-            if (mask_val & 8) component_count++;
+            int component_count = CountDxilMaskComponents(mask);
             std::string load_func = (component_count == 1) ? "Load" :
                                     std::format("Load{}", component_count);
             assignment_type = (component_count == 1) ? "int" :
@@ -3088,13 +3537,77 @@ class Decompiler {
                 res_name,
             };
           } else if (preprocess_state.IsHeapResource(ref)) {
+            int component_count = CountDxilMaskComponents(mask);
+            std::string load_func = (component_count == 1) ? "Load" :
+                                    std::format("Load{}", component_count);
+            auto byte_address = BuildStructuredByteAddress(index, elementOffset, preprocess_state.GetResourceStride(ref));
+            assignment_value = std::format("asint({}.{}({}))", res_name, load_func, byte_address);
+            std::string count_str = std::to_string(component_count);
             if (resource_class == "0") {
               preprocess_state.srv_binding_load_variables[variable] = {
-                  nullptr, ParseInt(index), ParseInt(elementOffset), ParseInt(alignment), res_name};
+                  nullptr, assignment_value, count_str, "raw", ""};
             } else {
               preprocess_state.uav_binding_load_variables[variable] = {
-                  nullptr, ParseInt(index), ParseInt(elementOffset), ParseInt(alignment), res_name};
+                  nullptr, assignment_value, count_str, "raw", ""};
             }
+            use_comment = true;
+          }
+        } else if (functionName == "@dx.op.rawBufferLoad.i64") {
+          // call %dx.types.ResRet.i64 @dx.op.rawBufferLoad.i64(i32 139, %dx.types.Handle %29, i32 %8, i32 0, i8 1, i32 8)  ; RawBufferLoad(srv,index,elementOffset,mask,alignment)
+          auto [opNumber, srv, index, elementOffset, mask, alignment] = StringViewSplit<6>(functionParamsString, param_regex, 2);
+          auto ref = std::string{srv.substr(1)};
+          auto binding = preprocess_state.resource_binding_variables.at(ref);
+          auto [res_name, range_index, resource_class] = binding;
+          bool is_raw_buffer = preprocess_state.GetResourceShape(ref) == Resource::ResourceKind::RawBuffer;
+
+          if (is_raw_buffer) {
+            int component_count = CountDxilMaskComponents(mask);
+            std::string load_type = (component_count == 1) ? "int64_t" : std::format("int64_t{}", component_count);
+            std::string byte_offset = ParseInt(index);
+            if (elementOffset != "undef" && elementOffset != "0") {
+              byte_offset = std::format("({} + {})", byte_offset, ParseInt(elementOffset));
+            }
+            assignment_type = load_type;
+            assignment_value = std::format("{}.Load<{}>({})", res_name, load_type, byte_offset);
+            std::string count_str = std::to_string(component_count);
+            if (resource_class == "0") {
+              preprocess_state.srv_binding_load_variables[variable] = {
+                  nullptr, assignment_value, count_str, "raw", ""};
+            } else {
+              preprocess_state.uav_binding_load_variables[variable] = {
+                  nullptr, assignment_value, count_str, "raw", ""};
+            }
+            use_comment = true;
+          } else if (!preprocess_state.IsHeapResource(ref) && resource_class == "0") {
+            preprocess_state.srv_binding_load_variables[variable] = {
+                &preprocess_state.srv_resources[range_index],
+                ParseInt(index),
+                ParseInt(elementOffset),
+                ParseInt(alignment),
+                res_name,
+            };
+          } else if (!preprocess_state.IsHeapResource(ref) && resource_class == "1") {
+            preprocess_state.uav_binding_load_variables[variable] = {
+                &preprocess_state.uav_resources[range_index],
+                ParseInt(index),
+                ParseInt(elementOffset),
+                ParseInt(alignment),
+                res_name,
+            };
+          } else if (preprocess_state.IsHeapResource(ref)) {
+            int component_count = CountDxilMaskComponents(mask);
+            std::string load_type = (component_count == 1) ? "int64_t" : std::format("int64_t{}", component_count);
+            auto byte_address = BuildStructuredByteAddress(index, elementOffset, preprocess_state.GetResourceStride(ref));
+            assignment_value = std::format("{}.Load<{}>({})", res_name, load_type, byte_address);
+            std::string count_str = std::to_string(component_count);
+            if (resource_class == "0") {
+              preprocess_state.srv_binding_load_variables[variable] = {
+                  nullptr, assignment_value, count_str, "raw", ""};
+            } else {
+              preprocess_state.uav_binding_load_variables[variable] = {
+                  nullptr, assignment_value, count_str, "raw", ""};
+            }
+            use_comment = true;
           }
         } else if (functionName == "@dx.op.bufferLoad.i32" || functionName == "@dx.op.bufferLoad.i16") {
           // call %dx.types.ResRet.i32 @dx.op.bufferLoad.i32(i32 68, %dx.types.Handle %4, i32 6, i32 undef)  ; BufferLoad(srv,index,wot)
@@ -3226,41 +3739,76 @@ class Decompiler {
           auto [srv_name, range_index, resource_class] = preprocess_state.resource_binding_variables.at(ref_resource);
           Resource::ResourceKind shape = preprocess_state.GetResourceShape(ref_resource);
 
-          std::string get_dimensions_arguments;
-          switch (shape) {
-            case SRVResource::ResourceKind::Texture1D:
-              assignment_type = "uint";
-              get_dimensions_arguments = std::format("_{}", variable);
-              break;
-            case SRVResource::ResourceKind::Texture2D:
-              assignment_type = "uint2";
-              get_dimensions_arguments = std::format("_{}.x, _{}.y", variable, variable);
-              break;
-            case SRVResource::ResourceKind::Texture2DArray:
-            case SRVResource::ResourceKind::Texture3D:
-              assignment_type = "uint3";
-              get_dimensions_arguments = std::format("_{}.x, _{}.y, _{}.z", variable, variable, variable);
-              break;
-            case SRVResource::ResourceKind::StructuredBuffer:
-            case SRVResource::ResourceKind::RawBuffer: {
-              // StructuredBuffer/ByteAddressBuffer: GetDimensions(numStructs, stride)
-              assignment_type = "uint2";
-              get_dimensions_arguments = std::format("_{}.x, _{}.y", variable, variable);
-              break;
-            }
-            default:
-              std::cerr << "Unexpected shape: " << Resource::ResourceKindString(shape) << "\n";
-              throw std::runtime_error("Unexpected shape");
-          }
+          const bool is_buffer = (shape == SRVResource::ResourceKind::StructuredBuffer
+                                  || shape == SRVResource::ResourceKind::RawBuffer);
 
-          bool has_mip_level = (mip_level != "0" && mip_level != "undef"
-                                && shape != SRVResource::ResourceKind::StructuredBuffer
-                                && shape != SRVResource::ResourceKind::RawBuffer);
-          if (has_mip_level) {
-            decompiled = std::format("{} _{}; uint _{}_levels; {}.GetDimensions({}, {}, _{}_levels);",
-                                     assignment_type, variable, variable, srv_name, ParseUint(mip_level), get_dimensions_arguments, variable);
+          // The DXIL %dx.types.Dimensions result is a 4-wide struct
+          // {width, height, depth/elements, numberOfLevels}. numberOfLevels lives at
+          // index 3, which HLSL exposes only through the mip/levels GetDimensions
+          // overload. Detect whether the shader reads index 3 (or requests a nonzero mip)
+          // and, if so, emit that overload with the level count bound to _var.w on a uint4
+          // so the corresponding extractvalue (.w) resolves.
+          bool reads_levels = false;
+          if (!is_buffer) {
+            const std::string dimensions_level_read = std::format("%dx.types.Dimensions %{}, 3", variable);
+            for (const auto& scan_line : this->lines) {
+              if (scan_line.find(dimensions_level_read) != std::string::npos) {
+                reads_levels = true;
+                break;
+              }
+            }
+          }
+          const bool has_mip_level = !is_buffer && (mip_level != "0" && mip_level != "undef");
+          const bool use_levels_form = has_mip_level || reads_levels;
+
+          if (is_buffer) {
+            // StructuredBuffer/ByteAddressBuffer: GetDimensions(numStructs, stride)
+            assignment_type = "uint2";
+            decompiled = std::format("uint2 _{}; {}.GetDimensions(_{}.x, _{}.y);",
+                                     variable, srv_name, variable, variable);
+          } else if (use_levels_form) {
+            const std::string mip = ParseUint(mip_level);
+            assignment_type = "uint4";
+            switch (shape) {
+              case SRVResource::ResourceKind::Texture1D:
+                decompiled = std::format("uint4 _{}; {}.GetDimensions({}, _{}.x, _{}.w);",
+                                         variable, srv_name, mip, variable, variable);
+                break;
+              case SRVResource::ResourceKind::Texture2D:
+                decompiled = std::format("uint4 _{}; {}.GetDimensions({}, _{}.x, _{}.y, _{}.w);",
+                                         variable, srv_name, mip, variable, variable, variable);
+                break;
+              case SRVResource::ResourceKind::Texture2DArray:
+              case SRVResource::ResourceKind::Texture3D:
+                decompiled = std::format("uint4 _{}; {}.GetDimensions({}, _{}.x, _{}.y, _{}.z, _{}.w);",
+                                         variable, srv_name, mip, variable, variable, variable, variable);
+                break;
+              default:
+                std::cerr << "Unexpected shape: " << Resource::ResourceKindString(shape) << "\n";
+                throw std::runtime_error("Unexpected shape");
+            }
           } else {
-            decompiled = std::format("{} _{}; {}.GetDimensions({});", assignment_type, variable, srv_name, get_dimensions_arguments);
+            switch (shape) {
+              case SRVResource::ResourceKind::Texture1D:
+                assignment_type = "uint";
+                decompiled = std::format("uint _{}; {}.GetDimensions(_{});",
+                                         variable, srv_name, variable);
+                break;
+              case SRVResource::ResourceKind::Texture2D:
+                assignment_type = "uint2";
+                decompiled = std::format("uint2 _{}; {}.GetDimensions(_{}.x, _{}.y);",
+                                         variable, srv_name, variable, variable);
+                break;
+              case SRVResource::ResourceKind::Texture2DArray:
+              case SRVResource::ResourceKind::Texture3D:
+                assignment_type = "uint3";
+                decompiled = std::format("uint3 _{}; {}.GetDimensions(_{}.x, _{}.y, _{}.z);",
+                                         variable, srv_name, variable, variable, variable);
+                break;
+              default:
+                std::cerr << "Unexpected shape: " << Resource::ResourceKindString(shape) << "\n";
+                throw std::runtime_error("Unexpected shape");
+            }
           }
           is_identity = false;  // Can never be identity
         } else if (functionName == "@dx.op.sampleBias.f32" || functionName == "@dx.op.sampleBias.f16") {
@@ -3291,8 +3839,8 @@ class Decompiler {
             offset = std::format("{}", ParseInt(offset0));
           }
 
-          auto [srv_name, srv_range_index, srv_resource_class] = preprocess_state.resource_binding_variables.at(ref_resource);
-          auto [sampler_name, sampler_range_index, sampler_resource_class] = preprocess_state.resource_binding_variables.at(ref_sampler);
+          auto [srv_name, srv_range_index, srv_resource_class] = GetResourceBindingVariable(ref_resource, preprocess_state);
+          auto [sampler_name, sampler_range_index, sampler_resource_class] = GetResourceBindingVariable(ref_sampler, preprocess_state);
           auto sampler_resource = preprocess_state.sampler_resources[sampler_range_index];
 
           assignment_type = preprocess_state.GetResourceDataType(ref_resource);
@@ -3351,8 +3899,8 @@ class Decompiler {
             ddy = std::format("{}", ParseFloat(ddy0));
           }
 
-          auto [srv_name, srv_range_index, srv_resource_class] = preprocess_state.resource_binding_variables.at(ref_resource);
-          auto [sampler_name, sampler_range_index, sampler_resource_class] = preprocess_state.resource_binding_variables.at(ref_sampler);
+          auto [srv_name, srv_range_index, srv_resource_class] = GetResourceBindingVariable(ref_resource, preprocess_state);
+          auto [sampler_name, sampler_range_index, sampler_resource_class] = GetResourceBindingVariable(ref_sampler, preprocess_state);
           auto sampler_resource = preprocess_state.sampler_resources[sampler_range_index];
 
           assignment_type = preprocess_state.GetResourceDataType(ref_resource);
@@ -3388,8 +3936,8 @@ class Decompiler {
             offset = std::format("{}", ParseInt(offset0));
           }
 
-          auto [srv_name, srv_range_index, srv_resource_class] = preprocess_state.resource_binding_variables.at(ref_resource);
-          auto [sampler_name, sampler_range_index, sampler_resource_class] = preprocess_state.resource_binding_variables.at(ref_sampler);
+          auto [srv_name, srv_range_index, srv_resource_class] = GetResourceBindingVariable(ref_resource, preprocess_state);
+          auto [sampler_name, sampler_range_index, sampler_resource_class] = GetResourceBindingVariable(ref_sampler, preprocess_state);
           auto sampler_resource = preprocess_state.sampler_resources[sampler_range_index];
 
           assignment_type = preprocess_state.GetResourceDataType(ref_resource);
@@ -3418,8 +3966,8 @@ class Decompiler {
             offset = std::format("{}", ParseInt(offset0));
           }
 
-          auto [srv_name, srv_range_index, srv_resource_class] = preprocess_state.resource_binding_variables.at(ref_resource);
-          auto [sampler_name, sampler_range_index, sampler_resource_class] = preprocess_state.resource_binding_variables.at(ref_sampler);
+          auto [srv_name, srv_range_index, srv_resource_class] = GetResourceBindingVariable(ref_resource, preprocess_state);
+          auto [sampler_name, sampler_range_index, sampler_resource_class] = GetResourceBindingVariable(ref_sampler, preprocess_state);
           auto sampler_resource = preprocess_state.sampler_resources[sampler_range_index];
           std::string channel_string;
           if (channel == "0") {
@@ -3441,6 +3989,22 @@ class Decompiler {
             assignment_type = "float4";
           }
           assignment_value = std::format("{}.Gather{}({}, {})", srv_name, channel_string, sampler_name, coords);
+        } else if (functionName == "@dx.op.textureGatherCmp.f32") {
+          // %X = call %dx.types.ResRet.f32 @dx.op.textureGatherCmp.f32(i32 74, %dx.types.Handle %srv, %dx.types.Handle %samp, float %c0, float %c1, float %c2, float %c3, i32 off0, i32 off1, i32 channel, float %cmpVal)
+          auto [op, srv, sampler, coord0, coord1, coord2, coord3, offset0, offset1, channel, compareValue] = StringViewSplit<11>(functionParamsString, param_regex, 2);
+          auto ref_resource = std::string{srv.substr(1)};
+          auto ref_sampler = std::string{sampler.substr(1)};
+          const bool has_coord_z = coord2 != "undef";
+          std::string coords;
+          if (has_coord_z) {
+            coords = std::format("float3({}, {}, {})", ParseFloat(coord0), ParseFloat(coord1), ParseFloat(coord2));
+          } else {
+            coords = std::format("float2({}, {})", ParseFloat(coord0), ParseFloat(coord1));
+          }
+          auto [srv_name, srv_range_index, srv_resource_class] = GetResourceBindingVariable(ref_resource, preprocess_state);
+          auto [sampler_name, sampler_range_index, sampler_resource_class] = GetResourceBindingVariable(ref_sampler, preprocess_state);
+          assignment_type = "float4";
+          assignment_value = std::format("{}.GatherCmp({}, {}, {})", srv_name, sampler_name, coords, ParseFloat(compareValue));
         } else if (functionName == "@dx.op.waveReadLaneFirst.f32") {
           // call float @dx.op.waveReadLaneFirst.f32(i32 118, float %503)  ; WaveReadLaneFirst(value)
           auto [op, value] = StringViewSplit<2>(functionParamsString, param_regex, 2);
@@ -3451,19 +4015,80 @@ class Decompiler {
           auto [op, value] = StringViewSplit<2>(functionParamsString, param_regex, 2);
           assignment_type = "int";
           assignment_value = std::format("WaveReadLaneFirst{}", ParseWrapped(ParseInt(value)));
+        } else if (functionName == "@dx.op.waveReadLaneFirst.i1") {
+          auto [op, value] = StringViewSplit<2>(functionParamsString, param_regex, 2);
+          assignment_type = "bool";
+          assignment_value = std::format("WaveReadLaneFirst{}", ParseWrapped(ParseBool(value)));
 
+        } else if (functionName == "@dx.op.unpack4x8.i32" || functionName == "@dx.op.unpack4x8.i16") {
+          // call %dx.types.fouri32 @dx.op.unpack4x8.i32(i32 219, i8 1, i32 %pk)  ; Unpack4x8(unpackMode,pk)
+          auto [opNumber, unpackMode, pk] = StringViewSplit<3>(functionParamsString, param_regex, 2);
+          if (unpackMode != "0" && unpackMode != "1") {
+            throw std::runtime_error(std::format("Unknown @dx.op.unpack4x8 unpack mode {}", unpackMode));
+          }
+          const bool signed_mode = unpackMode == "1";
+          const bool unpack_i32 = functionName.ends_with(".i32");
+          const auto packed_type = signed_mode ? "int8_t4_packed" : "uint8_t4_packed";
+          const auto packed_value = CastType(packed_type, ParseUint(pk));
+          if (unpack_i32) {
+            assignment_type = signed_mode ? "int4" : "uint4";
+            assignment_value = std::format("{}({})", signed_mode ? "unpack_s8s32" : "unpack_u8u32", packed_value);
+            aggregate_extract_types[std::string(variable)] = signed_mode ? "int" : "uint";
+          } else {
+            assignment_type = signed_mode ? "int16_t4" : "uint16_t4";
+            assignment_value = std::format("{}({})", signed_mode ? "unpack_s8s16" : "unpack_u8u16", packed_value);
+            aggregate_extract_types[std::string(variable)] = signed_mode ? "int16_t" : "uint16_t";
+          }
+        } else if (functionName == "@dx.op.pack4x8.i32" || functionName == "@dx.op.pack4x8.i16") {
+          // call i32 @dx.op.pack4x8.i32(i32 220, i8 0, i32 %x, i32 %y, i32 %z, i32 %w)  ; Pack4x8(packMode,x,y,z,w)
+          auto [opNumber, packMode, x, y, z, w] = StringViewSplit<6>(functionParamsString, param_regex, 2);
+          const bool pack_i16 = functionName.ends_with(".i16");
+          std::string pack_function;
+          std::string vector_value;
+          if (packMode == "0") {
+            // Truncating signed/unsigned packing has identical low 8-bit results.
+            pack_function = "pack_s8";
+            vector_value = pack_i16
+                               ? std::format("uint16_t4({}, {}, {}, {})", ParseUint(x), ParseUint(y), ParseUint(z), ParseUint(w))
+                               : std::format("uint4({}, {}, {}, {})", ParseUint(x), ParseUint(y), ParseUint(z), ParseUint(w));
+          } else if (packMode == "1") {
+            pack_function = "pack_clamp_u8";
+            vector_value = pack_i16
+                               ? std::format("int16_t4({}, {}, {}, {})", ParseInt(x), ParseInt(y), ParseInt(z), ParseInt(w))
+                               : std::format("int4({}, {}, {}, {})", ParseInt(x), ParseInt(y), ParseInt(z), ParseInt(w));
+          } else if (packMode == "2") {
+            pack_function = "pack_clamp_s8";
+            vector_value = pack_i16
+                               ? std::format("int16_t4({}, {}, {}, {})", ParseInt(x), ParseInt(y), ParseInt(z), ParseInt(w))
+                               : std::format("int4({}, {}, {}, {})", ParseInt(x), ParseInt(y), ParseInt(z), ParseInt(w));
+          } else {
+            throw std::runtime_error(std::format("Unknown @dx.op.pack4x8 pack mode {}", packMode));
+          }
+          assignment_type = "uint";
+          assignment_value = std::format("(uint){}({})", pack_function, vector_value);
         } else if (functionName == "@dx.op.waveActiveOp.i32") {
           // call i32 @dx.op.waveActiveOp.i32(i32 119, i32 %140, i8 3, i8 1)  ; WaveActiveOp(value,op,sop)
           auto [op, value, op2, sop] = StringViewSplit<4>(functionParamsString, param_regex, 2);
           assignment_type = "int";
+          const bool use_unsigned_overload = (sop == "1");
+          auto parsed_value = ParseInt(value);
+          if (use_unsigned_overload) {
+            parsed_value = std::format("(uint){}", ParseWrapped(parsed_value));
+          } else if (sop != "0") {
+            throw std::runtime_error("Unknown wave active signedness");
+          }
+          auto make_wave_active_call = [&](std::string_view function_name) {
+            auto wave_call = std::format("{}{}", function_name, ParseWrapped(parsed_value));
+            return use_unsigned_overload ? std::format("(int){}", ParseWrapped(wave_call)) : wave_call;
+          };
           if (op2 == "0") {
-            assignment_value = std::format("WaveActiveSum{}", ParseWrapped(ParseInt(value)));
+            assignment_value = make_wave_active_call("WaveActiveSum");
           } else if (op2 == "1") {
-            assignment_value = std::format("WaveActiveProduct{}", ParseWrapped(ParseInt(value)));
+            assignment_value = make_wave_active_call("WaveActiveProduct");
           } else if (op2 == "2") {
-            assignment_value = std::format("WaveActiveMin{}", ParseWrapped(ParseInt(value)));
+            assignment_value = make_wave_active_call("WaveActiveMin");
           } else if (op2 == "3") {
-            assignment_value = std::format("WaveActiveMax{}", ParseWrapped(ParseInt(value)));
+            assignment_value = make_wave_active_call("WaveActiveMax");
           } else {
             throw std::runtime_error("Unknown wave active op");
           }
@@ -3552,6 +4177,27 @@ class Decompiler {
           // %347 = call i32 @dx.op.waveGetLaneIndex(i32 111)  ; WaveGetLaneIndex()
           assignment_type = "int";
           assignment_value = "WaveGetLaneIndex()";
+        } else if (functionName == "@dx.op.waveActiveAllEqual.i32"
+                   || functionName == "@dx.op.waveActiveAllEqual.f32"
+                   || functionName == "@dx.op.waveActiveAllEqual.i1") {
+          // %254 = call i1 @dx.op.waveActiveAllEqual.i32(i32 115, i32 %246)  ; WaveActiveAllEqual(value)
+          auto [op, value] = StringViewSplit<2>(functionParamsString, param_regex, 2);
+          assignment_type = "bool";
+          if (functionName.ends_with(".f32")) {
+            assignment_value = std::format("WaveActiveAllEqual{}", ParseWrapped(ParseFloat(value)));
+          } else if (functionName.ends_with(".i1")) {
+            assignment_value = std::format("WaveActiveAllEqual{}", ParseWrapped(ParseBool(value)));
+          } else {
+            assignment_value = std::format("WaveActiveAllEqual{}", ParseWrapped(ParseInt(value)));
+          }
+        } else if (functionName == "@dx.op.sampleIndex.i32") {
+          // %36 = call i32 @dx.op.sampleIndex.i32(i32 90)  ; SampleIndex()
+          assignment_type = "uint";
+          assignment_value = "SV_SampleIndex";
+        } else if (functionName == "@dx.op.isHelperLane.i1") {
+          // %449 = call i1 @dx.op.isHelperLane.i1(i32 221)  ; IsHelperLane()
+          assignment_type = "bool";
+          assignment_value = "IsHelperLane()";
         } else if (functionName == "@dx.op.waveActiveBallot") {
           // %X = call %dx.types.fouri32 @dx.op.waveActiveBallot(i32 116, i1 %cond)  ; WaveActiveBallot(cond)
           auto [opNumber, cond] = StringViewSplit<2>(functionParamsString, param_regex, 2);
@@ -3594,6 +4240,12 @@ class Decompiler {
           else if (wave_op == "1") op_name = "WaveMultiPrefixProduct";
           else op_name = std::format("WaveMultiPrefixOp/*op={}*/", wave_op);
           assignment_value = std::format("{}({}, {})", op_name, val_parsed, mask_str);
+        } else if (functionName == "@dx.op.waveMultiPrefixBitCount") {
+          // %170 = call i32 @dx.op.waveMultiPrefixBitCount(i32 167, i1 true, i32 %166, i32 %167, i32 %168, i32 %169)  ; WaveMultiPrefixBitCount(value,mask0,mask1,mask2,mask3)
+          auto [op_id, value, m0, m1, m2, m3] = StringViewSplit<6>(functionParamsString, param_regex, 2);
+          auto mask_str = std::format("uint4({}, {}, {}, {})", ParseUint(m0), ParseUint(m1), ParseUint(m2), ParseUint(m3));
+          assignment_type = "uint";
+          assignment_value = std::format("WaveMultiPrefixCountBits({}, {})", ParseBool(value), mask_str);
         } else if (functionName == "@dx.op.quadReadLaneAt.f32") {
           // call float @dx.op.quadReadLaneAt.f32(i32 122, float %val, i32 0)  ; QuadReadLaneAt(value,quadLane)
           auto [op, value, quadLane] = StringViewSplit<3>(functionParamsString, param_regex, 2);
@@ -3611,6 +4263,28 @@ class Decompiler {
           auto [op, value, quadLane] = StringViewSplit<3>(functionParamsString, param_regex, 2);
           assignment_type = "int16_t";
           assignment_value = std::format("QuadReadLaneAt({}, {})", ParseInt(value), ParseInt(quadLane));
+        } else if (functionName == "@dx.op.quadOp.f32") {
+          // %1158 = call float @dx.op.quadOp.f32(i32 123, float %1143, i8 0)  ; QuadOp(value,op)
+          // op: 0=ReadAcrossX, 1=ReadAcrossY, 2=ReadAcrossDiagonal
+          auto [op, value, quadOp] = StringViewSplit<3>(functionParamsString, param_regex, 2);
+          assignment_type = "float";
+          if (quadOp == "0") {
+            assignment_value = std::format("QuadReadAcrossX({})", ParseFloat(value));
+          } else if (quadOp == "1") {
+            assignment_value = std::format("QuadReadAcrossY({})", ParseFloat(value));
+          } else {
+            assignment_value = std::format("QuadReadAcrossDiagonal({})", ParseFloat(value));
+          }
+        } else if (functionName == "@dx.op.quadOp.i32") {
+          auto [op, value, quadOp] = StringViewSplit<3>(functionParamsString, param_regex, 2);
+          assignment_type = "int";
+          if (quadOp == "0") {
+            assignment_value = std::format("QuadReadAcrossX({})", ParseInt(value));
+          } else if (quadOp == "1") {
+            assignment_value = std::format("QuadReadAcrossY({})", ParseInt(value));
+          } else {
+            assignment_value = std::format("QuadReadAcrossDiagonal({})", ParseInt(value));
+          }
         } else if (functionName == "@dx.op.legacyF32ToF16") {
           //   %1390 = call i32 @dx.op.legacyF32ToF16(i32 130, float %115)  ; LegacyF32ToF16(value)
           auto [op, value] = StringViewSplit<2>(functionParamsString, param_regex, 2);
@@ -3794,6 +4468,7 @@ class Decompiler {
 
           auto uav_resource = preprocess_state.uav_resources[uav_range_index];
           const bool has_offset_y = offset1 != "undef";
+          const bool has_offset_z = offset2 != "undef";
           const bool is_raw_buffer = (uav_resource.shape == Resource::ResourceKind::RawBuffer);
           const bool is_structured = (uav_resource.shape == Resource::ResourceKind::StructuredBuffer);
           std::string target;
@@ -3826,6 +4501,8 @@ class Decompiler {
             target = std::format("{}[{}]{}", uav_name, ParseInt(offset0), field_access);
           } else if (is_structured) {
             target = std::format("{}[{}]", uav_name, ParseInt(offset0));
+          } else if (has_offset_z) {
+            target = std::format("{}[int3({}, {}, {})]", uav_name, ParseInt(offset0), ParseInt(offset1), ParseInt(offset2));
           } else if (has_offset_y) {
             target = std::format("{}[int2({}, {})]", uav_name, ParseInt(offset0), ParseInt(offset1));
           } else {
@@ -3872,12 +4549,15 @@ class Decompiler {
           switch (op_code) {
             case 184: assignment_value = std::format("{}.CommittedStatus()", rq_var); break;
             case 185: assignment_value = std::format("{}.CandidateType()", rq_var); break;
+            case 195: assignment_value = std::format("{}.RayFlags()", rq_var); break;
             case 201: assignment_value = std::format("{}.CandidateInstanceIndex()", rq_var); break;
             case 202: assignment_value = std::format("{}.CandidateInstanceID()", rq_var); break;
             case 203: assignment_value = std::format("{}.CandidateGeometryIndex()", rq_var); break;
             case 204: assignment_value = std::format("{}.CandidatePrimitiveIndex()", rq_var); break;
+            case 214: assignment_value = std::format("{}.CandidateInstanceContributionToHitGroupIndex()", rq_var); break;
             case 207: assignment_value = std::format("{}.CommittedInstanceIndex()", rq_var); break;
             case 208: assignment_value = std::format("{}.CommittedInstanceID()", rq_var); break;
+            case 215: assignment_value = std::format("{}.CommittedInstanceContributionToHitGroupIndex()", rq_var); break;
             case 209: assignment_value = std::format("{}.CommittedGeometryIndex()", rq_var); break;
             case 210: assignment_value = std::format("{}.CommittedPrimitiveIndex()", rq_var); break;
             default: throw std::runtime_error(std::format("Unknown rayQuery_StateScalar.i32 opcode {}", op_code));
@@ -3890,9 +4570,8 @@ class Decompiler {
           std::string rq_var = std::format("_{}", ParseVariable(rayQueryHandle).substr(1));
           assignment_type = "float";
           switch (op_code) {
-            case 195: assignment_value = std::format("{}.CandidateTriangleRayT()", rq_var); break;
             case 198: assignment_value = std::format("{}.RayTMin()", rq_var); break;
-            case 199: assignment_value = std::format("{}.CandidateRayT()", rq_var); break;
+            case 199: assignment_value = std::format("{}.CandidateTriangleRayT()", rq_var); break;
             case 200: assignment_value = std::format("{}.CommittedRayT()", rq_var); break;
             default: throw std::runtime_error(std::format("Unknown rayQuery_StateScalar.f32 opcode {}", op_code));
           }
@@ -3904,6 +4583,7 @@ class Decompiler {
           std::string rq_var = std::format("_{}", ParseVariable(rayQueryHandle).substr(1));
           assignment_type = "bool";
           switch (op_code) {
+            case 190: assignment_value = std::format("{}.CandidateProceduralPrimitiveNonOpaque()", rq_var); break;
             case 191: assignment_value = std::format("{}.CandidateTriangleFrontFace()", rq_var); break;
             case 192: assignment_value = std::format("{}.CommittedTriangleFrontFace()", rq_var); break;
             default: throw std::runtime_error(std::format("Unknown rayQuery_StateScalar.i1 opcode {}", op_code));
@@ -3916,14 +4596,39 @@ class Decompiler {
           std::string rq_var = std::format("_{}", ParseVariable(rayQueryHandle).substr(1));
           int comp = 0;
           FromStringView(component, comp);
-          std::string swizzle = (comp == 0) ? ".x" : ".y";
+          // Barycentrics are float2 (component 0/1); ray origin/direction are float3 (0/1/2).
+          std::string swizzle = (comp == 0) ? ".x" : (comp == 1) ? ".y" : ".z";
           assignment_type = "float";
+          // Opcodes per DXIL DxilConstants.h (OpCode enum).
           switch (op_code) {
-            case 186: assignment_value = std::format("{}.WorldRayOrigin(){}", rq_var, swizzle); break;
-            case 187: assignment_value = std::format("{}.WorldRayDirection(){}", rq_var, swizzle); break;
             case 193: assignment_value = std::format("{}.CandidateTriangleBarycentrics(){}", rq_var, swizzle); break;
             case 194: assignment_value = std::format("{}.CommittedTriangleBarycentrics(){}", rq_var, swizzle); break;
+            case 196: assignment_value = std::format("{}.WorldRayOrigin(){}", rq_var, swizzle); break;
+            case 197: assignment_value = std::format("{}.WorldRayDirection(){}", rq_var, swizzle); break;
+            case 205: assignment_value = std::format("{}.CandidateObjectRayOrigin(){}", rq_var, swizzle); break;
+            case 206: assignment_value = std::format("{}.CandidateObjectRayDirection(){}", rq_var, swizzle); break;
+            case 211: assignment_value = std::format("{}.CommittedObjectRayOrigin(){}", rq_var, swizzle); break;
+            case 212: assignment_value = std::format("{}.CommittedObjectRayDirection(){}", rq_var, swizzle); break;
             default: throw std::runtime_error(std::format("Unknown rayQuery_StateVector.f32 opcode {}", op_code));
+          }
+        } else if (functionName == "@dx.op.rayQuery_StateMatrix.f32") {
+          // %16 = call float @dx.op.rayQuery_StateMatrix.f32(i32 186, i32 %4, i32 0, i8 0)  ; RayQuery_CandidateObjectToWorld3x4(rayQueryHandle,row,col)
+          // Per-element read of a float3x4 object/world transform: (handle, row, col).
+          auto [opNumber, rayQueryHandle, row, col] = StringViewSplit<4>(functionParamsString, param_regex, 2);
+          int op_code = 0;
+          FromStringView(opNumber, op_code);
+          std::string rq_var = std::format("_{}", ParseVariable(rayQueryHandle).substr(1));
+          int row_index = 0;
+          int col_index = 0;
+          FromStringView(row, row_index);
+          FromStringView(col, col_index);
+          assignment_type = "float";
+          switch (op_code) {
+            case 186: assignment_value = std::format("{}.CandidateObjectToWorld3x4()[{}][{}]", rq_var, row_index, col_index); break;
+            case 187: assignment_value = std::format("{}.CandidateWorldToObject3x4()[{}][{}]", rq_var, row_index, col_index); break;
+            case 188: assignment_value = std::format("{}.CommittedObjectToWorld3x4()[{}][{}]", rq_var, row_index, col_index); break;
+            case 189: assignment_value = std::format("{}.CommittedWorldToObject3x4()[{}][{}]", rq_var, row_index, col_index); break;
+            default: throw std::runtime_error(std::format("Unknown rayQuery_StateMatrix.f32 opcode {}", op_code));
           }
         } else {
           std::cerr << line << "\n";
@@ -3951,28 +4656,44 @@ class Decompiler {
             int literal_index;
             FromStringView(index, literal_index);
 
-            // Check if this cbuffer uses dynamic access (float4 array only)
-            auto cbv_range_idx = static_cast<uint32_t>(cbv_resource - preprocess_state.cbv_resources.data());
-            if (preprocess_state.cbv_dynamic_access_indices.count(cbv_range_idx)) {
-              // Use raw array access: cbuffer_raw[regIndex].component (uint4, reinterpret as float)
-              assignment_value = std::format("asfloat({}_raw[{}u].{})", cbv_resource->name, cbv_variable_index, ParseIndex(index));
-            } else {
-              auto value_from_reflection = preprocess_state.ResourceVariableNameAtIndex(*cbv_resource, (cbv_variable_index * 16) + (literal_index * 4));
+            auto value_from_reflection = preprocess_state.ResourceVariableNameAtIndex(*cbv_resource, (cbv_variable_index * 16) + (literal_index * 4));
 
-              if (value_from_reflection.empty()) {
-                int real_index = cbv_variable_index;
-                char sub_index = VECTOR_INDEXES[literal_index];
-                std::string suffix = std::format("{:03}{}", real_index, sub_index);
-                assignment_value = std::format("{}_{}", cbv_binding_name, suffix);
-                cbv_resource->data_types[suffix] = "float";
-              } else {
-                // Use binding name for array cbuffers (includes array index), direct for regular
-                if (cbv_resource->array_size.has_value()) {
-                  assignment_value = std::format("{}.{}", cbv_binding_name, value_from_reflection);
-                } else {
-                  assignment_value = value_from_reflection;
+            // Check if this cbuffer uses dynamic access (overlapping raw float4/uint4 arrays)
+            auto cbv_range_idx = static_cast<uint32_t>(cbv_resource - preprocess_state.cbv_resources.data());
+            if (!value_from_reflection.empty()) {
+              // Even when a cbuffer also needs raw dynamic views, prefer reflected
+              // fields for static loads so generated HLSL remains readable.
+              std::string field = cbv_resource->array_size.has_value()
+                                      ? std::format("{}.{}", cbv_binding_name, value_from_reflection)
+                                      : value_from_reflection;
+              // Reconstructed layouts may type this register as int elsewhere;
+              // asfloat() preserves the DXIL float load's bit interpretation.
+              assignment_value = preprocess_state.CBufferFieldTypesReliable(*cbv_resource)
+                                     ? field
+                                     : std::format("asfloat({})", field);
+            } else if (preprocess_state.cbv_dynamic_access_indices.count(cbv_range_idx)) {
+              // Use raw float access to preserve cbufferLoadLegacy.f32 in recompiled DXIL.
+              const uint32_t full_register_count = cbv_resource->buffer_size / 16u;
+              const uint32_t tail_bytes = cbv_resource->buffer_size % 16u;
+              const uint32_t tail_component_count = (tail_bytes + 3u) / 4u;
+              const uint32_t component_index = static_cast<uint32_t>(literal_index);
+              const bool uses_full_register_tail = !cbv_resource->array_size.has_value();
+              if (tail_bytes != 0u && cbv_variable_index >= full_register_count) {
+                if (cbv_variable_index != full_register_count || component_index >= tail_component_count) {
+                  throw std::runtime_error("Static cbuffer f32 access exceeds dynamic raw tail view");
                 }
+                assignment_value = uses_full_register_tail
+                                     ? std::format("{}_raw[{}u].{}", cbv_resource->name, cbv_variable_index, ParseIndex(index))
+                                     : std::format("{}_raw_tail.{}", cbv_resource->name, ParseIndex(index));
+              } else {
+                assignment_value = std::format("{}_raw[{}u].{}", cbv_resource->name, cbv_variable_index, ParseIndex(index));
               }
+            } else {
+              int real_index = cbv_variable_index;
+              char sub_index = VECTOR_INDEXES[literal_index];
+              std::string suffix = std::format("{:03}{}", real_index, sub_index);
+              assignment_value = std::format("{}_{}", cbv_binding_name, suffix);
+              cbv_resource->data_types[suffix] = "float";
             }
 
             assignment_type = "float";
@@ -3994,27 +4715,44 @@ class Decompiler {
             int literal_index;
             FromStringView(index, literal_index);
 
-            // Check if this cbuffer uses dynamic access (float4 array only)
-            auto cbv_range_idx = static_cast<uint32_t>(cbv_resource - preprocess_state.cbv_resources.data());
-            if (preprocess_state.cbv_dynamic_access_indices.count(cbv_range_idx)) {
-              // Use raw array access: cbuffer_raw[regIndex].component
-              assignment_value = std::format("asint({}_raw[{}u].{})", cbv_resource->name, cbv_variable_index, ParseIndex(index));
-            } else {
-              auto value_from_reflection = preprocess_state.ResourceVariableNameAtIndex(*cbv_resource, (cbv_variable_index * 16) + (literal_index * 4));
+            auto value_from_reflection = preprocess_state.ResourceVariableNameAtIndex(*cbv_resource, (cbv_variable_index * 16) + (literal_index * 4));
 
-              if (value_from_reflection.empty()) {
-                int real_index = cbv_variable_index;
-                char sub_index = VECTOR_INDEXES[literal_index];
-                std::string suffix = std::format("{:03}{}", real_index, sub_index);
-                assignment_value = std::format("{}_{}", cbv_binding_name, suffix);
-                cbv_resource->data_types[suffix] = "int";
-              } else {
-                if (cbv_resource->array_size.has_value()) {
-                  assignment_value = std::format("{}.{}", cbv_binding_name, value_from_reflection);
-                } else {
-                  assignment_value = value_from_reflection;
+            // Check if this cbuffer uses dynamic access (overlapping raw float4/uint4 arrays)
+            auto cbv_range_idx = static_cast<uint32_t>(cbv_resource - preprocess_state.cbv_resources.data());
+            if (!value_from_reflection.empty()) {
+              // Even when a cbuffer also needs raw dynamic views, prefer reflected
+              // fields for static loads so generated HLSL remains readable.
+              std::string field = cbv_resource->array_size.has_value()
+                                      ? std::format("{}.{}", cbv_binding_name, value_from_reflection)
+                                      : value_from_reflection;
+              // Reconstructed layouts may type this register as float; asint()
+              // preserves the DXIL integer load's bit interpretation.
+              assignment_value = preprocess_state.CBufferFieldTypesReliable(*cbv_resource)
+                                     ? field
+                                     : std::format("asint({})", field);
+            } else if (preprocess_state.cbv_dynamic_access_indices.count(cbv_range_idx)) {
+              // Use raw uint access to preserve cbufferLoadLegacy.i32 in recompiled DXIL.
+              const uint32_t full_register_count = cbv_resource->buffer_size / 16u;
+              const uint32_t tail_bytes = cbv_resource->buffer_size % 16u;
+              const uint32_t tail_component_count = (tail_bytes + 3u) / 4u;
+              const uint32_t component_index = static_cast<uint32_t>(literal_index);
+              const bool uses_full_register_tail = !cbv_resource->array_size.has_value();
+              if (tail_bytes != 0u && cbv_variable_index >= full_register_count) {
+                if (cbv_variable_index != full_register_count || component_index >= tail_component_count) {
+                  throw std::runtime_error("Static cbuffer i32 access exceeds dynamic raw tail view");
                 }
+                assignment_value = uses_full_register_tail
+                                     ? std::format("asint({}_raw_uint[{}u].{})", cbv_resource->name, cbv_variable_index, ParseIndex(index))
+                                     : std::format("asint({}_raw_uint_tail.{})", cbv_resource->name, ParseIndex(index));
+              } else {
+                assignment_value = std::format("asint({}_raw_uint[{}u].{})", cbv_resource->name, cbv_variable_index, ParseIndex(index));
               }
+            } else {
+              int real_index = cbv_variable_index;
+              char sub_index = VECTOR_INDEXES[literal_index];
+              std::string suffix = std::format("{:03}{}", real_index, sub_index);
+              assignment_value = std::format("{}_{}", cbv_binding_name, suffix);
+              cbv_resource->data_types[suffix] = "int";
             }
 
             assignment_type = "int";
@@ -4030,32 +4768,41 @@ class Decompiler {
             int literal_index;
             FromStringView(index, literal_index);
 
+            auto value_from_reflection = preprocess_state.ResourceVariableNameAtIndex(*cbv_resource, (cbv_variable_index * 16) + (literal_index * 2));
+
             auto cbv_range_idx = static_cast<uint32_t>(cbv_resource - preprocess_state.cbv_resources.data());
-            if (preprocess_state.cbv_dynamic_access_indices.count(cbv_range_idx)) {
+            if (!value_from_reflection.empty()) {
+              if (cbv_resource->array_size.has_value()) {
+                assignment_value = std::format("{}.{}", cbv_binding_name, value_from_reflection);
+              } else {
+                assignment_value = value_from_reflection;
+              }
+            } else if (preprocess_state.cbv_dynamic_access_indices.count(cbv_range_idx)) {
               // f16.8: indices 0-3 = low 16 bits of xyzw, 4-7 = high 16 bits
               int component = literal_index % 4;
               bool high_half = literal_index >= 4;
+              const uint32_t full_register_count = cbv_resource->buffer_size / 16u;
+              const uint32_t tail_bytes = cbv_resource->buffer_size % 16u;
+              const uint32_t tail_component_count = (tail_bytes + 3u) / 4u;
+              const bool uses_full_register_tail = !cbv_resource->array_size.has_value();
+              const bool use_tail = tail_bytes != 0u && cbv_variable_index >= full_register_count;
+              if (use_tail && (cbv_variable_index != full_register_count || static_cast<uint32_t>(component) >= tail_component_count)) {
+                throw std::runtime_error("Static cbuffer f16 access exceeds dynamic raw tail view");
+              }
+              const auto raw_uint_access = (use_tail && !uses_full_register_tail)
+                                             ? std::format("{}_raw_uint_tail.{}", cbv_resource->name, VECTOR_INDEXES[component])
+                                             : std::format("{}_raw_uint[{}u].{}", cbv_resource->name, cbv_variable_index, VECTOR_INDEXES[component]);
               if (high_half) {
-                assignment_value = std::format("f16tof32({}_raw[{}u].{} >> 16u)", cbv_resource->name, cbv_variable_index, VECTOR_INDEXES[component]);
+                assignment_value = std::format("f16tof32({} >> 16u)", raw_uint_access);
               } else {
-                assignment_value = std::format("f16tof32({}_raw[{}u].{})", cbv_resource->name, cbv_variable_index, VECTOR_INDEXES[component]);
+                assignment_value = std::format("f16tof32({})", raw_uint_access);
               }
             } else {
-              auto value_from_reflection = preprocess_state.ResourceVariableNameAtIndex(*cbv_resource, (cbv_variable_index * 16) + (literal_index * 2));
-
-              if (value_from_reflection.empty()) {
-                int real_index = cbv_variable_index;
-                char sub_index = VECTOR_INDEXES[literal_index % 4];
-                std::string suffix = std::format("{:03}{}", real_index, sub_index);
-                assignment_value = std::format("{}_{}", cbv_binding_name, suffix);
-                cbv_resource->data_types[suffix] = "half";
-              } else {
-                if (cbv_resource->array_size.has_value()) {
-                  assignment_value = std::format("{}.{}", cbv_binding_name, value_from_reflection);
-                } else {
-                  assignment_value = value_from_reflection;
-                }
-              }
+              int real_index = cbv_variable_index;
+              char sub_index = VECTOR_INDEXES[literal_index % 4];
+              std::string suffix = std::format("{:03}{}", real_index, sub_index);
+              assignment_value = std::format("{}_{}", cbv_binding_name, suffix);
+              cbv_resource->data_types[suffix] = "half";
             }
           }
           assignment_type = "half";
@@ -4086,12 +4833,16 @@ class Decompiler {
               FromStringView(element_offset, literal_element_offset);
               int literal_alignment;
               FromStringView(alignment, literal_alignment);
-              // Use binding name (includes array index for unbounded arrays) instead of resource name
-              auto& access_name = srv_binding_name.empty() ? srv_resource->name : srv_binding_name;
-              assignment_value = std::format("{}[{}]{}",
-                                             access_name,
-                                             ParseInt(srv_index),
-                                             preprocess_state.ResourceVariableNameAtIndex(*srv_resource, (literal_element_offset) + (literal_index * 4)));
+              if (srv_resource) {
+                auto& access_name = srv_binding_name.empty() ? srv_resource->name : srv_binding_name;
+                assignment_value = std::format("{}[{}]{}",
+                                               access_name,
+                                               ParseInt(srv_index),
+                                               preprocess_state.ResourceVariableNameAtIndex(*srv_resource, (literal_element_offset) + (literal_index * 4)));
+              } else {
+                // Heap resource without type info — use raw component access
+                assignment_value = std::format("{}[{}].{}", srv_binding_name, ParseInt(srv_index), VECTOR_INDEXES[literal_index]);
+              }
               is_identity = false;
               use_comment = false;
             }
@@ -4117,10 +4868,16 @@ class Decompiler {
               FromStringView(element_offset, literal_element_offset);
               int literal_alignment;
               FromStringView(alignment, literal_alignment);
-              assignment_value = std::format("{}[{}]{}",
-                                             (uav_binding_name.empty() ? uav_resource->name : uav_binding_name),
-                                             ParseInt(srv_index),
-                                             preprocess_state.ResourceVariableNameAtIndex(*uav_resource, (literal_element_offset) + (literal_index * 4)));
+              if (uav_resource) {
+                auto& access_name = uav_binding_name.empty() ? uav_resource->name : uav_binding_name;
+                assignment_value = std::format("{}[{}]{}",
+                                               access_name,
+                                               ParseInt(srv_index),
+                                               preprocess_state.ResourceVariableNameAtIndex(*uav_resource, (literal_element_offset) + (literal_index * 4)));
+              } else {
+                // Heap resource without type info — use raw component access
+                assignment_value = std::format("{}[{}].{}", uav_binding_name, ParseInt(srv_index), VECTOR_INDEXES[literal_index]);
+              }
               is_identity = false;
               use_comment = false;
             }
@@ -4157,11 +4914,16 @@ class Decompiler {
               FromStringView(element_offset, literal_element_offset);
               int literal_alignment;
               FromStringView(alignment, literal_alignment);
-              auto& access_name = srv_binding_name.empty() ? srv_resource->name : srv_binding_name;
-              assignment_value = std::format("{}[{}]{}",
-                                             access_name,
-                                             ParseInt(srv_index),
-                                             preprocess_state.ResourceVariableNameAtIndex(*srv_resource, (literal_element_offset) + (literal_index * 2)));
+              if (srv_resource) {
+                auto& access_name = srv_binding_name.empty() ? srv_resource->name : srv_binding_name;
+                assignment_value = std::format("{}[{}]{}",
+                                               access_name,
+                                               ParseInt(srv_index),
+                                               preprocess_state.ResourceVariableNameAtIndex(*srv_resource, (literal_element_offset) + (literal_index * 2)));
+              } else {
+                // Heap resource without type info — use raw component access
+                assignment_value = std::format("{}[{}].{}", srv_binding_name, ParseInt(srv_index), VECTOR_INDEXES[literal_index]);
+              }
               is_identity = false;
               use_comment = false;
             }
@@ -4187,10 +4949,16 @@ class Decompiler {
               FromStringView(element_offset, literal_element_offset);
               int literal_alignment;
               FromStringView(alignment, literal_alignment);
-              assignment_value = std::format("{}[{}]{}",
-                                             (uav_binding_name.empty() ? uav_resource->name : uav_binding_name),
-                                             ParseInt(srv_index),
-                                             preprocess_state.ResourceVariableNameAtIndex(*uav_resource, (literal_element_offset) + (literal_index * 2)));
+              if (uav_resource) {
+                auto& access_name = uav_binding_name.empty() ? uav_resource->name : uav_binding_name;
+                assignment_value = std::format("{}[{}]{}",
+                                               access_name,
+                                               ParseInt(srv_index),
+                                               preprocess_state.ResourceVariableNameAtIndex(*uav_resource, (literal_element_offset) + (literal_index * 2)));
+              } else {
+                // Heap resource without type info — use raw component access
+                assignment_value = std::format("{}[{}].{}", uav_binding_name, ParseInt(srv_index), VECTOR_INDEXES[literal_index]);
+              }
               is_identity = false;
               use_comment = false;
             }
@@ -4223,11 +4991,16 @@ class Decompiler {
               FromStringView(element_offset, literal_element_offset);
               int literal_alignment;
               FromStringView(alignment, literal_alignment);
-              auto& access_name = srv_binding_name.empty() ? srv_resource->name : srv_binding_name;
-              assignment_value = std::format("{}[{}]{}",
-                                             access_name,
-                                             ParseInt(srv_index),
-                                             preprocess_state.ResourceVariableNameAtIndex(*srv_resource, (literal_element_offset) + (literal_index * 4)));
+              if (srv_resource) {
+                auto& access_name = srv_binding_name.empty() ? srv_resource->name : srv_binding_name;
+                assignment_value = std::format("{}[{}]{}",
+                                               access_name,
+                                               ParseInt(srv_index),
+                                               preprocess_state.ResourceVariableNameAtIndex(*srv_resource, (literal_element_offset) + (literal_index * 4)));
+              } else {
+                // Heap resource without type info — use raw component access
+                assignment_value = std::format("{}[{}].{}", srv_binding_name, ParseInt(srv_index), VECTOR_INDEXES[literal_index]);
+              }
               is_identity = false;
               use_comment = false;
             }
@@ -4253,10 +5026,16 @@ class Decompiler {
               FromStringView(element_offset, literal_element_offset);
               int literal_alignment;
               FromStringView(alignment, literal_alignment);
-              assignment_value = std::format("{}[{}]{}",
-                                             (uav_binding_name.empty() ? uav_resource->name : uav_binding_name),
-                                             ParseInt(srv_index),
-                                             preprocess_state.ResourceVariableNameAtIndex(*uav_resource, (literal_element_offset) + (literal_index * 4)));
+              if (uav_resource) {
+                auto& access_name = uav_binding_name.empty() ? uav_resource->name : uav_binding_name;
+                assignment_value = std::format("{}[{}]{}",
+                                               access_name,
+                                               ParseInt(srv_index),
+                                               preprocess_state.ResourceVariableNameAtIndex(*uav_resource, (literal_element_offset) + (literal_index * 4)));
+              } else {
+                // Heap resource without type info — use raw component access
+                assignment_value = std::format("{}[{}].{}", uav_binding_name, ParseInt(srv_index), VECTOR_INDEXES[literal_index]);
+              }
               is_identity = false;
               use_comment = false;
             }
@@ -4291,11 +5070,16 @@ class Decompiler {
               FromStringView(element_offset, literal_element_offset);
               int literal_alignment;
               FromStringView(alignment, literal_alignment);
-              auto& access_name = srv_binding_name.empty() ? srv_resource->name : srv_binding_name;
-              assignment_value = std::format("{}[{}]{}",
-                                             access_name,
-                                             ParseInt(srv_index),
-                                             preprocess_state.ResourceVariableNameAtIndex(*srv_resource, (literal_element_offset) + (literal_index * 2)));
+              if (srv_resource) {
+                auto& access_name = srv_binding_name.empty() ? srv_resource->name : srv_binding_name;
+                assignment_value = std::format("{}[{}]{}",
+                                               access_name,
+                                               ParseInt(srv_index),
+                                               preprocess_state.ResourceVariableNameAtIndex(*srv_resource, (literal_element_offset) + (literal_index * 2)));
+              } else {
+                // Heap resource without type info — use raw component access
+                assignment_value = std::format("{}[{}].{}", srv_binding_name, ParseInt(srv_index), VECTOR_INDEXES[literal_index]);
+              }
               is_identity = false;
               use_comment = false;
             }
@@ -4321,10 +5105,91 @@ class Decompiler {
               FromStringView(element_offset, literal_element_offset);
               int literal_alignment;
               FromStringView(alignment, literal_alignment);
-              assignment_value = std::format("{}[{}]{}",
-                                             (uav_binding_name.empty() ? uav_resource->name : uav_binding_name),
-                                             ParseInt(srv_index),
-                                             preprocess_state.ResourceVariableNameAtIndex(*uav_resource, (literal_element_offset) + (literal_index * 2)));
+              if (uav_resource) {
+                auto& access_name = uav_binding_name.empty() ? uav_resource->name : uav_binding_name;
+                assignment_value = std::format("{}[{}]{}",
+                                               access_name,
+                                               ParseInt(srv_index),
+                                               preprocess_state.ResourceVariableNameAtIndex(*uav_resource, (literal_element_offset) + (literal_index * 2)));
+              } else {
+                // Heap resource without type info — use raw component access
+                assignment_value = std::format("{}[{}].{}", uav_binding_name, ParseInt(srv_index), VECTOR_INDEXES[literal_index]);
+              }
+              is_identity = false;
+              use_comment = false;
+            }
+          } else {
+            assignment_value = std::format("{}.{}", ParseVariable(input), ParseIndex(index));
+            is_identity = true;
+          }
+        } else if (type == R"(%dx.types.ResRet.i64)") {
+          auto source_variable = raw_source_variable;
+          assignment_type = "int64_t";
+          if (auto pair = preprocess_state.srv_binding_load_variables.find(source_variable);
+              pair != preprocess_state.srv_binding_load_variables.end()) {
+            const auto& [srv_resource, srv_index, element_offset, alignment, srv_binding_name] = pair->second;
+            if (alignment == "raw") {
+              int comp_count = 0;
+              FromStringView(element_offset, comp_count);
+              int literal_index;
+              FromStringView(index, literal_index);
+              if (comp_count == 1) {
+                assignment_value = srv_index;
+              } else {
+                assignment_value = std::format("{}.{}", srv_index, ParseIndex(index));
+              }
+              is_identity = false;
+              use_comment = false;
+            } else {
+              int literal_index;
+              FromStringView(index, literal_index);
+              int literal_element_offset;
+              FromStringView(element_offset, literal_element_offset);
+              int literal_alignment;
+              FromStringView(alignment, literal_alignment);
+              if (srv_resource) {
+                auto& access_name = srv_binding_name.empty() ? srv_resource->name : srv_binding_name;
+                assignment_value = std::format("{}[{}]{}",
+                                               access_name,
+                                               ParseInt(srv_index),
+                                               preprocess_state.ResourceVariableNameAtIndex(*srv_resource, (literal_element_offset) + (literal_index * 8)));
+              } else {
+                assignment_value = std::format("{}[{}].{}", srv_binding_name, ParseInt(srv_index), VECTOR_INDEXES[literal_index]);
+              }
+              is_identity = false;
+              use_comment = false;
+            }
+          } else if (auto pair = preprocess_state.uav_binding_load_variables.find(source_variable);
+                     pair != preprocess_state.uav_binding_load_variables.end()) {
+            const auto& [uav_resource, srv_index, element_offset, alignment, uav_binding_name] = pair->second;
+            if (alignment == "raw") {
+              int comp_count = 0;
+              FromStringView(element_offset, comp_count);
+              int literal_index;
+              FromStringView(index, literal_index);
+              if (comp_count == 1) {
+                assignment_value = srv_index;
+              } else {
+                assignment_value = std::format("{}.{}", srv_index, ParseIndex(index));
+              }
+              is_identity = false;
+              use_comment = false;
+            } else {
+              int literal_index;
+              FromStringView(index, literal_index);
+              int literal_element_offset;
+              FromStringView(element_offset, literal_element_offset);
+              int literal_alignment;
+              FromStringView(alignment, literal_alignment);
+              if (uav_resource) {
+                auto& access_name = uav_binding_name.empty() ? uav_resource->name : uav_binding_name;
+                assignment_value = std::format("{}[{}]{}",
+                                               access_name,
+                                               ParseInt(srv_index),
+                                               preprocess_state.ResourceVariableNameAtIndex(*uav_resource, (literal_element_offset) + (literal_index * 8)));
+              } else {
+                assignment_value = std::format("{}[{}].{}", uav_binding_name, ParseInt(srv_index), VECTOR_INDEXES[literal_index]);
+              }
               is_identity = false;
               use_comment = false;
             }
@@ -4337,8 +5202,15 @@ class Decompiler {
           assignment_value = std::format("{}.{}", ParseVariable(input), ParseIndex(index));
           is_identity = true;
         } else if (type == R"(%dx.types.fouri32)") {
-          // extractvalue %dx.types.fouri32 %928, 0  — from WaveMatch
-          assignment_type = "uint";
+          // extractvalue %dx.types.fouri32 %928, 0  — from WaveMatch/Unpack4x8
+          auto aggregate_type = aggregate_extract_types.find(raw_source_variable);
+          assignment_type = aggregate_type != aggregate_extract_types.end() ? aggregate_type->second : "uint";
+          assignment_value = std::format("{}.{}", ParseVariable(input), ParseIndex(index));
+          is_identity = true;
+        } else if (type == R"(%dx.types.fouri16)") {
+          // extractvalue %dx.types.fouri16 %13, 0  — from Unpack4x8.i16
+          auto aggregate_type = aggregate_extract_types.find(raw_source_variable);
+          assignment_type = aggregate_type != aggregate_extract_types.end() ? aggregate_type->second : "uint16_t";
           assignment_value = std::format("{}.{}", ParseVariable(input), ParseIndex(index));
           is_identity = true;
         } else {
@@ -4412,7 +5284,7 @@ class Decompiler {
         // %39 = fcmp fast ogt float %37, 0.000000e+00
         auto [fast, op, value_type, a, b] = StringViewMatch<5>(assignment, std::regex{R"(fcmp (fast )?(\S+) (\S+) (\S+), (\S+))"});
 
-        bool is_fast = !fast.empty();
+        (void)fast;
         assignment_type = "bool";
 
         auto a_parsed = ParseByType(a, value_type);
@@ -4434,42 +5306,17 @@ class Decompiler {
         } else if (op == "ord") {
           assignment_value = std::format("(!isnan{} && !isnan{})", ParseWrapped(a_parsed), ParseWrapped(b_parsed));
         } else if (op == "ueq") {
-          // With fast: unordered == ordered, emit direct comparison
-          if (is_fast) {
-            assignment_value = std::format("({} == {})", a_parsed, b_parsed);
-          } else {
-            assignment_value = std::format("!({} != {})", a_parsed, b_parsed);
-          }
+          assignment_value = std::format("!({} != {})", a_parsed, b_parsed);
         } else if (op == "ugt") {
-          if (is_fast) {
-            assignment_value = std::format("({} > {})", a_parsed, b_parsed);
-          } else {
-            assignment_value = std::format("!({} <= {})", a_parsed, b_parsed);
-          }
+          assignment_value = std::format("!({} <= {})", a_parsed, b_parsed);
         } else if (op == "uge") {
-          if (is_fast) {
-            assignment_value = std::format("({} >= {})", a_parsed, b_parsed);
-          } else {
-            assignment_value = std::format("!({} < {})", a_parsed, b_parsed);
-          }
+          assignment_value = std::format("!({} < {})", a_parsed, b_parsed);
         } else if (op == "ult") {
-          if (is_fast) {
-            assignment_value = std::format("({} < {})", a_parsed, b_parsed);
-          } else {
-            assignment_value = std::format("!({} >= {})", a_parsed, b_parsed);
-          }
+          assignment_value = std::format("!({} >= {})", a_parsed, b_parsed);
         } else if (op == "ule") {
-          if (is_fast) {
-            assignment_value = std::format("({} <= {})", a_parsed, b_parsed);
-          } else {
-            assignment_value = std::format("!({} > {})", a_parsed, b_parsed);
-          }
+          assignment_value = std::format("!({} > {})", a_parsed, b_parsed);
         } else if (op == "une") {
-          if (is_fast) {
-            assignment_value = std::format("({} != {})", a_parsed, b_parsed);
-          } else {
-            assignment_value = std::format("!({} == {})", a_parsed, b_parsed);
-          }
+          assignment_value = std::format("!({} == {})", a_parsed, b_parsed);
         } else if (op == "uno") {
           assignment_value = std::format("(isnan{} || isnan{})", ParseWrapped(a_parsed), ParseWrapped(b_parsed));
         } else {
@@ -4483,9 +5330,9 @@ class Decompiler {
         std::string cast;
 
         if (op.starts_with("u")) {
-          cast = "(uint)";
+          cast = (type == "i64") ? "(uint64_t)" : "(uint)";
         } else if (op.starts_with("s")) {
-          cast = "(int)";
+          cast = (type == "i64") ? "(int64_t)" : "(int)";
         }
 
         // Convert negative constants to unsigned equivalents for unsigned comparisons
@@ -4556,7 +5403,7 @@ class Decompiler {
         // uitofp i16 %32 to float
         auto [from_type, a, to_type] = StringViewMatch<3>(assignment, std::regex{R"(uitofp (\S+) (\S+) to (\S+))"});
         assignment_type = ParseType(to_type);
-        assignment_value = std::format("{}(({}){})", assignment_type, ParseUnsignedType(from_type), ParseUint(a));
+        assignment_value = std::format("({})(({}){})", assignment_type, ParseUnsignedType(from_type), ParseUint(a));
       } else if (instruction == "fptoui") {
         auto [a] = StringViewMatch<1>(assignment, std::regex{R"(fptoui (?:\S+) (\S+) to (?:\S+))"});
         assignment_type = "uint";
@@ -4581,7 +5428,7 @@ class Decompiler {
           assignment_value = std::format("{} && {}", ParseBool(a), ParseBool(b));
         } else {
           assignment_type = ParseType(type);
-          assignment_value = std::format("{} & {}", ParseInt(a), ParseInt(b));
+          assignment_value = std::format("{} & {}", ParseByType(a, type), ParseByType(b, type));
         }
       } else if (instruction == "urem") {
         //   %100 = urem i32 %99, 5
@@ -4761,7 +5608,7 @@ class Decompiler {
           } else {
             assignment_type = "float";
           }
-          assignment_value = stored_pointers[source];
+          assignment_value = ResolveStoredPointer(source, preprocess_state);
         }
       } else if (instruction == "bitcast") {
         // %63 = bitcast i32 %62 to float
@@ -4799,6 +5646,11 @@ class Decompiler {
         auto [source_type, source_variable, dest_type] = StringViewMatch<3>(assignment, std::regex{R"(trunc (\S+) (\S+) to (\S+))"});
         if (source_type.empty()) {
           // decompiled = std::format("// {}", line);
+        } else if (dest_type == "i1") {
+          // trunc iN to i1 keeps only the least-significant bit as a bool.
+          // A plain (bool) cast would be wrong (it tests != 0 over all bits).
+          assignment_type = "bool";
+          assignment_value = std::format("({} & 1) != 0", ParseWrapped(ParseVariable(source_variable, ParseType(source_type))));
         } else {
           assignment_type = ParseType(dest_type);
           assignment_value = std::format("{}{}", ParseTrunc(dest_type), ParseWrapped(ParseVariable(source_variable, ParseType(source_type))));
@@ -4949,7 +5801,7 @@ class Decompiler {
           op_str = std::string(op);
           operand_str_raw = std::string(operand);
           if (pointer.starts_with('%')) {
-            parsed_pointer = stored_pointers.count(pointer.substr(1)) ? stored_pointers[pointer.substr(1)] : std::format("_{}", pointer.substr(1));
+            parsed_pointer = ResolveStoredPointer(pointer.substr(1), preprocess_state);
           } else if (pointer.starts_with('@')) {
             if (auto pair = preprocess_state.global_variables.find(std::string(pointer));
                 pair != preprocess_state.global_variables.end()) {
@@ -5151,9 +6003,10 @@ class Decompiler {
 
         auto [opNumber, uav, index, elementOffset, value0, value1, value2, value3, mask, alignment] = StringViewSplit<10>(functionParamsString, param_regex, 2);
         auto ref = std::string{uav.substr(1)};
-        auto binding_store_f32 = preprocess_state.resource_binding_variables.at(ref);
+        auto binding_store_f32 = GetResourceBindingVariable(ref, preprocess_state);
         auto [res_name, range_index, resource_class] = binding_store_f32;
         bool is_raw_buffer = preprocess_state.GetResourceShape(ref) == Resource::ResourceKind::RawBuffer;
+        bool is_heap_resource = preprocess_state.IsHeapResource(ref);
 
         const bool has_value_y = value1 != "undef";
         const bool has_value_z = value2 != "undef";
@@ -5185,15 +6038,18 @@ class Decompiler {
         // assert(is_raw_buffer);
 
         // assert(elementOffset == "undef");
-        if (is_raw_buffer) {
+        if (is_raw_buffer || is_heap_resource) {
           int component_count = 1;
           if (has_value_w) component_count = 4;
           else if (has_value_z) component_count = 3;
           else if (has_value_y) component_count = 2;
           std::string store_func = (component_count == 1) ? "Store" :
                                    std::format("Store{}", component_count);
+          std::string byte_address = is_heap_resource
+              ? BuildStructuredByteAddress(index, elementOffset, preprocess_state.GetResourceStride(ref))
+              : ParseInt(index);
           decompiled = std::format("{}.{}({}, asuint({}));",
-                                   res_name, store_func, ParseInt(index), value);
+                                   res_name, store_func, byte_address, value);
         } else if (elementOffset.starts_with("%")) {
           // Dynamic element offset on a StructuredBuffer — resolve using struct layout.
           auto& uav_resource = preprocess_state.uav_resources[range_index];
@@ -5293,9 +6149,10 @@ class Decompiler {
 
         auto [opNumber, uav, index, elementOffset, value0, value1, value2, value3, mask, alignment] = StringViewSplit<10>(functionParamsString, param_regex, 2);
         auto ref = std::string{uav.substr(1)};
-        auto binding_store_i32 = preprocess_state.resource_binding_variables.at(ref);
+        auto binding_store_i32 = GetResourceBindingVariable(ref, preprocess_state);
         auto [res_name, range_index, resource_class] = binding_store_i32;
         bool is_raw_buffer = preprocess_state.GetResourceShape(ref) == Resource::ResourceKind::RawBuffer;
+        bool is_heap_resource = preprocess_state.IsHeapResource(ref);
 
         const bool has_value_y = value1 != "undef";
         const bool has_value_z = value2 != "undef";
@@ -5324,11 +6181,14 @@ class Decompiler {
           }
         }
 
-        if (is_raw_buffer) {
+        if (is_raw_buffer || is_heap_resource) {
+          std::string byte_address = is_heap_resource
+              ? BuildStructuredByteAddress(index, elementOffset, preprocess_state.GetResourceStride(ref))
+              : ParseInt(index);
           decompiled = std::format("{}.{}({}, asuint({}));",
                                    res_name,
                                    has_value_w ? "Store4" : has_value_z ? "Store3" : has_value_y ? "Store2" : "Store",
-                                   ParseInt(index), value);
+                                   byte_address, value);
         } else if (elementOffset.starts_with("%")) {
           // Dynamic element offset on a StructuredBuffer — resolve using struct layout.
           // Extract the constant field offset from the IR definition of the offset variable.
@@ -5428,6 +6288,38 @@ class Decompiler {
                                      res_name, ParseInt(index), value);
           }
         }
+      } else if (functionName == "@dx.op.rawBufferStore.i64") {
+        // call void @dx.op.rawBufferStore.i64(i32 140, %dx.types.Handle %5, i32 %4, i32 0, i64 0, i64 undef, i64 undef, i64 undef, i8 1, i32 8)
+        auto [opNumber, uav, index, elementOffset, value0, value1, value2, value3, mask, alignment] = StringViewSplit<10>(functionParamsString, param_regex, 2);
+        auto ref = std::string{uav.substr(1)};
+        auto [res_name, range_index, resource_class] = GetResourceBindingVariable(ref, preprocess_state);
+        bool is_raw_buffer = preprocess_state.GetResourceShape(ref) == Resource::ResourceKind::RawBuffer;
+        bool is_heap_resource = preprocess_state.IsHeapResource(ref);
+        const bool has_value_y = value1 != "undef";
+        std::string value;
+        if (has_value_y) {
+          value = std::format("uint64_t2({}, {})", ParseInt64(value0), ParseInt64(value1));
+        } else {
+          value = ParseInt64(value0);
+        }
+        if (is_raw_buffer || is_heap_resource) {
+          std::string byte_address = is_heap_resource
+              ? BuildStructuredByteAddress(index, elementOffset, preprocess_state.GetResourceStride(ref))
+              : ParseInt(index);
+          decompiled = std::format("{}.Store({}, {});", res_name, byte_address, value);
+        } else {
+          int literal_element_offset = 0;
+          if (elementOffset != "undef") {
+            FromStringView(elementOffset, literal_element_offset);
+          }
+          auto& uav_resource = preprocess_state.uav_resources[range_index];
+          std::string field_access = preprocess_state.ResourceFieldNameAtOffset(uav_resource, literal_element_offset);
+          if (!field_access.empty()) {
+            decompiled = std::format("{}[{}]{} = {};", res_name, ParseInt(index), field_access, value);
+          } else {
+            decompiled = std::format("{}[{}] = {};", res_name, ParseInt(index), value);
+          }
+        }
       } else if (functionName == "@dx.op.storeOutput.f32" || functionName == "@dx.op.storeOutput.f16") {
         // call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float %2772)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
         auto [opNumber, outputSigId, rowIndex, colIndex, value] = StringViewSplit<5>(functionParamsString, param_regex, 2);
@@ -5465,7 +6357,6 @@ class Decompiler {
         const bool has_coord_z = coord2 != "undef";
         std::string coords;
         auto [uav_name, uav_range_index, resource_class] = preprocess_state.resource_binding_variables.at(ref_resource);
-        auto uav_resource = preprocess_state.uav_resources[uav_range_index];
         if (has_coord_z) {
           coords = std::format("int3({}, {}, {})", ParseInt(coord0), ParseInt(coord1), ParseInt(coord2));
         } else if (has_coord_y) {
@@ -5476,14 +6367,15 @@ class Decompiler {
         bool has_value_y = value1 != "undef";
         bool has_value_z = value2 != "undef";
         bool has_value_w = value3 != "undef";
+        const auto uav_data_type = preprocess_state.GetResourceDataType(ref_resource);
 
-        if (has_value_w && value3 == value0 && uav_resource.data_type != "float4") {
+        if (has_value_w && value3 == value0 && uav_data_type != "float4") {
           has_value_w = false;
         }
-        if (has_value_z && value2 == value0 && uav_resource.data_type != "float3") {
+        if (has_value_z && value2 == value0 && uav_data_type != "float3") {
           has_value_z = false;
         }
-        if (has_value_y && value1 == value0 && uav_resource.data_type != "float2") {
+        if (has_value_y && value1 == value0 && uav_data_type != "float2") {
           has_value_y = false;
         }
         std::string value;
@@ -5506,7 +6398,6 @@ class Decompiler {
         const bool has_coord_z = coord2 != "undef";
         std::string coords;
         auto [uav_name, uav_range_index, resource_class] = preprocess_state.resource_binding_variables.at(ref_resource);
-        auto uav_resource = preprocess_state.uav_resources[uav_range_index];
         if (has_coord_z) {
           coords = std::format("int3({}, {}, {})", ParseInt(coord0), ParseInt(coord1), ParseInt(coord2));
         } else if (has_coord_y) {
@@ -5517,14 +6408,15 @@ class Decompiler {
         bool has_value_y = value1 != "undef";
         bool has_value_z = value2 != "undef";
         bool has_value_w = value3 != "undef";
+        const auto uav_data_type = preprocess_state.GetResourceDataType(ref_resource);
 
-        if (has_value_w && value3 == value0 && uav_resource.data_type != "uint4") {
+        if (has_value_w && value3 == value0 && uav_data_type != "uint4") {
           has_value_w = false;
         }
-        if (has_value_z && value2 == value0 && uav_resource.data_type != "uint3") {
+        if (has_value_z && value2 == value0 && uav_data_type != "uint3") {
           has_value_z = false;
         }
-        if (has_value_y && value1 == value0 && uav_resource.data_type != "uint2") {
+        if (has_value_y && value1 == value0 && uav_data_type != "uint2") {
           has_value_y = false;
         }
         std::string value;
@@ -5844,7 +6736,7 @@ class Decompiler {
           parsed_value = std::format("{}({})", cast, parsed_value);
         }
       }
-      std::string decompiled = std::format("{} = {};", stored_pointers[pointer], parsed_value);
+      std::string decompiled = std::format("{} = {};", ResolveStoredPointer(pointer, preprocess_state), parsed_value);
 
 #if DECOMPILER_DXC_DEBUG >= 3
       std::cout << decompiled << "\n";
@@ -5865,27 +6757,31 @@ class Decompiler {
     auto DecompileLines(PreprocessState& preprocess_state) {
       for (auto it = this->lines.begin(); it != this->lines.end(); ++it) {
         auto& line = *it;
-        if (line.starts_with("  %")) {
-          this->AddCodeAssign(line, preprocess_state);
-        } else if (line.starts_with("  call ")) {
-          this->AddCodeCall(line, preprocess_state);
-        } else if (line.starts_with("  store ")) {
-          this->AddCodeStore(line, preprocess_state);
-        } else if (line.starts_with("  ret ")) {
-          this->CloseBranch();
-        } else if (line.starts_with("  br ")) {
-          this->AddCodeBranch(line, preprocess_state);
-        } else if (line.starts_with("  switch ")) {
-          this->AddCodeSwitch(line, preprocess_state, it);
-        } else if (line.empty()) {
-          //
-        } else if (line == "entry:") {
-          // noop
-        } else if (line.starts_with("; <label>:")) {
-          this->ParseBlockDefinition(line);
-        } else {
-          std::cerr << line << "\n";
-          throw std::runtime_error("Unexpected code block");
+        try {
+          if (line.starts_with("  %")) {
+            this->AddCodeAssign(line, preprocess_state);
+          } else if (line.starts_with("  call ")) {
+            this->AddCodeCall(line, preprocess_state);
+          } else if (line.starts_with("  store ")) {
+            this->AddCodeStore(line, preprocess_state);
+          } else if (line.starts_with("  ret ")) {
+            this->CloseBranch();
+          } else if (line.starts_with("  br ")) {
+            this->AddCodeBranch(line, preprocess_state);
+          } else if (line.starts_with("  switch ")) {
+            this->AddCodeSwitch(line, preprocess_state, it);
+          } else if (line.empty()) {
+            //
+          } else if (line == "entry:") {
+            // noop
+          } else if (line.starts_with("; <label>:")) {
+            this->ParseBlockDefinition(line);
+          } else {
+            std::cerr << line << "\n";
+            throw std::runtime_error("Unexpected code block");
+          }
+        } catch (const std::exception& ex) {
+          throw std::runtime_error(std::format("{} while decompiling DXIL line: {}", ex.what(), StringViewTrim(line)));
         }
       }
     }
@@ -6789,6 +7685,30 @@ class Decompiler {
     }
   }
 
+  static void DisambiguateOutputSignatureNames(
+      const std::vector<Signature>& input_signatures,
+      std::vector<Signature>& output_signatures) {
+    std::set<std::string> used_names;
+    for (const auto& signature : input_signatures) {
+      used_names.insert(signature.VariableString());
+    }
+
+    for (auto& signature : output_signatures) {
+      auto variable_name = signature.VariableString();
+      if (!used_names.contains(variable_name)) {
+        used_names.insert(variable_name);
+        continue;
+      }
+
+      auto renamed_variable = std::format("__out_{}", variable_name);
+      for (uint32_t suffix = 1; used_names.contains(renamed_variable); ++suffix) {
+        renamed_variable = std::format("__out_{}_{}", variable_name, suffix);
+      }
+      signature.variable_name_override = renamed_variable;
+      used_names.insert(renamed_variable);
+    }
+  }
+
   void Init() {
     this->line_number = 0;
     this->state = TokenizerState::START;
@@ -7111,6 +8031,7 @@ class Decompiler {
             if (!created_signatures) {
               CreateSignatures(input_sigs_packed, input_sigs_property, preprocess_state.input_signature);
               CreateSignatures(output_sigs_packed, output_sigs_property, preprocess_state.output_signature);
+              DisambiguateOutputSignatureNames(preprocess_state.input_signature, preprocess_state.output_signature);
               created_signatures = true;
             };
             if (line.empty() || line[0] == '\0') {
@@ -7456,12 +8377,25 @@ class Decompiler {
           auto [range_index, bind_index] = handle_it->second;
           if (range_index >= preprocess_state.cbv_resources.size()) continue;
 
-          // Skip if this cbuffer handle has dynamic access (uses raw array style)
-          if (preprocess_state.cbv_handles_with_dynamic_access.contains(std::format("%{}", handle_ref))) continue;
-          if (preprocess_state.cbv_dynamic_access_indices.count(range_index)) continue;
-
           auto& cbv_resource = preprocess_state.cbv_resources[range_index];
           cbuf_load_map[var] = {range_index, reg_index, cbv_resource.name};
+        }
+      }
+
+      // Detect dynamic (variable register index) cbuffer loads up front. The main
+      // DecompileLines pass records these too, but it runs after this pre-pass, so
+      // detect them here so the resolver below can route static accesses through
+      // the raw views instead of emitting named fields whose packoffset would
+      // overlap the raw float4 array.
+      static const auto cbuf_dynamic_load_regex = std::regex(
+          R"(^\s+%\d+ = call %dx\.types\.CBufRet\.\w+ @dx\.op\.cbufferLoadLegacy\.\w+\(i32 \d+, %dx\.types\.Handle %(\d+), i32 %)");
+      for (const auto& src_line : current_code_function->lines) {
+        std::match_results<std::string_view::const_iterator> m;
+        if (std::regex_search(src_line.begin(), src_line.end(), m, cbuf_dynamic_load_regex)) {
+          auto handle_it = cbv_handles.find(m[1].str());
+          if (handle_it != cbv_handles.end()) {
+            preprocess_state.cbv_dynamic_access_indices.insert(handle_it->second.first);
+          }
         }
       }
 
@@ -7484,39 +8418,121 @@ class Decompiler {
           std::string assignment_type;
           std::string assignment_value;
 
+          const bool cbv_is_dynamic = preprocess_state.cbv_dynamic_access_indices.count(range_index) != 0u;
+          const bool cbv_types_reliable = preprocess_state.CBufferFieldTypesReliable(cbv_resource);
           if (ret_type == "f32") {
             assignment_type = "float";
             auto value_from_reflection = preprocess_state.ResourceVariableNameAtIndex(cbv_resource, (reg_index * 16) + (component_index * 4));
-            if (value_from_reflection.empty()) {
+            if (!value_from_reflection.empty()) {
+              std::string field = cbv_resource.array_size.has_value()
+                                      ? std::format("{}.{}", binding_name, value_from_reflection)
+                                      : value_from_reflection;
+              // Reconstructed layouts may type this register as int elsewhere;
+              // asfloat() preserves the DXIL float load's bit interpretation.
+              assignment_value = cbv_types_reliable ? field : std::format("asfloat({})", field);
+            } else if (cbv_is_dynamic) {
+              // Route through the raw view so named fields don't overlap it.
+              assignment_value = std::format("{}_raw[{}u].{}", binding_name, reg_index, VECTOR_INDEXES[component_index]);
+            } else {
               char sub_index = VECTOR_INDEXES[component_index];
               std::string suffix = std::format("{:03}{}", reg_index, sub_index);
               assignment_value = std::format("{}_{}", binding_name, suffix);
-            } else {
-              if (cbv_resource.array_size.has_value()) {
-                assignment_value = std::format("{}.{}", binding_name, value_from_reflection);
-              } else {
-                assignment_value = value_from_reflection;
-              }
+              // Record the register accessor so the cbuffer declaration emits a
+              // matching named field. Without this, the alias produced here wins
+              // over the main extractvalue handler (which would record it), and
+              // the field is referenced but never declared.
+              cbv_resource.data_types.try_emplace(suffix, "float");
             }
           } else if (ret_type == "i32") {
             assignment_type = "int";
             auto value_from_reflection = preprocess_state.ResourceVariableNameAtIndex(cbv_resource, (reg_index * 16) + (component_index * 4));
-            if (value_from_reflection.empty()) {
+            if (!value_from_reflection.empty()) {
+              std::string field = cbv_resource.array_size.has_value()
+                                      ? std::format("{}.{}", binding_name, value_from_reflection)
+                                      : value_from_reflection;
+              // Reconstructed layouts may type this register as float; asint()
+              // preserves the DXIL integer load's bit interpretation.
+              assignment_value = cbv_types_reliable ? field : std::format("asint({})", field);
+            } else if (cbv_is_dynamic) {
+              assignment_value = std::format("asint({}_raw_uint[{}u].{})", binding_name, reg_index, VECTOR_INDEXES[component_index]);
+            } else {
               char sub_index = VECTOR_INDEXES[component_index];
               std::string suffix = std::format("{:03}{}", reg_index, sub_index);
               assignment_value = std::format("{}_{}", binding_name, suffix);
-            } else {
-              if (cbv_resource.array_size.has_value()) {
-                assignment_value = std::format("{}.{}", binding_name, value_from_reflection);
-              } else {
-                assignment_value = value_from_reflection;
-              }
+              cbv_resource.data_types.try_emplace(suffix, "int");
             }
           }
 
           if (!assignment_value.empty()) {
             cbuffer_prepass_aliases.emplace(var, std::pair<std::string, std::string>(assignment_type, assignment_value));
           }
+        }
+      }
+
+      // Structural emission can encounter a use of a late extractvalue before
+      // source-order parsing reaches the extractvalue definition. Keep this
+      // narrow: only pre-seed identity aliases for extractvalues from
+      // textureLoad results, because those source result variables are emitted
+      // as real HLSL locals (e.g. `float4 _4595 = tex.Load(...)`).
+      {
+        static const auto texture_load_regex = std::regex(
+            R"(^\s+%(\d+) = call %dx\.types\.ResRet\.(f32|f16|i32|i16) @dx\.op\.textureLoad\.)");
+        static const auto texture_extract_regex = std::regex(
+            R"(^\s+%(\d+) = extractvalue %dx\.types\.ResRet\.(f32|f16|i32|i16) %(\d+), (\d+))");
+        static const auto def_regex = std::regex(R"(^\s+%(\d+)\s*=)");
+        static const auto use_regex = std::regex(R"(%(\d+))");
+
+        std::map<std::string, std::string> texture_load_types;
+        std::map<std::string, size_t> first_use_line;
+        for (size_t line_index = 0; line_index < current_code_function->lines.size(); ++line_index) {
+          const auto& src_line = current_code_function->lines[line_index];
+          std::match_results<std::string_view::const_iterator> m;
+          if (std::regex_search(src_line.begin(), src_line.end(), m, texture_load_regex)) {
+            texture_load_types.emplace(m[1].str(), m[2].str());
+          }
+
+          auto search_start = src_line.begin();
+          std::match_results<std::string_view::const_iterator> dm;
+          std::string defined_var;
+          if (std::regex_search(src_line.begin(), src_line.end(), dm, def_regex)) {
+            defined_var = dm[1].str();
+            search_start = dm[0].second;
+          }
+
+          std::match_results<std::string_view::const_iterator> um;
+          while (std::regex_search(search_start, src_line.end(), um, use_regex)) {
+            std::string used_var = um[1].str();
+            if (used_var != defined_var) {
+              first_use_line.try_emplace(used_var, line_index);
+            }
+            search_start = um[0].second;
+          }
+        }
+
+        for (size_t line_index = 0; line_index < current_code_function->lines.size(); ++line_index) {
+          const auto& src_line = current_code_function->lines[line_index];
+          std::match_results<std::string_view::const_iterator> m;
+          if (!std::regex_search(src_line.begin(), src_line.end(), m, texture_extract_regex)) continue;
+
+          const std::string var = m[1].str();
+          const std::string ret_type = m[2].str();
+          const std::string source_var = m[3].str();
+          uint32_t component_index = 0;
+          FromStringView(std::string_view(m[4].str()), component_index);
+          if (component_index >= 4) continue;
+          if (!texture_load_types.contains(source_var)) continue;
+          auto first_use_it = first_use_line.find(var);
+          if (first_use_it == first_use_line.end() || first_use_it->second >= line_index) continue;
+
+          std::string assignment_type;
+          if (ret_type == "f32") assignment_type = "float";
+          else if (ret_type == "f16") assignment_type = "half";
+          else if (ret_type == "i16") assignment_type = "int16_t";
+          else assignment_type = "int";
+
+          cbuffer_prepass_aliases.emplace(
+              var,
+              std::pair<std::string, std::string>{assignment_type, std::format("_{}.{}", source_var, VECTOR_INDEXES[component_index])});
         }
       }
 
@@ -7776,11 +8792,8 @@ class Decompiler {
         }
       }
 
-      // Sanitize struct name for HLSL (replace <, >, spaces with underscores)
-      std::string sanitized_name(struct_name);
-      std::ranges::replace(sanitized_name, '<', '_');
-      std::ranges::replace(sanitized_name, '>', '_');
-      std::ranges::replace(sanitized_name, ' ', '_');
+      // Sanitize struct name for HLSL (replace <, >, spaces, dots with underscores)
+      std::string sanitized_name = SanitizeHlslTypeName(struct_name);
       string_stream << spacing << "struct " << sanitized_name << " {\n";
       indent_spacing();
       for (const auto& [declaration, name, type_name, optional_offset] : definition.variables) {
@@ -7791,17 +8804,23 @@ class Decompiler {
 
         assert(!type_name_parsed.empty());
 
-        if (is_host.empty() && !is_struct.empty()) {
+        if (auto matrix_declaration = ParseReflectedMatrixDeclaration(declaration, name)) {
+          string_stream << spacing << matrix_declaration->major << " "
+                        << matrix_declaration->scalar_type << matrix_declaration->row_count << "x" << matrix_declaration->column_count << " " << name;
+          if (matrix_declaration->array_size.has_value()) {
+            string_stream << "[" << matrix_declaration->array_size.value() << "]";
+          }
+        } else if (is_host.empty() && !is_struct.empty()) {
           // Sanitize struct name for HLSL
-          std::string sanitized_type(type_name_parsed);
-          std::ranges::replace(sanitized_type, '<', '_');
-          std::ranges::replace(sanitized_type, '>', '_');
-          std::ranges::replace(sanitized_type, ' ', '_');
+          std::string sanitized_type = SanitizeHlslTypeName(type_name_parsed);
           if (added_definitions.contains(std::string(info.data_type))) {
             // Struct already declared — emit as field reference
             string_stream << spacing << sanitized_type << " " << name;
           } else {
             declare_definition(info.data_type, name);
+          }
+          for (const auto& array_size : info.array_sizes) {
+            string_stream << "[" << array_size << "]";
           }
         } else {
           // Determine the HLSL type name
@@ -7840,10 +8859,10 @@ class Decompiler {
             string_stream << info.vector_size;
           }
           string_stream << " " << name;
-        }
 
-        for (const auto& array_size : info.array_sizes) {
-          string_stream << "[" << array_size << "]";
+          for (const auto& array_size : info.array_sizes) {
+            string_stream << "[" << array_size << "]";
+          }
         }
 
         string_stream << ";\n";
@@ -7985,18 +9004,40 @@ class Decompiler {
 
     // CBV
 
+    auto emit_raw_cbuffer_views = [&](const CBVResource& cbv_resource, bool use_full_register_tail) {
+      const uint32_t full_register_count = cbv_resource.buffer_size / 16u;
+      const uint32_t tail_bytes = cbv_resource.buffer_size % 16u;
+      const uint32_t tail_component_count = (tail_bytes + 3u) / 4u;
+      const uint32_t raw_array_register_count = std::max(1u, full_register_count + ((use_full_register_tail && tail_bytes != 0u) ? 1u : 0u));
+      auto vector_type = [](std::string_view scalar_type, uint32_t component_count) {
+        if (component_count <= 1u) return std::string(scalar_type);
+        return std::format("{}{}", scalar_type, component_count);
+      };
+
+      string_stream << "  // Raw views preserve dynamic cbufferLoadLegacy.f32/i32 access.\n";
+      string_stream << "  float4 " << cbv_resource.name << "_raw[" << raw_array_register_count << "] : packoffset(c0);\n";
+      string_stream << "  uint4 " << cbv_resource.name << "_raw_uint[" << raw_array_register_count << "] : packoffset(c0);\n";
+      if (!use_full_register_tail && tail_component_count != 0u) {
+        string_stream << "  " << vector_type("float", tail_component_count) << " " << cbv_resource.name << "_raw_tail : packoffset(c" << full_register_count << ");\n";
+        string_stream << "  " << vector_type("uint", tail_component_count) << " " << cbv_resource.name << "_raw_uint_tail : packoffset(c" << full_register_count << ");\n";
+      }
+    };
+
     for (size_t cbv_idx = 0; cbv_idx < preprocess_state.cbv_resources.size(); ++cbv_idx) {
       const auto& cbv_resource = preprocess_state.cbv_resources[cbv_idx];
+      const bool has_dynamic_access = preprocess_state.cbv_dynamic_access_indices.count(static_cast<uint32_t>(cbv_idx)) != 0u;
 
-      // For cbuffers with dynamic access, emit as float4 array only
-      if (preprocess_state.cbv_dynamic_access_indices.count(static_cast<uint32_t>(cbv_idx))) {
-        uint32_t num_float4s = static_cast<uint32_t>(ceil(static_cast<float>(cbv_resource.buffer_size) / 16.f));
+      // Array cbuffers with dynamic indexing cannot currently carry both a
+      // ConstantBuffer<T>[] declaration and an overlapping raw register view.
+      // Keep the legacy raw-only form for that rare case; non-array cbuffers
+      // below retain rich reflected fields and add raw overlay views.
+      if (has_dynamic_access && cbv_resource.array_size.has_value()) {
         string_stream << "cbuffer " << cbv_resource.name << " : register(b" << cbv_resource.signature_index;
         if (cbv_resource.space != 0u) {
           string_stream << ", space" << cbv_resource.space;
         }
         string_stream << ") {\n";
-        string_stream << "  uint4 " << cbv_resource.name << "_raw[" << num_float4s << "];\n";
+        emit_raw_cbuffer_views(cbv_resource, false);
         string_stream << "};\n\n";
         continue;
       }
@@ -8063,6 +9104,12 @@ class Decompiler {
 
       indent_spacing();
 
+      const bool use_struct_view = preprocess_state.UsesCBufferStructView(cbv_resource, definition);
+      if (use_struct_view) {
+        string_stream << spacing << "struct {\n";
+        indent_spacing();
+      }
+
       bool use_cbuffer_float4 = false;
 
       // Detect if any field uses native 16-bit types (half) — packoffset is not valid for these
@@ -8084,19 +9131,45 @@ class Decompiler {
       // 16-bit fields (half/min16float) are emitted as named fields with packoffset.
       // The decompiler always compiles with -enable-16bit-types, so layout is consistent.
 
+      int padding_counter = 0;
+      auto emit_padding_bytes = [&](int from_offset, int to_offset) {
+        int padding_bytes = to_offset - from_offset;
+        while (padding_bytes > 0) {
+          const int register_component = (from_offset % 16) / 4;
+          const int components_left_in_register = 4 - register_component;
+          const int padding_components = std::min(components_left_in_register, padding_bytes / 4);
+          if (padding_components <= 0) break;
+          std::string padding_type = (padding_components > 1) ? std::format("uint{}", padding_components) : "uint";
+          string_stream << spacing << padding_type << " _padding_" << padding_counter++ << ";\n";
+          const int emitted_bytes = padding_components * 4;
+          from_offset += emitted_bytes;
+          padding_bytes -= emitted_bytes;
+        }
+      };
+
       if (use_cbuffer_float4) {
         string_stream << "  float4 " << cbv_resource.name;
         string_stream << "[" << ceil(static_cast<float>(cbv_resource.buffer_size) / 16.f) << "] : packoffset(c0);\n";
-      } else if (definition.has_offsets || cbv_resource.buffer_size == definition.size) {
-        int padding_counter = 0;
+      } else if (preprocess_state.CBufferLayoutResolvable(cbv_resource, definition)) {
         for (const auto& [declaration, name, type_name, optional_offset] : definition.variables) {
           DataType info(type_name);
+
+          // Zero-size aggregate fields (e.g. an empty `%struct.Foo = type {}`)
+          // carry no data. Emitting them as a cbuffer member with a packoffset is
+          // invalid ("register or offset bind not valid") and they are never
+          // accessed, so skip them entirely.
+          if (info.data_type.starts_with("%") && preprocess_state.GetTypeSize(info) == 0) {
+            continue;
+          }
 
           // Fields with no name are padding or unused — emit a placeholder
           if (name.empty()) {
             auto item_offset = offset;
             if (optional_offset.has_value()) {
               item_offset = optional_offset.value();
+              if (use_struct_view && item_offset > offset) {
+                emit_padding_bytes(offset, item_offset);
+              }
               offset = item_offset;
             }
             auto field_size = preprocess_state.GetTypeSize(info);
@@ -8105,12 +9178,23 @@ class Decompiler {
             if (padding_components == 0) padding_components = 1;
             std::string padding_type = (padding_components > 1) ? std::format("int{}", padding_components) : "int";
             string_stream << spacing << padding_type << " _padding_" << padding_counter++;
-            if (!has_16bit_fields) {
+            if (!has_16bit_fields && !use_struct_view) {
               string_stream << std::format(" : packoffset(c{:03}.{})", item_offset / 16, VECTOR_INDEXES[item_offset % 16 / 4]);
             }
             string_stream << ";\n";
             offset += static_cast<int>(field_size);
             continue;
+          }
+
+          auto item_offset = offset;
+          if (optional_offset.has_value()) {
+            item_offset = optional_offset.value();
+            if (use_struct_view && item_offset > offset) {
+              emit_padding_bytes(offset, item_offset);
+            }
+            if (use_struct_view) {
+              offset = item_offset;
+            }
           }
 
           if (type_name.starts_with("%class") || info.data_type.starts_with("class.matrix.") || info.data_type.starts_with("%class.matrix.")) {
@@ -8153,7 +9237,7 @@ class Decompiler {
           } else if (info.data_type.starts_with("%struct.")) {
             if (added_definitions.contains(std::string(info.data_type))) {
               // Struct already declared — just reference it by name
-              auto struct_type_name = std::string(info.data_type.substr(8));  // strip "%struct."
+              auto struct_type_name = SanitizeHlslTypeName(info.data_type.substr(8));  // strip "%struct."
               string_stream << spacing << struct_type_name << " " << name;
             } else {
               declare_definition(info.data_type, name);
@@ -8163,7 +9247,7 @@ class Decompiler {
             // host struct
             static const std::regex PATTERN = std::regex(R"(%hostlayout.struct\.(.*))");
             auto [struct_name] = StringViewMatch<1>(type_name, PATTERN);
-            string_stream << spacing << struct_name << " " << name;
+            string_stream << spacing << SanitizeHlslTypeName(struct_name) << " " << name;
           } else if (info.data_type.starts_with("%\"")) {
             // host struct
             static const std::regex PATTERN = std::regex(R"(%\"[^"]*\")");
@@ -8174,7 +9258,7 @@ class Decompiler {
             static const std::regex BARE_TYPE_PATTERN = std::regex(R"(%(?:hostlayout\.)?(?:struct\.)?(.+))");
             auto [bare_name] = StringViewMatch<1>(info.data_type, BARE_TYPE_PATTERN);
             if (!bare_name.empty()) {
-              string_stream << spacing << bare_name << " " << name;
+              string_stream << spacing << SanitizeHlslTypeName(bare_name) << " " << name;
             }
           } else {
             assert(false);
@@ -8184,12 +9268,10 @@ class Decompiler {
             string_stream << "[" << array_size << "]";
           };
 
-          auto item_offset = offset;
-          if (optional_offset.has_value()) {
-            item_offset = optional_offset.value();
+          if (optional_offset.has_value() && !use_struct_view) {
             offset = item_offset;
           }
-          if (has_16bit_fields) {
+          if (has_16bit_fields || use_struct_view) {
             string_stream << ";\n";
           } else {
             string_stream << std::format(" : packoffset(c{:03}.{});\n", item_offset / 16, VECTOR_INDEXES[item_offset % 16 / 4], item_offset);
@@ -8222,6 +9304,14 @@ class Decompiler {
           uint32_t num_float4s = static_cast<uint32_t>(ceil(static_cast<float>(cbv_resource.buffer_size) / 16.f));
           string_stream << "  float4 " << cbv_resource.name << "_data[" << num_float4s << "];\n";
         }
+      }
+      if (use_struct_view) {
+        unindent_spacing();
+        string_stream << spacing << "} " << preprocess_state.CBufferStructViewName(cbv_resource) << " : packoffset(c000.x);\n";
+      }
+      if (has_dynamic_access) {
+        string_stream << "\n";
+        emit_raw_cbuffer_views(cbv_resource, true);
       }
       unindent_spacing();
       // string_stream << "  } " << cbv_resource.name << " : packoffset(c0);\n";
@@ -9531,6 +10621,10 @@ class Decompiler {
           for (const auto& hl : cb.hlsl_lines) {
             std::smatch m;
             if (std::regex_search(hl, m, heap_re)) {
+              static const std::regex temp_ref_re(R"(_\d+)");
+              if (std::regex_search(hl, temp_ref_re)) {
+                continue;
+              }
               static const std::regex name_re(R"((_HeapResource_\d+))");
               std::smatch nm;
               if (std::regex_search(hl, nm, name_re)) {


### PR DESCRIPTION
This adds multiple new options for the decompiler:

 --structural
 --mermaid_decompile
 --stackify
 
Structural is based on latest work from ShortFuse with modifications to handle many different edge cases with certain branching patterns and conditionals. It is the best path for producing HLSL with the most likeness to the original. The other two options still have failure cases on certain patterns. 

The decompiler should now handle the vast majority of SM6 shaders, including large RayTracing shaders (~21000 line shader from Pragmata works fine for example). 

I kept the other two options as mermaid kind of shows proof of concept and there was a lot of time put into both mermaid and stackify. They could potentially provide useful insights for future efforts. 

The exe has been shared several times and its probably time to get the code out of just my local.