### PR TITLE
feat(masseffectandromeda): add game

### DIFF
--- a/src/games/masseffectandromeda/addon.cpp
+++ b/src/games/masseffectandromeda/addon.cpp
@@ -42,8 +42,10 @@ renodx::mods::shader::CustomShaders custom_shaders = {
     CustomShaderEntry(0xE3D57A10),  // CA on  / grain on
     CustomShaderEntryCallback(0xF5B0DBFA, SetSwapchainPresentFlag),  // main HDR present (1:1), RCAS gate
     CustomShaderEntryCallback(0xAFFFA4AB, SetSwapchainPresentFlag),  // upscaling HDR present (res scale < 100%)
+    CustomShaderEntryCallback(0x8498DBD5, SetSwapchainPresentFlag),  // HDR present at Post Process = Low
     CustomShaderEntry(0xF5B7A93D),  // loading-screen / video present (1:1)
     CustomShaderEntry(0x667C56AF),  // loading-screen / video present (upscaled)
+    CustomShaderEntry(0x182C8867),  // loading-screen / video present (1:1, scene sampler on s1)
     // FMV YUV->RGB decode: flags fxVideoActive so the present treats the layer as video, not UI.
     CustomShaderEntryCallback(0x7ED07F45, [](reshade::api::command_list* cmd_list) {
       shader_injection.fxVideoActive = 1.f;

--- a/src/games/masseffectandromeda/addon.cpp
+++ b/src/games/masseffectandromeda/addon.cpp
@@ -144,8 +144,8 @@ renodx::utils::settings::Settings settings = {
         .section = "Color Grading",
         .tooltip = "Adjusts highlight brightness. 50 = vanilla.",
         .max = 100.f,
-        .parse = [](float value) { return value * 0.02f; },
         .is_enabled = []() { return shader_injection.toneMapType == 1.f; },
+        .parse = [](float value) { return value * 0.02f; },
         .is_visible = []() { return current_settings_mode >= 1.f; },
     },
     new renodx::utils::settings::Setting{
@@ -156,8 +156,8 @@ renodx::utils::settings::Settings settings = {
         .section = "Color Grading",
         .tooltip = "Adjusts shadow brightness. 50 = vanilla.",
         .max = 100.f,
-        .parse = [](float value) { return value * 0.02f; },
         .is_enabled = []() { return shader_injection.toneMapType == 1.f; },
+        .parse = [](float value) { return value * 0.02f; },
         .is_visible = []() { return current_settings_mode >= 1.f; },
     },
     new renodx::utils::settings::Setting{
@@ -168,8 +168,8 @@ renodx::utils::settings::Settings settings = {
         .section = "Color Grading",
         .tooltip = "Adjusts contrast. 50 = vanilla.",
         .max = 100.f,
-        .parse = [](float value) { return value * 0.02f; },
         .is_enabled = []() { return shader_injection.toneMapType == 1.f; },
+        .parse = [](float value) { return value * 0.02f; },
         .is_visible = []() { return current_settings_mode >= 1.f; },
     },
     new renodx::utils::settings::Setting{
@@ -180,8 +180,8 @@ renodx::utils::settings::Settings settings = {
         .section = "Color Grading",
         .tooltip = "Flare/Glare Compensation",
         .max = 100.f,
-        .parse = [](float value) { return value * 0.02f; },
         .is_enabled = []() { return shader_injection.toneMapType == 1.f; },
+        .parse = [](float value) { return value * 0.02f; },
         .is_visible = []() { return current_settings_mode >= 1.f; },
     },
     new renodx::utils::settings::Setting{
@@ -192,8 +192,8 @@ renodx::utils::settings::Settings settings = {
         .section = "Color Grading",
         .tooltip = "Adjusts overall saturation. 50 = vanilla.",
         .max = 100.f,
-        .parse = [](float value) { return value * 0.02f; },
         .is_enabled = []() { return shader_injection.toneMapType == 1.f; },
+        .parse = [](float value) { return value * 0.02f; },
         .is_visible = []() { return current_settings_mode >= 1.f; },
     },
     new renodx::utils::settings::Setting{
@@ -204,8 +204,8 @@ renodx::utils::settings::Settings settings = {
         .section = "Color Grading",
         .tooltip = "Adds or removes highlight color.",
         .max = 100.f,
-        .parse = [](float value) { return value * 0.02f; },
         .is_enabled = []() { return shader_injection.toneMapType == 1.f; },
+        .parse = [](float value) { return value * 0.02f; },
         .is_visible = []() { return current_settings_mode >= 1.f; },
     },
     new renodx::utils::settings::Setting{
@@ -216,8 +216,8 @@ renodx::utils::settings::Settings settings = {
         .section = "Color Grading",
         .tooltip = "Shifts highlight hue toward the per-channel (SDR-display) look. 0 = vanilla.",
         .max = 100.f,
-        .parse = [](float value) { return value * 0.01f; },
         .is_enabled = []() { return shader_injection.toneMapType == 1.f; },
+        .parse = [](float value) { return value * 0.01f; },
         .is_visible = []() { return current_settings_mode >= 1.f; },
     },
     new renodx::utils::settings::Setting{
@@ -228,8 +228,8 @@ renodx::utils::settings::Settings settings = {
         .section = "Effects",
         .tooltip = "Scales the game's bloom. 50 = vanilla, 0 = off.",
         .max = 100.f,
-        .parse = [](float value) { return value * 0.02f; },
         .is_enabled = []() { return shader_injection.toneMapType == 1.f; },
+        .parse = [](float value) { return value * 0.02f; },
         .is_visible = []() { return current_settings_mode >= 1.f; },
     },
     new renodx::utils::settings::Setting{
@@ -240,8 +240,8 @@ renodx::utils::settings::Settings settings = {
         .section = "Effects",
         .tooltip = "Scales the game's vignette. 50 = vanilla, 0 = off.",
         .max = 100.f,
-        .parse = [](float value) { return value * 0.02f; },
         .is_enabled = []() { return shader_injection.toneMapType == 1.f; },
+        .parse = [](float value) { return value * 0.02f; },
         .is_visible = []() { return current_settings_mode >= 1.f; },
     },
     new renodx::utils::settings::Setting{
@@ -252,8 +252,8 @@ renodx::utils::settings::Settings settings = {
         .section = "Effects",
         .tooltip = "Scales the game's chromatic aberration. 100 = vanilla, 0 = off (requires the in-game CA setting on).",
         .max = 100.f,
-        .parse = [](float value) { return value * 0.01f; },
         .is_enabled = []() { return shader_injection.toneMapType == 1.f; },
+        .parse = [](float value) { return value * 0.01f; },
         .is_visible = []() { return current_settings_mode >= 1.f; },
     },
     new renodx::utils::settings::Setting{
@@ -266,8 +266,8 @@ renodx::utils::settings::Settings settings = {
         .max = 100.f,
         // Deliberate linear response (slider% -> CUSTOM_SHARPNESS directly). Some sibling RCAS sliders
         // use an exp2 curve, so the same % is not perceptually comparable across mods.
-        .parse = [](float value) { return value * 0.01f; },
         .is_enabled = []() { return shader_injection.toneMapType == 1.f; },
+        .parse = [](float value) { return value * 0.01f; },
         .is_visible = []() { return current_settings_mode >= 1.f; },
     },
     new renodx::utils::settings::Setting{

--- a/src/games/masseffectandromeda/addon.cpp
+++ b/src/games/masseffectandromeda/addon.cpp
@@ -1,0 +1,489 @@
+/*
+ * Copyright (C) 2026 Hlib Omelchenko
+ * Copyright (C) 2026 Carlos Lopez
+ * SPDX-License-Identifier: MIT
+ */
+
+#define ImTextureID ImU64
+
+#define DEBUG_LEVEL_0
+
+#include <random>
+
+#include <deps/imgui/imgui.h>
+#include <include/reshade.hpp>
+
+#include <embed/shaders.h>
+
+#include "../../mods/shader.hpp"
+#include "../../mods/swapchain.hpp"
+#include "../../templates/settings.hpp"
+#include "../../utils/date.hpp"
+#include "../../utils/settings.hpp"
+#include "./shared.h"
+
+namespace {
+
+ShaderInjectData shader_injection;
+
+// RCAS swapchain gate: flag the swapchain draw so in-shader RCAS runs once on the visible frame
+// (each HDR present also draws an offscreen sibling). Set before the draw; reset in OnPresent.
+bool SetSwapchainPresentFlag(reshade::api::command_list* cmd_list) {
+  shader_injection.fxSwapchainPresent = renodx::utils::swapchain::HasBackBufferRenderTarget(cmd_list) ? 1.f : 0.f;
+  return true;
+}
+
+renodx::mods::shader::CustomShaders custom_shaders = {
+    // Scene tonemap + grade (bloom / vignette / exposure / film grain). Four permutations
+    // selected by the in-game {Chromatic Aberration, Film Grain} toggles — all share one core.
+    CustomShaderEntry(0xB6A91712),  // CA off / grain off
+    CustomShaderEntry(0x376C116B),  // CA off / grain on
+    CustomShaderEntry(0xEB91AB31),  // CA on  / grain off
+    CustomShaderEntry(0xE3D57A10),  // CA on  / grain on
+    CustomShaderEntryCallback(0xF5B0DBFA, SetSwapchainPresentFlag),  // main HDR present (1:1), RCAS gate
+    CustomShaderEntryCallback(0xAFFFA4AB, SetSwapchainPresentFlag),  // upscaling HDR present (res scale < 100%)
+    CustomShaderEntry(0xF5B7A93D),  // loading-screen / video present (1:1)
+    CustomShaderEntry(0x667C56AF),  // loading-screen / video present (upscaled)
+    // FMV YUV->RGB decode: flags fxVideoActive so the present treats the layer as video, not UI.
+    CustomShaderEntryCallback(0x7ED07F45, [](reshade::api::command_list* cmd_list) {
+      shader_injection.fxVideoActive = 1.f;
+      return true;
+    }),
+};
+
+float current_settings_mode = 0;
+
+renodx::utils::settings::Settings settings = {
+    new renodx::utils::settings::Setting{
+        .key = "SettingsMode",
+        .binding = &current_settings_mode,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 0.f,
+        .can_reset = false,
+        .label = "Settings Mode",
+        .tooltip = "Simple hides the advanced color grading and effect controls.",
+        .labels = {"Simple", "Advanced"},
+        .is_global = true,
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapType",
+        .binding = &shader_injection.toneMapType,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 1.f,
+        .label = "Tone Mapper",
+        .section = "Tone Mapping",
+        .tooltip = "Vanilla = untouched native HDR. Vanilla+ = paper white, highlight roll-off, color grading and effects.",
+        .labels = {"Vanilla", "Vanilla+"},
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapPeakNits",
+        .binding = &shader_injection.toneMapPeakNits,
+        .default_value = 1000.f,
+        .can_reset = true,
+        .label = "Peak Brightness",
+        .section = "Tone Mapping",
+        .tooltip = "Sets the value of peak white in nits",
+        .min = 100.f,
+        .max = 4000.f,
+        .is_enabled = []() { return shader_injection.toneMapType == 1.f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapGameNits",
+        .binding = &shader_injection.toneMapGameNits,
+        .default_value = 203.f,
+        .can_reset = true,
+        .label = "Game Brightness",
+        .section = "Tone Mapping",
+        .tooltip = "Sets the value of 100% white in nits",
+        .min = 48.f,
+        .max = 500.f,
+        .is_enabled = []() { return shader_injection.toneMapType == 1.f; },  // Vanilla+
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapUINits",
+        .binding = &shader_injection.toneMapUINits,
+        .default_value = 203.f,
+        .can_reset = true,
+        .label = "UI Brightness",
+        .section = "Tone Mapping",
+        .tooltip = "Sets the brightness of UI and HUD elements in nits",
+        .min = 48.f,
+        .max = 500.f,
+        .is_enabled = []() { return shader_injection.toneMapType == 1.f; },  // Vanilla+
+    },
+    new renodx::utils::settings::Setting{
+        .key = "GammaCorrection",
+        .binding = &shader_injection.gammaCorrection,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 1.f,
+        .label = "Gamma Correction",
+        .section = "Tone Mapping",
+        .tooltip = "Emulates a display EOTF.",
+        .labels = {"Off", "2.2", "BT.1886"},
+        .is_enabled = []() { return shader_injection.toneMapType == 1.f; },  // Vanilla+
+        .is_visible = []() { return current_settings_mode >= 1.f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeExposure",
+        .binding = &shader_injection.colorGradeExposure,
+        .default_value = 1.f,
+        .label = "Exposure",
+        .section = "Color Grading",
+        .tooltip = "Scene exposure. 1.0 = vanilla.",
+        .min = 0.25f,
+        .max = 4.f,
+        .format = "%.2f",
+        .is_enabled = []() { return shader_injection.toneMapType == 1.f; },
+        .is_visible = []() { return current_settings_mode >= 1.f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeHighlights",
+        .binding = &shader_injection.colorGradeHighlights,
+        .default_value = 50.f,
+        .label = "Highlights",
+        .section = "Color Grading",
+        .tooltip = "Adjusts highlight brightness. 50 = vanilla.",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+        .is_enabled = []() { return shader_injection.toneMapType == 1.f; },
+        .is_visible = []() { return current_settings_mode >= 1.f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeShadows",
+        .binding = &shader_injection.colorGradeShadows,
+        .default_value = 50.f,
+        .label = "Shadows",
+        .section = "Color Grading",
+        .tooltip = "Adjusts shadow brightness. 50 = vanilla.",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+        .is_enabled = []() { return shader_injection.toneMapType == 1.f; },
+        .is_visible = []() { return current_settings_mode >= 1.f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeContrast",
+        .binding = &shader_injection.colorGradeContrast,
+        .default_value = 50.f,
+        .label = "Contrast",
+        .section = "Color Grading",
+        .tooltip = "Adjusts contrast. 50 = vanilla.",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+        .is_enabled = []() { return shader_injection.toneMapType == 1.f; },
+        .is_visible = []() { return current_settings_mode >= 1.f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeFlare",
+        .binding = &shader_injection.colorGradeFlare,
+        .default_value = 0.f,
+        .label = "Flare",
+        .section = "Color Grading",
+        .tooltip = "Flare/Glare Compensation",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+        .is_enabled = []() { return shader_injection.toneMapType == 1.f; },
+        .is_visible = []() { return current_settings_mode >= 1.f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeSaturation",
+        .binding = &shader_injection.colorGradeSaturation,
+        .default_value = 50.f,
+        .label = "Saturation",
+        .section = "Color Grading",
+        .tooltip = "Adjusts overall saturation. 50 = vanilla.",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+        .is_enabled = []() { return shader_injection.toneMapType == 1.f; },
+        .is_visible = []() { return current_settings_mode >= 1.f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeHighlightSaturation",
+        .binding = &shader_injection.colorGradeHighlightSaturation,
+        .default_value = 50.f,
+        .label = "Highlight Saturation",
+        .section = "Color Grading",
+        .tooltip = "Adds or removes highlight color.",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+        .is_enabled = []() { return shader_injection.toneMapType == 1.f; },
+        .is_visible = []() { return current_settings_mode >= 1.f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeHueShift",
+        .binding = &shader_injection.colorGradeHueShift,
+        .default_value = 0.f,
+        .label = "Hue Shift",
+        .section = "Color Grading",
+        .tooltip = "Shifts highlight hue toward the per-channel (SDR-display) look. 0 = vanilla.",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.01f; },
+        .is_enabled = []() { return shader_injection.toneMapType == 1.f; },
+        .is_visible = []() { return current_settings_mode >= 1.f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "FxBloom",
+        .binding = &shader_injection.fxBloom,
+        .default_value = 50.f,
+        .label = "Bloom",
+        .section = "Effects",
+        .tooltip = "Scales the game's bloom. 50 = vanilla, 0 = off.",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+        .is_enabled = []() { return shader_injection.toneMapType == 1.f; },
+        .is_visible = []() { return current_settings_mode >= 1.f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "FxVignette",
+        .binding = &shader_injection.fxVignette,
+        .default_value = 50.f,
+        .label = "Vignette",
+        .section = "Effects",
+        .tooltip = "Scales the game's vignette. 50 = vanilla, 0 = off.",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+        .is_enabled = []() { return shader_injection.toneMapType == 1.f; },
+        .is_visible = []() { return current_settings_mode >= 1.f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "FxChromaticAberration",
+        .binding = &shader_injection.fxChromaticAberration,
+        .default_value = 100.f,
+        .label = "Chromatic Aberration",
+        .section = "Effects",
+        .tooltip = "Scales the game's chromatic aberration. 100 = vanilla, 0 = off (requires the in-game CA setting on).",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.01f; },
+        .is_enabled = []() { return shader_injection.toneMapType == 1.f; },
+        .is_visible = []() { return current_settings_mode >= 1.f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "FxSharpness",
+        .binding = &shader_injection.fxSharpness,
+        .default_value = 0.f,
+        .label = "RCAS Sharpening",
+        .section = "Effects",
+        .tooltip = "Adds RCAS, as implemented by Lilium for HDR. Disable other sharpening (DLAA / ReShade) to avoid double-sharpening.",
+        .max = 100.f,
+        // Deliberate linear response (slider% -> CUSTOM_SHARPNESS directly). Some sibling RCAS sliders
+        // use an exp2 curve, so the same % is not perceptually comparable across mods.
+        .parse = [](float value) { return value * 0.01f; },
+        .is_enabled = []() { return shader_injection.toneMapType == 1.f; },
+        .is_visible = []() { return current_settings_mode >= 1.f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "FxFilmGrainType",
+        .binding = &shader_injection.fxFilmGrainType,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 0.f,
+        .label = "Film Grain Type",
+        .section = "Effects",
+        .tooltip = "Vanilla keeps the game's own grain. Monochrome / Colored use RenoDX perceptual grain "
+                   "(reduces banding).",
+        .labels = {"Vanilla", "Monochrome", "Colored"},
+        .is_enabled = []() { return shader_injection.toneMapType == 1.f; },
+        .is_visible = []() { return current_settings_mode >= 1.f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "FxFilmGrain",
+        .binding = &shader_injection.fxFilmGrain,
+        .default_value = 50.f,
+        .label = "Film Grain",
+        .section = "Effects",
+        .tooltip = "Film grain strength. Reduces banding.",
+        .max = 100.f,
+        .is_enabled = []() { return shader_injection.toneMapType == 1.f && shader_injection.fxFilmGrainType != 0.f; },
+        .parse = [](float value) { return value * 0.01f; },
+        .is_visible = []() { return current_settings_mode >= 1.f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "FxHDRVideos",
+        .binding = &shader_injection.fxHDRVideos,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 1.f,
+        .label = "HDR Videos",
+        .section = "Effects",
+        .tooltip = "Inverse tonemaps SDR videos (BT.2446a)",
+        .labels = {"Off", "On"},
+        .is_enabled = []() { return shader_injection.toneMapType == 1.f; },
+        .is_visible = []() { return current_settings_mode >= 1.f; },
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::BUTTON,
+        .label = "Reset All",
+        .section = "Options",
+        .group = "button-line-1",
+        .on_change = []() { renodx::utils::settings::ResetSettings(); },
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::BUTTON,
+        .label = "RenoDX Discord",
+        .section = "Links",
+        .group = "button-line-2",
+        .tint = 0x5865F2,
+        .on_change = []() { renodx::utils::platform::LaunchURL("https://discord.gg/", "2fJJMBReAW"); },
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::BUTTON,
+        .label = "HDR Den Discord",
+        .section = "Links",
+        .group = "button-line-2",
+        .tint = 0x5865F2,
+        .on_change = []() { renodx::utils::platform::LaunchURL("https://discord.gg/", "qVSPcABQF4"); },
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::BUTTON,
+        .label = "More Mods",
+        .section = "Links",
+        .group = "button-line-2",
+        .tint = 0x2B3137,
+        .on_change = []() { renodx::utils::platform::LaunchURL("https://github.com/clshortfuse/renodx/wiki/Mods"); },
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::BUTTON,
+        .label = "Github",
+        .section = "Links",
+        .group = "button-line-2",
+        .tint = 0x2B3137,
+        .on_change = []() { renodx::utils::platform::LaunchURL("https://github.com/clshortfuse/renodx"); },
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::TEXT,
+        .label = std::string("Build: ") + renodx::utils::date::ISO_DATE_TIME,
+        .section = "About",
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::TEXT,
+        .label = "- Requires HDR on in game",
+        .section = "About",
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::TEXT,
+        .label = "- Vanilla+: set the in-game Peak Brightness to MAX; the addon's Peak Brightness sets your display peak.",
+        .section = "About",
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::TEXT,
+        .label = "- Vanilla = untouched native HDR (all other controls disabled).",
+        .section = "About",
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::TEXT,
+        .label = "- Thanks and credits to Lilium (EndlesslyFlowering) for the RCAS implementation.",
+        .section = "About",
+    },
+};
+
+void OnPresetOff() {
+  // "Off" preset = pure native HDR passthrough (Vanilla); nothing else applies.
+  renodx::utils::settings::UpdateSettings({
+      {"ToneMapType", 0.f},
+      {"ToneMapPeakNits", 1000.f},
+      {"ToneMapGameNits", 203.f},
+      {"ToneMapUINits", 203.f},
+      {"ColorGradeExposure", 1.f},
+      {"ColorGradeHighlights", 50.f},
+      {"ColorGradeShadows", 50.f},
+      {"ColorGradeContrast", 50.f},
+      {"ColorGradeFlare", 0.f},
+      {"ColorGradeSaturation", 50.f},
+      {"ColorGradeHighlightSaturation", 50.f},
+      {"ColorGradeHueShift", 0.f},
+      {"GammaCorrection", 1.f},
+      {"FxBloom", 50.f},
+      {"FxVignette", 50.f},
+      {"FxChromaticAberration", 100.f},
+      {"FxSharpness", 0.f},
+      {"FxFilmGrainType", 0.f},
+      {"FxFilmGrain", 50.f},
+      {"FxHDRVideos", 1.f},
+  });
+}
+
+bool fired_on_init_swapchain = false;
+
+// Seed the Peak Brightness default from the display's HDR metadata (RDR1 pattern).
+void OnInitSwapchain(reshade::api::swapchain* swapchain, bool resize) {
+  if (fired_on_init_swapchain) return;
+  // Latch only on a successful read: the transient 1280x720 boot swapchain may have no metadata,
+  // and we must not pin the default to 1000 and block re-seeding from the real HDR swapchain.
+  auto peak = renodx::utils::swapchain::GetPeakNits(swapchain);
+  if (!peak.has_value()) return;
+  auto* peak_setting = renodx::utils::settings::FindSetting("ToneMapPeakNits");
+  if (peak_setting != nullptr) {
+    peak_setting->default_value = roundf(peak.value());
+  }
+  fired_on_init_swapchain = true;
+}
+
+// Feed a fresh per-frame random seed for the perceptual film grain (TW3 pattern).
+void OnPresent(
+    reshade::api::command_queue* queue,
+    reshade::api::swapchain* swapchain,
+    const reshade::api::rect* source_rect,
+    const reshade::api::rect* dest_rect,
+    uint32_t dirty_rect_count,
+    const reshade::api::rect* dirty_rects) {
+  static std::mt19937 random_generator(std::random_device{}());
+  static const auto random_range = static_cast<float>(std::mt19937::max() - std::mt19937::min());
+  shader_injection.customRandom = static_cast<float>(random_generator() - std::mt19937::min()) / random_range;
+
+  // Reset the FMV flag each frame; the 0x7ED07F45 callback re-sets it when video decodes.
+  shader_injection.fxVideoActive = 0.f;
+  // RCAS gate safe default: set per present draw by SetSwapchainPresentFlag; reset here so a present
+  // without it falls back to 0 (RCAS off), not a stale 1.
+  shader_injection.fxSwapchainPresent = 0.f;
+}
+
+bool initialized = false;
+
+}  // namespace
+
+extern "C" __declspec(dllexport) constexpr const char* NAME = "RenoDX";
+extern "C" __declspec(dllexport) constexpr const char* DESCRIPTION = "RenoDX Native HDR Fix for Mass Effect: Andromeda";
+
+BOOL APIENTRY DllMain(HMODULE h_module, DWORD fdw_reason, LPVOID lpv_reserved) {
+  switch (fdw_reason) {
+    case DLL_PROCESS_ATTACH:
+      if (!reshade::register_addon(h_module)) return FALSE;
+
+      if (!initialized) {
+        renodx::mods::shader::force_pipeline_cloning = true;
+        renodx::mods::shader::expected_constant_buffer_index = 13;
+        renodx::mods::shader::allow_multiple_push_constants = true;
+
+        renodx::mods::swapchain::SetUseHDR10(true);
+        // Frostbite BitBlt swapchain: Windows scans out HDR only in exclusive fullscreen, so
+        // virtualize it (prevent_full_screen) and keep the flip-model + HDR10 colorspace outside
+        // it (force_borderless; false makes the game's Fullscreen mode present black).
+        renodx::mods::swapchain::force_borderless = true;
+        renodx::mods::swapchain::prevent_full_screen = true;
+        renodx::mods::swapchain::use_resource_cloning = true;
+        // Clone the graded buffer to fp16. render_target filter keeps the same-format 33^3 3D LUT
+        // out of the clone path (a 2D view on the cloned 3D resource -> DXGI_ERROR_DEVICE_REMOVED).
+        renodx::mods::swapchain::resource_upgrade_infos.push_back({
+            .old_format = reshade::api::format::r10g10b10a2_typeless,
+            .new_format = reshade::api::format::r16g16b16a16_float,
+            .use_resource_view_cloning = true,
+            .usage_include = reshade::api::resource_usage::render_target,
+        });
+
+        initialized = true;
+      }
+
+      reshade::register_event<reshade::addon_event::init_swapchain>(OnInitSwapchain);  // seed peak default
+      reshade::register_event<reshade::addon_event::present>(OnPresent);               // per-frame grain seed
+
+      break;
+    case DLL_PROCESS_DETACH:
+      reshade::unregister_event<reshade::addon_event::init_swapchain>(OnInitSwapchain);  // seed peak default
+      reshade::unregister_event<reshade::addon_event::present>(OnPresent);               // per-frame grain seed
+      reshade::unregister_addon(h_module);
+      break;
+  }
+
+  renodx::utils::settings::Use(fdw_reason, &settings, &OnPresetOff);
+  renodx::mods::swapchain::Use(fdw_reason, &shader_injection);
+  renodx::mods::shader::Use(fdw_reason, custom_shaders, &shader_injection);
+
+  return TRUE;
+}

--- a/src/games/masseffectandromeda/bicubic_upscale.hlsli
+++ b/src/games/masseffectandromeda/bicubic_upscale.hlsli
@@ -1,0 +1,46 @@
+#ifndef SRC_GAMES_MASSEFFECTANDROMEDA_BICUBIC_UPSCALE_HLSLI_
+#define SRC_GAMES_MASSEFFECTANDROMEDA_BICUBIC_UPSCALE_HLSLI_
+
+// 16-tap separable Catmull-Rom bicubic, faithful port of the vanilla upscale front-end
+// (0xAFFFA4AB / 0x667C56AF). Scale-agnostic via cb0[0] (.xy = source res px, .zw = texel 1/res).
+// Returns the raw resampled texel (caller decodes: LUT vs sRGB).
+
+// 4-tap Catmull-Rom-family cubic weights (sum to 1), matching the vanilla shader's basis.
+float4 BicubicWeights(float t) {
+  const float t2 = t * t;
+  const float t3 = t2 * t;
+  return float4(
+      -t3 + 2.f * t2 - t,   // tap -1
+      t3 - 2.f * t2 + 1.f,  // tap  0
+      -t3 + t2 + t,         // tap +1
+      t3 - t2);             // tap +2
+}
+
+float3 SampleSceneBicubic(Texture2D<float4> tex, SamplerState smp, float2 uv, float4 cb0_0) {
+  const float2 res = cb0_0.xy;     // source resolution (px)
+  const float2 texel = cb0_0.zw;   // source texel size (1/res)
+
+  // Sub-texel fraction at the resolved sample (texel-centered).
+  const float2 f = frac(uv * res - 0.5f);
+
+  // Base = the tap -1 UV; four columns/rows at +0,+1,+2,+3 texels.
+  const float2 base = uv - (1.f + f) * texel;
+  const float4 xs = base.x + float4(0.f, 1.f, 2.f, 3.f) * texel.x;
+  const float4 ys = base.y + float4(0.f, 1.f, 2.f, 3.f) * texel.y;
+
+  const float4 wx = BicubicWeights(f.x);
+  const float4 wy = BicubicWeights(f.y);
+
+  float3 result = 0.f;
+  [unroll]
+  for (int j = 0; j < 4; ++j) {
+    float3 row = wx.x * tex.SampleLevel(smp, float2(xs.x, ys[j]), 0.f).rgb
+               + wx.y * tex.SampleLevel(smp, float2(xs.y, ys[j]), 0.f).rgb
+               + wx.z * tex.SampleLevel(smp, float2(xs.z, ys[j]), 0.f).rgb
+               + wx.w * tex.SampleLevel(smp, float2(xs.w, ys[j]), 0.f).rgb;
+    result += wy[j] * row;
+  }
+  return max(0.f, result);
+}
+
+#endif  // SRC_GAMES_MASSEFFECTANDROMEDA_BICUBIC_UPSCALE_HLSLI_

--- a/src/games/masseffectandromeda/lilium_rcas.hlsli
+++ b/src/games/masseffectandromeda/lilium_rcas.hlsli
@@ -50,10 +50,10 @@ float3 ApplyRCAS(
   // 0.99 limiter bounds overshoot; eps-guard the black-neighborhood denominator (4*max4 -> 0 -> NaN).
   const float limited_max4 = min(max4, 0.99f);
   const float hitMin = min4 * rcp(max(4.f * limited_max4, MEA_RCAS_EPS));
-  // Guard the min4==1 singularity (denom 0 -> rcp inf) sign-preservingly: min4 can be <1 or >1, so
-  // only nudge sub-eps magnitudes; non-singular pixels stay bit-identical.
+  // Sign-preserving guard for the min4==1 singularity. Sign matters: rcp_norm lets min4 > 1 (denom > 0
+  // -> lobe clamps to 0), so a fixed -eps would flip it and false-sharpen flat-white/bright regions.
   float hitMaxDenom = 4.f * min4 - 4.f;
-  hitMaxDenom = (abs(hitMaxDenom) < MEA_RCAS_EPS) ? -MEA_RCAS_EPS : hitMaxDenom;
+  hitMaxDenom = (abs(hitMaxDenom) < MEA_RCAS_EPS) ? (hitMaxDenom < 0.f ? -MEA_RCAS_EPS : MEA_RCAS_EPS) : hitMaxDenom;
   const float hitMax = (1.f - limited_max4) * rcp(hitMaxDenom);
   float lobe = max(-MEA_RCAS_LIMIT, min(max(-hitMin, hitMax), 0.f)) * CUSTOM_SHARPNESS;
 

--- a/src/games/masseffectandromeda/lilium_rcas.hlsli
+++ b/src/games/masseffectandromeda/lilium_rcas.hlsli
@@ -1,0 +1,75 @@
+#ifndef SRC_GAMES_MASSEFFECTANDROMEDA_LILIUM_RCAS_HLSLI_
+#define SRC_GAMES_MASSEFFECTANDROMEDA_LILIUM_RCAS_HLSLI_
+
+// Lilium HDR RCAS (FSR Robust Contrast Adaptive Sharpening) for MEA.
+// center_color = LUT-linearized scene (1.0 ~= diffuse white). Neighbors linearize through the same
+// SampleOutputLut + scene_scale as the center, so sharpness 0 is a pure passthrough. Scene is
+// diffuse-relative, so luma is normalized by the HDR headroom ratio for the FSR math (else min4 > 1
+// silently disables sharpening). Caller gates to Vanilla+ AND the swapchain present.
+// Requires shared.h (renodx + CUSTOM_SHARPNESS + injectedData) first.
+
+#define MEA_RCAS_LIMIT 0.1875f  // FSR_RCAS_LIMIT: limit of natural-looking sharpening
+#define MEA_RCAS_EPS 1e-6f      // denominator guard (black / flat neighborhoods -> 0 * rcp(0) = NaN)
+
+// One RCAS tap: scene sample -> scene_scale -> shared SampleOutputLut -> BT.709 luma (same path as
+// the present center, so they can't drift).
+float RcasTapLuma(
+    Texture2D<float4> scene_tex, SamplerState scene_smp,
+    Texture1D<float4> lut_tex, SamplerState lut_smp,
+    float2 uv, float scene_scale) {
+  const float3 c = SampleOutputLut(
+      lut_tex, lut_smp, max(0.f, scene_tex.SampleLevel(scene_smp, uv, 0.f).rgb * scene_scale));
+  return renodx::color::y::from::BT709(max(0.f, c));
+}
+
+float3 ApplyRCAS(
+    float3 center_color, float2 tex_coord,
+    Texture2D<float4> scene_tex, SamplerState scene_smp,
+    Texture1D<float4> lut_tex, SamplerState lut_smp,
+    float scene_scale) {
+  if (CUSTOM_SHARPNESS == 0.f) return center_color;
+
+  uint width, height;
+  scene_tex.GetDimensions(width, height);
+  const float2 texel_size = 1.f / float2(width, height);
+
+  // Normalize luma to ~[0,1] by the HDR headroom ratio so the FSR math behaves above diffuse white.
+  // RCAS is scale-covariant (lobe + blend are pure luma ratios), so the un-normalized center blends directly.
+  const float rcp_norm = rcp(max(injectedData.toneMapPeakNits / max(injectedData.toneMapGameNits, 1.f), 1.f));
+
+  // Minimal 3x3 cross:  b / d e f / h. All neighbors go through the one shared linearizer (RcasTapLuma).
+  const float bLum = RcasTapLuma(scene_tex, scene_smp, lut_tex, lut_smp, tex_coord + float2(0.f, -1.f) * texel_size, scene_scale) * rcp_norm;
+  const float dLum = RcasTapLuma(scene_tex, scene_smp, lut_tex, lut_smp, tex_coord + float2(-1.f, 0.f) * texel_size, scene_scale) * rcp_norm;
+  const float eLum = renodx::color::y::from::BT709(center_color) * rcp_norm;
+  const float fLum = RcasTapLuma(scene_tex, scene_smp, lut_tex, lut_smp, tex_coord + float2(1.f, 0.f) * texel_size, scene_scale) * rcp_norm;
+  const float hLum = RcasTapLuma(scene_tex, scene_smp, lut_tex, lut_smp, tex_coord + float2(0.f, 1.f) * texel_size, scene_scale) * rcp_norm;
+
+  const float min4 = min(min(min(bLum, dLum), fLum), hLum);
+  const float max4 = max(max(max(bLum, dLum), fLum), hLum);
+
+  // 0.99 limiter bounds overshoot; eps-guard the black-neighborhood denominator (4*max4 -> 0 -> NaN).
+  const float limited_max4 = min(max4, 0.99f);
+  const float hitMin = min4 * rcp(max(4.f * limited_max4, MEA_RCAS_EPS));
+  // Guard the min4==1 singularity (denom 0 -> rcp inf) sign-preservingly: min4 can be <1 or >1, so
+  // only nudge sub-eps magnitudes; non-singular pixels stay bit-identical.
+  float hitMaxDenom = 4.f * min4 - 4.f;
+  hitMaxDenom = (abs(hitMaxDenom) < MEA_RCAS_EPS) ? -MEA_RCAS_EPS : hitMaxDenom;
+  const float hitMax = (1.f - limited_max4) * rcp(hitMaxDenom);
+  float lobe = max(-MEA_RCAS_LIMIT, min(max(-hitMin, hitMax), 0.f)) * CUSTOM_SHARPNESS;
+
+  // Noise removal: damp the lobe where the center is a local outlier (grain). Eps-guard the
+  // flat-region denominator (max - min over the 5 taps -> 0 -> NaN).
+  float nz = 0.25f * (bLum + dLum + fLum + hLum) - eLum;
+  const float maxLuma = max(max(max(bLum, dLum), max(eLum, fLum)), hLum);
+  const float minLuma = min(min(min(bLum, dLum), min(eLum, fLum)), hLum);
+  nz = saturate(abs(nz) * rcp(max(maxLuma - minLuma, MEA_RCAS_EPS)));
+  nz = -0.5f * nz + 1.f;
+  lobe *= nz;
+
+  const float rcpL = rcp(4.f * lobe + 1.f);
+  const float pixLum = ((bLum + dLum + hLum + fLum) * lobe + eLum) * rcpL;
+  // Norm-independent luma ratio applied to the un-normalized center (norm cancels in the ratio).
+  return clamp(renodx::math::DivideSafe(pixLum, eLum, 1.f), 0.f, 4.f) * center_color;
+}
+
+#endif  // SRC_GAMES_MASSEFFECTANDROMEDA_LILIUM_RCAS_HLSLI_

--- a/src/games/masseffectandromeda/loading_core.hlsli
+++ b/src/games/masseffectandromeda/loading_core.hlsli
@@ -1,0 +1,54 @@
+#ifndef SRC_GAMES_MASSEFFECTANDROMEDA_LOADING_CORE_HLSLI_
+#define SRC_GAMES_MASSEFFECTANDROMEDA_LOADING_CORE_HLSLI_
+
+// Shared loading/video present tail for both 1:1 (0xF5B7A93D) and upscale (0x667C56AF) -> HDR10 PQ.
+// No 1D output LUT here: the loading art (scene) is sRGB-encoded, decoded to linear directly.
+// cb2 = cbData[2]: .x scene scale, .y UI gate, .z UI alpha factor. Requires shared.h first.
+
+float4 LoadingPresentScene(
+    float4 scene, float2 texcoord, float4 cb2,
+    Texture2D<float4> uiTexture, SamplerState uiSampler) {
+  scene *= cb2.x;
+
+  float3 color = renodx::color::srgb::DecodeSafe(max(0.f, scene.rgb));
+
+  // Vanilla = native passthrough (diffuse 100, nothing applied).
+  // Vanilla+ = exposure/grade + EOTF + roll-off (pins peak) + paper white.
+  const PresentParams p = GetPresentParams();
+
+  if (p.full) {
+    // Grade + EOTF + roll-off + Hue Shift. The loading pass has no separate pre-tonemap exposure,
+    // so apply the Exposure slider here.
+    color = ApplyVanillaPlus(color, injectedData.colorGradeExposure, p.paperWhite);
+  }
+
+  float3 scene_nits = max(0.f, color * p.paperWhite);
+
+  if (cb2.y > 0.f) {
+    float4 ui = uiTexture.SampleLevel(uiSampler, texcoord, 0.f);
+
+    float3 uiTermNits;
+    if (injectedData.fxVideoActive != 0.f) {
+      // FMV decoded into this layer. Decode the sRGB-encoded video and bind to Game Brightness (paper
+      // white), never UI Brightness. Inverse tone map to HDR only in Vanilla+ with HDR Videos on;
+      // otherwise present at paper white.
+      const float3 v = renodx::color::srgb::DecodeSafe(max(0.f, ui.rgb));
+      uiTermNits = (p.full && injectedData.fxHDRVideos == 1.f)
+          ? renodx::tonemap::inverse::bt2446a::BT709(v, p.paperWhite, injectedData.toneMapPeakNits)
+          : v * p.paperWhite;
+    } else {
+      // Raw unorm UI/HUD. Decode with sRGB by default, or the selected gamma (2.2 / BT.1886) when
+      // SDR EOTF emulation is on.
+      const float3 uiLinear = (p.eotf != 0.f)
+          ? renodx::color::gamma::DecodeSafe(max(0.f, ui.rgb), EotfGamma())
+          : renodx::color::srgb::DecodeSafe(max(0.f, ui.rgb));
+      uiTermNits = uiLinear * p.uiNits;
+    }
+
+    CompositeUI(scene_nits, scene.a, ui.a, cb2, uiTermNits);
+  }
+
+  return float4(FinalizeToPQ(scene_nits), scene.a);
+}
+
+#endif  // SRC_GAMES_MASSEFFECTANDROMEDA_LOADING_CORE_HLSLI_

--- a/src/games/masseffectandromeda/metadata.json
+++ b/src/games/masseffectandromeda/metadata.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://cdn.jsdelivr.net/gh/clshortfuse/renodx/renodx-metadata-schema.json",
+  "id": "masseffectandromeda",
+  "title": "Mass Effect: Andromeda",
+  "maintainers": [
+    "DristoforColumb"
+  ],
+  "status": "stable",
+  "deploy": {
+    "steam_appid": 1238000
+  }
+}

--- a/src/games/masseffectandromeda/output_0xF5B0DBFA.ps_5_0.hlsl
+++ b/src/games/masseffectandromeda/output_0xF5B0DBFA.ps_5_0.hlsl
@@ -1,0 +1,30 @@
+#include "./shared.h"
+#include "./lilium_rcas.hlsli"
+#include "./present_core.hlsli"
+
+Texture2D<float4> sceneTexture : register(t0);
+Texture2D<float4> uiTexture : register(t1);
+Texture1D<float4> outputLut : register(t2);
+
+SamplerState sceneSampler : register(s0);
+SamplerState lutSampler : register(s1);
+SamplerState uiSampler : register(s2);
+
+cbuffer cbData : register(b0) {
+  float4 cbData[3] : packoffset(c0);
+}
+
+struct PSInput {
+  float4 position : SV_Position;
+  float2 texcoord : TEXCOORD;
+};
+
+// Main HDR present (1:1). Single scene tap; the tail (LUT linearize / grade / RCAS / EOTF / UI / PQ)
+// is the shared PresentScene. outputLut (t2) linearizes the PQ graded buffer to scene-linear.
+
+float4 main(PSInput input) : SV_Target {
+  float4 scene = sceneTexture.SampleLevel(sceneSampler, input.texcoord, 0.f);
+  return PresentScene(scene, input.texcoord, cbData[2],
+                      sceneTexture, sceneSampler, uiTexture, uiSampler, outputLut, lutSampler,
+                      false);  // 1:1: scene == output res, RCAS active
+}

--- a/src/games/masseffectandromeda/output_loading_0x182C8867.ps_5_0.hlsl
+++ b/src/games/masseffectandromeda/output_loading_0x182C8867.ps_5_0.hlsl
@@ -1,0 +1,25 @@
+#include "./shared.h"
+#include "./loading_core.hlsli"
+
+// Loading/video present permutation (1:1, single tap). Same as 0xF5B7A93D — sRGB-encoded art (no 1D
+// LUT), shared LoadingPresentScene tail — but binds the scene sampler on s1 instead of s0.
+
+Texture2D<float4> sceneTexture : register(t0);
+Texture2D<float4> uiTexture : register(t1);
+
+SamplerState sceneSampler : register(s1);  // scene (s1 here, not s0)
+SamplerState uiSampler : register(s2);
+
+cbuffer cbData : register(b0) {
+  float4 cbData[3] : packoffset(c0);
+}
+
+struct PSInput {
+  float4 position : SV_Position;
+  float2 texcoord : TEXCOORD;
+};
+
+float4 main(PSInput input) : SV_Target {
+  float4 scene = sceneTexture.SampleLevel(sceneSampler, input.texcoord, 0.f);
+  return LoadingPresentScene(scene, input.texcoord, cbData[2], uiTexture, uiSampler);
+}

--- a/src/games/masseffectandromeda/output_loading_0xF5B7A93D.ps_5_0.hlsl
+++ b/src/games/masseffectandromeda/output_loading_0xF5B7A93D.ps_5_0.hlsl
@@ -1,0 +1,24 @@
+#include "./shared.h"
+#include "./loading_core.hlsli"
+
+Texture2D<float4> sceneTexture : register(t0);
+Texture2D<float4> uiTexture : register(t1);
+
+SamplerState sceneSampler : register(s0);
+SamplerState uiSampler : register(s2);
+
+cbuffer cbData : register(b0) {
+  float4 cbData[3] : packoffset(c0);
+}
+
+struct PSInput {
+  float4 position : SV_Position;
+  float2 texcoord : TEXCOORD;
+};
+
+// Loading/video present (1:1). Art (t0) is sRGB-encoded (no 1D LUT); tail is the shared
+// LoadingPresentScene. Without it the vanilla pass PQ-encodes the art at ~1500 nits.
+float4 main(PSInput input) : SV_Target {
+  float4 scene = sceneTexture.SampleLevel(sceneSampler, input.texcoord, 0.f);
+  return LoadingPresentScene(scene, input.texcoord, cbData[2], uiTexture, uiSampler);
+}

--- a/src/games/masseffectandromeda/output_pplow_0x8498DBD5.ps_5_0.hlsl
+++ b/src/games/masseffectandromeda/output_pplow_0x8498DBD5.ps_5_0.hlsl
@@ -1,0 +1,32 @@
+#include "./shared.h"
+#include "./lilium_rcas.hlsli"
+#include "./present_core.hlsli"
+
+// HDR present permutation used at Post Process Quality = Low (the game swaps 0xF5B0DBFA -> this).
+// Tail is byte-identical to 0xF5B0DBFA's (scene -> scale -> 1D LUT linearize -> UI composite ->
+// 709->2020 -> PQ), but it single-taps the scene with a bilinear upscale rather than 1:1.
+// Binding quirk (like 0xAFFFA4AB): s1 = scene + LUT sampler, s2 = UI, no s0.
+// isUpscale = true: the scene is smaller than the output (bilinear upscale), so RCAS is skipped.
+
+Texture2D<float4> sceneTexture : register(t0);
+Texture2D<float4> uiTexture : register(t1);
+Texture1D<float4> outputLut : register(t2);
+
+SamplerState sceneLutSampler : register(s1);  // scene tap + output LUT
+SamplerState uiSampler : register(s2);
+
+cbuffer cbData : register(b0) {
+  float4 cbData[3] : packoffset(c0);
+}
+
+struct PSInput {
+  float4 position : SV_Position;
+  float2 texcoord : TEXCOORD;
+};
+
+float4 main(PSInput input) : SV_Target {
+  float4 scene = sceneTexture.SampleLevel(sceneLutSampler, input.texcoord, 0.f);
+  return PresentScene(scene, input.texcoord, cbData[2],
+                      sceneTexture, sceneLutSampler, uiTexture, uiSampler, outputLut, sceneLutSampler,
+                      true);  // scene != output (bilinear upscale) -> RCAS skipped
+}

--- a/src/games/masseffectandromeda/output_upscale_0xAFFFA4AB.ps_5_0.hlsl
+++ b/src/games/masseffectandromeda/output_upscale_0xAFFFA4AB.ps_5_0.hlsl
@@ -1,0 +1,32 @@
+#include "./shared.h"
+#include "./lilium_rcas.hlsli"
+#include "./present_core.hlsli"
+#include "./bicubic_upscale.hlsli"
+
+// Upscaling HDR present (Resolution Scale < 100%; game swaps 0xF5B0DBFA -> this). Like 0xF5B0DBFA but
+// the scene is a 16-tap bicubic fetch; tail is the shared PresentScene.
+// Binding quirk: s1 = scene taps AND LUT, s2 = UI, no s0. cbData[0].xy = source res, .zw = texel (1/res).
+
+Texture2D<float4> sceneTexture : register(t0);
+Texture2D<float4> uiTexture : register(t1);
+Texture1D<float4> outputLut : register(t2);
+
+SamplerState sceneLutSampler : register(s1);  // scene bicubic taps + output LUT
+SamplerState uiSampler : register(s2);
+
+cbuffer cbData : register(b0) {
+  float4 cbData[3] : packoffset(c0);
+}
+
+struct PSInput {
+  float4 position : SV_Position;
+  float2 texcoord : TEXCOORD;
+};
+
+float4 main(PSInput input) : SV_Target {
+  // Bicubic-upscaled scene (alpha = 1, matching the vanilla upscale present which doesn't carry scene alpha).
+  float4 scene = float4(SampleSceneBicubic(sceneTexture, sceneLutSampler, input.texcoord, cbData[0]), 1.f);
+  return PresentScene(scene, input.texcoord, cbData[2],
+                      sceneTexture, sceneLutSampler, uiTexture, uiSampler, outputLut, sceneLutSampler,
+                      true);  // upscale: bicubic center, RCAS skipped (asymmetric neighborhood)
+}

--- a/src/games/masseffectandromeda/output_upscale_loading_0x667C56AF.ps_5_0.hlsl
+++ b/src/games/masseffectandromeda/output_upscale_loading_0x667C56AF.ps_5_0.hlsl
@@ -1,0 +1,29 @@
+#include "./shared.h"
+#include "./loading_core.hlsli"
+#include "./bicubic_upscale.hlsli"
+
+// Upscaling loading/video present (Resolution Scale != 100%; game swaps 0xF5B7A93D -> this). Like
+// 0xF5B7A93D but the sRGB art is a 16-tap bicubic fetch; tail is the shared LoadingPresentScene.
+// Binding quirk: s1 = scene taps, s2 = UI, no s0/LUT. cbData[0].xy = source res, .zw = texel (1/res).
+
+Texture2D<float4> sceneTexture : register(t0);
+Texture2D<float4> uiTexture : register(t1);
+
+SamplerState sceneSampler : register(s1);  // scene bicubic taps
+SamplerState uiSampler : register(s2);
+
+cbuffer cbData : register(b0) {
+  float4 cbData[3] : packoffset(c0);
+}
+
+struct PSInput {
+  float4 position : SV_Position;
+  float2 texcoord : TEXCOORD;
+};
+
+float4 main(PSInput input) : SV_Target {
+  // Bicubic-upscale the sRGB-encoded art (resample-then-decode, matching vanilla); LoadingPresentScene
+  // does the sRGB decode. Alpha = 1, matching the vanilla upscale present (no scene alpha carried).
+  float4 scene = float4(SampleSceneBicubic(sceneTexture, sceneSampler, input.texcoord, cbData[0]), 1.f);
+  return LoadingPresentScene(scene, input.texcoord, cbData[2], uiTexture, uiSampler);
+}

--- a/src/games/masseffectandromeda/present_core.hlsli
+++ b/src/games/masseffectandromeda/present_core.hlsli
@@ -1,0 +1,64 @@
+#ifndef SRC_GAMES_MASSEFFECTANDROMEDA_PRESENT_CORE_HLSLI_
+#define SRC_GAMES_MASSEFFECTANDROMEDA_PRESENT_CORE_HLSLI_
+
+// Shared HDR present tail for both 1:1 (0xF5B0DBFA) and upscale (0xAFFFA4AB) presents -> HDR10 PQ.
+// Caller supplies the scene fetch (single tap vs bicubic) and bindings.
+// scene: rgb = pre-scale graded buffer, a = layer alpha. cb2 = cbData[2]: .x scene scale,
+// .y UI gate, .z UI alpha factor. Requires shared.h + lilium_rcas.hlsli first.
+
+float4 PresentScene(
+    float4 scene, float2 texcoord, float4 cb2,
+    Texture2D<float4> sceneTexture, SamplerState sceneSampler,
+    Texture2D<float4> uiTexture, SamplerState uiSampler,
+    Texture1D<float4> outputLut, SamplerState lutSampler,
+    bool isUpscale) {
+  scene *= cb2.x;
+
+  float3 color = SampleOutputLut(outputLut, lutSampler, max(0.f, scene.rgb));
+  color = max(0.f, color);
+
+  // Vanilla = pure native passthrough (diffuse 100 nits, nothing applied).
+  // Vanilla+ = paper white + highlight roll-off (pins peak) + grade + EOTF + effects.
+  const PresentParams p = GetPresentParams();
+
+  if (p.full) {
+    // RCAS (no-op at 0), before grade + UI composite so the HUD stays crisp. Swapchain-only (gate).
+    // Skipped on upscale: bicubic center vs source-res point neighbors = asymmetric; 1:1 only.
+    if (injectedData.fxSwapchainPresent != 0.f && !isUpscale) {
+      color = ApplyRCAS(color, texcoord, sceneTexture, sceneSampler, outputLut, lutSampler, cb2.x);
+    }
+
+    // Grade + EOTF + roll-off + Hue Shift. Exposure is applied pre-tonemap in tonemap_grade, so pass 1.0.
+    color = ApplyVanillaPlus(color, 1.f, p.paperWhite);
+
+    // Perceptual film grain (Luminance / Per-Channel) in paper-white-relative units.
+    if (injectedData.fxFilmGrain > 0.f) {
+      const float strength = injectedData.fxFilmGrain * 0.03f;
+      if (injectedData.fxFilmGrainType == FILM_GRAIN_LUMINANCE) {
+        color = renodx::effects::ApplyFilmGrain(color, texcoord, injectedData.customRandom, strength, 1.f);
+      } else if (injectedData.fxFilmGrainType == FILM_GRAIN_PER_CHANNEL) {
+        const float r = injectedData.customRandom;
+        const float3 seed = float3(r, frac(r * 1.6180339887f + 0.5f), frac(r * 3.1415926535f + 0.25f));
+        color = renodx::effects::ApplyFilmGrainColored(color, texcoord, seed, strength, 1.f);
+      }
+    }
+  }
+
+  float3 scene_nits = max(0.f, color * p.paperWhite);
+
+  if (cb2.y > 0.f) {
+    float4 ui = uiTexture.SampleLevel(uiSampler, texcoord, 0.f);
+
+    // The UI arrives sRGB-decoded (t1 is an _srgb view). When SDR EOTF emulation is on,
+    // re-interpret it with the selected gamma (2.2 / BT.1886) to match the scene's SDR look.
+    float3 uiRgb = ui.rgb;
+    if (p.eotf != 0.f) {
+      uiRgb = renodx::color::correct::Gamma(uiRgb, false, EotfGamma());
+    }
+    CompositeUI(scene_nits, scene.a, ui.a, cb2, uiRgb * p.uiNits);
+  }
+
+  return float4(FinalizeToPQ(scene_nits), scene.a);
+}
+
+#endif  // SRC_GAMES_MASSEFFECTANDROMEDA_PRESENT_CORE_HLSLI_

--- a/src/games/masseffectandromeda/shared.h
+++ b/src/games/masseffectandromeda/shared.h
@@ -1,0 +1,152 @@
+#ifndef SRC_GAMES_MASSEFFECTANDROMEDA_SHARED_H_
+#define SRC_GAMES_MASSEFFECTANDROMEDA_SHARED_H_
+
+// Must be 32-bit aligned.
+struct ShaderInjectData {
+  float toneMapType;       // 0 = Vanilla (pure native passthrough), 1 = Vanilla+ (full pipeline)
+  float toneMapPeakNits;   // display peak the roll-off pins highlights to (Vanilla+)
+  float toneMapGameNits;
+  float toneMapUINits;
+  float colorGradeExposure;
+  float colorGradeHighlights;
+  float colorGradeShadows;
+  float colorGradeContrast;
+  float colorGradeSaturation;
+  float colorGradeHighlightSaturation;  // 1.0 = vanilla; >1 boosts highlight color, <1 blows out to white
+  float colorGradeFlare;
+  float colorGradeHueShift;  // 0 = keep BioWare hue, >0 = blend highlights toward per-channel hue
+  float gammaCorrection;   // 0 = Off, 1 = 2.2, 2 = BT.1886 (2.4); RenoDX per-channel gamma correction
+  float fxBloom;           // additive bloom scale (1.0 = vanilla)
+  float fxVignette;             // vignette strength (1.0 = vanilla, 0 = off)
+  float fxChromaticAberration;  // chromatic aberration strength (1.0 = vanilla, 0 = off)
+  float fxFilmGrain;       // perceptual film grain strength (0 = off)
+  float fxFilmGrainType;   // 0 = Vanilla (game grain), 1 = Luminance, 2 = Per-Channel (perceptual)
+  float fxHDRVideos;       // 0 = Off, 1 = BT.2446a (FMV inverse tone map)
+  float fxVideoActive;     // runtime flag: an FMV decode pass ran this frame
+  float fxSharpness;       // Lilium HDR RCAS strength (0 = off), Vanilla+ only
+  float fxSwapchainPresent;  // runtime flag: 1 when the present draw targets the swapchain (RCAS gate)
+  float customRandom;      // per-frame random seed for perceptual grain
+};
+
+#ifndef __cplusplus
+cbuffer shader_injection : register(b13) {
+  ShaderInjectData injectedData : packoffset(c0);
+}
+
+#define TONE_MAP_VANILLA 0.f
+#define TONE_MAP_VANILLA_PLUS 1.f
+
+#define FILM_GRAIN_VANILLA 0.f
+#define FILM_GRAIN_LUMINANCE 1.f
+#define FILM_GRAIN_PER_CHANNEL 2.f
+
+#define CUSTOM_SHARPNESS injectedData.fxSharpness
+
+// "Full pipeline" (Vanilla+) predicate. Reads only injectedData, so usable from any pass.
+bool IsVanillaPlus() {
+  return injectedData.toneMapType == TONE_MAP_VANILLA_PLUS;
+}
+
+#include "../../shaders/renodx.hlsl"
+
+// Game's 1D output LUT: linearizes the PQ-encoded graded buffer to scene-linear (1.0 = diffuse white).
+// Shared by the present center tap and RCAS neighbors so both linearize identically.
+float3 SampleOutputLut(Texture1D<float4> lut_tex, SamplerState lut_smp, float3 color) {
+  return float3(
+      lut_tex.SampleLevel(lut_smp, color.r, 0.f).r,
+      lut_tex.SampleLevel(lut_smp, color.g, 0.f).r,
+      lut_tex.SampleLevel(lut_smp, color.b, 0.f).r);
+}
+
+// SDR EOTF emulation = RenoDX per-channel gamma correction. 0 = Off, 1 = 2.2, 2 = BT.1886 (2.4).
+// GammaSafe is sign-preserving (color grading can push a channel negative; non-Safe Gamma -> NaN).
+float3 ApplyEotfEmulation(float3 color) {
+  if (injectedData.gammaCorrection == renodx::draw::GAMMA_CORRECTION_GAMMA_2_2) {
+    color = renodx::color::correct::GammaSafe(color, false, 2.2f);
+  } else if (injectedData.gammaCorrection == renodx::draw::GAMMA_CORRECTION_GAMMA_2_4) {
+    color = renodx::color::correct::GammaSafe(color, false, 2.4f);
+  }
+  return color;
+}
+
+// Selected EOTF gamma (2.4 = BT.1886, else 2.2) so the present tails re-interpret the UI to match.
+float EotfGamma() {
+  return injectedData.gammaCorrection == renodx::draw::GAMMA_CORRECTION_GAMMA_2_4 ? 2.4f : 2.2f;
+}
+
+// Per-present tone-map params, shared by both present tails. Vanilla pins diffuse/UI to 100 nits
+// and disables EOTF; Vanilla+ follows the Game/UI Brightness sliders and the EOTF selector.
+struct PresentParams {
+  bool full;
+  float paperWhite;
+  float uiNits;
+  float eotf;
+};
+PresentParams GetPresentParams() {
+  PresentParams p;
+  p.full = IsVanillaPlus();
+  p.paperWhite = p.full ? max(injectedData.toneMapGameNits, 1.f) : 100.f;
+  p.uiNits = p.full ? max(injectedData.toneMapUINits, 1.f) : 100.f;
+  p.eotf = p.full ? injectedData.gammaCorrection : 0.f;
+  return p;
+}
+
+// Final HDR10 output, shared by both present tails: BT.709 nits -> BT.2020 -> ST.2084 PQ. Caller
+// supplies the alpha.
+float3 FinalizeToPQ(float3 scene_nits) {
+  return renodx::color::pq::EncodeSafe(renodx::color::bt2020::from::BT709(scene_nits), 1.f);
+}
+
+// UI/video over-scene alpha composite (cb2.z = UI alpha factor; ui_term_nits = linearized UI in nits).
+// max(0,...) guards the pow: cb2.z is unclamped, so ui.a*cb2.z can exceed 1 and pow(negative) = NaN
+// on the fp16 target (vanilla wrote UNORM, which clamped).
+void CompositeUI(inout float3 scene_nits, inout float scene_a, float ui_alpha_src, float4 cb2, float3 ui_term_nits) {
+  const float uiAlpha = 1.f - pow(max(0.f, 1.f - ui_alpha_src * cb2.z), 2.f);
+  const float sceneAlpha = 1.f - uiAlpha;
+  scene_nits = scene_nits * sceneAlpha + ui_term_nits;
+  scene_a = scene_a * sceneAlpha + uiAlpha;
+}
+
+// Vanilla+ finalize: color grade -> EOTF -> luminance-preserving roll-off (pins peak to Peak
+// Brightness) -> Hue Shift. exposure is 1.0 for the main pass (applied pre-tonemap) / the slider for
+// loading; paperWhite = diffuse-white nits the roll-off is relative to.
+float3 ApplyVanillaPlus(float3 color, float exposure, float paperWhite) {
+  // User color grading (neutral sliders early-return to a no-op).
+  renodx::color::grade::Config cg = renodx::color::grade::config::Create(
+      exposure,
+      injectedData.colorGradeHighlights,
+      injectedData.colorGradeShadows,
+      injectedData.colorGradeContrast,
+      injectedData.colorGradeFlare,
+      injectedData.colorGradeSaturation,
+      0.f,  // dechroma
+      0.f,  // hue_correction_strength
+      float3(0.f, 0.f, 0.f),
+      renodx::color::grade::config::hue_correction_type::INPUT,
+      -1.f * (injectedData.colorGradeHighlightSaturation - 1.f));  // blowout (highlight saturation, centered at 1.0)
+  color = renodx::color::grade::config::ApplyUserColorGrading(color, cg);
+
+  // SDR EOTF emulation (selected gamma).
+  color = ApplyEotfEmulation(color);
+
+  // Highlight roll-off pins the peak to Peak Brightness so paper white only moves diffuse/mids
+  // (not the peak). Luminance-preserving (keeps hue). Requires the in-game Peak Brightness at MAX.
+  const float peak = max(injectedData.toneMapPeakNits / paperWhite, 1.f + 1e-3f);
+  const float rolloffStart = min(1.f, peak * 0.5f);
+  const float3 preRolloff = color;
+  const float y = renodx::color::y::from::BT709(color);
+  const float yNew = renodx::tonemap::ExponentialRollOff(y, rolloffStart, peak);
+  color = renodx::color::correct::Luminance(color, y, yNew);
+
+  // Hue Shift: blend toward the per-channel roll-off hue (the SDR-display look). 0 = keep BioWare hue.
+  if (injectedData.colorGradeHueShift > 0.f) {
+    const float3 perChannel = renodx::tonemap::ExponentialRollOff(preRolloff, rolloffStart, peak);
+    color = renodx::color::correct::Hue(color, perChannel, injectedData.colorGradeHueShift);
+  }
+
+  return color;
+}
+
+#endif
+
+#endif  // SRC_GAMES_MASSEFFECTANDROMEDA_SHARED_H_

--- a/src/games/masseffectandromeda/tonemap_grade_0x376C116B.ps_5_0.hlsl
+++ b/src/games/masseffectandromeda/tonemap_grade_0x376C116B.ps_5_0.hlsl
@@ -1,0 +1,4 @@
+// Scene tonemap+grade — CA off / grain on (vanilla film grain on t4).
+#define MEA_TONEMAP_CA 0
+#define MEA_TONEMAP_GRAIN 1
+#include "./tonemap_grade_common.hlsli"

--- a/src/games/masseffectandromeda/tonemap_grade_0xB6A91712.ps_5_0.hlsl
+++ b/src/games/masseffectandromeda/tonemap_grade_0xB6A91712.ps_5_0.hlsl
@@ -1,0 +1,4 @@
+// Scene tonemap+grade — CA off / grain off.
+#define MEA_TONEMAP_CA 0
+#define MEA_TONEMAP_GRAIN 0
+#include "./tonemap_grade_common.hlsli"

--- a/src/games/masseffectandromeda/tonemap_grade_0xE3D57A10.ps_5_0.hlsl
+++ b/src/games/masseffectandromeda/tonemap_grade_0xE3D57A10.ps_5_0.hlsl
@@ -1,0 +1,4 @@
+// Scene tonemap+grade — CA on (per-channel) / grain on (vanilla film grain on t4).
+#define MEA_TONEMAP_CA 1
+#define MEA_TONEMAP_GRAIN 1
+#include "./tonemap_grade_common.hlsli"

--- a/src/games/masseffectandromeda/tonemap_grade_0xEB91AB31.ps_5_0.hlsl
+++ b/src/games/masseffectandromeda/tonemap_grade_0xEB91AB31.ps_5_0.hlsl
@@ -1,0 +1,4 @@
+// Scene tonemap+grade — CA on (per-channel) / grain off.
+#define MEA_TONEMAP_CA 1
+#define MEA_TONEMAP_GRAIN 0
+#include "./tonemap_grade_common.hlsli"

--- a/src/games/masseffectandromeda/tonemap_grade_common.hlsli
+++ b/src/games/masseffectandromeda/tonemap_grade_common.hlsli
@@ -1,0 +1,128 @@
+#include "./shared.h"
+
+// Faithful Frostbite scene tonemap+grade pass (VS 0xCD03DB44), shared by all four {CA, grain} perms.
+// Builds linear scene -> *0.01 -> ST.2084 PQ -> 33^3 LUT (PQ space), as vanilla. Parametrized by:
+//   MEA_TONEMAP_CA     0 = distortion warp (0xB6A91712 / 0x376C116B); 1 = chromatic aberration (0xEB91AB31 / 0xE3D57A10)
+//   MEA_TONEMAP_GRAIN  0 = no noise (grain-off); 1 = vanilla grain on t4 (grain-on)
+// Vanilla+ user controls (neutral at vanilla): fxBloom, colorGradeExposure, fxVignette, fxChromaticAberration.
+
+#ifndef MEA_TONEMAP_CA
+#define MEA_TONEMAP_CA 0
+#endif
+#ifndef MEA_TONEMAP_GRAIN
+#define MEA_TONEMAP_GRAIN 0
+#endif
+
+Texture2D<float4> sceneTexture : register(t0);
+Texture3D<float4> colorGradingTexture : register(t1);
+Texture2D<float4> distortionTexture : register(t2);
+Texture2D<float4> bloomTexture : register(t3);
+#if MEA_TONEMAP_GRAIN
+Texture2D<float4> noiseTexture : register(t4);
+#endif
+
+SamplerState sceneSampler : register(s0);
+SamplerState colorGradingSampler : register(s1);
+SamplerState distortionSampler : register(s2);
+SamplerState bloomSampler : register(s3);
+#if MEA_TONEMAP_GRAIN
+SamplerState noiseSampler : register(s4);
+#endif
+
+cbuffer cbData : register(b0) {
+  float4 cbData[14] : packoffset(c0);
+}
+
+struct PSInput {
+  float4 position : SV_Position;
+  float4 texcoord0 : TEXCOORD0;
+  float2 texcoord : TEXCOORD1;
+};
+
+struct PSOutput {
+  float4 color : SV_Target0;
+  float luma : SV_Target1;
+};
+
+// Vignette, blended toward 1.0 (no darkening) by the user Vignette control in Vanilla+ (1.0 = vanilla).
+float ApplyVignette(float2 uv) {
+  float2 vignette_uv = (uv - 0.5f) * cbData[10].xy;
+  float vignette = dot(vignette_uv, vignette_uv);
+  vignette = saturate(1.f - vignette * cbData[11].w);
+  vignette = exp(log(max(vignette, 0.000001f)) * cbData[10].z);
+  const bool full = IsVanillaPlus();
+  // max() guards the >50 range: lerp extrapolates past 1.0 and could drive corners to a negative multiplier.
+  return full ? max(0.f, lerp(1.f, vignette, injectedData.fxVignette)) : vignette;
+}
+
+// Scene composite (distortion warp / chromatic aberration + bloom + exposure + vignette) -> linear HDR.
+float3 ApplyScenePost(float2 uv) {
+  float3 distortion = distortionTexture.Sample(distortionSampler, uv).xyz;
+
+  // Vanilla mode applies nothing; Vanilla+ applies the user effect controls.
+  const bool full = IsVanillaPlus();
+
+#if MEA_TONEMAP_CA
+  // Chromatic aberration (port of 0xEB91AB31): split the base distorted UV per channel by cb0[12]
+  // (0.5 = no split). Red at cb0[12].xy, green at .zw, blue keeps base UV + the dist.z bloom blend.
+  float2 base_uv = distortion.xy * cbData[13].xy + cbData[13].zw + uv;
+  float scene_b = sceneTexture.Sample(sceneSampler, base_uv).z;
+  float3 bloom = bloomTexture.Sample(bloomSampler, base_uv).xyz;
+  // User Chromatic Aberration control (Vanilla+): lerp the per-channel split toward 0.5 (no split).
+  const float caScale = full ? injectedData.fxChromaticAberration : 1.f;
+  float2 caXY = lerp(0.5f, cbData[12].xy, caScale);
+  float2 caZW = lerp(0.5f, cbData[12].zw, caScale);
+  float2 red_uv = (base_uv - 0.5f) * 2.f * caXY + 0.5f;
+  float2 green_uv = (base_uv - 0.5f) * 2.f * caZW + 0.5f;
+  float blend_b = distortion.z * (bloom.z - scene_b) + scene_b;
+  float scene_r = sceneTexture.Sample(sceneSampler, red_uv).x;
+  float scene_g = sceneTexture.Sample(sceneSampler, green_uv).y;
+  float3 color = float3(scene_r, scene_g, blend_b);
+#else
+  // Single-sample distortion warp (0xB6A91712): scene/bloom lerp by distortion.z.
+  float2 distorted_uv = distortion.xy * cbData[13].xy + cbData[13].zw + uv;
+  float3 scene = sceneTexture.Sample(sceneSampler, distorted_uv).rgb;
+  float3 bloom = bloomTexture.Sample(bloomSampler, distorted_uv).rgb;
+  float3 color = lerp(scene, bloom, distortion.z);
+#endif
+
+  const float bloomScale = full ? injectedData.fxBloom : 1.f;
+  const float expScale = full ? injectedData.colorGradeExposure : 1.f;
+
+  // Additive bloom glow (1.0 = vanilla).
+  color = bloom * cbData[8].xyz * bloomScale + color;
+  // Pre-tonemap exposure / grade scale (cb0[5]) (1.0 = vanilla).
+  color *= cbData[5].xyz * expScale;
+  color *= ApplyVignette(uv);
+  return color;
+}
+
+// PQ-encode the linear scene (1.0 == 100 nits) and sample the native 33^3 grade LUT (PQ space).
+float3 SampleNativeGrade(float3 color) {
+  float3 pq_color = renodx::color::pq::EncodeSafe(color, 100.f);
+  pq_color = pq_color * 0.96969697f + 0.01515152f;
+  return colorGradingTexture.Sample(colorGradingSampler, pq_color).rgb;
+}
+
+PSOutput main(PSInput input) {
+  PSOutput output;
+
+  float3 linear_scene = ApplyScenePost(input.texcoord);
+  float3 graded = SampleNativeGrade(linear_scene);
+
+#if MEA_TONEMAP_GRAIN
+  // Vanilla film grain (additive, post-LUT). Kept in native modes and Vanilla+ Film Grain = Vanilla;
+  // Luminance / Per-Channel skip it here and apply perceptual grain in the present pass instead.
+  if (!IsVanillaPlus() || injectedData.fxFilmGrainType == FILM_GRAIN_VANILLA) {
+    float2 noise_uv = input.texcoord * cbData[2].xy + cbData[2].zw;
+    float noise = noiseTexture.Sample(noiseSampler, noise_uv).x;
+    graded += (noise - 0.5f) * cbData[1].xyz;
+  }
+#endif
+
+  output.color.rgb = graded;
+  output.color.a = 1.f;
+  output.luma = dot(graded, float3(0.299f, 0.587f, 0.114f));
+
+  return output;
+}

--- a/src/games/masseffectandromeda/videos_0x7ED07F45.ps_5_0.hlsl
+++ b/src/games/masseffectandromeda/videos_0x7ED07F45.ps_5_0.hlsl
@@ -1,0 +1,36 @@
+#include "./shared.h"
+
+// FMV YUV->RGB decode. Faithful 1:1 vanilla reconstruction (BT.601 limited-range), sRGB-encoded into
+// the r8g8b8a8 video buffer. Registered via callback only to flag fxVideoActive; decode is unchanged.
+Texture2D<float4> lumaTexture : register(t0);    // Y
+Texture2D<float4> crTexture : register(t1);      // Cr
+Texture2D<float4> cbTexture : register(t2);      // Cb
+
+SamplerState lumaSampler : register(s0);
+SamplerState crSampler : register(s1);
+SamplerState cbSampler : register(s2);
+
+struct PSInput {
+  float4 position : SV_Position;
+  float4 color : TEXCOORD0;     // vertex color / tint
+  float2 texcoord : TEXCOORD1;
+};
+
+float4 main(PSInput input) : SV_Target {
+  float y = lumaTexture.Sample(lumaSampler, input.texcoord).r;
+  float cr = crTexture.Sample(crSampler, input.texcoord).r;
+  float cb = cbTexture.Sample(cbSampler, input.texcoord).r;
+
+  // BT.601 limited-range YCbCr -> RGB, vanilla constants verbatim (NOT bt709). Kept hand-rolled over
+  // renodx::color::bt601::YCbCrLimited: the helper drifts ~0.1-0.5% from these rounded constants, and
+  // it wants (Y,Cb,Cr) while our planes are t0=Y, t1=Cr, t2=Cb (Cr before Cb) — easy silent swap.
+  float3 rgb;
+  rgb.r = 1.164124f * y + 1.595795f * cr - 0.870655f;
+  rgb.g = 1.164124f * y - 0.813477f * cr - 0.391449f * cb + 0.529705f;
+  rgb.b = 1.164124f * y + 2.017822f * cb - 1.081669f;
+
+  float4 output;
+  output.rgb = rgb * input.color.rgb;
+  output.a = input.color.a;
+  return output;
+}


### PR DESCRIPTION
Native HDR fix for Mass Effect: Andromeda (Frostbite 3, D3D11).

**Required in-game settings**
- HDR: On (HDR10), Framebuffer Format: HALF16 (64 bits)
- Post Process Quality: Medium or higher (grading effects no-op on Low)
- HDR10 Peak Value: max - then set the add-on's Peak Brightness to your display peak

**Features**
- Vanilla (untouched native HDR) / Vanilla+ (paper white, roll-off, grading, effects)
- Gamma Correction (Off / 2.2 / BT.1886), paper white / peak / UI brightness
- Color grade (exposure, highlights, shadows, contrast, saturation, hue shift, flare),
  bloom / vignette / chromatic aberration, perceptual film grain, RCAS sharpening, AutoHDR videos