### PR TITLE
feat(okami): add Okami HD HDR addon

### DIFF
--- a/src/games/okami/addon.cpp
+++ b/src/games/okami/addon.cpp
@@ -1,0 +1,249 @@
+/*
+ * Copyright (C) 2026 megazeban
+ * SPDX-License-Identifier: MIT
+ */
+
+#define ImTextureID ImU64
+
+#define DEBUG_LEVEL_0
+
+#include <deps/imgui/imgui.h>
+#include <embed/shaders.h>
+#include <include/reshade.hpp>
+
+#include "../../mods/shader.hpp"
+#include "../../mods/swapchain.hpp"
+#include "../../utils/settings.hpp"
+#include "./shared.h"
+
+namespace {
+
+renodx::mods::shader::CustomShaders custom_shaders = {
+    // Only the final swapchain blit is replaced. ALL HDR conversion (RenoDRT /
+    // ACES tone map, grade, scRGB encode) happens there, on the final composited
+    // FP16 frame - the one place every pixel exists and where the real bloom /
+    // emissive over-range survives. The game's tone-curve / exposure / bloom
+    // passes run vanilla on the FP16-upgraded targets.
+    CustomSwapchainShader(0x03CF7614),
+};
+
+ShaderInjectData shader_injection;
+
+renodx::utils::settings::Settings settings = {
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapType",
+        .binding = &RENODX_TONE_MAP_TYPE,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 3.f,
+        .can_reset = false,
+        .label = "Tone Mapper",
+        .section = "Tone Mapping",
+        .tooltip = "Vanilla preserves the game's exact SDR look, lifted into the HDR container."
+                   "\nACES / RenoDRT re-tone-map the real scene for true HDR highlight rolloff (RenoDRT recommended).",
+        .labels = {"Vanilla", "None", "ACES", "RenoDRT"},
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapPeakNits",
+        .binding = &RENODX_PEAK_WHITE_NITS,
+        .default_value = 1000.f,
+        .can_reset = false,
+        .label = "Peak Brightness",
+        .section = "Tone Mapping",
+        .tooltip = "Sets the value of peak white in nits",
+        .min = 48.f,
+        .max = 4000.f,
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapGameNits",
+        .binding = &RENODX_DIFFUSE_WHITE_NITS,
+        .default_value = 203.f,
+        .label = "Game Brightness",
+        .section = "Tone Mapping",
+        .tooltip = "Sets the value of 100% white in nits",
+        .min = 48.f,
+        .max = 500.f,
+    },
+    new renodx::utils::settings::Setting{
+        .key = "GammaCorrection",
+        .binding = &RENODX_GAMMA_CORRECTION,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 1.f,
+        .label = "Gamma Correction",
+        .section = "Tone Mapping",
+        .tooltip = "Emulates a display EOTF. 2.2 is the standard sRGB-display gamma.",
+        .labels = {"Off", "2.2", "BT.1886"},
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeExposure",
+        .binding = &RENODX_TONE_MAP_EXPOSURE,
+        .default_value = 1.f,
+        .label = "Exposure",
+        .section = "Color Grading",
+        .tooltip = "Adjusts the overall brightness of the image (multiplier).",
+        .max = 2.f,
+        .format = "%.2f",
+        .is_enabled = []() { return RENODX_TONE_MAP_TYPE >= 1; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeHighlights",
+        .binding = &RENODX_TONE_MAP_HIGHLIGHTS,
+        .default_value = 50.f,
+        .label = "Highlights",
+        .section = "Color Grading",
+        .tooltip = "Raises or lowers the brightest parts of the image.",
+        .max = 100.f,
+        .is_enabled = []() { return RENODX_TONE_MAP_TYPE >= 1; },
+        .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeShadows",
+        .binding = &RENODX_TONE_MAP_SHADOWS,
+        .default_value = 50.f,
+        .label = "Shadows",
+        .section = "Color Grading",
+        .tooltip = "Lifts or crushes the darkest parts of the image.",
+        .max = 100.f,
+        .is_enabled = []() { return RENODX_TONE_MAP_TYPE >= 1; },
+        .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeContrast",
+        .binding = &RENODX_TONE_MAP_CONTRAST,
+        .default_value = 50.f,
+        .label = "Contrast",
+        .section = "Color Grading",
+        .tooltip = "Increases or decreases the difference between dark and light tones.",
+        .max = 100.f,
+        .is_enabled = []() { return RENODX_TONE_MAP_TYPE >= 1; },
+        .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeSaturation",
+        .binding = &RENODX_TONE_MAP_SATURATION,
+        .default_value = 50.f,
+        .label = "Saturation",
+        .section = "Color Grading",
+        .tooltip = "Increases or decreases the intensity of colors.",
+        .max = 100.f,
+        .is_enabled = []() { return RENODX_TONE_MAP_TYPE >= 1; },
+        .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeHighlightSaturation",
+        .binding = &RENODX_TONE_MAP_HIGHLIGHT_SATURATION,
+        .default_value = 50.f,
+        .label = "Highlight Saturation",
+        .section = "Color Grading",
+        .tooltip = "Adds or removes color in the highlights.",
+        .max = 100.f,
+        .is_enabled = []() { return RENODX_TONE_MAP_TYPE >= 1; },
+        .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeBlowout",
+        .binding = &RENODX_TONE_MAP_BLOWOUT,
+        .default_value = 0.f,
+        .label = "Blowout",
+        .section = "Color Grading",
+        .tooltip = "Controls highlight desaturation due to overexposure.",
+        .max = 100.f,
+        .is_enabled = []() { return RENODX_TONE_MAP_TYPE >= 1; },
+        .parse = [](float value) { return value * 0.01f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeFlare",
+        .binding = &RENODX_TONE_MAP_FLARE,
+        .default_value = 0.f,
+        .label = "Flare",
+        .section = "Color Grading",
+        .tooltip = "Deepens near-black tones to counteract veiling glare / a raised black floor (great on OLED).",
+        .max = 100.f,
+        .is_enabled = []() { return RENODX_TONE_MAP_TYPE == 3.f; },
+        .parse = [](float value) { return value * 0.01f; },
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::BUTTON,
+        .label = "Discord",
+        .section = "Links",
+        .group = "button-line-1",
+        .tint = 0x5865F2,
+        .on_change = []() {
+          renodx::utils::platform::LaunchURL("https://discord.gg/F6AUTeWJHM");
+        },
+    },
+    new renodx::utils::settings::Setting{
+        .value_type = renodx::utils::settings::SettingValueType::BUTTON,
+        .label = "Github",
+        .section = "Links",
+        .group = "button-line-1",
+        .on_change = []() {
+          renodx::utils::platform::LaunchURL("https://github.com/clshortfuse/renodx");
+        },
+    },
+};
+
+void OnPresetOff() {
+  renodx::utils::settings::UpdateSetting("ToneMapType", 0.f);
+  renodx::utils::settings::UpdateSetting("ToneMapPeakNits", 203.f);
+  renodx::utils::settings::UpdateSetting("ToneMapGameNits", 203.f);
+  renodx::utils::settings::UpdateSetting("GammaCorrection", 0.f);
+  renodx::utils::settings::UpdateSetting("ColorGradeExposure", 1.f);
+  renodx::utils::settings::UpdateSetting("ColorGradeHighlights", 50.f);
+  renodx::utils::settings::UpdateSetting("ColorGradeShadows", 50.f);
+  renodx::utils::settings::UpdateSetting("ColorGradeContrast", 50.f);
+  renodx::utils::settings::UpdateSetting("ColorGradeSaturation", 50.f);
+  renodx::utils::settings::UpdateSetting("ColorGradeHighlightSaturation", 50.f);
+  renodx::utils::settings::UpdateSetting("ColorGradeBlowout", 0.f);
+  renodx::utils::settings::UpdateSetting("ColorGradeFlare", 0.f);
+}
+
+bool fired_on_init_swapchain = false;
+
+void OnInitSwapchain(reshade::api::swapchain* swapchain, bool resize) {
+  if (fired_on_init_swapchain) return;
+  fired_on_init_swapchain = true;
+  auto peak = renodx::utils::swapchain::GetPeakNits(swapchain);
+  if (peak.has_value()) {
+    settings[1]->default_value = peak.value();  // ToneMapPeakNits
+    settings[1]->can_reset = true;
+  }
+}
+
+}  // namespace
+
+extern "C" __declspec(dllexport) constexpr const char* NAME = "RenoDX";
+extern "C" __declspec(dllexport) constexpr const char* DESCRIPTION = "RenoDX for Okami HD";
+
+BOOL APIENTRY DllMain(HMODULE h_module, DWORD fdw_reason, LPVOID lpv_reserved) {
+  switch (fdw_reason) {
+    case DLL_PROCESS_ATTACH:
+      if (!reshade::register_addon(h_module)) return FALSE;
+
+      renodx::mods::swapchain::use_resource_cloning = true;
+
+      // Upgrade the game's B8G8R8A8 render targets to FP16 so the composited
+      // frame carries real HDR over-range (additive bloom / emissive above 1.0)
+      // to the blit. Filtered to render targets so asset textures (skins,
+      // environment art) aren't promoted.
+      renodx::mods::swapchain::resource_upgrade_infos.push_back({
+          .old_format = reshade::api::format::b8g8r8a8_unorm,
+          .new_format = reshade::api::format::r16g16b16a16_float,
+          .ignore_size = true,
+          .usage_include = reshade::api::resource_usage::render_target,
+      });
+
+      reshade::register_event<reshade::addon_event::init_swapchain>(OnInitSwapchain);
+
+      break;
+    case DLL_PROCESS_DETACH:
+      reshade::unregister_event<reshade::addon_event::init_swapchain>(OnInitSwapchain);
+      reshade::unregister_addon(h_module);
+      break;
+  }
+
+  renodx::utils::settings::Use(fdw_reason, &settings, &OnPresetOff);
+  renodx::mods::shader::Use(fdw_reason, custom_shaders, &shader_injection);
+  renodx::mods::swapchain::Use(fdw_reason, &shader_injection);
+
+  return TRUE;
+}

--- a/src/games/okami/blit_0x03CF7614.ps_4_1.hlsl
+++ b/src/games/okami/blit_0x03CF7614.ps_4_1.hlsl
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2026 megazeban
+ * SPDX-License-Identifier: MIT
+ *
+ * Okami HD - final upscale blit to the swapchain (hash 0x03CF7614)
+ *
+ * ALL HDR conversion happens here, on the FINAL composited frame, because that
+ * is the only place the whole image exists.
+ *
+ * DevKit-confirmed pipeline: Okami HD is a hard-clip-SDR game. The final image is
+ * assembled directly in display-referred SDR across hundreds of draws - scene
+ * geometry, the HUD alpha-blended straight in, then bloom. There is NO master
+ * tone-map pass, NO HDR scene buffer, and NO whole-image LUT.
+ *
+ * IMPORTANT - why the 3-arg ToneMapPass with a saturate() base (not the 1-arg
+ * form the hard-clip reference src/games/hollowknight-silksong uses): that
+ * reference reads a CLEAN SDR render. Okami's composite is the FP16-UPGRADED
+ * buffer, so the game's additive / blend ops no longer clamp - it carries
+ * sub-zero and out-of-gamut values (most visibly tiny negative blend noise across
+ * the dark sky) that 8-bit unorm would have clamped to [0,1]. Feeding that
+ * straight into the 1-arg ToneMapPass(DecodeSafe(composite)) sent ~70% of the
+ * frame negative / invalid (measured). So we reconstruct off a gamut-safe base:
+ *   untonemapped = DecodeSafe(composite)            // real FP16 over-range (and dirt)
+ *   neutral/graded = DecodeSafe(saturate(composite)) // clamped, gamut-safe SDR
+ *   ToneMapPass(untonemapped, graded, neutral)       // luminance reconstruction:
+ *     SDR preserved off the clean base, real over-range lifted by the luminance
+ *     ratio and hue-matched to the clean base -> stays in BT.709 (0% invalid).
+ * The genuine HDR is still only the additive bloom / emissive over-range; nothing
+ * is guessed (not ITM). Grade / brightness / gamma are all global.
+ *
+ * Registered as a CustomSwapchainShader, so the conversion only runs on the draw
+ * whose render target is the swapchain backbuffer. The bloom-downscale and
+ * history-copy draws that share this hash keep the vanilla blit.
+ *
+ * NOTE: the composite is treated as sRGB-encoded (DecodeSafe below) - validated
+ * clean in-game. If exposure ever looks off, try a gamma-2.2 decode instead.
+ */
+
+#include "./shared.h"
+
+SamplerState gLinearSampler : register(s0);
+Texture2D<float4> gBaseTexture : register(t0);
+
+void main(
+    float4 v0 : SV_Position,
+    float4 v1 : TEXCOORD0,
+    out float4 o0 : SV_Target0) {
+  float3 composite = gBaseTexture.Sample(gLinearSampler, v1.xy).rgb;
+
+  // DevKit / live-shader passthrough guard: emit the raw blit when the injection
+  // buffer isn't bound (peak nits invalid) instead of garbage.
+  if (RENODX_PEAK_WHITE_NITS <= 0.f) {
+    o0 = float4(composite, 1.f);
+    return;
+  }
+
+  // Reconstruct HDR off a gamut-safe SDR base (see header). saturate() clamps the
+  // dirty FP16 composite to [0,1] BT.709; the over-range is recovered via the
+  // luminance ratio inside ToneMapPass.
+  float3 untonemapped = renodx::color::srgb::DecodeSafe(composite);
+  float3 neutral_sdr = renodx::color::srgb::DecodeSafe(saturate(composite));
+  float3 graded_sdr = neutral_sdr;
+
+  float3 color = renodx::draw::ToneMapPass(untonemapped, graded_sdr, neutral_sdr);
+  color = renodx::draw::RenderIntermediatePass(color);  // encode intermediate
+  color = renodx::draw::SwapChainPass(color);           // decode + scRGB
+  o0 = float4(color, 1.f);
+}

--- a/src/games/okami/metadata.json
+++ b/src/games/okami/metadata.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://cdn.jsdelivr.net/gh/clshortfuse/renodx/renodx-metadata-schema.json",
+  "id": "okami",
+  "title": "Okami HD",
+  "maintainers": [
+    "megazeban"
+  ],
+  "status": "beta",
+  "deploy": {
+    "steam_appid": 587620,
+    "game_exe": "okami.exe",
+    "process_name": "okami",
+    "api": "d3d11",
+    "architecture": "x64"
+  }
+}

--- a/src/games/okami/shared.h
+++ b/src/games/okami/shared.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2026 megazeban
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef SRC_OKAMI_SHARED_H_
+#define SRC_OKAMI_SHARED_H_
+
+// Drive the shared renodx::draw HDR config from runtime-injected settings. Only
+// the fields exposed in the UI are mapped here; everything else in
+// renodx::draw::BuildConfig() falls back to its compile-time default (scRGB
+// swap-chain encode, BT.709 working space, etc.), except where overridden below.
+#define RENODX_PEAK_WHITE_NITS               shader_injection.peak_white_nits
+#define RENODX_DIFFUSE_WHITE_NITS            shader_injection.diffuse_white_nits
+// UI/graphics white is tied to game white: all HDR conversion runs on the final
+// composite (including the baked-in HUD), so there is no separately-composited UI
+// layer to scale, and a single global brightness is what the game wants.
+#define RENODX_GRAPHICS_WHITE_NITS           shader_injection.diffuse_white_nits
+#define RENODX_TONE_MAP_TYPE                 shader_injection.tone_map_type
+#define RENODX_TONE_MAP_EXPOSURE             shader_injection.tone_map_exposure
+#define RENODX_TONE_MAP_HIGHLIGHTS           shader_injection.tone_map_highlights
+#define RENODX_TONE_MAP_SHADOWS              shader_injection.tone_map_shadows
+#define RENODX_TONE_MAP_CONTRAST             shader_injection.tone_map_contrast
+#define RENODX_TONE_MAP_SATURATION           shader_injection.tone_map_saturation
+#define RENODX_TONE_MAP_HIGHLIGHT_SATURATION shader_injection.tone_map_highlight_saturation
+#define RENODX_TONE_MAP_BLOWOUT              shader_injection.tone_map_blowout
+#define RENODX_TONE_MAP_FLARE                shader_injection.tone_map_flare
+#define RENODX_GAMMA_CORRECTION              shader_injection.gamma_correction
+// RenoDRT tone-map curve. The renodx::draw default is Daniele, but the
+// handle-sdr-tonemap-lut skill prefers the current methods (Neutwo / Reinhard)
+// and says not to use Daniele/Hermite as new choices. Fixed, not exposed - one
+// curve is plenty for Okami's sparse, near-white over-range.
+#define RENODX_RENO_DRT_TONE_MAP_METHOD      renodx::tonemap::renodrt::config::tone_map_method::NEUTWO
+// Hue correction (strength + processor), working color space, and per-channel
+// scaling are NOT exposed: Okami's HDR over-range is near-white, so there is no
+// bright saturated content for them to act on differently. They fall back to
+// renodx::draw::BuildConfig() defaults (hue correction on / OKLab, BT709,
+// luminance scaling).
+
+struct ShaderInjectData {
+  float peak_white_nits;
+  float diffuse_white_nits;
+  float tone_map_type;
+  float tone_map_exposure;
+  float tone_map_highlights;
+  float tone_map_shadows;
+  float tone_map_contrast;
+  float tone_map_saturation;
+  float tone_map_highlight_saturation;
+  float tone_map_blowout;
+  float tone_map_flare;
+  float gamma_correction;
+};
+
+#ifndef __cplusplus
+cbuffer cb13 : register(b13) {
+  ShaderInjectData shader_injection : packoffset(c0);
+}
+
+#include "../../shaders/renodx.hlsl"
+#endif
+
+#endif  // SRC_OKAMI_SHARED_H_


### PR DESCRIPTION
## Okami HD — Native HDR addon

Adds a RenoDX HDR addon for **Okami HD** (Steam 587620, D3D11).

### Approach
Okami HD is a hard-clip-SDR game — DevKit-confirmed: the final image is assembled directly in SDR across ~190 draws, with no master tone-map pass, no HDR scene buffer, and no whole-image LUT (its 256×1 1D LUT only feeds the half-res bloom bright-pass).

- Render targets are upgraded to FP16 (scRGB) so the game's own additive bloom/emissive survives above 1.0 instead of clamping.
- The final upscale blit (`0x03CF7614`) is replaced via `CustomSwapchainShader` and does all HDR conversion on the final composited frame.
- HDR is **recovered** from that real over-range and tone-mapped with RenoDRT (Neutwo) / ACES off a gamut-safe `saturate()` SDR base — no inverse tonemapping. The game's tone-curve / exposure / bloom passes run unmodified on the FP16 targets.

### Settings
Tone Mapper (Vanilla / None / ACES / RenoDRT), Peak / Game brightness, Gamma (Off / 2.2 / BT.1886), and color grading (exposure, highlights, shadows, contrast, saturation, highlight saturation, blowout, flare).

### Validation
Lilium HDR Analysis across multiple night scenes: 0% invalid, ~98% BT.709, real recovered highlights (torches/portal ~900–1000 nits) while dark scenes stay dark (avg ~15 nits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)