### PR TITLE
[mod:dishonored2] Add RenoDX support

### DIFF
--- a/src/games/dishonored2/0x11E16EF3.ps_5_0.hlsl
+++ b/src/games/dishonored2/0x11E16EF3.ps_5_0.hlsl
@@ -1,0 +1,216 @@
+/*
+ * Copyright (C) 2026 RenoDX contributors
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "./shared.h"
+
+struct AutoExposureData {
+  float engine_luminance_factor;
+  float luminance_factor;
+  float min_luminance_ldr;
+  float max_luminance_ldr;
+  float middle_grey_luminance_ldr;
+  float ev;
+  float f_stop;
+  uint peak_histogram_value;
+};
+
+cbuffer PerViewCB : register(b1) {
+  float4x4 view_matrix : packoffset(c6);
+  float4 subpixel_offset : packoffset(c10);
+  uint use_compressed_hdr_buffers : packoffset(c44.w);
+  float2 resolution_scale : packoffset(c48.z);
+};
+
+cbuffer PerInstanceCB : register(b2) {
+  float4 position_to_view_texture : packoffset(c0);
+  float4 tone_map_parameters : packoffset(c1);
+  float4 tone_map_coefficients_high : packoffset(c2);
+  float4 tone_map_coefficients_low : packoffset(c3);
+  float4 use_default_lens_dirt : packoffset(c4);
+  float2 gamma_brightness : packoffset(c5);
+  uint2 exposure_index : packoffset(c5.z);
+  uint black_and_white_mode : packoffset(c6);
+  float view_white_level : packoffset(c6.y);
+  float lens_flare_streak_width : packoffset(c6.w);
+  float lens_flare_streak_radius : packoffset(c7);
+  float lens_flare_streak_opacity : packoffset(c7.y);
+  float lens_flare_streak_offset : packoffset(c7.z);
+  float lens_dirt_strength : packoffset(c7.w);
+  float lens_dirt_blend_weight : packoffset(c8);
+  uint bloom_enabled : packoffset(c8.y);
+  float bloom_veil_strength : packoffset(c8.z);
+};
+
+SamplerState linear_clamp_sampler : register(s0);
+
+Texture2D<float4> lens_dirt_to_texture : register(t0);
+Texture2D<float4> lens_dirt_from_texture : register(t1);
+Texture2D<float4> lens_flare_texture : register(t2);
+Texture2D<float4> bloom_texture : register(t3);
+Texture2D<float4> scene_texture : register(t4);
+StructuredBuffer<AutoExposureData> auto_exposure_buffer : register(t5);
+
+static const float3 BT709_LUMINANCE = float3(0.2126f, 0.7152f, 0.0722f);
+
+float3 PreserveBlackAndWhite(float3 color) {
+  return black_and_white_mode != 0u ? dot(color, BT709_LUMINANCE).xxx : color;
+}
+
+float ComputeStreakMask(float2 texture_coordinate) {
+  float view_sine;
+  float view_cosine;
+  sincos(view_matrix._m02 + view_matrix._m21, view_sine, view_cosine);
+
+  const float2 centered_coordinate = texture_coordinate - 0.5f;
+  const float2 streak_coordinate = float2(
+      dot(float2(view_cosine, -0.5f * view_sine), centered_coordinate),
+      dot(float2(0.5f * view_sine, view_cosine), centered_coordinate));
+  const float radius_squared = dot(streak_coordinate, streak_coordinate);
+
+  const float2 absolute_coordinate = abs(streak_coordinate);
+  const float smaller_axis = min(absolute_coordinate.x, absolute_coordinate.y);
+  const float larger_axis = max(absolute_coordinate.x, absolute_coordinate.y);
+  const float axis_ratio = smaller_axis / larger_axis;
+  const float ratio_squared = axis_ratio * axis_ratio;
+
+  float atan_polynomial = mad(0.0208350997f, ratio_squared, -0.0851330012f);
+  atan_polynomial = mad(atan_polynomial, ratio_squared, 0.180141002f);
+  atan_polynomial = mad(atan_polynomial, ratio_squared, -0.330299497f);
+  atan_polynomial = mad(atan_polynomial, ratio_squared, 0.999866009f);
+
+  float polar_angle = axis_ratio * atan_polynomial;
+  if (absolute_coordinate.y < absolute_coordinate.x) {
+    polar_angle = 1.57079637f - polar_angle;
+  }
+  if (streak_coordinate.y < 0.f) {
+    polar_angle -= 3.141593f;
+  }
+  if (min(streak_coordinate.x, streak_coordinate.y) < 0.f
+      && max(streak_coordinate.x, streak_coordinate.y) >= 0.f) {
+    polar_angle = -polar_angle;
+  }
+  polar_angle += 3.14159274f;
+
+  const float noise_position = polar_angle * 651.898621f;
+  const float noise_cell = floor(noise_position);
+  const float noise_low = frac(sin(noise_cell) * 43758.5469f);
+  const float noise_high = frac(sin(noise_cell + 1.f) * 43758.5469f);
+  const float angular_noise = lerp(noise_low, noise_high, frac(noise_position));
+
+  const float streak_radius = mad(
+      angular_noise,
+      lens_flare_streak_offset,
+      lens_flare_streak_radius);
+  const float distance_from_streak = abs(radius_squared - streak_radius * streak_radius);
+  const float streak_edge = saturate(
+      (distance_from_streak - lens_flare_streak_width)
+      / -lens_flare_streak_width);
+  return streak_edge * streak_edge * (3.f - 2.f * streak_edge);
+}
+
+float3 ApplyVanillaToneCurve(float3 color) {
+  const bool3 use_low_curve = color < tone_map_parameters.xxx;
+
+  const float4 red_coefficients = use_low_curve.x
+                                      ? tone_map_coefficients_low
+                                      : tone_map_coefficients_high;
+  const float4 green_coefficients = use_low_curve.y
+                                        ? tone_map_coefficients_low
+                                        : tone_map_coefficients_high;
+  const float4 blue_coefficients = use_low_curve.z
+                                       ? tone_map_coefficients_low
+                                       : tone_map_coefficients_high;
+
+  float3 mapped;
+  mapped.r = mad(red_coefficients.x, color.r, red_coefficients.z)
+             / mad(red_coefficients.y, color.r, red_coefficients.w);
+  mapped.g = mad(green_coefficients.x, color.g, green_coefficients.z)
+             / mad(green_coefficients.y, color.g, green_coefficients.w);
+  mapped.b = mad(blue_coefficients.x, color.b, blue_coefficients.z)
+             / mad(blue_coefficients.y, color.b, blue_coefficients.w);
+
+  return mapped;
+}
+
+float3 ApplyGammaBrightness(float3 color) {
+  return exp2(
+      log2(saturate(color * gamma_brightness.y))
+      * gamma_brightness.x);
+}
+
+void main(
+    float4 interpolant : INTERP0,
+    float4 pixel_position : SV_POSITION0,
+    out float4 output_color : SV_TARGET0) {
+  const uint2 pixel_coordinate = (uint2)pixel_position.xy;
+  float3 scene_color = scene_texture.Load(int3(pixel_coordinate, 0)).rgb;
+
+  const float exposure = view_white_level
+                         * auto_exposure_buffer[exposure_index.y].engine_luminance_factor;
+  if (use_compressed_hdr_buffers != 0u) {
+    scene_color *= exposure;
+  }
+
+  if (bloom_enabled != 0u) {
+    const float2 bloom_coordinate = resolution_scale * interpolant.xy;
+    const float2 lens_dirt_coordinate = interpolant.xy + subpixel_offset.xy;
+
+    float3 lens_dirt;
+    if (use_default_lens_dirt.x > 0.f) {
+      lens_dirt = lens_dirt_from_texture.SampleLevel(linear_clamp_sampler, lens_dirt_coordinate, 0.f).rgb;
+    } else {
+      const float3 dirt_from = lens_dirt_from_texture.SampleLevel(linear_clamp_sampler, lens_dirt_coordinate, 0.f).rgb;
+      const float3 dirt_to = lens_dirt_to_texture.SampleLevel(linear_clamp_sampler, lens_dirt_coordinate, 0.f).rgb;
+      lens_dirt = lerp(dirt_from, dirt_to, lens_dirt_blend_weight);
+    }
+    lens_dirt = PreserveBlackAndWhite(lens_dirt);
+    lens_dirt *= DISHONORED2_LENS_DIRT_AMOUNT;
+
+    if (bloom_veil_strength > 0.f) {
+      float3 bloom = bloom_texture.SampleLevel(linear_clamp_sampler, bloom_coordinate, 0.f).rgb;
+      if (use_compressed_hdr_buffers != 0u) {
+        bloom *= exposure;
+      }
+      bloom *= bloom_veil_strength;
+      bloom = PreserveBlackAndWhite(bloom);
+      bloom *= 1.f + lens_dirt_strength * lens_dirt;
+      scene_color += bloom * DISHONORED2_BLOOM_INTENSITY;
+    }
+
+    lens_dirt += ComputeStreakMask(interpolant.xy) * lens_flare_streak_opacity;
+
+    const float2 inverse_resolution_scale = rcp(resolution_scale);
+    const float2 lens_flare_coordinate = saturate(
+        bloom_coordinate - position_to_view_texture.zw * inverse_resolution_scale);
+    float3 lens_flare = lens_flare_texture.SampleLevel(linear_clamp_sampler, lens_flare_coordinate, 0.f).rgb;
+    if (use_compressed_hdr_buffers != 0u) {
+      lens_flare *= exposure;
+    }
+    lens_flare *= mad(lens_dirt, 0.8f, 0.2f);
+    scene_color += PreserveBlackAndWhite(lens_flare);
+  }
+
+  const float3 untonemapped = max(scene_color, 0.f) * interpolant.z;
+  float3 neutral_sdr = ApplyVanillaToneCurve(untonemapped);
+  float3 graded_sdr = ApplyGammaBrightness(neutral_sdr);
+
+  if (shader_injection.override_black_clip != 0.f
+      && RENODX_TONE_MAP_TYPE != 0.f) {
+    const float3 neutral_black = ApplyVanillaToneCurve(0.f);
+    const float3 graded_black = ApplyGammaBrightness(neutral_black);
+    neutral_sdr = Dishonored2RemoveBlackFloor(neutral_sdr, neutral_black);
+    graded_sdr = Dishonored2RemoveBlackFloor(graded_sdr, graded_black);
+  }
+
+  float3 final_color = graded_sdr;
+  if (RENODX_TONE_MAP_TYPE != 0.f) {
+    final_color = renodx::draw::ToneMapPass(
+        untonemapped,
+        graded_sdr,
+        neutral_sdr);
+  }
+
+  output_color = float4(renodx::draw::RenderIntermediatePass(final_color), 1.f);
+}

--- a/src/games/dishonored2/0x1A0CD2AE.ps_5_0.hlsl
+++ b/src/games/dishonored2/0x1A0CD2AE.ps_5_0.hlsl
@@ -1,0 +1,158 @@
+#include "./shared.h"
+
+// ---- Created with 3Dmigoto v1.3.16 on Thu Aug 06 15:37:32 2026
+
+cbuffer PerViewCB : register(b1) {
+  float4 cb_alwaystweak : packoffset(c0);
+  float4 cb_viewrandom : packoffset(c1);
+  float4x4 cb_viewprojectionmatrix : packoffset(c2);
+  float4x4 cb_viewmatrix : packoffset(c6);
+  float4 cb_subpixeloffset : packoffset(c10);
+  float4x4 cb_projectionmatrix : packoffset(c11);
+  float4x4 cb_previousviewprojectionmatrix : packoffset(c15);
+  float4x4 cb_previousviewmatrix : packoffset(c19);
+  float4x4 cb_previousprojectionmatrix : packoffset(c23);
+  float4 cb_mousecursorposition : packoffset(c27);
+  float4 cb_mousebuttonsdown : packoffset(c28);
+  float4 cb_jittervectors : packoffset(c29);
+  float4x4 cb_inverseviewprojectionmatrix : packoffset(c30);
+  float4x4 cb_inverseviewmatrix : packoffset(c34);
+  float4x4 cb_inverseprojectionmatrix : packoffset(c38);
+  float4 cb_globalviewinfos : packoffset(c42);
+  float3 cb_wscamforwarddir : packoffset(c43);
+  uint cb_alwaysone : packoffset(c43.w);
+  float3 cb_wscamupdir : packoffset(c44);
+  uint cb_usecompressedhdrbuffers : packoffset(c44.w);
+  float3 cb_wscampos : packoffset(c45);
+  float cb_time : packoffset(c45.w);
+  float3 cb_wscamleftdir : packoffset(c46);
+  float cb_systime : packoffset(c46.w);
+  float2 cb_jitterrelativetopreviousframe : packoffset(c47);
+  float2 cb_worldtime : packoffset(c47.z);
+  float2 cb_shadowmapatlasslicedimensions : packoffset(c48);
+  float2 cb_resolutionscale : packoffset(c48.z);
+  float2 cb_parallelshadowmapslicedimensions : packoffset(c49);
+  float cb_framenumber : packoffset(c49.z);
+  uint cb_alwayszero : packoffset(c49.w);
+}
+
+SamplerState smp_bilinearsampler_s : register(s0);
+Texture2D<float4> ro_identity_bufferin : register(t0);
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(
+    float4 v0 : INTERP0,
+    float4 pixel_position : SV_POSITION0,
+    out float4 o0 : SV_TARGET0) {
+  float4 r0, r1, r2, r3, r4, r5, r6, r7, r8;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+
+  r0.xy = cb_resolutionscale.xy * v0.xy;
+  ro_identity_bufferin.GetDimensions(0, fDest.x, fDest.y, fDest.z);
+  r0.zw = fDest.xy;
+  r1.xy = r0.xy * r0.zw + float2(-0.5, -0.5);
+  r1.xy = floor(r1.xy);
+  r2.xyzw = float4(0.5, 0.5, -0.5, -0.5) + r1.xyxy;
+  r1.xy = float2(2.5, 2.5) + r1.xy;
+  r0.xy = r0.xy * r0.zw + -r2.xy;
+  r0.zw = float2(1, 1) / r0.zw;
+  r1.zw = r0.xy * r0.xy;
+  r3.xy = r1.zw * r0.xy;
+  r3.zw = float2(2.5, 2.5) * r1.zw;
+  r3.xy = r3.xy * float2(1.5, 1.5) + -r3.zw;
+  r3.xy = float2(1, 1) + r3.xy;
+  r3.zw = r1.zw * r0.xy + r0.xy;
+  r0.xy = r1.zw * r0.xy + -r1.zw;
+  r1.zw = -r3.zw * float2(0.5, 0.5) + r1.zw;
+  r3.zw = float2(1, 1) + -r1.zw;
+  r3.zw = r3.zw + -r3.xy;
+  r3.zw = -r0.xy * float2(0.5, 0.5) + r3.zw;
+  r0.xy = float2(0.5, 0.5) * r0.xy;
+  r3.xy = r3.xy + r3.zw;
+  r3.zw = r3.zw / r3.xy;
+  r2.xy = r3.zw + r2.xy;
+  r4.xyzw = r2.zyxw * r0.zwzw;
+  r2.xy = r1.xy * r0.zw;
+  r5.xyzw = ro_identity_bufferin.SampleLevel(smp_bilinearsampler_s, r4.zw, 0).xyzw;
+  r5.rgb = renodx::draw::InvertIntermediatePass(r5.rgb);
+  r5.xyzw = r5.xyzw * r3.xxxx;
+  r5.xyzw = r5.xyzw * r1.wwww;
+  r6.xyzw = ro_identity_bufferin.SampleLevel(smp_bilinearsampler_s, r4.xw, 0).xyzw;
+  r6.rgb = renodx::draw::InvertIntermediatePass(r6.rgb);
+  r6.xyzw = r6.xyzw * r1.zzzz;
+  r5.xyzw = r6.xyzw * r1.wwww + r5.xyzw;
+  r2.zw = r4.wy;
+  r6.xyzw = ro_identity_bufferin.SampleLevel(smp_bilinearsampler_s, r2.xz, 0).xyzw;
+  r6.rgb = renodx::draw::InvertIntermediatePass(r6.rgb);
+  r7.xyzw = ro_identity_bufferin.SampleLevel(smp_bilinearsampler_s, r2.xw, 0).xyzw;
+  r7.rgb = renodx::draw::InvertIntermediatePass(r7.rgb);
+  r7.xyzw = r7.xyzw * r0.xxxx;
+  r6.xyzw = r6.xyzw * r0.xxxx;
+  r5.xyzw = r6.xyzw * r1.wwww + r5.xyzw;
+  r6.xyzw = ro_identity_bufferin.SampleLevel(smp_bilinearsampler_s, r4.xy, 0).xyzw;
+  r6.rgb = renodx::draw::InvertIntermediatePass(r6.rgb);
+  r8.xyzw = ro_identity_bufferin.SampleLevel(smp_bilinearsampler_s, r4.zy, 0).xyzw;
+  r8.rgb = renodx::draw::InvertIntermediatePass(r8.rgb);
+  r8.xyzw = r8.xyzw * r3.xxxx;
+  r6.xyzw = r6.xyzw * r1.zzzz;
+  r5.xyzw = r6.xyzw * r3.yyyy + r5.xyzw;
+  r5.xyzw = r8.xyzw * r3.yyyy + r5.xyzw;
+  r5.xyzw = r7.xyzw * r3.yyyy + r5.xyzw;
+  r4.y = r2.y;
+  r2.xyzw = ro_identity_bufferin.SampleLevel(smp_bilinearsampler_s, r2.xy, 0).xyzw;
+  r2.rgb = renodx::draw::InvertIntermediatePass(r2.rgb);
+  r2.xyzw = r2.xyzw * r0.xxxx;
+  r6.xyzw = ro_identity_bufferin.SampleLevel(smp_bilinearsampler_s, r4.xy, 0).xyzw;
+  r6.rgb = renodx::draw::InvertIntermediatePass(r6.rgb);
+  r4.xyzw = ro_identity_bufferin.SampleLevel(smp_bilinearsampler_s, r4.zy, 0).xyzw;
+  r4.rgb = renodx::draw::InvertIntermediatePass(r4.rgb);
+  r3.xyzw = r4.xyzw * r3.xxxx;
+  r1.xyzw = r6.xyzw * r1.zzzz;
+  r1.xyzw = r1.xyzw * r0.yyyy + r5.xyzw;
+  r1.xyzw = r3.xyzw * r0.yyyy + r1.xyzw;
+  o0.xyzw = r2.xyzw * r0.yyyy + r1.xyzw;
+
+  if (DISHONORED2_SHARPENING > 0.f) {
+    const float2 input_uv = cb_resolutionscale.xy * v0.xy;
+    const float2 texel_size = 1.f / fDest.xy;
+    const float3 sample_left = renodx::draw::InvertIntermediatePass(
+        ro_identity_bufferin.SampleLevel(
+            smp_bilinearsampler_s, input_uv - float2(texel_size.x, 0.f), 0.f).rgb);
+    const float3 sample_right = renodx::draw::InvertIntermediatePass(
+        ro_identity_bufferin.SampleLevel(
+            smp_bilinearsampler_s, input_uv + float2(texel_size.x, 0.f), 0.f).rgb);
+    const float3 sample_up = renodx::draw::InvertIntermediatePass(
+        ro_identity_bufferin.SampleLevel(
+            smp_bilinearsampler_s, input_uv - float2(0.f, texel_size.y), 0.f).rgb);
+    const float3 sample_down = renodx::draw::InvertIntermediatePass(
+        ro_identity_bufferin.SampleLevel(
+            smp_bilinearsampler_s, input_uv + float2(0.f, texel_size.y), 0.f).rgb);
+    const float3 neighborhood_average =
+        (sample_left + sample_right + sample_up + sample_down) * 0.25f;
+    const float3 neighborhood_min = min(
+        min(sample_left, sample_right), min(sample_up, sample_down));
+    const float3 neighborhood_max = max(
+        max(sample_left, sample_right), max(sample_up, sample_down));
+    const float3 sharpened = clamp(
+        o0.rgb + (o0.rgb - neighborhood_average) * 2.f,
+        min(neighborhood_min, o0.rgb),
+        max(neighborhood_max, o0.rgb));
+    o0.rgb = lerp(o0.rgb, sharpened, saturate(DISHONORED2_SHARPENING));
+  }
+
+  if (DISHONORED2_FILM_GRAIN > 0.f) {
+    const float frame_phase = (float)(cb_framenumber % 1024u);
+    const float grain = frac(sin(
+        dot(floor(pixel_position.xy), float2(12.9898f, 78.233f))
+        + frame_phase * 0.754877666f) * 43758.5453f) - 0.5f;
+    o0.rgb = max(
+        0.f,
+        o0.rgb * (1.f + grain * 0.06f * saturate(DISHONORED2_FILM_GRAIN)));
+  }
+
+  o0.rgb = renodx::draw::RenderIntermediatePass(o0.rgb);
+  return;
+}

--- a/src/games/dishonored2/0xA6F33860.ps_5_0.hlsl
+++ b/src/games/dishonored2/0xA6F33860.ps_5_0.hlsl
@@ -1,0 +1,251 @@
+#include "./shared.h"
+
+struct postfx_luminance_autoexposure_t {
+  float EngineLuminanceFactor;
+  float LuminanceFactor;
+  float MinLuminanceLDR;
+  float MaxLuminanceLDR;
+  float MiddleGreyLuminanceLDR;
+  float EV;
+  float Fstop;
+  uint PeakHistogramValue;
+};
+
+cbuffer PerInstanceCB : register(b2) {
+  float4 cb_positiontoviewtexture : packoffset(c0);
+  float4 cb_postfx_tonemapping_tonemappingparms : packoffset(c1);
+  float4 cb_postfx_tonemapping_tonemappingcoeffs1 : packoffset(c2);
+  float4 cb_postfx_tonemapping_tonemappingcoeffs0 : packoffset(c3);
+  float4 cb_postfx_lensdirt_usedefault : packoffset(c4);
+  float2 cb_env_tonemapping_gamma_brightness : packoffset(c5);
+  uint2 cb_postfx_luminance_exposureindex : packoffset(c5.z);
+  float cb_env_bloom_veil_strength : packoffset(c6);
+  float cb_view_white_level : packoffset(c6.y);
+  float cb_postfx_luminance_customevbias : packoffset(c6.z);
+  float cb_postfx_lensflares_streakwidth : packoffset(c6.w);
+  float cb_postfx_lensflares_streakradius : packoffset(c7);
+  float cb_postfx_lensflares_streakopacity : packoffset(c7.y);
+  float cb_postfx_lensflares_streakoffset : packoffset(c7.z);
+  float cb_postfx_bloom_lensdirt_strength : packoffset(c7.w);
+  float cb_postfx_bloom_lensdirt_blendweight : packoffset(c8);
+  uint cb_postfx_bloom_enabled : packoffset(c8.y);
+}
+
+cbuffer PerViewCB : register(b1) {
+  float4 cb_alwaystweak : packoffset(c0);
+  float4 cb_viewrandom : packoffset(c1);
+  float4x4 cb_viewprojectionmatrix : packoffset(c2);
+  float4x4 cb_viewmatrix : packoffset(c6);
+  float4 cb_subpixeloffset : packoffset(c10);
+  float4x4 cb_projectionmatrix : packoffset(c11);
+  float4x4 cb_previousviewprojectionmatrix : packoffset(c15);
+  float4x4 cb_previousviewmatrix : packoffset(c19);
+  float4x4 cb_previousprojectionmatrix : packoffset(c23);
+  float4 cb_mousecursorposition : packoffset(c27);
+  float4 cb_mousebuttonsdown : packoffset(c28);
+  float4 cb_jittervectors : packoffset(c29);
+  float4x4 cb_inverseviewprojectionmatrix : packoffset(c30);
+  float4x4 cb_inverseviewmatrix : packoffset(c34);
+  float4x4 cb_inverseprojectionmatrix : packoffset(c38);
+  float4 cb_globalviewinfos : packoffset(c42);
+  float3 cb_wscamforwarddir : packoffset(c43);
+  uint cb_alwaysone : packoffset(c43.w);
+  float3 cb_wscamupdir : packoffset(c44);
+  uint cb_usecompressedhdrbuffers : packoffset(c44.w);
+  float3 cb_wscampos : packoffset(c45);
+  float cb_time : packoffset(c45.w);
+  float3 cb_wscamleftdir : packoffset(c46);
+  float cb_systime : packoffset(c46.w);
+  float2 cb_jitterrelativetopreviousframe : packoffset(c47);
+  float2 cb_worldtime : packoffset(c47.z);
+  float2 cb_shadowmapatlasslicedimensions : packoffset(c48);
+  float2 cb_resolutionscale : packoffset(c48.z);
+  float2 cb_parallelshadowmapslicedimensions : packoffset(c49);
+  float cb_framenumber : packoffset(c49.z);
+  uint cb_alwayszero : packoffset(c49.w);
+}
+
+SamplerState smp_linearclamp_s : register(s0);
+Texture2D<float4> ro_postfx_bloom_lensdirt_to : register(t0);
+Texture2D<float4> ro_postfx_bloom_lensdirt_from : register(t1);
+Texture3D<float4> ro_tonemapping_finalcolorcube : register(t2);
+Texture2D<float4> ro_postfx_lensflares_texlensflares : register(t3);
+Texture2D<float4> ro_postfx_bloom_texbloom : register(t4);
+Texture2D<float4> ro_viewcolormap : register(t5);
+StructuredBuffer<postfx_luminance_autoexposure_t>
+    ro_postfx_luminance_buffautoexposure : register(t6);
+
+float3 ApplyVanillaToneCurve(float3 color) {
+  const bool3 use_low_curve =
+      color < cb_postfx_tonemapping_tonemappingparms.xxx;
+  const float4 coefficients_r = use_low_curve.r
+                                    ? cb_postfx_tonemapping_tonemappingcoeffs0
+                                    : cb_postfx_tonemapping_tonemappingcoeffs1;
+  const float4 coefficients_g = use_low_curve.g
+                                    ? cb_postfx_tonemapping_tonemappingcoeffs0
+                                    : cb_postfx_tonemapping_tonemappingcoeffs1;
+  const float4 coefficients_b = use_low_curve.b
+                                    ? cb_postfx_tonemapping_tonemappingcoeffs0
+                                    : cb_postfx_tonemapping_tonemappingcoeffs1;
+
+  float3 numerator;
+  numerator.r = coefficients_r.x * color.r + coefficients_r.z;
+  numerator.g = coefficients_g.x * color.g + coefficients_g.z;
+  numerator.b = coefficients_b.x * color.b + coefficients_b.z;
+
+  float3 denominator;
+  denominator.r = coefficients_r.y * color.r + coefficients_r.w;
+  denominator.g = coefficients_g.y * color.g + coefficients_g.w;
+  denominator.b = coefficients_b.y * color.b + coefficients_b.w;
+  return numerator / denominator;
+}
+
+float3 ApplyGammaBrightness(float3 color) {
+  color = saturate(cb_env_tonemapping_gamma_brightness.yyy * color);
+  return exp2(
+      cb_env_tonemapping_gamma_brightness.xxx * log2(color));
+}
+
+void main(float4 v0 : INTERP0, float4 v1 : SV_POSITION0,
+          out float4 o0 : SV_TARGET0) {
+  float4 r0, r1, r2, r3, r4;
+
+  r0.xy = (uint2)v1.xy;
+  r0.zw = float2(0.f, 0.f);
+  r0.xyz = ro_viewcolormap.Load(r0.xyz).xyz;
+  r0.w = ro_postfx_luminance_buffautoexposure[cb_postfx_luminance_exposureindex.y]
+             .EngineLuminanceFactor;
+  r0.w = cb_view_white_level * r0.w;
+  r1.xyz = r0.xyz * r0.www;
+  r0.xyz = cb_usecompressedhdrbuffers ? r1.xyz : r0.xyz;
+
+  if (cb_postfx_bloom_enabled != 0u) {
+    r1.xy = cb_resolutionscale.xy * v0.xy;
+    if (0.f < cb_postfx_lensdirt_usedefault.x) {
+      r1.zw = cb_subpixeloffset.xy + v0.xy;
+      r2.xyz = ro_postfx_bloom_lensdirt_from.SampleLevel(
+                                                smp_linearclamp_s, r1.zw, 0.f)
+                   .xyz;
+    } else {
+      r1.zw = cb_subpixeloffset.xy + v0.xy;
+      r3.xyz = ro_postfx_bloom_lensdirt_from.SampleLevel(
+                                                smp_linearclamp_s, r1.zw, 0.f)
+                   .xyz;
+      r4.xyz = ro_postfx_bloom_lensdirt_to.SampleLevel(
+                                              smp_linearclamp_s, r1.zw, 0.f)
+                   .xyz;
+      r4.xyz = r4.xyz - r3.xyz;
+      r2.xyz = cb_postfx_bloom_lensdirt_blendweight * r4.xyz + r3.xyz;
+    }
+    r2.xyz *= DISHONORED2_LENS_DIRT_AMOUNT;
+
+    if (0.f < cb_env_bloom_veil_strength) {
+      r3.xyz = ro_postfx_bloom_texbloom.SampleLevel(
+                                           smp_linearclamp_s, r1.xy, 0.f)
+                   .xyz;
+      r4.xyz = r3.xyz * r0.www;
+      r3.xyz = cb_usecompressedhdrbuffers ? r4.xyz : r3.xyz;
+      r3.xyz = cb_env_bloom_veil_strength * r3.xyz;
+      r4.xyz = cb_postfx_bloom_lensdirt_strength * r2.xyz;
+      r3.xyz = r4.xyz * r3.xyz + r3.xyz;
+      r0.xyz = r3.xyz * DISHONORED2_BLOOM_INTENSITY + r0.xyz;
+    }
+
+    r1.zw = float2(-0.5f, -0.5f) + v0.xy;
+    r2.w = cb_viewmatrix._m02 + cb_viewmatrix._m21;
+    sincos(r2.w, r3.x, r4.x);
+    r3.xy = float2(-0.5f, 0.5f) * r3.xx;
+    r3.z = r4.x;
+    r4.x = dot(r3.zx, r1.zw);
+    r4.y = dot(r3.yz, r1.zw);
+    r1.z = dot(r4.xy, r4.xy);
+    r1.w = min(abs(r4.x), abs(r4.y));
+    r2.w = max(abs(r4.x), abs(r4.y));
+    r2.w = 1.f / r2.w;
+    r1.w = r2.w * r1.w;
+    r2.w = r1.w * r1.w;
+    r3.x = r2.w * 0.0208350997f - 0.0851330012f;
+    r3.x = r2.w * r3.x + 0.180141002f;
+    r3.x = r2.w * r3.x - 0.330299497f;
+    r2.w = r2.w * r3.x + 0.999866009f;
+    r3.x = r2.w * r1.w;
+    r3.y = abs(r4.y) < abs(r4.x);
+    r3.x = r3.x * -2.f + 1.57079637f;
+    r3.x = r3.y ? r3.x : 0.f;
+    r1.w = r1.w * r2.w + r3.x;
+    r2.w = r4.y < -r4.y;
+    r2.w = r2.w ? -3.141593f : 0.f;
+    r1.w = r2.w + r1.w;
+    r2.w = min(r4.x, r4.y);
+    r3.x = max(r4.x, r4.y);
+    r2.w = r2.w < -r2.w;
+    r3.x = r3.x >= -r3.x;
+    r2.w = r2.w ? r3.x : 0.f;
+    r1.w = r2.w ? -r1.w : r1.w;
+    r1.w = 3.14159274f + r1.w;
+    r2.w = 651.898621f * r1.w;
+    r2.w = floor(r2.w);
+    r3.x = sin(r2.w);
+    r3.x = 43758.5469f * r3.x;
+    r3.y = 1.f + r2.w;
+    r3.y = sin(r3.y);
+    r3.y = 43758.5469f * r3.y;
+    r3.xy = frac(r3.xy);
+    r1.w = r1.w * 651.898621f - r2.w;
+    r2.w = r3.y - r3.x;
+    r1.w = r1.w * r2.w + r3.x;
+    r1.w = r1.w * cb_postfx_lensflares_streakoffset
+           + cb_postfx_lensflares_streakradius;
+    r1.z = -r1.w * r1.w + r1.z;
+    r1.z = -cb_postfx_lensflares_streakwidth + abs(r1.z);
+    r1.w = 1.f / -cb_postfx_lensflares_streakwidth;
+    r1.z = saturate(r1.z * r1.w);
+    r1.w = r1.z * -2.f + 3.f;
+    r1.z = r1.z * r1.z;
+    r1.z = r1.w * r1.z;
+    r2.xyz = r1.zzz * cb_postfx_lensflares_streakopacity + r2.xyz;
+    r1.zw = float2(1.f, 1.f) / cb_resolutionscale.xy;
+    r1.xy = saturate(-cb_positiontoviewtexture.zw * r1.zw + r1.xy);
+    r1.xyz = ro_postfx_lensflares_texlensflares.SampleLevel(
+                                                   smp_linearclamp_s, r1.xy, 0.f)
+                 .xyz;
+    r3.xyz = r1.xyz * r0.www;
+    r1.xyz = cb_usecompressedhdrbuffers ? r3.xyz : r1.xyz;
+    r2.xyz = r2.xyz * float3(0.8f, 0.8f, 0.8f)
+             + float3(0.2f, 0.2f, 0.2f);
+    r0.xyz = r1.xyz * r2.xyz + r0.xyz;
+  }
+
+  const float3 untonemapped = max(0.f, r0.xyz) * v0.zzz;
+  float3 neutral_sdr = ApplyVanillaToneCurve(untonemapped);
+
+  float3 lut_coordinates = neutral_sdr * 31.f + 0.5f;
+  lut_coordinates *= 0.03125f;
+  float3 graded_sdr = ro_tonemapping_finalcolorcube.SampleLevel(
+                                                       smp_linearclamp_s, lut_coordinates, 0.f)
+                          .xyz;
+  graded_sdr = ApplyGammaBrightness(graded_sdr);
+
+  if (shader_injection.override_black_clip != 0.f
+      && RENODX_TONE_MAP_TYPE != 0.f) {
+    const float3 neutral_black = ApplyVanillaToneCurve(0.f);
+    const float3 black_lut_coordinates =
+        (neutral_black * 31.f + 0.5f) * 0.03125f;
+    float3 graded_black = ro_tonemapping_finalcolorcube.SampleLevel(
+                                                           smp_linearclamp_s,
+                                                           black_lut_coordinates,
+                                                           0.f)
+                              .xyz;
+    graded_black = ApplyGammaBrightness(graded_black);
+
+    neutral_sdr = Dishonored2RemoveBlackFloor(neutral_sdr, neutral_black);
+    graded_sdr = Dishonored2RemoveBlackFloor(graded_sdr, graded_black);
+  }
+
+  const float3 hdr_color = RENODX_TONE_MAP_TYPE == 0.f
+                               ? graded_sdr
+                               : renodx::draw::ToneMapPass(
+                                     untonemapped, graded_sdr, neutral_sdr);
+  o0.rgb = renodx::draw::RenderIntermediatePass(hdr_color);
+  o0.a = 1.f;
+}

--- a/src/games/dishonored2/addon.cpp
+++ b/src/games/dishonored2/addon.cpp
@@ -1,0 +1,438 @@
+/*
+ * Copyright (C) 2026 RenoDX contributors
+ * SPDX-License-Identifier: MIT
+ */
+
+#define ImTextureID                   ImU64
+#define RENODX_MODS_SWAPCHAIN_VERSION 2
+
+#include <vector>
+
+#include <deps/imgui/imgui.h>
+#include <embed/shaders.h>
+#include <include/reshade.hpp>
+
+#include "../../mods/shader.hpp"
+#include "../../mods/swapchain.hpp"
+#include "../../utils/random.hpp"
+#include "../../utils/settings.hpp"
+#include "./shared.h"
+
+namespace {
+
+ShaderInjectData shader_injection = {};
+float current_settings_mode = 0.f;
+
+bool OnToneMapDraw(reshade::api::command_list* cmd_list) {
+  auto render_targets = renodx::utils::swapchain::GetRenderTargets(cmd_list);
+  bool changed = false;
+
+  for (const auto render_target : render_targets) {
+    changed = renodx::mods::swapchain::ActivateCloneHotSwap(
+                  cmd_list->get_device(), render_target)
+              || changed;
+  }
+
+  if (changed) {
+    renodx::mods::swapchain::FlushDescriptors(cmd_list);
+    renodx::mods::swapchain::RewriteRenderTargets(
+        cmd_list,
+        static_cast<uint32_t>(render_targets.size()),
+        render_targets.data(),
+        {0u});
+  }
+  return true;
+}
+
+// Dishonored 2 repeatedly requests exclusive fullscreen when its window gains
+// focus. Match Dishonored2GraphicalUpgrade's modern-windowed behavior without
+// invoking RenoDX's fake-fullscreen window resize path.
+bool OnCreateSwapchainModernWindowed(
+    reshade::api::device_api,
+    reshade::api::swapchain_desc& desc,
+    void*) {
+  desc.back_buffer.texture.format = reshade::api::format::r10g10b10a2_unorm;
+  if (desc.back_buffer_count < 2u) desc.back_buffer_count = 2u;
+  desc.present_mode = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+  desc.fullscreen_state = false;
+  desc.present_flags |= DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING;
+  desc.fullscreen_refresh_rate = 0.f;
+  desc.sync_interval = 0u;
+  return true;
+}
+
+bool OnSetFullscreenStateModernWindowed(
+    reshade::api::swapchain*,
+    bool fullscreen,
+    void*) {
+  return fullscreen;
+}
+
+#define Dishonored2ToneMapShader(hash)                                   \
+  {                                                                      \
+    hash, { .crc32 = hash, .code = __##hash, .on_draw = &OnToneMapDraw } \
+  }
+
+renodx::mods::shader::CustomShaders custom_shaders = {
+    Dishonored2ToneMapShader(0xA6F33860),  // Main tonemap with 3D color cube.
+    Dishonored2ToneMapShader(0x11E16EF3),  // Black-and-white tonemap variant.
+    CustomShaderEntry(0x1A0CD2AE),         // Final upscale/copy before Iggy UI.
+};
+
+#undef Dishonored2ToneMapShader
+
+renodx::utils::settings::Setting* peak_nits_setting = nullptr;
+
+renodx::utils::settings::Settings settings = {
+    new renodx::utils::settings::Setting{
+        .key = "SettingsMode",
+        .binding = &current_settings_mode,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 0.f,
+        .can_reset = false,
+        .label = "Settings Mode",
+        .labels = {"Simple", "Advanced"},
+        .is_global = true,
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapType",
+        .binding = &shader_injection.tone_map_type,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 3.f,
+        .can_reset = true,
+        .label = "Tone Mapper",
+        .section = "Tone Mapping",
+        .tooltip = "Selects the HDR tone mapper.",
+        .labels = {"Vanilla", "None", "ACES", "RenoDRT"},
+    },
+    peak_nits_setting = new renodx::utils::settings::Setting{
+        .key = "ToneMapPeakNits",
+        .binding = &shader_injection.peak_white_nits,
+        .default_value = 1000.f,
+        .can_reset = true,
+        .label = "Peak Brightness",
+        .section = "Tone Mapping",
+        .tooltip = "Sets the peak display brightness in nits.",
+        .min = 200.f,
+        .max = 4000.f,
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapGameNits",
+        .binding = &shader_injection.diffuse_white_nits,
+        .default_value = 203.f,
+        .label = "Game Brightness",
+        .section = "Tone Mapping",
+        .tooltip = "Sets diffuse white brightness in nits.",
+        .min = 80.f,
+        .max = 500.f,
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapUINits",
+        .binding = &shader_injection.graphics_white_nits,
+        .default_value = 203.f,
+        .label = "UI Brightness",
+        .section = "Tone Mapping",
+        .tooltip = "Sets UI and HUD white brightness independently from the scene.",
+        .min = 80.f,
+        .max = 500.f,
+    },
+    new renodx::utils::settings::Setting{
+        .key = "GammaCorrection",
+        .binding = &shader_injection.gamma_correction,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 1.f,
+        .label = "SDR EOTF Emulation",
+        .section = "Tone Mapping",
+        .tooltip = "Matches the SDR look before expanding highlights.",
+        .labels = {"Off", "Gamma 2.2", "BT.1886"},
+        .is_visible = []() { return current_settings_mode >= 1.f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "OverrideBlackClip",
+        .binding = &shader_injection.override_black_clip,
+        .value_type = renodx::utils::settings::SettingValueType::BOOLEAN,
+        .default_value = 0.f,
+        .label = "Override Black Clip / Fix Raised Blacks",
+        .section = "Tone Mapping",
+        .tooltip = "Reanchors Dishonored 2's tone-curve and 3D LUT black point to true "
+                   "black and disables RenoDRT flare. Disable if an intentionally faded "
+                   "scene looks too dark.",
+        .is_enabled = []() { return shader_injection.tone_map_type != 0.f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "BloomIntensity",
+        .binding = &shader_injection.bloom_intensity,
+        .default_value = 100.f,
+        .label = "Bloom Intensity",
+        .section = "Graphical Upgrade",
+        .tooltip = "Adjusts bloom before HDR tone mapping.",
+        .max = 200.f,
+        .parse = [](float value) { return value * 0.01f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "LensDirtAmount",
+        .binding = &shader_injection.lens_dirt_amount,
+        .default_value = 100.f,
+        .label = "Lens Dirt",
+        .section = "Graphical Upgrade",
+        .tooltip = "Controls the game's lens-dirt texture without changing bloom.",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.01f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "Sharpening",
+        .binding = &shader_injection.sharpening,
+        .default_value = 0.f,
+        .label = "HDR-safe Sharpening",
+        .section = "Graphical Upgrade",
+        .tooltip = "Applies local contrast sharpening without clipping HDR highlights.",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.01f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "FilmGrain",
+        .binding = &shader_injection.film_grain,
+        .default_value = 0.f,
+        .label = "Film Grain",
+        .section = "Graphical Upgrade",
+        .tooltip = "Adds luminance-preserving monochrome film grain in linear HDR.",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.01f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeScene",
+        .binding = &shader_injection.color_grade_strength,
+        .default_value = 100.f,
+        .label = "Scene Grading",
+        .section = "Color Grading",
+        .tooltip = "Controls the strength of the game's 3D color cube.",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.01f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeExposure",
+        .binding = &shader_injection.tone_map_exposure,
+        .default_value = 1.f,
+        .label = "Exposure",
+        .section = "Color Grading",
+        .max = 2.f,
+        .format = "%.2f",
+        .is_visible = []() { return current_settings_mode >= 1.f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeHighlights",
+        .binding = &shader_injection.tone_map_highlights,
+        .default_value = 50.f,
+        .label = "Highlights",
+        .section = "Color Grading",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+        .is_visible = []() { return current_settings_mode >= 1.f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeShadows",
+        .binding = &shader_injection.tone_map_shadows,
+        .default_value = 50.f,
+        .label = "Shadows",
+        .section = "Color Grading",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+        .is_visible = []() { return current_settings_mode >= 1.f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeContrast",
+        .binding = &shader_injection.tone_map_contrast,
+        .default_value = 50.f,
+        .label = "Contrast",
+        .section = "Color Grading",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeSaturation",
+        .binding = &shader_injection.tone_map_saturation,
+        .default_value = 50.f,
+        .label = "Saturation",
+        .section = "Color Grading",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeHighlightSaturation",
+        .binding = &shader_injection.tone_map_highlight_saturation,
+        .default_value = 50.f,
+        .label = "Highlight Saturation",
+        .section = "Color Grading",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.02f; },
+        .is_visible = []() { return current_settings_mode >= 1.f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeBlowout",
+        .binding = &shader_injection.tone_map_blowout,
+        .default_value = 0.f,
+        .label = "Highlight Desaturation",
+        .section = "Color Grading",
+        .max = 100.f,
+        .parse = [](float value) { return value * 0.01f; },
+        .is_visible = []() { return current_settings_mode >= 1.f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ColorGradeFlare",
+        .binding = &shader_injection.tone_map_flare,
+        .default_value = 0.f,
+        .label = "Flare",
+        .section = "Color Grading",
+        .tooltip = "Adds a soft shadow toe. Ignored while Override Black Clip is enabled.",
+        .max = 100.f,
+        .is_enabled = []() { return shader_injection.override_black_clip == 0.f; },
+        .parse = [](float value) { return value * 0.02f; },
+        .is_visible = []() { return current_settings_mode >= 1.f; },
+    },
+    new renodx::utils::settings::Setting{
+        .key = "ToneMapScaling",
+        .binding = &shader_injection.tone_map_per_channel,
+        .value_type = renodx::utils::settings::SettingValueType::INTEGER,
+        .default_value = 0.f,
+        .label = "Tone Map Scaling",
+        .section = "Tone Mapping",
+        .labels = {"Luminance", "Per Channel"},
+        .is_visible = []() { return current_settings_mode >= 1.f; },
+    },
+};
+
+void OnPresetOff() {
+  renodx::utils::settings::UpdateSetting("ToneMapType", 0.f);
+  renodx::utils::settings::UpdateSetting("ToneMapPeakNits", 203.f);
+  renodx::utils::settings::UpdateSetting("ToneMapGameNits", 203.f);
+  renodx::utils::settings::UpdateSetting("ToneMapUINits", 203.f);
+  renodx::utils::settings::UpdateSetting("GammaCorrection", 0.f);
+  renodx::utils::settings::UpdateSetting("OverrideBlackClip", 0.f);
+  renodx::utils::settings::UpdateSetting("BloomIntensity", 100.f);
+  renodx::utils::settings::UpdateSetting("LensDirtAmount", 100.f);
+  renodx::utils::settings::UpdateSetting("Sharpening", 0.f);
+  renodx::utils::settings::UpdateSetting("FilmGrain", 0.f);
+  renodx::utils::settings::UpdateSetting("ColorGradeScene", 100.f);
+  renodx::utils::settings::UpdateSetting("ColorGradeExposure", 1.f);
+  renodx::utils::settings::UpdateSetting("ColorGradeHighlights", 50.f);
+  renodx::utils::settings::UpdateSetting("ColorGradeShadows", 50.f);
+  renodx::utils::settings::UpdateSetting("ColorGradeContrast", 50.f);
+  renodx::utils::settings::UpdateSetting("ColorGradeSaturation", 50.f);
+  renodx::utils::settings::UpdateSetting("ColorGradeHighlightSaturation", 50.f);
+  renodx::utils::settings::UpdateSetting("ColorGradeBlowout", 0.f);
+  renodx::utils::settings::UpdateSetting("ColorGradeFlare", 0.f);
+}
+
+bool initialized_peak_nits = false;
+
+void OnInitSwapchain(reshade::api::swapchain* swapchain, bool resize) {
+  // The generic swapchain handler marks recreated back buffers for cloning,
+  // but their RTVs may already exist. Propagate that state to existing views
+  // so the first post-resize bind creates the FP16 clone at draw time, after
+  // VoidEngine's burst of ResizeBuffers calls has finished.
+  const auto back_buffer_count = swapchain->get_back_buffer_count();
+  for (uint32_t index = 0; index < back_buffer_count; ++index) {
+    const auto buffer = swapchain->get_back_buffer(index);
+    std::vector<uint64_t> view_handles;
+    renodx::utils::resource::ResourceUpgradeInfo* clone_target = nullptr;
+
+    renodx::utils::resource::GetResourceInfo(
+        buffer,
+        [&](const renodx::utils::resource::ResourceInfo& info) {
+          if (!info.clone_enabled || info.clone_target == nullptr) return;
+          view_handles.assign(
+              info.resource_view_handles.begin(), info.resource_view_handles.end());
+          clone_target = info.clone_target;
+        });
+
+    if (clone_target != nullptr && !view_handles.empty()) {
+      renodx::utils::resource::upgrade::UpdateResourceViewsCloneState(
+          view_handles, true, false, clone_target);
+    }
+  }
+
+  if (initialized_peak_nits) return;
+  initialized_peak_nits = true;
+
+  const auto detected_peak_nits = renodx::utils::swapchain::GetPeakNits(swapchain);
+  if (detected_peak_nits.has_value()) {
+    peak_nits_setting->default_value = roundf(detected_peak_nits.value());
+    peak_nits_setting->can_reset = true;
+  }
+}
+
+}  // namespace
+
+extern "C" __declspec(dllexport) constexpr const char* NAME = "RenoDX";
+extern "C" __declspec(dllexport) constexpr const char* DESCRIPTION =
+    "RenoDX for Dishonored 2";
+extern "C" __declspec(dllexport) const uint32_t
+    DISHONORED2_GRAPHICAL_UPGRADE_COMPATIBILITY_ABI = 1u;
+
+BOOL APIENTRY DllMain(HMODULE h_module, DWORD fdw_reason, LPVOID) {
+  switch (fdw_reason) {
+    case DLL_PROCESS_ATTACH:
+      if (!reshade::register_addon(h_module)) return FALSE;
+
+      renodx::mods::shader::force_pipeline_cloning = true;
+      renodx::mods::shader::expected_constant_buffer_index = 13;
+      renodx::mods::shader::expected_constant_buffer_space = 50;
+
+      renodx::mods::swapchain::expected_constant_buffer_index = 13;
+      renodx::mods::swapchain::expected_constant_buffer_space = 50;
+      renodx::mods::swapchain::use_resource_cloning = true;
+      renodx::mods::swapchain::swapchain_proxy_compatibility_mode = false;
+      renodx::mods::swapchain::swapchain_proxy_revert_state = true;
+      renodx::mods::swapchain::force_borderless = false;
+      renodx::mods::swapchain::prevent_full_screen = false;
+      renodx::mods::swapchain::force_screen_tearing = false;
+      renodx::mods::swapchain::set_color_space = true;
+      renodx::mods::swapchain::SetUseHDR10();
+      renodx::mods::swapchain::swap_chain_proxy_vertex_shader =
+          __swap_chain_proxy_vertex_shader;
+      renodx::mods::swapchain::swap_chain_proxy_pixel_shader =
+          __swap_chain_proxy_pixel_shader;
+
+      renodx::mods::swapchain::resource_upgrade_infos.push_back({
+          .old_format = reshade::api::format::r8g8b8a8_typeless,
+          .new_format = reshade::api::format::r16g16b16a16_float,
+          .use_resource_view_cloning = true,
+          .use_resource_view_hot_swap = true,
+          .aspect_ratio = renodx::mods::swapchain::ResourceUpgradeInfo::BACK_BUFFER,
+          .aspect_ratio_tolerance = 0.01f,
+          .usage_include = reshade::api::resource_usage::render_target,
+          .name = "Dishonored 2 post-tonemap intermediate",
+      });
+
+      break;
+
+    case DLL_PROCESS_DETACH:
+      reshade::unregister_event<reshade::addon_event::create_swapchain>(
+          OnCreateSwapchainModernWindowed);
+      reshade::unregister_event<reshade::addon_event::set_fullscreen_state>(
+          OnSetFullscreenStateModernWindowed);
+      reshade::unregister_event<reshade::addon_event::init_swapchain>(OnInitSwapchain);
+      break;
+  }
+
+  renodx::utils::random::Use(
+      fdw_reason, {&shader_injection.swap_chain_output_dither_seed});
+  renodx::utils::settings::Use(fdw_reason, &settings, &OnPresetOff);
+  renodx::mods::swapchain::Use(fdw_reason, &shader_injection);
+  renodx::mods::shader::Use(fdw_reason, custom_shaders, &shader_injection);
+  if (fdw_reason == DLL_PROCESS_ATTACH) {
+    // Register after swapchain::Use so the game-specific policy is applied
+    // after generic swapchain changes and clone targets exist before init.
+    reshade::register_event<reshade::addon_event::create_swapchain>(
+        OnCreateSwapchainModernWindowed);
+    reshade::register_event<reshade::addon_event::set_fullscreen_state>(
+        OnSetFullscreenStateModernWindowed);
+    reshade::register_event<reshade::addon_event::init_swapchain>(OnInitSwapchain);
+  }
+  if (fdw_reason == DLL_PROCESS_DETACH) {
+    // The modules unregister ReShade events in Use(), so the add-on must remain
+    // registered until all module teardown has completed.
+    reshade::unregister_addon(h_module);
+  }
+  return TRUE;
+}

--- a/src/games/dishonored2/metadata.json
+++ b/src/games/dishonored2/metadata.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://cdn.jsdelivr.net/gh/clshortfuse/renodx/renodx-metadata-schema.json",
+  "id": "dishonored2",
+  "title": "Dishonored 2",
+  "status": "beta",
+  "deploy": {
+    "game_exe": "Dishonored2.exe",
+    "process_name": "Dishonored2",
+    "api": "d3d11",
+    "steam_appid": 403640,
+    "gog_product_id": 1431426311,
+    "architecture": [
+      "x64"
+    ]
+  }
+}

--- a/src/games/dishonored2/shared.h
+++ b/src/games/dishonored2/shared.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2026 RenoDX contributors
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef SRC_GAMES_DISHONORED2_SHARED_H_
+#define SRC_GAMES_DISHONORED2_SHARED_H_
+
+struct ShaderInjectData {
+  float peak_white_nits;
+  float diffuse_white_nits;
+  float graphics_white_nits;
+  float color_grade_strength;
+
+  float tone_map_type;
+  float tone_map_exposure;
+  float tone_map_highlights;
+  float tone_map_shadows;
+
+  float tone_map_contrast;
+  float tone_map_saturation;
+  float tone_map_highlight_saturation;
+  float tone_map_blowout;
+
+  float tone_map_flare;
+  float tone_map_hue_correction;
+  float tone_map_hue_shift;
+  float tone_map_working_color_space;
+
+  float tone_map_clamp_color_space;
+  float tone_map_clamp_peak;
+  float tone_map_hue_processor;
+  float tone_map_per_channel;
+
+  float gamma_correction;
+  float swap_chain_custom_color_space;
+  float swap_chain_output_dither_seed;
+  float override_black_clip;
+
+  float bloom_intensity;
+  float lens_dirt_amount;
+  float sharpening;
+  float film_grain;
+};
+
+#ifndef __cplusplus
+#if ((__SHADER_TARGET_MAJOR == 5 && __SHADER_TARGET_MINOR >= 1) || __SHADER_TARGET_MAJOR >= 6)
+cbuffer shader_injection : register(b13, space50) {
+#else
+cbuffer shader_injection : register(b13) {
+#endif
+  ShaderInjectData shader_injection : packoffset(c0);
+}
+
+#define RENODX_PEAK_WHITE_NITS               shader_injection.peak_white_nits
+#define RENODX_DIFFUSE_WHITE_NITS            shader_injection.diffuse_white_nits
+#define RENODX_GRAPHICS_WHITE_NITS           shader_injection.graphics_white_nits
+#define RENODX_COLOR_GRADE_STRENGTH          shader_injection.color_grade_strength
+#define RENODX_TONE_MAP_TYPE                 shader_injection.tone_map_type
+#define RENODX_TONE_MAP_EXPOSURE             shader_injection.tone_map_exposure
+#define RENODX_TONE_MAP_HIGHLIGHTS           shader_injection.tone_map_highlights
+#define RENODX_TONE_MAP_SHADOWS              shader_injection.tone_map_shadows
+#define RENODX_TONE_MAP_CONTRAST             shader_injection.tone_map_contrast
+#define RENODX_TONE_MAP_SATURATION           shader_injection.tone_map_saturation
+#define RENODX_TONE_MAP_HIGHLIGHT_SATURATION shader_injection.tone_map_highlight_saturation
+#define RENODX_TONE_MAP_BLOWOUT              shader_injection.tone_map_blowout
+#define RENODX_TONE_MAP_FLARE                (shader_injection.override_black_clip != 0.f ? 0.f : shader_injection.tone_map_flare)
+#define RENODX_TONE_MAP_PER_CHANNEL          shader_injection.tone_map_per_channel
+#define RENODX_GAMMA_CORRECTION              shader_injection.gamma_correction
+#define DISHONORED2_BLOOM_INTENSITY          shader_injection.bloom_intensity
+#define DISHONORED2_LENS_DIRT_AMOUNT         shader_injection.lens_dirt_amount
+#define DISHONORED2_SHARPENING                shader_injection.sharpening
+#define DISHONORED2_FILM_GRAIN                shader_injection.film_grain
+// VoidEngine's late Iggy UI renders through non-sRGB views and intentionally
+// blends in gamma space. Keep the FP16 intermediate sRGB-encoded until every UI
+// draw is complete, then decode once in the swap-chain proxy for HDR output.
+#define RENODX_INTERMEDIATE_ENCODING         1.f
+#define RENODX_SWAP_CHAIN_DECODING           1.f
+#define RENODX_SWAP_CHAIN_CUSTOM_COLOR_SPACE shader_injection.swap_chain_custom_color_space
+#define RENODX_SWAP_CHAIN_OUTPUT_DITHER_BITS 10.f
+#define RENODX_SWAP_CHAIN_OUTPUT_DITHER_SEED shader_injection.swap_chain_output_dither_seed
+#define RENODX_SWAP_CHAIN_OUTPUT_PRESET      renodx::draw::SWAP_CHAIN_OUTPUT_PRESET_HDR10
+#define RENODX_RENO_DRT_TONE_MAP_METHOD      renodx::tonemap::renodrt::config::tone_map_method::DANIELE
+
+#include "../../shaders/renodx.hlsl"
+
+float3 Dishonored2RemoveBlackFloor(float3 color, float3 black_point) {
+  return saturate(
+      max(0.f, color - black_point)
+      / max(1e-4f, 1.f - black_point));
+}
+
+#endif
+
+#endif  // SRC_GAMES_DISHONORED2_SHARED_H_

--- a/src/games/dishonored2/swap_chain_proxy_pixel_shader.ps_5_0.hlsl
+++ b/src/games/dishonored2/swap_chain_proxy_pixel_shader.ps_5_0.hlsl
@@ -1,0 +1,11 @@
+#include "./shared.h"
+
+Texture2D<float4> source_texture : register(t0);
+SamplerState source_sampler : register(s0);
+
+float4 main(float4 position : SV_POSITION, float2 uv : TEXCOORD0) : SV_TARGET {
+  float4 color = source_texture.Sample(source_sampler, uv);
+  color.rgb = renodx::draw::SwapChainPass(color.rgb, position.xy);
+  color.a = 1.f;
+  return color;
+}

--- a/src/games/dishonored2/swap_chain_proxy_vertex_shader.vs_5_0.hlsl
+++ b/src/games/dishonored2/swap_chain_proxy_vertex_shader.vs_5_0.hlsl
@@ -1,0 +1,8 @@
+void main(
+    uint id : SV_VERTEXID,
+    out float4 position : SV_POSITION,
+    out float2 uv : TEXCOORD0) {
+  uv.x = (id == 1) ? 2.f : 0.f;
+  uv.y = (id == 2) ? 2.f : 0.f;
+  position = float4(uv * float2(2.f, -2.f) + float2(-1.f, 1.f), 0.f, 1.f);
+}

--- a/src/mods/swapchain_v2.hpp
+++ b/src/mods/swapchain_v2.hpp
@@ -475,6 +475,7 @@ static void DestroySwapchainProxyItems(reshade::api::device* device, DeviceData*
   for (auto& [handle, pass] : data->swapchain_proxy_passes) {
     assert(pass != nullptr);
     pass->Destroy(device);
+    delete pass;
   }
   data->swapchain_proxy_passes.clear();
 }
@@ -1251,6 +1252,7 @@ inline void OnPresent(
 
   if (!proxy_pass->Render(swapchain, queue)) {
     proxy_pass->Destroy(device);
+    delete proxy_pass;
     data->swapchain_proxy_passes.erase(back_buffer_handle);
   }
 }


### PR DESCRIPTION
## Supersedes #620

This Draft replaces #620 with the same nine-file Dishonored 2 diff replayed as two clean commits directly on clshortfuse/renodx:main. It intentionally excludes local Test25/PsychoV work and generated artifacts.

## Summary

- Adds a native RenoDX addon for Dishonored 2 (D3D11, x64).
- Replaces the main tonemap/3D LUT shader, the black-and-white tonemap variant, and the final upscale/copy pass before Iggy UI.
- Upgrades the post-tonemap back-buffer-sized intermediate from RGBA8 typeless to an FP16 clone and presents through a thin HDR10 `SwapChainPass` proxy.
- Preserves the game's late gamma-space Iggy UI composition by keeping the FP16 intermediate sRGB-encoded until final output.
- Exports `DISHONORED2_GRAPHICAL_UPGRADE_COMPATIBILITY_ABI = 1` for optional Dishonored2GraphicalUpgrade integration.
- Releases dynamically allocated swapchain proxy passes during teardown and failed proxy rendering.

## Why

Dishonored 2 exposes the real scene, exposure, bloom, vanilla tone curve, and 3D color grade in the target tonemap shaders. This implementation feeds those proven pre-SDR and vanilla-reference signals into `ToneMapPass` instead of inverse-tonemapping a completed SDR frame. The FP16 resource clone prevents the upgraded result from being clipped by the original RGBA8 intermediate, while the proxy shader is limited to final HDR10 encoding.

## Defaults

New installations keep the original presentation effects neutral by default:

- RenoDRT remains the default HDR tone mapper.
- Black-clip override is off.
- Bloom and lens dirt remain at 100%.
- Sharpening and added film grain are off.
- Preset Off restores the vanilla tonemap, 203-nit scene/UI values, original effects, and disables custom grading controls.

Existing saved settings continue to use their stored values.

## Build verification

Validated from a clean branch based on `clshortfuse/main`:

```text
cmake --preset clang-x64
cmake --build --preset clang-x64-release --target dishonored2 --verbose
```

Checks performed:

- `git diff --check`
- `metadata.json` validated against `renodx-metadata-schema.json`
- Generated non-empty embeds for `0xA6F33860`, `0x11E16EF3`, `0x1A0CD2AE`, and both swapchain proxy shaders
- Produced `build/Release/renodx-dishonored2.addon64`
- Confirmed x86-64 exports: `NAME`, `DESCRIPTION`, and `DISHONORED2_GRAPHICAL_UPGRADE_COMPATIBILITY_ABI`
- Confirmed no generated `.cso` or addon binaries are included in the diff

## Runtime verification boundary

The source build before this clean upstream port was tested in game by the author. Its ReShade 6.8 log confirms addon loading, registration of all three replacement hashes, and simultaneous Dishonored2GraphicalUpgrade loading. The binary built from this exact upstream branch has not yet been runtime-retested, so this PR is intentionally a Draft.

## Draft note

The current implementation selects HDR10 output at startup and does not yet expose a synchronized SDR/HDR output toggle. This is left explicit for maintainer feedback rather than expanding the initial port beyond the tested game path.