### PR TITLE
Fix/exp33 unreal hdr UI composite

### DIFF
--- a/src/games/clairobscur_expedition33/composite.hlsl
+++ b/src/games/clairobscur_expedition33/composite.hlsl
@@ -36,8 +36,8 @@ renodx::draw::Config GetSwapchainConfig(bool is_pq = true) {
 
 bool HandleUICompositing(float4 ui_color_gamma, float4 scene_color_pq, inout float4 output_color, uint output_mode = 0u) {
   if (RENODX_TONE_MAP_TYPE == 0.f) return false;
-  // Unreal HDR: defer to UE native composite_hdr fallthrough (same as ToneMap Vanilla).
-  // Fixes status-icon dark boxes without rewriting UI blend math.
+  // Unreal HDR: defer to UE native composite_hdr fallthrough (same as ToneMap Vanilla)
+  // fixes dark boxes around combat status icons without rewriting UI blend math
   if (CUSTOM_UNREAL_HDR == 1.f) return false;
   float ui_alpha = ui_color_gamma.a;
 

--- a/src/games/clairobscur_expedition33/composite.hlsl
+++ b/src/games/clairobscur_expedition33/composite.hlsl
@@ -36,6 +36,9 @@ renodx::draw::Config GetSwapchainConfig(bool is_pq = true) {
 
 bool HandleUICompositing(float4 ui_color_gamma, float4 scene_color_pq, inout float4 output_color, uint output_mode = 0u) {
   if (RENODX_TONE_MAP_TYPE == 0.f) return false;
+  // Unreal HDR: defer to UE native composite_hdr fallthrough (same as ToneMap Vanilla).
+  // Fixes status-icon dark boxes without rewriting UI blend math.
+  if (CUSTOM_UNREAL_HDR == 1.f) return false;
   float ui_alpha = ui_color_gamma.a;
 
   float3 ui_color_linear;


### PR DESCRIPTION
## Summary
Fixes an issue where `HandleUICompositing` draws fugly, dark translucent boxes around the combat status icons. 
<img width="341" height="100" alt="image" src="https://github.com/user-attachments/assets/9a615637-1ff4-40fa-86c4-1e05c688eeb7" />
<img width="500" height="100" alt="image" src="https://github.com/user-attachments/assets/d7f53bba-5304-40b6-9576-d9d9b7e68efc" />


This happens specifically usung "Unreal HDR" path with any non-Vanilla tonemapper. `ToneMap == Vanilla` already early-outs to UE native `composite_hdr` safely. this change just mirrors that behavior when `CUSTOM_UNREAL_HDR == 1`. 


## Test plan
- [x] Tested on public `clairobscur_expedition33` rebuild
- [x] Unreal HDR + non-Vanilla ToneMap — combat status icon boxes are gone
