### PR TITLE
feat(devkit): track submission order instead of draw order

### DIFF
--- a/src/addons/devkit/addon.cpp
+++ b/src/addons/devkit/addon.cpp
@@ -116,6 +116,7 @@ inline constexpr std::wstring_view DEVKIT_MCP_PIPE_PREFIX = L"renodx-devkit-mcp"
 
 std::atomic<reshade::api::device*> snapshot_device = nullptr;
 std::atomic<reshade::api::device*> snapshot_queued_device = nullptr;
+std::atomic<uint32_t> snapshot_submission_counter = 0u;
 auto devkit_mcp_session = devkit_mcp_server_session::Create(DEVKIT_MCP_PIPE_PREFIX);
 std::atomic<uint32_t> devkit_primary_device_api = 0u;
 
@@ -227,6 +228,9 @@ struct DrawDetails {
   } draw_method;
 
   std::chrono::time_point<std::chrono::system_clock> timestamp;
+  uint64_t cmd_list_handle = 0u;
+  uint32_t cmd_list_draw_index = 0u;
+  uint32_t submission_order = 0u;
   std::map<std::pair<uint32_t, uint32_t>, ResourceViewDetails> srv_binds;
   std::map<std::pair<uint32_t, uint32_t>, ResourceViewDetails> uav_binds;
   std::map<std::pair<uint32_t, uint32_t>, reshade::api::buffer_range> constants;
@@ -318,6 +322,7 @@ struct __declspec(uuid("3224946b-5c5f-478a-8691-83fbb9f88f1b")) CommandListData 
   std::map<uint32_t, ResourceViewDetails> render_targets;
   std::optional<reshade::api::blend_desc> blend_desc = std::nullopt;
   std::optional<reshade::api::rasterizer_desc> rasterizer_desc = std::nullopt;
+  uint32_t draw_counter = 0u;
 
   // std::vector<PipelineBindDetails> pipeline_binds;
 };
@@ -381,6 +386,7 @@ struct __declspec(uuid("0190ec1a-2e19-74a6-ad41-4df0d4d8caed")) DeviceData {
   std::unordered_map<uint32_t, ShaderDetails> shader_details;
   // std::vector<CommandListData> command_list_data;
   std::vector<DrawDetails> draw_details_list;
+  std::unordered_map<uint64_t, std::vector<size_t>> draw_detail_indexes_by_cmd_list;
   std::unordered_set<uint64_t> live_pipelines;
   std::unordered_map<uint64_t, std::unordered_map<reshade::api::format, reshade::api::resource_view>> preview_srvs;
   std::shared_mutex mutex;
@@ -4295,9 +4301,14 @@ bool OnCopyResource(
     DrawDetails draw_details = {
         .draw_method = DrawDetails::DrawMethods::COPY,
         .timestamp = std::chrono::system_clock::now(),
+        .cmd_list_handle = reinterpret_cast<uint64_t>(cmd_list),
         .copy_source = source,
         .copy_destination = dest,
     };
+    if (auto* command_list_data = renodx::utils::data::Get<CommandListData>(cmd_list);
+        command_list_data != nullptr) {
+      draw_details.cmd_list_draw_index = command_list_data->draw_counter++;
+    }
 
     auto* device_data = renodx::utils::data::Get<DeviceData>(device);
     if (device_data == nullptr) return false;
@@ -4305,7 +4316,11 @@ bool OnCopyResource(
     if (snapshot_trace_with_snapshot) {
       reshade::log::message(reshade::log::level::debug, std::format("Snapshot #{}", device_data->draw_details_list.size()).c_str());
     }
-    device_data->draw_details_list.push_back(draw_details);
+    const auto draw_index = device_data->draw_details_list.size();
+    device_data->draw_details_list.push_back(std::move(draw_details));
+    if (device_data->draw_details_list.back().cmd_list_handle != 0u) {
+      device_data->draw_detail_indexes_by_cmd_list[device_data->draw_details_list.back().cmd_list_handle].push_back(draw_index);
+    }
     device_data->snapshot_rows_valid = false;
   } else {
     reshade::log::message(reshade::log::level::debug, "Foreign Copy.");
@@ -4332,9 +4347,14 @@ bool OnCopyTextureRegion(
     DrawDetails draw_details = {
         .draw_method = DrawDetails::DrawMethods::COPY,
         .timestamp = std::chrono::system_clock::now(),
+        .cmd_list_handle = reinterpret_cast<uint64_t>(cmd_list),
         .copy_source = source,
         .copy_destination = dest,
     };
+    if (auto* command_list_data = renodx::utils::data::Get<CommandListData>(cmd_list);
+        command_list_data != nullptr) {
+      draw_details.cmd_list_draw_index = command_list_data->draw_counter++;
+    }
 
     auto* device_data = renodx::utils::data::Get<DeviceData>(device);
     if (device_data == nullptr) return false;
@@ -4342,7 +4362,11 @@ bool OnCopyTextureRegion(
     if (snapshot_trace_with_snapshot) {
       reshade::log::message(reshade::log::level::debug, std::format("Snapshot #{}", device_data->draw_details_list.size()).c_str());
     }
-    device_data->draw_details_list.push_back(draw_details);
+    const auto draw_index = device_data->draw_details_list.size();
+    device_data->draw_details_list.push_back(std::move(draw_details));
+    if (device_data->draw_details_list.back().cmd_list_handle != 0u) {
+      device_data->draw_detail_indexes_by_cmd_list[device_data->draw_details_list.back().cmd_list_handle].push_back(draw_index);
+    }
     device_data->snapshot_rows_valid = false;
   } else {
     reshade::log::message(reshade::log::level::debug, "Foreign Copy.");
@@ -4586,6 +4610,8 @@ bool OnDraw(reshade::api::command_list* cmd_list, DrawDetails::DrawMethods draw_
     DrawDetails draw_details = {};
     draw_details.timestamp = std::chrono::system_clock::now();
     draw_details.draw_method = draw_method;
+    draw_details.cmd_list_handle = reinterpret_cast<uint64_t>(cmd_list);
+    draw_details.cmd_list_draw_index = command_list_data->draw_counter++;
     draw_details.constants = command_list_data->constants;
     // draw_details.pipeline_binds = command_list_data->pipeline_binds;
     if (draw_method == DrawDetails::DrawMethods::DISPATCH) {
@@ -4907,7 +4933,12 @@ bool OnDraw(reshade::api::command_list* cmd_list, DrawDetails::DrawMethods draw_
     if (snapshot_trace_with_snapshot) {
       reshade::log::message(reshade::log::level::debug, std::format("Snapshot #{}", device_data->draw_details_list.size()).c_str());
     }
+    const auto draw_index = device_data->draw_details_list.size();
+    const auto cmd_list_handle = draw_details.cmd_list_handle;
     device_data->draw_details_list.push_back(std::move(draw_details));
+    if (cmd_list_handle != 0u) {
+      device_data->draw_detail_indexes_by_cmd_list[cmd_list_handle].push_back(draw_index);
+    }
     device_data->snapshot_rows_valid = false;
     // command_list_data->draw_details.clear();
   } else if (snapshot_device != nullptr) {
@@ -8638,6 +8669,34 @@ void OnRegisterOverlay(reshade::api::effect_runtime* runtime) {
   ImGui::EndChild();
 }
 
+void OnExecuteCommandList(
+    reshade::api::command_queue* queue,
+    reshade::api::command_list* cmd_list) {
+  if (snapshot_device == nullptr) return;
+
+  auto* device = cmd_list->get_device();
+  if (device != snapshot_device) return;
+
+  auto* device_data = renodx::utils::data::Get<DeviceData>(device);
+  if (device_data == nullptr) return;
+
+  const uint32_t order = snapshot_submission_counter.fetch_add(1u, std::memory_order_relaxed) + 1u;
+  const uint64_t cmd_handle = reinterpret_cast<uint64_t>(cmd_list);
+
+  std::unique_lock lock(device_data->mutex);
+  const auto index_pair = device_data->draw_detail_indexes_by_cmd_list.find(cmd_handle);
+  if (index_pair == device_data->draw_detail_indexes_by_cmd_list.end()) return;
+
+  for (const auto draw_index : index_pair->second) {
+    if (draw_index >= device_data->draw_details_list.size()) continue;
+    auto& draw = device_data->draw_details_list[draw_index];
+    if (draw.submission_order == 0u) {
+      draw.submission_order = order;
+    }
+  }
+  device_data->draw_detail_indexes_by_cmd_list.erase(index_pair);
+}
+
 void OnPresent(
     reshade::api::command_queue* queue,
     reshade::api::swapchain* swapchain,
@@ -8745,10 +8804,12 @@ void OnPresent(
       auto* device_data = get_data();
       std::unique_lock lock(device_data->mutex);
       device_data->draw_details_list.clear();
+      device_data->draw_detail_indexes_by_cmd_list.clear();
       device_data->resource_usage_by_handle.clear();
       device_data->snapshot_rows.clear();
       device_data->snapshot_row_layout_key = 0u;
       device_data->snapshot_rows_valid = false;
+      snapshot_submission_counter.store(0u, std::memory_order_relaxed);
       snapshot_device = device;
       snapshot_queued_device = nullptr;
     }
@@ -8757,9 +8818,12 @@ void OnPresent(
     auto* device_data = get_data();
     std::unique_lock lock(device_data->mutex);
     std::ranges::sort(device_data->draw_details_list, [](const DrawDetails& a, const DrawDetails& b) {
+      if (a.submission_order != b.submission_order) return a.submission_order < b.submission_order;
+      if (a.cmd_list_handle == b.cmd_list_handle) return a.cmd_list_draw_index < b.cmd_list_draw_index;
       return a.timestamp < b.timestamp;
     });
 
+    device_data->draw_detail_indexes_by_cmd_list.clear();
     device_data->shader_draw_indexes.clear();
     device_data->resource_usage_by_handle.clear();
     for (auto i = 0; i < device_data->draw_details_list.size(); ++i) {
@@ -8851,6 +8915,7 @@ BOOL APIENTRY DllMain(HMODULE h_module, DWORD fdw_reason, LPVOID lpv_reserved) {
       reshade::register_event<reshade::addon_event::draw_or_dispatch_indirect>(OnDrawOrDispatchIndirect);
       reshade::register_event<reshade::addon_event::dispatch>(OnDispatch);
       reshade::register_event<reshade::addon_event::present>(OnPresent);
+      reshade::register_event<reshade::addon_event::execute_command_list>(OnExecuteCommandList);
       reshade::register_event<reshade::addon_event::create_swapchain>(OnCreateSwapchain);
       reshade::register_event<reshade::addon_event::init_swapchain>(OnInitSwapchain);
       reshade::register_event<reshade::addon_event::destroy_swapchain>(OnDestroySwapchain);
@@ -8889,6 +8954,7 @@ BOOL APIENTRY DllMain(HMODULE h_module, DWORD fdw_reason, LPVOID lpv_reserved) {
       reshade::unregister_event<reshade::addon_event::destroy_resource>(OnDestroyResource);
       reshade::unregister_event<reshade::addon_event::create_swapchain>(OnCreateSwapchain);
       reshade::unregister_event<reshade::addon_event::dispatch>(OnDispatch);
+      reshade::unregister_event<reshade::addon_event::execute_command_list>(OnExecuteCommandList);
       reshade::unregister_event<reshade::addon_event::init_swapchain>(OnInitSwapchain);
       reshade::unregister_event<reshade::addon_event::destroy_swapchain>(OnDestroySwapchain);
       reshade::unregister_event<reshade::addon_event::push_descriptors>(OnPushDescriptors);

--- a/src/addons/devkit/addon.cpp
+++ b/src/addons/devkit/addon.cpp
@@ -133,6 +133,12 @@ std::atomic_bool shaders_pane_show_pixel_shaders = true;
 std::atomic_bool shaders_pane_show_compute_shaders = true;
 
 uint32_t skip_draw_count = 0;
+
+[[nodiscard]] bool SupportsSnapshotSubmissionOrder(reshade::api::device_api api) {
+  return api == reshade::api::device_api::d3d12
+         || api == reshade::api::device_api::vulkan;
+}
+
 void QueueSnapshotCapture(reshade::api::device* device) {
   snapshot_queued_device = device;
   if (snapshot_trace_with_snapshot.load()) {
@@ -4132,14 +4138,26 @@ void OnInitCommandList(reshade::api::command_list* cmd_list) {
 }
 
 void OnDestroyCommandList(reshade::api::command_list* cmd_list) {
+  auto* device = cmd_list->get_device();
+  if (SupportsSnapshotSubmissionOrder(device->get_api())) {
+    if (auto* device_data = renodx::utils::data::Get<DeviceData>(device);
+        device_data != nullptr) {
+      const std::unique_lock lock(device_data->mutex);
+      device_data->draw_detail_indexes_by_cmd_list.erase(reinterpret_cast<uint64_t>(cmd_list));
+    }
+  }
+
   renodx::utils::data::Delete<CommandListData>(cmd_list);
 }
 
 void OnResetCommandList(reshade::api::command_list* cmd_list) {
-  if (auto* device_data = renodx::utils::data::Get<DeviceData>(cmd_list->get_device());
-      device_data != nullptr) {
-    const std::unique_lock lock(device_data->mutex);
-    device_data->draw_detail_indexes_by_cmd_list.erase(reinterpret_cast<uint64_t>(cmd_list));
+  auto* device = cmd_list->get_device();
+  if (SupportsSnapshotSubmissionOrder(device->get_api())) {
+    if (auto* device_data = renodx::utils::data::Get<DeviceData>(device);
+        device_data != nullptr) {
+      const std::unique_lock lock(device_data->mutex);
+      device_data->draw_detail_indexes_by_cmd_list.erase(reinterpret_cast<uint64_t>(cmd_list));
+    }
   }
 
   auto* data = renodx::utils::data::Get<CommandListData>(cmd_list);
@@ -4329,7 +4347,7 @@ bool OnCopyResource(
     }
     const auto draw_index = device_data->draw_details_list.size();
     device_data->draw_details_list.push_back(std::move(draw_details));
-    if (device_data->draw_details_list.back().cmd_list_handle != 0u) {
+    if (SupportsSnapshotSubmissionOrder(device->get_api()) && device_data->draw_details_list.back().cmd_list_handle != 0u) {
       device_data->draw_detail_indexes_by_cmd_list[device_data->draw_details_list.back().cmd_list_handle].push_back(draw_index);
     }
     device_data->snapshot_rows_valid = false;
@@ -4375,7 +4393,7 @@ bool OnCopyTextureRegion(
     }
     const auto draw_index = device_data->draw_details_list.size();
     device_data->draw_details_list.push_back(std::move(draw_details));
-    if (device_data->draw_details_list.back().cmd_list_handle != 0u) {
+    if (SupportsSnapshotSubmissionOrder(device->get_api()) && device_data->draw_details_list.back().cmd_list_handle != 0u) {
       device_data->draw_detail_indexes_by_cmd_list[device_data->draw_details_list.back().cmd_list_handle].push_back(draw_index);
     }
     device_data->snapshot_rows_valid = false;
@@ -4947,7 +4965,7 @@ bool OnDraw(reshade::api::command_list* cmd_list, DrawDetails::DrawMethods draw_
     const auto draw_index = device_data->draw_details_list.size();
     const auto cmd_list_handle = draw_details.cmd_list_handle;
     device_data->draw_details_list.push_back(std::move(draw_details));
-    if (cmd_list_handle != 0u) {
+    if (SupportsSnapshotSubmissionOrder(device->get_api()) && cmd_list_handle != 0u) {
       device_data->draw_detail_indexes_by_cmd_list[cmd_list_handle].push_back(draw_index);
     }
     device_data->snapshot_rows_valid = false;
@@ -5218,7 +5236,7 @@ void RenderCapturePane(reshade::api::device* device, DeviceData* data) {
         | (snapshot_pane_show_compute_shaders ? 1u << 2u : 0u)
         | (snapshot_pane_filter_resources_by_shader_use ? 1u << 3u : 0u)
         | (snapshot_pane_expand_all_nodes ? 1u << 4u : 0u)
-        | (snapshot_pane_show_non_executed_command_lists ? 1u << 5u : 0u);
+    | (snapshot_pane_show_non_executed_command_lists ? 1u << 5u : 0u);
 
     const auto focus_pending_draw = [&](int draw_index) {
       if (draw_index == pending_draw_index_focus) {
@@ -6350,7 +6368,11 @@ void RenderCapturePane(reshade::api::device* device, DeviceData* data) {
 
       for (int draw_index = 0; draw_index < static_cast<int>(data->draw_details_list.size()); ++draw_index) {
         const auto& draw_details = data->draw_details_list[static_cast<size_t>(draw_index)];
-        if (!snapshot_pane_show_non_executed_command_lists && draw_details.HasUnknownSubmissionOrder()) continue;
+        if (SupportsSnapshotSubmissionOrder(device->get_api())
+            && !snapshot_pane_show_non_executed_command_lists
+            && draw_details.HasUnknownSubmissionOrder()) {
+          continue;
+        }
         const bool draw_node_open = get_tree_node_open_state(draw_index, snapshot_pane_expand_all_nodes);
         const int draw_row_index = append_row({
             .kind = SnapshotRow::Kind::DRAW,
@@ -8691,6 +8713,7 @@ void OnExecuteCommandList(
 
   auto* device = cmd_list->get_device();
   if (device != snapshot_device) return;
+  if (!SupportsSnapshotSubmissionOrder(device->get_api())) return;
 
   auto* device_data = renodx::utils::data::Get<DeviceData>(device);
   if (device_data == nullptr) return;

--- a/src/addons/devkit/addon.cpp
+++ b/src/addons/devkit/addon.cpp
@@ -127,6 +127,7 @@ std::atomic_bool snapshot_pane_show_compute_shaders = true;
 std::atomic_bool snapshot_pane_show_blends = true;
 std::atomic_bool snapshot_pane_expand_all_nodes = true;
 std::atomic_bool snapshot_pane_filter_resources_by_shader_use = true;
+std::atomic_bool snapshot_pane_show_non_executed_command_lists = false;
 std::atomic_bool shaders_pane_show_vertex_shaders = false;
 std::atomic_bool shaders_pane_show_pixel_shaders = true;
 std::atomic_bool shaders_pane_show_compute_shaders = true;
@@ -254,6 +255,10 @@ struct DrawDetails {
   [[nodiscard]] bool IsDispatch() const {
     return draw_method == DrawMethods::DISPATCH;
   };
+
+  [[nodiscard]] bool HasUnknownSubmissionOrder() const {
+    return submission_order == 0u;
+  }
 
   [[nodiscard]] std::string DrawMethodString() const {
     switch (draw_method) {
@@ -5206,7 +5211,8 @@ void RenderCapturePane(reshade::api::device* device, DeviceData* data) {
         | (snapshot_pane_show_pixel_shaders ? 1u << 1u : 0u)
         | (snapshot_pane_show_compute_shaders ? 1u << 2u : 0u)
         | (snapshot_pane_filter_resources_by_shader_use ? 1u << 3u : 0u)
-        | (snapshot_pane_expand_all_nodes ? 1u << 4u : 0u);
+        | (snapshot_pane_expand_all_nodes ? 1u << 4u : 0u)
+        | (snapshot_pane_show_non_executed_command_lists ? 1u << 5u : 0u);
 
     const auto focus_pending_draw = [&](int draw_index) {
       if (draw_index == pending_draw_index_focus) {
@@ -6338,6 +6344,7 @@ void RenderCapturePane(reshade::api::device* device, DeviceData* data) {
 
       for (int draw_index = 0; draw_index < static_cast<int>(data->draw_details_list.size()); ++draw_index) {
         const auto& draw_details = data->draw_details_list[static_cast<size_t>(draw_index)];
+        if (!snapshot_pane_show_non_executed_command_lists && draw_details.HasUnknownSubmissionOrder()) continue;
         const bool draw_node_open = get_tree_node_open_state(draw_index, snapshot_pane_expand_all_nodes);
         const int draw_row_index = append_row({
             .kind = SnapshotRow::Kind::DRAW,
@@ -7359,6 +7366,7 @@ struct SettingsDeviceOption {
     DrawSettingBoolCheckbox("Show Vertex Shaders", "SnapshotPaneShowVertexShaders", &snapshot_pane_show_vertex_shaders);
     DrawSettingBoolCheckbox("Show Pixel Shaders", "SnapshotPaneShowPixelShaders", &snapshot_pane_show_pixel_shaders);
     DrawSettingBoolCheckbox("Show Compute Shaders", "SnapshotPaneShowComputeShaders", &snapshot_pane_show_compute_shaders);
+    DrawSettingBoolCheckbox("Show Non-Executed Command Lists", "SnapshotPaneShowNonExecutedCommandLists", &snapshot_pane_show_non_executed_command_lists);
     DrawSettingBoolCheckbox("Expand All Nodes", "SnapshotPaneExpandAllNodes", &snapshot_pane_expand_all_nodes);
     DrawSettingBoolCheckbox("Filter Resources by Shader Use", "SnapshotPaneFilterResourcesByShaderUse", &snapshot_pane_filter_resources_by_shader_use);
     DrawSettingBoolCheckbox("Show Blends", "SnapshotPaneShowBlends", &snapshot_pane_show_blends);
@@ -8410,6 +8418,7 @@ void InitializeUserSettings() {
            {"SnapshotPaneShowBlends", &snapshot_pane_show_blends},
            {"SnapshotPaneExpandAllNodes", &snapshot_pane_expand_all_nodes},
            {"SnapshotPaneFilterResourcesByShaderUse", &snapshot_pane_filter_resources_by_shader_use},
+           {"SnapshotPaneShowNonExecutedCommandLists", &snapshot_pane_show_non_executed_command_lists},
            {"ShadersPaneShowVertexShaders", &shaders_pane_show_vertex_shaders},
            {"ShadersPaneShowPixelShaders", &shaders_pane_show_pixel_shaders},
            {"ShadersPaneShowComputeShaders", &shaders_pane_show_compute_shaders},
@@ -8818,7 +8827,10 @@ void OnPresent(
     auto* device_data = get_data();
     std::unique_lock lock(device_data->mutex);
     std::ranges::sort(device_data->draw_details_list, [](const DrawDetails& a, const DrawDetails& b) {
-      if (a.submission_order != b.submission_order) return a.submission_order < b.submission_order;
+      const bool a_unknown_submission = a.submission_order == 0u;
+      const bool b_unknown_submission = b.submission_order == 0u;
+      if (a_unknown_submission != b_unknown_submission) return !a_unknown_submission;
+      if (!a_unknown_submission && a.submission_order != b.submission_order) return a.submission_order < b.submission_order;
       if (a.cmd_list_handle == b.cmd_list_handle) return a.cmd_list_draw_index < b.cmd_list_draw_index;
       return a.timestamp < b.timestamp;
     });

--- a/src/addons/devkit/addon.cpp
+++ b/src/addons/devkit/addon.cpp
@@ -4136,6 +4136,12 @@ void OnDestroyCommandList(reshade::api::command_list* cmd_list) {
 }
 
 void OnResetCommandList(reshade::api::command_list* cmd_list) {
+  if (auto* device_data = renodx::utils::data::Get<DeviceData>(cmd_list->get_device());
+      device_data != nullptr) {
+    const std::unique_lock lock(device_data->mutex);
+    device_data->draw_detail_indexes_by_cmd_list.erase(reinterpret_cast<uint64_t>(cmd_list));
+  }
+
   auto* data = renodx::utils::data::Get<CommandListData>(cmd_list);
   if (data == nullptr) return;
   renodx::utils::data::Delete<CommandListData>(cmd_list);

--- a/src/utils/shader_compiler_watcher.hpp
+++ b/src/utils/shader_compiler_watcher.hpp
@@ -265,7 +265,6 @@ static bool CompileCustomShaders() {
     }
 
     std::vector<std::filesystem::path> shader_file_paths;
-    const auto normalized_directory = NormalizePathForComparison(directory);
     for (auto iterator = std::filesystem::recursive_directory_iterator(
              directory,
              std::filesystem::directory_options::skip_permission_denied);

--- a/src/utils/shader_compiler_watcher.hpp
+++ b/src/utils/shader_compiler_watcher.hpp
@@ -265,9 +265,20 @@ static bool CompileCustomShaders() {
     }
 
     std::vector<std::filesystem::path> shader_file_paths;
-    for (const auto& entry : std::filesystem::recursive_directory_iterator(
+    const auto normalized_directory = NormalizePathForComparison(directory);
+    for (auto iterator = std::filesystem::recursive_directory_iterator(
              directory,
-             std::filesystem::directory_options::skip_permission_denied)) {
+             std::filesystem::directory_options::skip_permission_denied);
+         iterator != std::filesystem::recursive_directory_iterator();
+         ++iterator) {
+      const auto& entry = *iterator;
+      if (entry.is_directory()) {
+        const auto folder_name = entry.path().filename().string();
+        if (!folder_name.empty() && folder_name.front() == '.') {
+          iterator.disable_recursion_pending();
+          continue;
+        }
+      }
       if (!entry.is_regular_file()) continue;
 
       const auto entry_path = NormalizePathForComparison(entry.path());


### PR DESCRIPTION
This change fixes the out of order drawing list in DX12/Vulkan.

Edit: Added a commit to skip live folders prepended with dots to match cmake's behavior

Edit 2: Added a boolean to show non executed command lists (disabled by default)